### PR TITLE
docs: link DeepSeek Harness Handbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Inside a project's Studio, the conversation, generated files, and live preview s
 
 For DeepSeek Harness, install the official `dsh` CLI first, then select it in OpenDesign or run `od agent setup deepseek-harness` to install/repair OD's connection component. For MCP integrations: `od mcp install <agent> --print` for a dry-run preview · `--uninstall` to remove · full list with `od mcp install --help`.
 
+For the runtime-side details behind this integration—profiles, plugins, MCP boundaries, sandbox behavior, and evidence-driven troubleshooting—see the independent multilingual [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook/).
+
 ¹ Automatic MCP configuration for Claude Desktop is currently supported on macOS and Windows only.
 
 <p align="center">


### PR DESCRIPTION
## Summary
- add the independent multilingual DeepSeek Harness Handbook beside the existing native runtime setup
- point DSH users to profiles, plugins, MCP, sandbox, and troubleshooting guidance

## Validation
- Documentation-only README change
- `git diff --check` passes
- Link target verified

This complements OpenDesign's native DSH integration without changing runtime behavior or dependencies.