### PR TITLE
fix(deck): make legacy thumbnail navigation instant

### DIFF
--- a/apps/daemon/src/prompts/deck-framework.ts
+++ b/apps/daemon/src/prompts/deck-framework.ts
@@ -1,3 +1,5 @@
+import { DECK_PROTOCOL_V1_INLINE_RUNTIME } from '@open-design/contracts/runtime/deck-protocol';
+
 /**
  * Stable deck framework injected into the system prompt when the active skill
  * mode is `deck`. The whole point: stop regenerating the scale-to-fit JS, the
@@ -43,7 +45,7 @@
  */
 
 export const DECK_SKELETON_HTML = `<!doctype html>
-<html lang="en">
+<html lang="en" data-od-deck-protocol="1">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -59,6 +61,7 @@ export const DECK_SKELETON_HTML = `<!doctype html>
          - Only .slide.active is visible at a time
          - Programmatic prev/next + counter elements kept outside the scaled
            stage but hidden by default so the host can render the UI chrome
+         - OD Deck Protocol v1 absolute navigation + slide-state events
          - Keyboard (← → space PgUp PgDn Home End R), half-slide click, and stored
            position survive iframe focus quirks
          - "Save as PDF" produces a multi-page vertical PDF, one slide
@@ -283,12 +286,14 @@ export const DECK_SKELETON_HTML = `<!doctype html>
         if (total) total.textContent = pad2(slides.length);
         if (prev) prev.toggleAttribute('disabled', idx <= 0);
         if (next) next.toggleAttribute('disabled', idx >= slides.length - 1);
+        postDeckState();
       }
       function go(i) {
         idx = Math.max(0, Math.min(slides.length - 1, i));
         paint();
         try { localStorage.setItem(STORE, String(idx)); } catch (_) {}
       }
+${DECK_PROTOCOL_V1_INLINE_RUNTIME}
       function onKey(e) {
         if (e.__odDeckKeyHandled) return;
         var t = e.target;
@@ -344,6 +349,7 @@ export const DECK_SKELETON_HTML = `<!doctype html>
       } catch (_) {}
 
       window.addEventListener('resize', fit);
+      announceDeckProtocol();
       fit();
       paint();
       focusDeck();
@@ -354,7 +360,7 @@ export const DECK_SKELETON_HTML = `<!doctype html>
 
 export const DECK_FRAMEWORK_DIRECTIVE = `# Slide deck — fixed framework (this is non-negotiable for deck mode)
 
-Decks regress when each turn re-authors the scale-to-fit logic, the keyboard handler, the slide visibility toggle, the counter, and the print rules. The user has hit this enough times that we now ship a **fixed framework**: 1920×1080 canvas, scale-to-fit, hidden programmatic prev/next + counter, capture-phase keyboard with R reset-to-first-slide, half-slide click navigation, localStorage position restore, and a print stylesheet that emits a multi-page vertical PDF on Save-as-PDF — all baked in.
+Decks regress when each turn re-authors the scale-to-fit logic, the keyboard handler, the slide visibility toggle, the counter, and the print rules. The user has hit this enough times that we now ship a **fixed framework**: 1920×1080 canvas, scale-to-fit, OD Deck Protocol v1 absolute navigation + state events, hidden programmatic prev/next + counter, capture-phase keyboard with R reset-to-first-slide, half-slide click navigation, localStorage position restore, and a print stylesheet that emits a multi-page vertical PDF on Save-as-PDF — all baked in.
 
 **You do not write any of that. You do not modify any of that.** Your job is to fill content slots only.
 

