### PR TITLE
docs: correct macOS Docker authentication guidance

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -345,7 +345,7 @@ open-design/
 - **media generation says `OD_BIN` is missing or daemon URL is `:0`** — run the media dispatcher checks above. Do not resume the old CLI session; reopen the project from the OpenDesign app so the daemon can inject fresh `OD_*` variables.
 - **Codex loads too much plugin context** — start OpenDesign with `OD_CODEX_DISABLE_PLUGINS=1 pnpm tools-dev` to make daemon-spawned Codex processes run with `--disable plugins`.
 - **artifact never renders** — first identify the run's handoff profile. For a filesystem-capable local runtime, confirm the agent created a previewable project file and that file-write events reached the daemon; it should not emit source in `<artifact>`. For a plain/text-only or BYOK run, confirm the response contains one complete `<artifact>` block. Check daemon logs for the first failed boundary instead of asking a filesystem runtime to fall back to inline source.
-- **`Authorization: Bearer <OD_API_TOKEN>` required on macOS** — Docker Desktop bridge networking makes the daemon see requests as non-loopback. Enable host networking in Docker Desktop and use `network_mode: host`. See [`deploy/README.md` — Docker Desktop on macOS](deploy/README.md#docker-desktop-on-macos).
+- **Browser authentication prompt on macOS** — keep Docker Desktop's default bridge networking. Sign in with username `open-design` and the `OD_API_TOKEN` value from `deploy/.env` as the password. Host networking is not required. See [`deploy/README.md` — Docker Desktop on macOS](deploy/README.md#docker-desktop-on-macos).
 
 ## Mapping back to the vision
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -79,7 +79,7 @@ docker compose up -d
 Open the app in your browser:
 
 ```text
-http://localhost:7456
+http://127.0.0.1:7456
 ```
 
 The first startup may take a few seconds while Docker pulls the latest image.
@@ -241,7 +241,7 @@ ls -la "$OD_BIN"
 
 `OD_DAEMON_URL` must be a real daemon port such as `http://127.0.0.1:7457`, not `http://127.0.0.1:0`. The `:0` value is only an internal "pick a free port" launch hint and should not leak into agent sessions.
 
-For the daemon-only production mode, the daemon serves the static Next.js export itself at `http://localhost:7456`, so no reverse proxy is involved.
+For the daemon-only production mode, the daemon serves the static Next.js export itself at `http://127.0.0.1:7456`, so no reverse proxy is involved.
 
 If you place nginx in front of the daemon, keep SSE routes unbuffered and uncompressed. A common failure is the browser console showing `net::ERR_INCOMPLETE_CHUNKED_ENCODING 200 (OK)` after 80-90 seconds because nginx `gzip on` buffers chunked SSE responses even when the daemon sends `X-Accel-Buffering: no`.
 

--- a/docs/i18n/QUICKSTART.th.md
+++ b/docs/i18n/QUICKSTART.th.md
@@ -359,7 +359,7 @@ open-design/
 - **media generation says `OD_BIN` is missing or daemon URL is `:0`** — รัน media dispatcher checks ด้านบน. อย่า resume CLI session เก่า; เปิด project จาก OpenDesign app ใหม่เพื่อให้ daemon inject variables `OD_*` ชุดใหม่.
 - **Codex loads too much plugin context** — start OpenDesign ด้วย `OD_CODEX_DISABLE_PLUGINS=1 pnpm tools-dev` เพื่อให้ daemon-spawned Codex processes รันด้วย `--disable plugins`.
 - **artifact never renders** — ตรวจ handoff profile ก่อน. สำหรับ local runtime ที่ใช้ filesystem ได้ ให้ตรวจว่า agent สร้าง project file ที่ preview ได้และ file events มาถึง daemon; path นี้ไม่ควรส่ง source ใน `<artifact>`. สำหรับ plain/text-only หรือ BYOK run ให้ตรวจว่ามี `<artifact>` block ที่สมบูรณ์หนึ่งก้อน แล้วหา boundary แรกที่ fail ใน daemon log.
-- **`Authorization: Bearer <OD_API_TOKEN>` required on macOS** — Docker Desktop bridge networking ทำให้ daemon มอง request เป็น non-loopback. เปิด host networking ใน Docker Desktop และใช้ `network_mode: host`. ดู [`deploy/README.md` — Docker Desktop on macOS](../../deploy/README.md#docker-desktop-on-macos).
+- **หน้าต่างยืนยันตัวตนใน browser บน macOS** — ใช้ bridge networking ค่าเริ่มต้นของ Docker Desktop ได้ตามเดิม เมื่อ browser แสดงหน้าต่าง sign-in ให้ใช้ `open-design` เป็น username และใช้ค่า `OD_API_TOKEN` จาก `deploy/.env` เป็น password โดยไม่จำเป็นต้องเปิด host networking ดูรายละเอียดที่ [`deploy/README.md` — Docker Desktop on macOS](../../deploy/README.md#docker-desktop-on-macos).
 
 ## Mapping back to the vision
 

--- a/docs/i18n/QUICKSTART.th.md
+++ b/docs/i18n/QUICKSTART.th.md
@@ -79,7 +79,7 @@ docker compose up -d
 เปิดแอปใน browser:
 
 ```text
-http://localhost:7456
+http://127.0.0.1:7456
 ```
 
 การ start ครั้งแรกอาจใช้เวลาสักครู่ขณะ Docker pull image ล่าสุด.
@@ -255,7 +255,7 @@ ls -la "$OD_BIN"
 
 `OD_DAEMON_URL` ต้องเป็น daemon port จริง เช่น `http://127.0.0.1:7457`, ไม่ใช่ `http://127.0.0.1:0`. ค่า `:0` เป็นเพียง launch hint ภายในสำหรับ "เลือก free port" และไม่ควรรั่วเข้า agent sessions.
 
-สำหรับ daemon-only production mode, daemon จะ serve static Next.js export เองที่ `http://localhost:7456` จึงไม่ต้องมี reverse proxy.
+สำหรับ daemon-only production mode, daemon จะ serve static Next.js export เองที่ `http://127.0.0.1:7456` จึงไม่ต้องมี reverse proxy.
 
 ถ้าวาง nginx ไว้หน้า daemon ให้ SSE routes เป็น unbuffered และ uncompressed. Failure ที่พบบ่อยคือ browser console แสดง `net::ERR_INCOMPLETE_CHUNKED_ENCODING 200 (OK)` หลัง 80-90 วินาที เพราะ nginx `gzip on` buffer chunked SSE responses แม้ daemon จะส่ง `X-Accel-Buffering: no`.
 


### PR DESCRIPTION
## Why

The macOS Docker troubleshooting entry in `QUICKSTART.md` still tells users
to enable host networking and use `network_mode: host`.

That host-networking workaround was valid for the earlier authentication
behavior documented in #3417, but it no longer matches the current Docker
authentication flow. The root README, `deploy/README.md`, and
`docs/deployment/docker.md` now document browser Basic authentication for
Docker bridge peers: username `open-design` and the `OD_API_TOKEN` value from
`deploy/.env`.

Following the stale instruction can send macOS users toward an unnecessary
networking change instead of the currently supported sign-in flow.

## What users will see

macOS Docker users are now told to keep the default bridge networking and
complete the browser sign-in prompt with:

- username: `open-design`
- password: the `OD_API_TOKEN` value from `deploy/.env`

The same correction is included in the Thai Quickstart, which carried the
same stale troubleshooting entry.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — documentation update only

## Screenshots

Not applicable; this PR changes troubleshooting documentation only.

## Bug fix verification

Documentation-only correction. The new wording was checked against the root
README, `deploy/README.md`, `docs/deployment/docker.md`, and the browser Basic
authentication behavior covered by `apps/daemon/tests/api-token-guard.test.ts`.

## Validation

- `git diff --check`
- `corepack pnpm i18n:check`
- confirmed the stale `Enable host networking` instruction no longer appears
  in the affected English and Thai Quickstarts