--- a/apps/daemon/tests/deck-export.test.ts
+++ b/apps/daemon/tests/deck-export.test.ts
@@ -149,7 +149,8 @@ describe('buildDeckRenderInput', () => {
 
       expect(request.input.html).toContain('data-od-deck-stage-fallback');
       expect(request.input.html).toContain("window.customElements.define('deck-stage'");
-      expect(request.input.html).toContain("type: 'od:slide-state'");
+      expect(request.input.html).toContain('type: "od:slide-state"');
+      expect(request.input.html).toContain('protocolVersion: 1');
     } finally {
       rmSync(projectsRoot, { recursive: true, force: true });
     }

--- a/apps/daemon/tests/prompts/__snapshots__/system-prompt-matrix.test.ts.snap
+++ b/apps/daemon/tests/prompts/__snapshots__/system-prompt-matrix.test.ts.snap
@@ -84,7 +84,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 87419,
+    "totalChars": 88985,
   },
   "deck-kind-with-skill-seed": {
     "sections": [
@@ -120,7 +120,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 83501,
+    "totalChars": 85067,
   },
   "design-full-stack": {
     "sections": [
@@ -165,7 +165,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 87375,
+    "totalChars": 88941,
   },
   "design-no-ds-multitarget": {
     "sections": [
@@ -211,7 +211,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 91071,
+    "totalChars": 92637,
   },
   "freeform-other-no-deck-signal": {
     "sections": [
@@ -254,7 +254,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 89603,
+    "totalChars": 91169,
   },
   "plan-mode": {
     "sections": [
@@ -286,7 +286,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 87471,
+    "totalChars": 89037,
   },
   "skip-discovery-brief": {
     "sections": [

--- a/apps/daemon/tests/prompts/system.test.ts
+++ b/apps/daemon/tests/prompts/system.test.ts
@@ -354,6 +354,16 @@ describe('composeSystemPrompt', () => {
     expect(prompt).toContain('no dark-on-dark labels');
   });
 
+  it('ships new Agent decks with OD Deck Protocol v1', () => {
+    const prompt = composeSystemPrompt({ skillMode: 'deck' });
+
+    expect(prompt).toContain('data-od-deck-protocol="1"');
+    expect(prompt).toContain("type: 'od:deck-ready'");
+    expect(prompt).toContain("data.type !== 'od:slide'");
+    expect(prompt).toContain('go(target);');
+    expect(prompt).toContain("type: 'od:slide-state'");
+  });
+
   it('injects nested-diagram discipline only through deck surfaces', () => {
     const heading = '## Nested / concentric diagram discipline';
 

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -10,9 +10,10 @@
  * lets the host advance / rewind slides without relying on the iframe
  * having keyboard focus. The host posts:
  *   { type: 'od:slide', action: 'next' | 'prev' | 'first' | 'last' | 'go', index?: number }
- * and the iframe responds with:
- *   { type: 'od:slide-state', active: number, count: number }
- * after every navigation so the host can render its own counter / dots.
+ * A v1-native artifact first announces `od:deck-ready`, then responds after
+ * every navigation with versioned `od:slide-state` events so the host can
+ * render its own counter / dots. Persisted legacy decks remain supported by
+ * the injected keyboard/hash/DOM adapters below.
  */
 import {
   DECK_EXPLICIT_SLIDE_SELECTOR,
@@ -22,6 +23,10 @@ import {
   DECK_STRUCTURED_SLIDE_SELECTOR,
   injectDeckStageFallback,
 } from '@open-design/contracts/runtime/deck-stage-fallback';
+import {
+  DECK_PROTOCOL_VERSION,
+  DECK_READY_MESSAGE_TYPE,
+} from '@open-design/contracts/runtime/deck-protocol';
 import {
   buildPreviewBaseHrefBridge,
   buildPreviewObservabilityBridge,
@@ -2929,6 +2934,12 @@ function injectDeckBridge(
     : 0;
   const hasInlineSlideMessageListener =
     /addEventListener\s*\(\s*['"]message['"]/i.test(doc) && /\bod:slide\b/.test(doc);
+  const artifactDeckProtocolVersion = new RegExp(
+    `\\bdata-od-deck-protocol\\s*=\\s*['"]${DECK_PROTOCOL_VERSION}['"]`,
+    'i',
+  ).test(doc)
+    ? DECK_PROTOCOL_VERSION
+    : 0;
   const hasInlineKeydownListener = !!options.artifactHasKeydownNavigation;
   const hasInlineHashNavigation =
     /(?:hashchange|onhashchange)/i.test(doc) && /location\.hash/i.test(doc);
@@ -3890,7 +3901,8 @@ function injectDeckBridge(
   }
   var odSlideMessageBeforeIndex = -1;
   var odDeckBridgeInstallingMessageListener = false;
-  var odHasExternalSlideMessageListener = ${JSON.stringify(hasInlineSlideMessageListener)};
+  var odDeckProtocolVersion = ${artifactDeckProtocolVersion};
+  var odHasExternalSlideMessageListener = ${JSON.stringify(hasInlineSlideMessageListener)} || odDeckProtocolVersion === ${DECK_PROTOCOL_VERSION};
   function odMaybeHandlesSlideMessages(listener) {
     try {
       var source = '';
@@ -3933,6 +3945,13 @@ function injectDeckBridge(
     try { window.addEventListener('message', listener, options); }
     finally { odDeckBridgeInstallingMessageListener = false; }
   }
+  addOdSlideMessageListener(function(ev){
+    var data = ev && ev.data;
+    if (!data || data.type !== ${JSON.stringify(DECK_READY_MESSAGE_TYPE)}) return;
+    if (data.protocolVersion !== ${DECK_PROTOCOL_VERSION}) return;
+    odDeckProtocolVersion = ${DECK_PROTOCOL_VERSION};
+    odHasExternalSlideMessageListener = true;
+  });
   addOdSlideMessageListener(function(ev){
     var data = ev && ev.data;
     if (!data || data.type !== 'od:slide') return;

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -3590,6 +3590,8 @@ function injectDeckBridge(
   // deferred artifact handler still runs afterwards, advancing a second time
   // and desyncing the artifact's internal index from the visible slide.
   var KEY_PROBE_WINDOW_MS = 48;
+  var KEYBOARD_UNLOCK_TIMEOUT_MS = 600;
+  var KEYBOARD_UNLOCK_RETRY_MS = 40;
   var DIRECT_INDEX_UNLOCK_TIMEOUT_MS = 1500;
   var preferredKeyTarget = null;
   var odNavigationSequence = 0;
@@ -3673,16 +3675,33 @@ function injectDeckBridge(
   }
   function stepToIndexViaKeys(target, navigationSequence, onDone){
     var guard = slides().length + 4;
+    var unlockDeadline = 0;
     function isCurrent(){ return navigationSequence === odNavigationSequence; }
     function step(){
       if (!isCurrent()) return;
       var current = activeIndex(slides());
       if (current === target) { onDone(true); return; }
       if (guard <= 0) { onDone(false); return; }
-      guard -= 1;
       goViaArtifactKeys(target > current ? 'ArrowRight' : 'ArrowLeft', function(moved){
         if (!isCurrent()) return;
-        if (!moved) { onDone(false); return; }
+        if (!moved) {
+          // A target that moved the deck on an earlier step is available but
+          // may be temporarily rejecting keys during an authored transition.
+          // Retry that same remaining step briefly before falling through to
+          // direct-index/DOM navigation, which would desynchronize private
+          // artifact state from the visible canvas.
+          if (preferredKeyTarget) {
+            if (!unlockDeadline) unlockDeadline = Date.now() + KEYBOARD_UNLOCK_TIMEOUT_MS;
+            if (Date.now() < unlockDeadline) {
+              setTimeout(function(){ if (isCurrent()) step(); }, KEYBOARD_UNLOCK_RETRY_MS);
+              return;
+            }
+          }
+          onDone(false);
+          return;
+        }
+        unlockDeadline = 0;
+        guard -= 1;
         step();
       }, isCurrent);
     }

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -3777,12 +3777,18 @@ function injectDeckBridge(
     if (navigateViaDeckStage(list, 'go', target)) return;
     if (isScrollDeck(list)) { scrollGo(target); return; }
     if (activeIndex(list) === target) { report(); return; }
-    goViaArtifactIndex(target, navigationSequence, function(moved){
+    // A thumbnail selection and the footer prev/next controls must enter the
+    // artifact through the same navigation path. Trying nav dots/hash routes
+    // first makes an otherwise keyboard-responsive deck wait out the direct
+    // index retry deadline before the bridge finally dispatches the keys that
+    // the footer uses immediately. Keep direct-index navigation as a fallback
+    // for dot/hash-only decks, but prefer the proven keyboard path.
+    stepToIndexViaKeys(target, navigationSequence, function(stepped){
       if (navigationSequence !== odNavigationSequence) return;
-      if (moved) { report(); return; }
-      stepToIndexViaKeys(target, navigationSequence, function(stepped){
+      if (stepped) { report(); return; }
+      goViaArtifactIndex(target, navigationSequence, function(moved){
         if (navigationSequence !== odNavigationSequence) return;
-        if (stepped) { report(); return; }
+        if (moved) { report(); return; }
         var now = slides();
         if (canSetActive(now) && setActive(target)) return;
         if (transformGo(target)) return;

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -3952,9 +3952,14 @@ function injectDeckBridge(
     odDeckProtocolVersion = ${DECK_PROTOCOL_VERSION};
     odHasExternalSlideMessageListener = true;
   });
+  function odIsSupportedSlideMessage(data) {
+    return !!data &&
+      data.type === 'od:slide' &&
+      (data.protocolVersion == null || data.protocolVersion === ${DECK_PROTOCOL_VERSION});
+  }
   addOdSlideMessageListener(function(ev){
     var data = ev && ev.data;
-    if (!data || data.type !== 'od:slide') return;
+    if (!odIsSupportedSlideMessage(data)) return;
     var before = activeIndex(slides());
     odSlideMessageBeforeIndex = before;
     setTimeout(function(){
@@ -3963,7 +3968,7 @@ function injectDeckBridge(
   }, true);
   addOdSlideMessageListener(function(ev){
     var data = ev && ev.data;
-    if (!data || data.type !== 'od:slide') return;
+    if (!odIsSupportedSlideMessage(data)) return;
     // Every newer host intent cancels an older multi-step jump, including a
     // request for the slide that is CURRENTLY visible. The older jump may not
     // have dispatched its first accepted key yet (the artifact can register on

--- a/apps/web/tests/runtime/deck-protocol-v1.test.ts
+++ b/apps/web/tests/runtime/deck-protocol-v1.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment node
+
+import { JSDOM } from 'jsdom';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DECK_PROTOCOL_V1_INLINE_RUNTIME,
+  DECK_PROTOCOL_VERSION,
+} from '@open-design/contracts/runtime/deck-protocol';
+
+function setupCanonicalProtocolDeck() {
+  const dom = new JSDOM(`<!doctype html><html data-od-deck-protocol="1"><body>
+    <section class="slide active">One</section>
+    <section class="slide">Two</section>
+    <section class="slide">Three</section>
+    <section class="slide">Four</section>
+  </body></html>`, {
+    runScripts: 'outside-only',
+    pretendToBeVisual: true,
+  });
+  const win = dom.window;
+  const postMessage = vi.fn();
+  Object.defineProperty(win, 'parent', {
+    configurable: true,
+    value: { postMessage },
+  });
+
+  const script = `
+    var slides = Array.prototype.slice.call(document.querySelectorAll('.slide'));
+    var idx = 0;
+    function paint() {
+      slides.forEach(function (slide, index) {
+        slide.classList.toggle('active', index === idx);
+      });
+      postDeckState();
+    }
+    function go(index) {
+      idx = Math.max(0, Math.min(slides.length - 1, index));
+      paint();
+    }
+${DECK_PROTOCOL_V1_INLINE_RUNTIME}
+    announceDeckProtocol();
+    paint();
+  `;
+  new win.Function(script).call(win);
+
+  return {
+    activeIndex: () => Array.from(win.document.querySelectorAll('.slide'))
+      .findIndex((slide) => slide.classList.contains('active')),
+    postMessage,
+    win,
+  };
+}
+
+describe('OD Deck Protocol v1', () => {
+  it('announces absolute navigation and state-event capabilities', () => {
+    const { postMessage, win } = setupCanonicalProtocolDeck();
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'od:deck-ready',
+      protocolVersion: DECK_PROTOCOL_VERSION,
+      capabilities: ['absolute-navigation', 'state-events'],
+    }, '*');
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'od:slide-state',
+      protocolVersion: DECK_PROTOCOL_VERSION,
+      active: 0,
+      count: 4,
+    }, '*');
+    win.close();
+  });
+
+  it('jumps directly to a thumbnail target without intermediate key events', () => {
+    const { activeIndex, postMessage, win } = setupCanonicalProtocolDeck();
+    const keydown = vi.fn();
+    win.addEventListener('keydown', keydown);
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'go', index: 3, protocolVersion: 1 },
+    }));
+
+    expect(activeIndex()).toBe(3);
+    expect(keydown).not.toHaveBeenCalled();
+    expect(postMessage).toHaveBeenLastCalledWith({
+      type: 'od:slide-state',
+      protocolVersion: DECK_PROTOCOL_VERSION,
+      active: 3,
+      count: 4,
+    }, '*');
+    win.close();
+  });
+
+  it('keeps unversioned legacy host commands compatible', () => {
+    const { activeIndex, win } = setupCanonicalProtocolDeck();
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'last' },
+    }));
+    expect(activeIndex()).toBe(3);
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'first' },
+    }));
+    expect(activeIndex()).toBe(0);
+    win.close();
+  });
+});

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-framework-deck.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-framework-deck.test.ts
@@ -90,6 +90,15 @@ describe('injectDeckBridge — framework-deck detection (#deck-stage)', () => {
     expect(out).toMatch(/<script[^>]*data-od-deck-bridge/);
   });
 
+  it('recognizes the canonical v1 marker before legacy navigation probing', () => {
+    const html = frameworkDeckHtml().replace('<html>', '<html data-od-deck-protocol="1">');
+    const out = buildSrcdoc(html, { deck: true });
+
+    expect(out).toContain('var odDeckProtocolVersion = 1;');
+    expect(out).toContain('odHasExternalSlideMessageListener = false || odDeckProtocolVersion === 1');
+    expect(out).toContain("data.type !== \"od:deck-ready\"");
+  });
+
   it('keeps a framework deck stage at its authored size when the shell is a flex container', () => {
     const out = buildSrcdoc(frameworkDeckHtml(), { deck: true });
     expect(out).toMatch(/<style[^>]*data-od-deck-fix/);

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-page-sync.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-page-sync.test.ts
@@ -334,21 +334,24 @@ describe('deck bridge - keyboard paging keeps page counters in sync', () => {
     expect(slideStatesOf(parentPostMessage).at(-1)).toMatchObject({ active: 1, count: 3 });
   });
 
-  it('jumps directly to a selected thumbnail without exposing intermediate slides', async () => {
+  it('routes a selected thumbnail through the same keyboard path as footer paging', () => {
     const { win, parentPostMessage, track, pagerCur, visited } = setupCustomCounterDeck({
-      navigationLockMs: 120,
       directIndexControls: true,
+      listenOn: 'window',
     });
     visited.length = 0;
 
     win.dispatchEvent(new win.MessageEvent('message', {
       data: { type: 'od:slide', action: 'go', index: 2 },
     }));
-    await new Promise<void>((resolve) => win.setTimeout(resolve, 100));
+
+    // The keyboard handler is synchronous, so the bridge reaches the target
+    // in the same task without entering the 1.5s direct-index retry path.
+    // Both steps happen before the browser can paint an intermediate slide.
     expect(track.style.transform).toBe('translateX(-200vw)');
     expect(pagerCur.textContent).toBe('3');
     expect(win.document.querySelectorAll('.slide')[2]?.classList.contains('is-active')).toBe(true);
-    expect(visited).toEqual([2]);
+    expect(visited).toEqual([1, 2]);
     expect(slideStatesOf(parentPostMessage).at(-1)).toMatchObject({ active: 2, count: 3 });
   });
 
@@ -420,7 +423,9 @@ describe('deck bridge - keyboard paging keeps page counters in sync', () => {
     expect(track.style.transform).toBe('translateX(-0vw)');
     expect(pagerCur.textContent).toBe('1');
     expect(win.document.querySelectorAll('.slide')[0]?.classList.contains('is-active')).toBe(true);
-    expect(visited).toEqual([2, 0]);
+    // The second selection arrives before the document-listener probe has
+    // moved at all, so it cancels the stale jump and keeps slide 1 selected.
+    expect(visited).toEqual([]);
     expect(slideStatesOf(parentPostMessage).at(-1)).toMatchObject({ active: 0, count: 3 });
   });
 

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-page-sync.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-page-sync.test.ts
@@ -52,6 +52,8 @@ interface CustomDeckOptions {
   navigationLockMs?: number;
   /** Expose one artifact-owned direct-index control per slide. */
   directIndexControls?: boolean;
+  /** Keep direct-index controls visible but ignore their click handlers. */
+  ignoreDirectIndexControls?: boolean;
 }
 
 function setupCustomCounterDeck(options: CustomDeckOptions = {}) {
@@ -134,7 +136,7 @@ function setupCustomCounterDeck(options: CustomDeckOptions = {}) {
       const dot = win.document.createElement('button');
       dot.className = 'nav-dot';
       dot.addEventListener('click', () => {
-        if (navigationLocked) return;
+        if (options.ignoreDirectIndexControls || navigationLocked) return;
         apply(index);
         lockNavigation();
       });
@@ -334,25 +336,32 @@ describe('deck bridge - keyboard paging keeps page counters in sync', () => {
     expect(slideStatesOf(parentPostMessage).at(-1)).toMatchObject({ active: 1, count: 3 });
   });
 
-  it('routes a selected thumbnail through the same keyboard path as footer paging', () => {
-    const { win, parentPostMessage, track, pagerCur, visited } = setupCustomCounterDeck({
-      directIndexControls: true,
-      listenOn: 'window',
-    });
-    visited.length = 0;
+  it('reaches a selected thumbnail before the direct-index retry window', async () => {
+    vi.useFakeTimers();
+    try {
+      const { win, parentPostMessage, track, pagerCur, visited } = setupCustomCounterDeck({
+        directIndexControls: true,
+        ignoreDirectIndexControls: true,
+        listenOn: 'window',
+      });
+      visited.length = 0;
 
-    win.dispatchEvent(new win.MessageEvent('message', {
-      data: { type: 'od:slide', action: 'go', index: 2 },
-    }));
+      win.dispatchEvent(new win.MessageEvent('message', {
+        data: { type: 'od:slide', action: 'go', index: 2 },
+      }));
+      await vi.advanceTimersByTimeAsync(1499);
 
-    // The keyboard handler is synchronous, so the bridge reaches the target
-    // in the same task without entering the 1.5s direct-index retry path.
-    // Both steps happen before the browser can paint an intermediate slide.
-    expect(track.style.transform).toBe('translateX(-200vw)');
-    expect(pagerCur.textContent).toBe('3');
-    expect(win.document.querySelectorAll('.slide')[2]?.classList.contains('is-active')).toBe(true);
-    expect(visited).toEqual([1, 2]);
-    expect(slideStatesOf(parentPostMessage).at(-1)).toMatchObject({ active: 2, count: 3 });
+      // The authored dots deliberately ignore clicks, matching the reported
+      // legacy deck. Keyboard navigation must still reach the target before
+      // the bridge's 1.5s direct-index retry window can expire.
+      expect(track.style.transform).toBe('translateX(-200vw)');
+      expect(pagerCur.textContent).toBe('3');
+      expect(win.document.querySelectorAll('.slide')[2]?.classList.contains('is-active')).toBe(true);
+      expect(visited).toEqual([1, 2]);
+      expect(slideStatesOf(parentPostMessage).at(-1)).toMatchObject({ active: 2, count: 3 });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('keeps keyboard-only deck state in sync across direct selection and later paging', async () => {

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-page-sync.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-page-sync.test.ts
@@ -369,6 +369,32 @@ describe('deck bridge - keyboard paging keeps page counters in sync', () => {
     }
   });
 
+  it('retries a proven keyboard path through an authored transition lock', async () => {
+    vi.useFakeTimers();
+    try {
+      const { win, parentPostMessage, track, pagerCur, visited } = setupCustomCounterDeck({
+        navigationLockMs: 120,
+        directIndexControls: true,
+        ignoreDirectIndexControls: true,
+        listenOn: 'window',
+      });
+      visited.length = 0;
+
+      win.dispatchEvent(new win.MessageEvent('message', {
+        data: { type: 'od:slide', action: 'go', index: 2 },
+      }));
+      await vi.advanceTimersByTimeAsync(499);
+
+      expect(track.style.transform).toBe('translateX(-200vw)');
+      expect(pagerCur.textContent).toBe('3');
+      expect(win.document.querySelectorAll('.slide')[2]?.classList.contains('is-active')).toBe(true);
+      expect(visited).toEqual([1, 2]);
+      expect(slideStatesOf(parentPostMessage).at(-1)).toMatchObject({ active: 2, count: 3 });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('ignores future-version bridge commands while accepting legacy and v1 navigation', async () => {
     vi.useFakeTimers();
     try {

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-page-sync.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-page-sync.test.ts
@@ -54,6 +54,8 @@ interface CustomDeckOptions {
   directIndexControls?: boolean;
   /** Keep direct-index controls visible but ignore their click handlers. */
   ignoreDirectIndexControls?: boolean;
+  /** Advertise a canonical deck protocol version in the source document. */
+  protocolVersion?: number;
 }
 
 function setupCustomCounterDeck(options: CustomDeckOptions = {}) {
@@ -75,7 +77,10 @@ function setupCustomCounterDeck(options: CustomDeckOptions = {}) {
     </div>
     <div class="deck-pager"><span id="pager-cur">1</span> / <span id="pager-total">3</span></div>
   `;
-  const srcdoc = buildSrcdoc(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+  const protocolAttribute = options.protocolVersion == null
+    ? ''
+    : ` data-od-deck-protocol="${options.protocolVersion}"`;
+  const srcdoc = buildSrcdoc(`<!doctype html><html${protocolAttribute}><body>${bodyHtml}</body></html>`, {
     deck: true,
   });
   const script = extractDeckBridgeScript(srcdoc);
@@ -359,6 +364,41 @@ describe('deck bridge - keyboard paging keeps page counters in sync', () => {
       expect(win.document.querySelectorAll('.slide')[2]?.classList.contains('is-active')).toBe(true);
       expect(visited).toEqual([1, 2]);
       expect(slideStatesOf(parentPostMessage).at(-1)).toMatchObject({ active: 2, count: 3 });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('ignores future-version bridge commands while accepting legacy and v1 navigation', async () => {
+    vi.useFakeTimers();
+    try {
+      const { win, track, pagerCur, visited } = setupCustomCounterDeck({
+        listenOn: 'window',
+        protocolVersion: 1,
+      });
+      visited.length = 0;
+
+      win.dispatchEvent(new win.MessageEvent('message', {
+        data: { type: 'od:slide', action: 'go', index: 2, protocolVersion: 2 },
+      }));
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(track.style.transform).toBe('translateX(-0vw)');
+      expect(pagerCur.textContent).toBe('1');
+      expect(visited).toEqual([]);
+
+      win.dispatchEvent(new win.MessageEvent('message', {
+        data: { type: 'od:slide', action: 'next' },
+      }));
+      await vi.advanceTimersByTimeAsync(100);
+      expect(pagerCur.textContent).toBe('2');
+
+      win.dispatchEvent(new win.MessageEvent('message', {
+        data: { type: 'od:slide', action: 'next', protocolVersion: 1 },
+      }));
+      await vi.advanceTimersByTimeAsync(100);
+      expect(track.style.transform).toBe('translateX(-200vw)');
+      expect(pagerCur.textContent).toBe('3');
+      expect(visited).toEqual([1, 2]);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/contracts/esbuild.config.mjs
+++ b/packages/contracts/esbuild.config.mjs
@@ -15,6 +15,7 @@ await build({
     "./src/api/reasoningExecution.ts",
     "./src/api/research.ts",
     "./src/runtime/deck-stage-fallback.ts",
+    "./src/runtime/deck-protocol.ts",
     "./src/runtime/preview-observability.ts",
     "./src/runtime/preview-guards.ts",
     "./src/runtime/html-injection-points.ts",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -50,6 +50,10 @@
       "types": "./dist/runtime/deck-stage-fallback.d.ts",
       "default": "./dist/runtime/deck-stage-fallback.mjs"
     },
+    "./runtime/deck-protocol": {
+      "types": "./dist/runtime/deck-protocol.d.ts",
+      "default": "./dist/runtime/deck-protocol.mjs"
+    },
     "./runtime/preview-observability": {
       "types": "./dist/runtime/preview-observability.d.ts",
       "default": "./dist/runtime/preview-observability.mjs"

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -55,6 +55,7 @@ export * from './examples.js';
 export * from './execution-profile.js';
 export * from './artifacts/od-card.js';
 export * from './runtime/deck-stage-fallback.js';
+export * from './runtime/deck-protocol.js';
 export * from './runtime/preview-observability.js';
 export * from './runtime/model-window-limit.js';
 export * from './runtime/membership-concurrency-limit.js';

--- a/packages/contracts/src/prompts/deck-framework.ts
+++ b/packages/contracts/src/prompts/deck-framework.ts
@@ -1,3 +1,5 @@
+import { DECK_PROTOCOL_V1_INLINE_RUNTIME } from '../runtime/deck-protocol.js';
+
 /**
  * Stable deck framework injected into the system prompt when the active skill
  * mode is `deck`. The whole point: stop regenerating the scale-to-fit JS, the
@@ -43,7 +45,7 @@
  */
 
 export const DECK_SKELETON_HTML = `<!doctype html>
-<html lang="en">
+<html lang="en" data-od-deck-protocol="1">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -58,6 +60,7 @@ export const DECK_SKELETON_HTML = `<!doctype html>
          - 1920×1080 fixed canvas, scaled to fit the viewport
          - Only .slide.active is visible at a time
          - Prev/next + counter rendered outside the scaled stage
+         - OD Deck Protocol v1 absolute navigation + slide-state events
          - Keyboard (← → space PgUp PgDn Home End), click, and stored
            position survive iframe focus quirks
          - "Save as PDF" produces a multi-page vertical PDF, one slide
@@ -280,12 +283,14 @@ export const DECK_SKELETON_HTML = `<!doctype html>
         if (total) total.textContent = pad2(slides.length);
         if (prev) prev.toggleAttribute('disabled', idx <= 0);
         if (next) next.toggleAttribute('disabled', idx >= slides.length - 1);
+        postDeckState();
       }
       function go(i) {
         idx = Math.max(0, Math.min(slides.length - 1, i));
         paint();
         try { localStorage.setItem(STORE, String(idx)); } catch (_) {}
       }
+${DECK_PROTOCOL_V1_INLINE_RUNTIME}
       function onKey(e) {
         if (e.__odDeckKeyHandled) return;
         var t = e.target;
@@ -317,6 +322,7 @@ export const DECK_SKELETON_HTML = `<!doctype html>
       } catch (_) {}
 
       window.addEventListener('resize', fit);
+      announceDeckProtocol();
       fit();
       paint();
       focusDeck();
@@ -327,7 +333,7 @@ export const DECK_SKELETON_HTML = `<!doctype html>
 
 export const DECK_FRAMEWORK_DIRECTIVE = `# Slide deck — fixed framework (this is non-negotiable for deck mode)
 
-Decks regress when each turn re-authors the scale-to-fit logic, the keyboard handler, the slide visibility toggle, the counter, and the print rules. The user has hit this enough times that we now ship a **fixed framework**: 1920×1080 canvas, scale-to-fit, prev/next + counter, capture-phase keyboard, click-anywhere focus, localStorage position restore, and a print stylesheet that emits a multi-page vertical PDF on Save-as-PDF — all baked in.
+Decks regress when each turn re-authors the scale-to-fit logic, the keyboard handler, the slide visibility toggle, the counter, and the print rules. The user has hit this enough times that we now ship a **fixed framework**: 1920×1080 canvas, scale-to-fit, OD Deck Protocol v1 absolute navigation + state events, prev/next + counter, capture-phase keyboard, click-anywhere focus, localStorage position restore, and a print stylesheet that emits a multi-page vertical PDF on Save-as-PDF — all baked in.
 
 **You do not write any of that. You do not modify any of that.** Your job is to fill content slots only.
 

--- a/packages/contracts/src/runtime/deck-protocol.ts
+++ b/packages/contracts/src/runtime/deck-protocol.ts
@@ -1,0 +1,78 @@
+export const DECK_PROTOCOL_VERSION = 1 as const;
+
+export const DECK_NAVIGATE_MESSAGE_TYPE = 'od:slide' as const;
+export const DECK_STATE_MESSAGE_TYPE = 'od:slide-state' as const;
+export const DECK_READY_MESSAGE_TYPE = 'od:deck-ready' as const;
+
+export const DECK_PROTOCOL_V1_CAPABILITIES = [
+  'absolute-navigation',
+  'state-events',
+] as const;
+
+export type DeckNavigationAction = 'next' | 'prev' | 'first' | 'last' | 'go';
+
+export interface DeckNavigateMessage {
+  type: typeof DECK_NAVIGATE_MESSAGE_TYPE;
+  action: DeckNavigationAction;
+  /** Zero-based target index. Required when action is `go`. */
+  index?: number;
+  /** Omitted by legacy hosts; v1 runtimes intentionally accept both forms. */
+  protocolVersion?: typeof DECK_PROTOCOL_VERSION;
+}
+
+export interface DeckStateMessage {
+  type: typeof DECK_STATE_MESSAGE_TYPE;
+  active: number;
+  count: number;
+  protocolVersion: typeof DECK_PROTOCOL_VERSION;
+}
+
+export interface DeckReadyMessage {
+  type: typeof DECK_READY_MESSAGE_TYPE;
+  protocolVersion: typeof DECK_PROTOCOL_VERSION;
+  capabilities: typeof DECK_PROTOCOL_V1_CAPABILITIES;
+}
+
+/**
+ * Canonical inline adapter used by the fixed Agent deck skeleton.
+ *
+ * The surrounding skeleton owns `idx`, `slides`, and `go(index)`. Keeping the
+ * host protocol in one shared literal prevents the daemon and API/BYOK prompt
+ * copies from growing different message dialects while leaving deck styling
+ * and standalone keyboard/click navigation fully local to the artifact.
+ */
+export const DECK_PROTOCOL_V1_INLINE_RUNTIME = `      var OD_DECK_PROTOCOL_VERSION = ${DECK_PROTOCOL_VERSION};
+      function postDeckState() {
+        try {
+          window.parent.postMessage({
+            type: '${DECK_STATE_MESSAGE_TYPE}',
+            protocolVersion: OD_DECK_PROTOCOL_VERSION,
+            active: idx,
+            count: slides.length
+          }, '*');
+        } catch (_) {}
+      }
+      function announceDeckProtocol() {
+        try {
+          window.parent.postMessage({
+            type: '${DECK_READY_MESSAGE_TYPE}',
+            protocolVersion: OD_DECK_PROTOCOL_VERSION,
+            capabilities: ${JSON.stringify(DECK_PROTOCOL_V1_CAPABILITIES)}
+          }, '*');
+        } catch (_) {}
+      }
+      window.addEventListener('message', function (event) {
+        var data = event && event.data;
+        if (!data || data.type !== '${DECK_NAVIGATE_MESSAGE_TYPE}') return;
+        if (data.protocolVersion != null && data.protocolVersion !== OD_DECK_PROTOCOL_VERSION) return;
+        var target = idx;
+        if (data.action === 'go') {
+          if (typeof data.index !== 'number' || !isFinite(data.index)) return;
+          target = Math.floor(data.index);
+        } else if (data.action === 'next') target = idx + 1;
+        else if (data.action === 'prev') target = idx - 1;
+        else if (data.action === 'first') target = 0;
+        else if (data.action === 'last') target = slides.length - 1;
+        else return;
+        go(target);
+      });`;

--- a/packages/contracts/src/runtime/deck-protocol.ts
+++ b/packages/contracts/src/runtime/deck-protocol.ts
@@ -11,14 +11,23 @@ export const DECK_PROTOCOL_V1_CAPABILITIES = [
 
 export type DeckNavigationAction = 'next' | 'prev' | 'first' | 'last' | 'go';
 
-export interface DeckNavigateMessage {
+interface DeckNavigateMessageBase {
   type: typeof DECK_NAVIGATE_MESSAGE_TYPE;
-  action: DeckNavigationAction;
-  /** Zero-based target index. Required when action is `go`. */
-  index?: number;
   /** Omitted by legacy hosts; v1 runtimes intentionally accept both forms. */
   protocolVersion?: typeof DECK_PROTOCOL_VERSION;
 }
+
+export type DeckNavigateMessage = DeckNavigateMessageBase & (
+  | {
+      action: 'go';
+      /** Zero-based target index. */
+      index: number;
+    }
+  | {
+      action: Exclude<DeckNavigationAction, 'go'>;
+      index?: never;
+    }
+);
 
 export interface DeckStateMessage {
   type: typeof DECK_STATE_MESSAGE_TYPE;

--- a/packages/contracts/src/runtime/deck-stage-fallback.ts
+++ b/packages/contracts/src/runtime/deck-stage-fallback.ts
@@ -1,4 +1,10 @@
 import { findRealTagOffset, HTML_TAG_PATTERNS } from './html-injection-points';
+import {
+  DECK_PROTOCOL_V1_CAPABILITIES,
+  DECK_PROTOCOL_VERSION,
+  DECK_READY_MESSAGE_TYPE,
+  DECK_STATE_MESSAGE_TYPE,
+} from './deck-protocol';
 
 const DECK_STAGE_OPEN_TAG_RE = /<deck-stage\b/i;
 const DECK_STAGE_FALLBACK_MARKER = 'data-od-deck-stage-fallback';
@@ -93,7 +99,22 @@ const DECK_STAGE_FALLBACK_SCRIPT = `<script data-od-deck-stage-fallback>(functio
 
   function postSlideState(active, count) {
     try {
-      window.parent.postMessage({ type: 'od:slide-state', active: active, count: count }, '*');
+      window.parent.postMessage({
+        type: ${JSON.stringify(DECK_STATE_MESSAGE_TYPE)},
+        protocolVersion: ${DECK_PROTOCOL_VERSION},
+        active: active,
+        count: count
+      }, '*');
+    } catch (_) {}
+  }
+
+  function postDeckReady() {
+    try {
+      window.parent.postMessage({
+        type: ${JSON.stringify(DECK_READY_MESSAGE_TYPE)},
+        protocolVersion: ${DECK_PROTOCOL_VERSION},
+        capabilities: ${JSON.stringify(DECK_PROTOCOL_V1_CAPABILITIES)}
+      }, '*');
     } catch (_) {}
   }
 
@@ -122,6 +143,7 @@ const DECK_STAGE_FALLBACK_SCRIPT = `<script data-od-deck-stage-fallback>(functio
 
     connectedCallback() {
       this._syncSize();
+      postDeckReady();
       this._refresh();
       window.addEventListener('message', this._onMessage);
       window.addEventListener('resize', this._onResize);

--- a/packages/contracts/src/runtime/deck-stage-fallback.ts
+++ b/packages/contracts/src/runtime/deck-stage-fallback.ts
@@ -297,6 +297,7 @@ const DECK_STAGE_FALLBACK_SCRIPT = `<script data-od-deck-stage-fallback>(functio
     _onMessage(ev) {
       var data = ev && ev.data;
       if (!data || data.type !== 'od:slide') return;
+      if (data.protocolVersion != null && data.protocolVersion !== ${DECK_PROTOCOL_VERSION}) return;
       this.go(data.action, data.index);
     }
 

--- a/packages/contracts/tests/deck-protocol.test.ts
+++ b/packages/contracts/tests/deck-protocol.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import type { DeckNavigateMessage } from '../src/runtime/deck-protocol';
+
+describe('deck navigation protocol types', () => {
+  it('requires an index only for absolute navigation', () => {
+    const absolute = {
+      type: 'od:slide',
+      action: 'go',
+      index: 2,
+      protocolVersion: 1,
+    } satisfies DeckNavigateMessage;
+    const relative = {
+      type: 'od:slide',
+      action: 'next',
+    } satisfies DeckNavigateMessage;
+
+    // @ts-expect-error Absolute navigation must name its zero-based target.
+    const missingIndex: DeckNavigateMessage = { type: 'od:slide', action: 'go' };
+    // @ts-expect-error Relative navigation must not carry an ambiguous index.
+    const unexpectedIndex: DeckNavigateMessage = {
+      type: 'od:slide',
+      action: 'next',
+      index: 2,
+    };
+
+    expect(absolute.index).toBe(2);
+    expect(relative.action).toBe('next');
+    void missingIndex;
+    void unexpectedIndex;
+  });
+});

--- a/packages/contracts/tests/deck-stage-fallback.test.ts
+++ b/packages/contracts/tests/deck-stage-fallback.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   DECK_EXPLICIT_SLIDE_SELECTOR,
@@ -11,6 +11,7 @@ import {
   injectDeckStageFallback,
   legacyDeckScreenNumber,
 } from '../src/runtime/deck-stage-fallback.js';
+import { DECK_PROTOCOL_VERSION } from '../src/runtime/deck-protocol.js';
 
 describe('deck-stage fallback runtime injection', () => {
   it('publishes one selector contract for legacy, modern, and imported slide markers', () => {
@@ -76,6 +77,32 @@ describe('deck-stage fallback runtime injection', () => {
     expect(out.indexOf(modifierGuard)).toBeLessThan(
       out.indexOf("String(key).toLowerCase() === 'r'"),
     );
+  });
+
+  it('accepts legacy and v1 navigation while rejecting other protocol versions', () => {
+    const html = '<deck-stage><section class="slide">One</section></deck-stage>';
+    const out = injectDeckStageFallback(html);
+    const handlerBody = /_onMessage\(ev\) \{([\s\S]*?)\n    \}\n\n    _onKeydown/.exec(out)?.[1];
+    expect(handlerBody).toBeTruthy();
+
+    const onMessage = new Function('ev', handlerBody ?? '') as (
+      this: { go: (action: unknown, index: unknown) => void },
+      ev: { data: Record<string, unknown> },
+    ) => void;
+    const go = vi.fn();
+    const receiver = { go };
+
+    onMessage.call(receiver, { data: { type: 'od:slide', action: 'next' } });
+    onMessage.call(receiver, {
+      data: { type: 'od:slide', action: 'go', index: 1, protocolVersion: DECK_PROTOCOL_VERSION },
+    });
+    onMessage.call(receiver, {
+      data: { type: 'od:slide', action: 'prev', protocolVersion: DECK_PROTOCOL_VERSION + 1 },
+    });
+
+    expect(go).toHaveBeenCalledTimes(2);
+    expect(go).toHaveBeenNthCalledWith(1, 'next', undefined);
+    expect(go).toHaveBeenNthCalledWith(2, 'go', 1);
   });
 
   it('keeps the injected script body free of a literal script close tag', () => {

--- a/packages/contracts/tests/deck-stage-fallback.test.ts
+++ b/packages/contracts/tests/deck-stage-fallback.test.ts
@@ -50,7 +50,9 @@ describe('deck-stage fallback runtime injection', () => {
     expect(htmlUsesDeckStageElement(html)).toBe(true);
     expect(out).toContain('data-od-deck-stage-fallback');
     expect(out).toContain("window.customElements.define('deck-stage'");
-    expect(out).toContain("type: 'od:slide-state'");
+    expect(out).toContain('type: "od:deck-ready"');
+    expect(out).toContain('type: "od:slide-state"');
+    expect(out).toContain('protocolVersion: 1');
     expect(out).toContain('get index()');
     expect(out).toContain('goTo(index)');
     expect(out).toContain("this.go('next')");

--- a/packages/contracts/tests/package-runtime.test.ts
+++ b/packages/contracts/tests/package-runtime.test.ts
@@ -41,6 +41,12 @@ describe('@open-design/contracts package runtime shape', () => {
     expect(pkg.exports?.['./runtime/deck-stage-fallback']?.types).toBe(
       './dist/runtime/deck-stage-fallback.d.ts',
     );
+    expect(pkg.exports?.['./runtime/deck-protocol']?.default).toBe(
+      './dist/runtime/deck-protocol.mjs',
+    );
+    expect(pkg.exports?.['./runtime/deck-protocol']?.types).toBe(
+      './dist/runtime/deck-protocol.d.ts',
+    );
     expect(pkg.exports?.['./api/handoff']?.default).toBe('./dist/api/handoff.mjs');
     expect(pkg.exports?.['./api/handoff']?.types).toBe('./dist/api/handoff.d.ts');
     expect(pkg.exports?.['./critique']?.default).toBe('./dist/critique.mjs');
@@ -68,6 +74,7 @@ describe('@open-design/contracts package runtime shape', () => {
     const handoff = await import('@open-design/contracts/api/handoff');
     const critique = await import('@open-design/contracts/critique');
     const deckStageFallback = await import('@open-design/contracts/runtime/deck-stage-fallback');
+    const deckProtocol = await import('@open-design/contracts/runtime/deck-protocol');
 
     expect(contracts.composeSystemPrompt).toEqual(expect.any(Function));
     expect(contracts.exampleHealthResponse).toEqual({ ok: true, service: 'daemon' });
@@ -86,6 +93,11 @@ describe('@open-design/contracts package runtime shape', () => {
     expect(connectionTest.isBlockedExternalApiHostname).toEqual(expect.any(Function));
     expect(research.RESEARCH_DEFAULT_MAX_SOURCES.shallow).toBe(5);
     expect(deckStageFallback.injectDeckStageFallback).toEqual(expect.any(Function));
+    expect(deckProtocol.DECK_PROTOCOL_VERSION).toBe(1);
+    expect(deckProtocol.DECK_PROTOCOL_V1_CAPABILITIES).toEqual([
+      'absolute-navigation',
+      'state-events',
+    ]);
     // The handoff DTO module is interface-only except for HANDOFF_SCHEMA_VERSION,
     // which exists precisely so esbuild emits a real `.mjs` and NodeNext
     // consumers can resolve the subpath. Importing it through the package

--- a/packages/contracts/tests/system-prompt.test.ts
+++ b/packages/contracts/tests/system-prompt.test.ts
@@ -147,6 +147,16 @@ describe('DISCOVERY_AND_PHILOSOPHY (contracts copy) — prompt routing parity', 
     expect(prompt).toContain('no dark-on-dark labels');
   });
 
+  it('ships API/BYOK decks with the same OD Deck Protocol v1', () => {
+    const prompt = composeSystemPrompt({ skillMode: 'deck' });
+
+    expect(prompt).toContain('data-od-deck-protocol="1"');
+    expect(prompt).toContain("type: 'od:deck-ready'");
+    expect(prompt).toContain("data.type !== 'od:slide'");
+    expect(prompt).toContain('go(target);');
+    expect(prompt).toContain("type: 'od:slide-state'");
+  });
+
   it('injects nested-diagram discipline through every contracts deck path only', () => {
     const heading = '## Nested / concentric diagram discipline';
 


### PR DESCRIPTION
## Why

While reproducing a reported Slides issue with an existing user deck, left-rail thumbnail navigation consistently took about three seconds even though the footer previous/next controls changed slides immediately. The legacy bridge attempted an unreliable direct-index/hash probe before falling back to keyboard navigation, so older deck dialects paid the compatibility timeout on every thumbnail click.

This PR removes that user-facing delay while preserving support for existing hash- and keyboard-driven decks. It also gives newly generated decks one canonical, versioned navigation protocol so future agents do not create more navigation dialects.

## What users will see

Clicking a slide thumbnail in the left preview rail changes to that slide immediately, including for existing decks that only implement legacy keyboard navigation. Footer previous/next controls continue to work as before. Newly generated decks use the versioned `od:deck:v1` protocol, while unversioned legacy messages remain supported.

## Surface area

- [x] **UI** — existing Slides thumbnail navigation behavior in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — adds the shared versioned deck navigation runtime contract in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — thumbnail navigation now takes the immediate legacy keyboard path before slower compatibility probes
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Behavior-only latency fix; the before and after frames are visually identical. Validation used a fully packaged macOS app and the reported legacy deck fixture: baseline thumbnail navigation reproduced at about 3 seconds, while the fixed package completed repeated cross-slide jumps in 3.7–16.4 ms.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-page-sync.test.ts`
- Did the test go red on `main` and green on this branch? **Yes** — the main bridge uses the direct-index path (`visited === [2]`), while the red spec requires the synchronous footer-equivalent keyboard path (`visited === [1, 2]`).
- Real-data verification: `/Users/elian/Downloads/open-design-seed-pitch.html` reproduced the delay in a baseline DMG install and switched in 3.7–16.4 ms in the fixed DMG install.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- Web full suite: 674 files passed; 7,139 tests passed, 1 expected failure, 11 skipped
- Contracts full suite: 53 files / 500 tests passed
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/prompts/system.test.ts` — 56 passed
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts --maxWorkers=2 tests/runtime/deck-protocol-v1.test.ts tests/runtime/srcdoc-deck-bridge-framework-deck.test.ts tests/runtime/srcdoc-deck-bridge-keyboard-page-sync.test.ts` — 21 passed
- Baseline packaged E2E: build DMG → install → start → upload reported legacy deck → reproduce ~3 s thumbnail delay
- Fixed packaged E2E: build DMG → install → start → upload same deck → repeated thumbnail jumps 3.7, 5.5, 11.6, 16.4 ms; footer next/previous 9.1/15.1 ms
