### PR TITLE
fix(web): allow confirmed restart from updater popup

### DIFF
--- a/apps/web/src/components/UpdaterPopup.tsx
+++ b/apps/web/src/components/UpdaterPopup.tsx
@@ -103,9 +103,10 @@ function updaterErrorCode(model: UpdaterModel): string | undefined {
 }
 
 /**
- * User-facing copy for a restart-safety preflight denial. The popup keeps
- * these denials hard-blocked (no force path — that lives in the app-menu
- * UpdateDialog), but the copy must say why instead of a generic failure.
+ * User-facing copy for a restart-safety preflight denial. The denial is a
+ * warning state, not a dead end: the popup pairs it with the same explicit
+ * "Restart anyway" override as the app-menu UpdateDialog, but the copy must
+ * still say why instead of a generic failure.
  */
 function restartSafetyText(t: Translator, safety: UpdaterRestartSafety): string {
   return safety.state === 'blocked'
@@ -126,6 +127,10 @@ export function UpdaterPopup({
   const [panelOpen, setPanelOpen] = useState(false);
   const [installState, setInstallState] = useState<InstallState>('idle');
   const [installError, setInstallError] = useState<string | null>(null);
+  // Non-null after a restart-safety preflight denial (active runs or unknown).
+  // Drives the panel's warning state with the Later / Try again / Restart
+  // anyway action set; cleared whenever a new attempt or a dismissal starts.
+  const [restartSafety, setRestartSafety] = useState<UpdaterRestartSafety | null>(null);
   const [allowSilentUpdatesChecked, setAllowSilentUpdatesChecked] = useState(() => allowSilentUpdates ?? true);
   const [silentUpdatesPersistError, setSilentUpdatesPersistError] = useState<string | null>(null);
   const [silentUpdatesPersisting, setSilentUpdatesPersisting] = useState(false);
@@ -309,6 +314,7 @@ export function UpdaterPopup({
       action: 'dismiss',
       ...versionProps,
     });
+    setRestartSafety(null);
     setPanelOpen(false);
   }, [analytics.track, installBusy, versionProps]);
 
@@ -330,18 +336,24 @@ export function UpdaterPopup({
     };
   }, [close, panelOpen]);
 
-  const installAndQuit = async () => {
+  const installOptions = (force: boolean) =>
+    force
+      ? { payload: { force: true, source: 'updater-prompt' } }
+      : { payload: { source: 'updater-prompt' } };
+
+  const installAndQuit = async (force: boolean) => {
     if (actionInFlightRef.current || !canStartInstall) return;
     actionInFlightRef.current = true;
     clearHandoffWatchdog();
     setInstallError(null);
+    setRestartSafety(null);
     setInstallState('opening');
     setPanelOpen(true);
     trackUpdateIndicatorClick(analytics.track, {
       page_name: 'home',
       area: 'update_prompt',
-      element: 'install_update',
-      action: 'install',
+      element: force ? 'restart_anyway' : 'install_update',
+      action: force ? 'force_restart' : 'install',
       ...versionProps,
     });
     try {
@@ -352,7 +364,8 @@ export function UpdaterPopup({
           // Installing the update is more important than persisting this preference.
         }
       }
-      const result = await openUpdaterInstaller({ payload: { source: 'updater-prompt' } });
+      const options = installOptions(force);
+      const result = await openUpdaterInstaller(options);
       if (!result.ok) {
         actionInFlightRef.current = false;
         setInstallError(installFailureText);
@@ -369,7 +382,14 @@ export function UpdaterPopup({
       if (result.model.errorMessage != null) {
         const safety = restartSafetyFromUpdaterStatus(result.status);
         actionInFlightRef.current = false;
-        setInstallError(safety == null ? installFailureText : restartSafetyText(t, safety));
+        // A safety denial is a warning state with an explicit override, not a
+        // generic failure — swapping the error for the warning keeps the copy
+        // in one place (the panel body) instead of both.
+        if (safety != null) {
+          setRestartSafety(safety);
+        } else {
+          setInstallError(installFailureText);
+        }
         setInstallState('idle');
         trackUpdateInstallResult(analytics.track, {
           page_name: 'home',
@@ -390,10 +410,13 @@ export function UpdaterPopup({
         result: 'success',
         ...versionProps,
       });
-      const quitResult = await quitAfterUpdaterInstallerOpen({ payload: { source: 'updater-prompt' } });
+      const quitResult = await quitAfterUpdaterInstallerOpen(options);
       if (!quitResult.ok) {
         const quitSafety = restartSafetyFromActionResult(quitResult);
-        if (quitSafety != null) setInstallError(restartSafetyText(t, quitSafety));
+        if (quitSafety != null) {
+          setInstallError(restartSafetyText(t, quitSafety));
+          setRestartSafety(quitSafety);
+        }
         clearHandoffWatchdog();
         actionInFlightRef.current = false;
         setInstallState('recoverable');
@@ -414,15 +437,18 @@ export function UpdaterPopup({
     }
   };
 
-  const retryQuit = async () => {
+  const retryQuit = async (force: boolean) => {
     if (actionInFlightRef.current || installState !== 'recoverable') return;
     actionInFlightRef.current = true;
     clearHandoffWatchdog();
+    setRestartSafety(null);
     setInstallState('quitting');
     startHandoffWatchdog();
     try {
-      const quitResult = await quitAfterUpdaterInstallerOpen({ payload: { source: 'updater-prompt' } });
+      const quitResult = await quitAfterUpdaterInstallerOpen(installOptions(force));
       if (quitResult.ok) return;
+      const quitSafety = restartSafetyFromActionResult(quitResult);
+      if (quitSafety != null) setRestartSafety(quitSafety);
     } catch {
       // Keep the explicit quit recovery action available.
     }
@@ -448,6 +474,7 @@ export function UpdaterPopup({
         onClick={() => {
           if (installBusy) return;
           if (panelOpen) {
+            setRestartSafety(null);
             setPanelOpen(false);
             return;
           }
@@ -472,16 +499,27 @@ export function UpdaterPopup({
             installBusy={installBusy}
             model={model}
             quitRecoverable={quitRecoverable}
+            restartSafety={restartSafety}
             silentUpdatesPersistError={silentUpdatesPersistError}
             silentUpdatesPersisting={silentUpdatesPersisting}
             t={t}
             onClose={close}
             onInstall={() => {
               if (installState === 'recoverable') {
-                void retryQuit();
+                void retryQuit(false);
               } else {
-                void installAndQuit();
+                void installAndQuit(false);
               }
+            }}
+            onRestartAnyway={() => {
+              if (installState === 'recoverable') {
+                void retryQuit(true);
+              } else {
+                void installAndQuit(true);
+              }
+            }}
+            onTryAgain={() => {
+              void installAndQuit(false);
             }}
             onSilentUpdatesChange={(next) => {
               void handleSilentUpdatesChange(next);
@@ -513,11 +551,14 @@ function UpdaterPopupPanel({
   installBusy,
   model,
   quitRecoverable,
+  restartSafety,
   silentUpdatesPersistError,
   silentUpdatesPersisting,
   t,
   onClose,
   onInstall,
+  onRestartAnyway,
+  onTryAgain,
   onSilentUpdatesChange,
 }: {
   allowSilentUpdatesChecked: boolean;
@@ -526,13 +567,26 @@ function UpdaterPopupPanel({
   installBusy: boolean;
   model: UpdaterModel;
   quitRecoverable: boolean;
+  restartSafety: UpdaterRestartSafety | null;
   silentUpdatesPersistError: string | null;
   silentUpdatesPersisting: boolean;
   t: Translator;
   onClose: () => void;
   onInstall: () => void;
+  onRestartAnyway: () => void;
+  onTryAgain: () => void;
   onSilentUpdatesChange: (allowSilentUpdates: boolean) => void;
 }) {
+  const laterButtonRef = useRef<HTMLButtonElement | null>(null);
+  const showInstallSafety = restartSafety != null && !quitRecoverable;
+
+  // A denial focuses the safe default action; Restart anyway must never be
+  // the initial focus (mirrors the app-menu UpdateDialog).
+  useEffect(() => {
+    if (restartSafety == null) return;
+    laterButtonRef.current?.focus();
+  }, [restartSafety]);
+
   return (
     <motion.section
       aria-labelledby="updater-popup-title"
@@ -549,11 +603,21 @@ function UpdaterPopupPanel({
           surfaces come from the what's-new document's `imageUrl` (see
           WhatsNewPopup), never from a bundled asset or a hardcoded URL. */}
       <div className="updater-popup__body">
-        <h2 id="updater-popup-title">{quitRecoverable ? t('updater.quitFailedTitle') : t('updater.ready')}</h2>
+        <h2 id="updater-popup-title">
+          {quitRecoverable ? t('updater.quitFailedTitle') : showInstallSafety ? t('updater.activeRunsTitle') : t('updater.ready')}
+        </h2>
         {quitRecoverable && model.updateKind === 'payload'
           ? null
-          : <p>{quitRecoverable ? t('updater.quitFailedBody') : versionText(t, model)}</p>}
-        {!quitRecoverable && model.reinstall?.url != null ? (
+          : (
+            <p>
+              {quitRecoverable
+                ? t('updater.quitFailedBody')
+                : showInstallSafety && restartSafety != null
+                  ? restartSafetyText(t, restartSafety)
+                  : versionText(t, model)}
+            </p>
+          )}
+        {!quitRecoverable && !showInstallSafety && model.reinstall?.url != null ? (
           <ReinstallLearnMoreLink t={t} url={model.reinstall.url} />
         ) : null}
         {channelLabel != null ? <span className="updater-popup__badge">{channelLabel}</span> : null}
@@ -582,18 +646,49 @@ function UpdaterPopupPanel({
           ) : null}
         </div> : null}
         <div className="updater-popup__actions">
-          <button className="updater-popup__button" disabled={installBusy} type="button" onClick={onClose}>
+          <button
+            className="updater-popup__button"
+            data-testid="updater-later-button"
+            disabled={installBusy}
+            ref={laterButtonRef}
+            type="button"
+            onClick={onClose}
+          >
             {t('updater.later')}
           </button>
-          <button
-            className="updater-popup__button updater-popup__button--primary"
-            data-testid="updater-install-button"
-            disabled={installBusy}
-            type="button"
-            onClick={onInstall}
-          >
-            {quitRecoverable ? t('updater.quitButton') : installActionText(t, model, installBusy)}
-          </button>
+          {showInstallSafety && restartSafety?.state === 'unknown' ? (
+            <button
+              className="updater-popup__button"
+              data-testid="updater-try-again-button"
+              disabled={installBusy}
+              type="button"
+              onClick={onTryAgain}
+            >
+              {t('updater.tryAgain')}
+            </button>
+          ) : null}
+          {showInstallSafety || (quitRecoverable && restartSafety != null) ? (
+            <button
+              className="updater-popup__button updater-popup__button--danger"
+              data-testid="updater-restart-anyway-button"
+              disabled={installBusy}
+              type="button"
+              onClick={onRestartAnyway}
+            >
+              {t('updater.restartAnyway')}
+            </button>
+          ) : null}
+          {!showInstallSafety ? (
+            <button
+              className="updater-popup__button updater-popup__button--primary"
+              data-testid="updater-install-button"
+              disabled={installBusy}
+              type="button"
+              onClick={onInstall}
+            >
+              {quitRecoverable ? t('updater.quitButton') : installActionText(t, model, installBusy)}
+            </button>
+          ) : null}
         </div>
       </div>
     </motion.section>

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -4128,6 +4128,7 @@ export const ar: Dict = {
   'updater.reinstallReadyGeneric': 'يتطلب هذا التحديث إعادة تثبيت كاملة. سيتم إغلاق OpenDesign وفتح المثبّت.',
   'updater.reinstallReadyVersion': 'يتطلب OpenDesign {version} إعادة تثبيت كاملة. سيتم إغلاق OpenDesign وفتح المثبّت.',
   'updater.restartAnyway': 'إعادة التشغيل على أي حال',
+  'updater.tryAgain': 'حاول مجددًا',
   'updater.upToDate': 'أنت تستخدم أحدث إصدار بالفعل.',
   'updater.viewVersionFeatures': 'استكشف ميزات الإصدار الجديد',
   'updater.manualDownload': 'تنزيل يدوي',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -4128,6 +4128,7 @@ export const de: Dict = {
   'updater.reinstallReadyGeneric': 'Dieses Update erfordert eine vollständige Neuinstallation. OpenDesign wird geschlossen und der Installer geöffnet.',
   'updater.reinstallReadyVersion': 'OpenDesign {version} erfordert eine vollständige Neuinstallation. OpenDesign wird geschlossen und der Installer geöffnet.',
   'updater.restartAnyway': 'Trotzdem neu starten',
+  'updater.tryAgain': 'Erneut versuchen',
   'updater.upToDate': 'Sie verwenden bereits die neueste Version.',
   'updater.viewVersionFeatures': 'Neue Funktionen entdecken',
   'updater.manualDownload': 'Manuell herunterladen',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -4204,6 +4204,7 @@ export const en: Dict = {
   'updater.reinstallReadyGeneric': 'This update requires a full reinstall. OpenDesign will close and open the installer.',
   'updater.reinstallReadyVersion': 'OpenDesign {version} requires a full reinstall. OpenDesign will close and open the installer.',
   'updater.restartAnyway': 'Restart anyway',
+  'updater.tryAgain': 'Try again',
   'updater.upToDate': 'You\'re already on the latest version.',
   'updater.viewVersionFeatures': 'Explore new features',
   'updater.manualDownload': 'Download manually',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -4128,6 +4128,7 @@ export const esES: Dict = {
   'updater.reinstallReadyGeneric': 'Esta actualización requiere una reinstalación completa. OpenDesign se cerrará y abrirá el instalador.',
   'updater.reinstallReadyVersion': 'OpenDesign {version} requiere una reinstalación completa. OpenDesign se cerrará y abrirá el instalador.',
   'updater.restartAnyway': 'Reiniciar de todos modos',
+  'updater.tryAgain': 'Reintentar',
   'updater.upToDate': 'Ya tienes la versión más reciente.',
   'updater.viewVersionFeatures': 'Descubrir las novedades',
   'updater.manualDownload': 'Descargar manualmente',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -4056,6 +4056,7 @@ export const fa: Dict = {
   'updater.reinstallReadyGeneric': 'این به‌روزرسانی به نصب مجدد کامل نیاز دارد. OpenDesign بسته می‌شود و نصب‌کننده باز خواهد شد.',
   'updater.reinstallReadyVersion': 'OpenDesign {version} به نصب مجدد کامل نیاز دارد. OpenDesign بسته می‌شود و نصب‌کننده باز خواهد شد.',
   'updater.restartAnyway': 'به‌هرحال راه‌اندازی مجدد شود',
+  'updater.tryAgain': 'تلاش دوباره',
   'updater.upToDate': 'شما هم‌اکنون آخرین نسخه را دارید.',
   'updater.viewVersionFeatures': 'مشاهده قابلیت‌های نسخه جدید',
   'updater.manualDownload': 'دانلود دستی',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -4190,6 +4190,7 @@ export const fr: Dict = {
   'updater.reinstallReadyGeneric': 'Cette mise à jour nécessite une réinstallation complète. OpenDesign va se fermer et ouvrir l\'installateur.',
   'updater.reinstallReadyVersion': 'OpenDesign {version} nécessite une réinstallation complète. OpenDesign va se fermer et ouvrir l\'installateur.',
   'updater.restartAnyway': 'Redémarrer quand même',
+  'updater.tryAgain': 'Réessayer',
   'updater.upToDate': 'Vous utilisez déjà la dernière version.',
   'updater.viewVersionFeatures': 'Découvrir les nouveautés',
   'updater.manualDownload': 'Télécharger manuellement',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -4128,6 +4128,7 @@ export const hu: Dict = {
   'updater.reinstallReadyGeneric': 'Ez a frissítés teljes újratelepítést igényel. Az OpenDesign bezárul, és megnyitja a telepítőt.',
   'updater.reinstallReadyVersion': 'Az OpenDesign {version} teljes újratelepítést igényel. Az OpenDesign bezárul, és megnyitja a telepítőt.',
   'updater.restartAnyway': 'Újraindítás mindenképp',
+  'updater.tryAgain': 'Próbálja újra',
   'updater.upToDate': 'Már a legújabb verziót használja.',
   'updater.viewVersionFeatures': 'Új funkciók felfedezése',
   'updater.manualDownload': 'Kézi letöltés',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -4190,6 +4190,7 @@ export const id: Dict = {
   'updater.reinstallReadyGeneric': 'Pembaruan ini memerlukan instal ulang penuh. OpenDesign akan menutup dan membuka pemasang.',
   'updater.reinstallReadyVersion': 'OpenDesign {version} memerlukan instal ulang penuh. OpenDesign akan menutup dan membuka pemasang.',
   'updater.restartAnyway': 'Tetap mulai ulang',
+  'updater.tryAgain': 'Coba lagi',
   'updater.upToDate': 'Anda sudah menggunakan versi terbaru.',
   'updater.viewVersionFeatures': 'Lihat fitur versi baru',
   'updater.manualDownload': 'Unduh manual',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -4128,6 +4128,7 @@ export const it: Dict = {
   'updater.reinstallReadyGeneric': 'Questo aggiornamento richiede una reinstallazione completa. OpenDesign si chiuderà e aprirà il programma di installazione.',
   'updater.reinstallReadyVersion': 'OpenDesign {version} richiede una reinstallazione completa. OpenDesign si chiuderà e aprirà il programma di installazione.',
   'updater.restartAnyway': 'Riavvia comunque',
+  'updater.tryAgain': 'Riprova',
   'updater.upToDate': 'Hai già la versione più recente.',
   'updater.viewVersionFeatures': 'Scopri le novità',
   'updater.manualDownload': 'Scarica manualmente',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -4128,6 +4128,7 @@ export const ja: Dict = {
   'updater.reinstallReadyGeneric': 'このアップデートには完全な再インストールが必要です。OpenDesign を終了してインストーラーを開きます。',
   'updater.reinstallReadyVersion': 'OpenDesign {version} には完全な再インストールが必要です。OpenDesign を終了してインストーラーを開きます。',
   'updater.restartAnyway': '再起動する',
+  'updater.tryAgain': '再試行',
   'updater.upToDate': 'すでに最新バージョンです。',
   'updater.viewVersionFeatures': '新バージョンの機能を見る',
   'updater.manualDownload': '手動でダウンロード',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -4128,6 +4128,7 @@ export const ko: Dict = {
   'updater.reinstallReadyGeneric': '이 업데이트는 전체 재설치가 필요합니다. OpenDesign이 종료되고 설치 프로그램이 열립니다.',
   'updater.reinstallReadyVersion': 'OpenDesign {version}은(는) 전체 재설치가 필요합니다. OpenDesign이 종료되고 설치 프로그램이 열립니다.',
   'updater.restartAnyway': '그래도 다시 시작',
+  'updater.tryAgain': '다시 시도',
   'updater.upToDate': '이미 최신 버전입니다.',
   'updater.viewVersionFeatures': '새 버전 기능 보기',
   'updater.manualDownload': '직접 다운로드',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -4128,6 +4128,7 @@ export const pl: Dict = {
   'updater.reinstallReadyGeneric': 'Ta aktualizacja wymaga pełnej ponownej instalacji. OpenDesign zamknie się i otworzy instalator.',
   'updater.reinstallReadyVersion': 'OpenDesign {version} wymaga pełnej ponownej instalacji. OpenDesign zamknie się i otworzy instalator.',
   'updater.restartAnyway': 'Uruchom ponownie mimo to',
+  'updater.tryAgain': 'Spróbuj ponownie',
   'updater.upToDate': 'Masz już najnowszą wersję.',
   'updater.viewVersionFeatures': 'Poznaj nowe funkcje',
   'updater.manualDownload': 'Pobierz ręcznie',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -4128,6 +4128,7 @@ export const ptBR: Dict = {
   'updater.reinstallReadyGeneric': 'Esta atualização exige uma reinstalação completa. O OpenDesign será fechado e o instalador será aberto.',
   'updater.reinstallReadyVersion': 'O OpenDesign {version} exige uma reinstalação completa. O OpenDesign será fechado e o instalador será aberto.',
   'updater.restartAnyway': 'Reiniciar mesmo assim',
+  'updater.tryAgain': 'Tentar novamente',
   'updater.upToDate': 'Você já está na versão mais recente.',
   'updater.viewVersionFeatures': 'Conhecer os novos recursos',
   'updater.manualDownload': 'Baixar manualmente',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -4128,6 +4128,7 @@ export const ru: Dict = {
   'updater.reinstallReadyGeneric': 'Это обновление требует полной переустановки. OpenDesign закроется и откроет установщик.',
   'updater.reinstallReadyVersion': 'OpenDesign {version} требует полной переустановки. OpenDesign закроется и откроет установщик.',
   'updater.restartAnyway': 'Всё равно перезапустить',
+  'updater.tryAgain': 'Повторить попытку',
   'updater.upToDate': 'У вас уже установлена последняя версия.',
   'updater.viewVersionFeatures': 'Что нового в этой версии',
   'updater.manualDownload': 'Скачать вручную',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -4190,6 +4190,7 @@ export const th: Dict = {
   'updater.reinstallReadyGeneric': 'การอัปเดตนี้ต้องติดตั้งใหม่ทั้งหมด OpenDesign จะปิดและเปิดตัวติดตั้ง',
   'updater.reinstallReadyVersion': 'OpenDesign {version} ต้องติดตั้งใหม่ทั้งหมด OpenDesign จะปิดและเปิดตัวติดตั้ง',
   'updater.restartAnyway': 'รีสตาร์ตต่อไป',
+  'updater.tryAgain': 'ลองอีกครั้ง',
   'updater.upToDate': 'คุณใช้เวอร์ชันล่าสุดอยู่แล้ว',
   'updater.viewVersionFeatures': 'ดูฟีเจอร์ใหม่',
   'updater.manualDownload': 'ดาวน์โหลดด้วยตนเอง',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -4128,6 +4128,7 @@ export const tr: Dict = {
   'updater.reinstallReadyGeneric': 'Bu güncelleme tam bir yeniden kurulum gerektirir. OpenDesign kapanacak ve yükleyiciyi açacak.',
   'updater.reinstallReadyVersion': 'OpenDesign {version} tam bir yeniden kurulum gerektirir. OpenDesign kapanacak ve yükleyiciyi açacak.',
   'updater.restartAnyway': 'Yine de yeniden başlat',
+  'updater.tryAgain': 'Tekrar dene',
   'updater.upToDate': 'Zaten en son sürümdesiniz.',
   'updater.viewVersionFeatures': 'Yeni özellikleri keşfet',
   'updater.manualDownload': 'Elle indir',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -4056,6 +4056,7 @@ export const uk: Dict = {
   'updater.reinstallReadyGeneric': 'Це оновлення потребує повного перевстановлення. OpenDesign закриється та відкриє інсталятор.',
   'updater.reinstallReadyVersion': 'OpenDesign {version} потребує повного перевстановлення. OpenDesign закриється та відкриє інсталятор.',
   'updater.restartAnyway': 'Усе одно перезапустити',
+  'updater.tryAgain': 'Спробувати ще раз',
   'updater.upToDate': 'У вас уже встановлено найновішу версію.',
   'updater.viewVersionFeatures': 'Переглянути нові функції',
   'updater.manualDownload': 'Завантажити вручну',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -4380,6 +4380,7 @@ export const zhCN: Dict = {
   "updater.reinstallReadyGeneric": "此更新需要完整重装。OpenDesign 将关闭并打开安装程序。",
   "updater.reinstallReadyVersion": "OpenDesign {version} 需要完整重装。OpenDesign 将关闭并打开安装程序。",
   "updater.restartAnyway": "仍然重启",
+  "updater.tryAgain": "重试",
 
   "whatsNew.updatedTitle": "OpenDesign {version} 已更新",
   "whatsNew.cta": "查看更新说明",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -4385,6 +4385,7 @@ export const zhTW: Dict = {
   "updater.reinstallReadyGeneric": "此更新需要完整重新安裝。OpenDesign 將關閉並開啟安裝程式。",
   "updater.reinstallReadyVersion": "OpenDesign {version} 需要完整重新安裝。OpenDesign 將關閉並開啟安裝程式。",
   "updater.restartAnyway": "仍然重新啟動",
+  "updater.tryAgain": "重試",
 
   "whatsNew.updatedTitle": "OpenDesign {version} 已更新",
   "whatsNew.cta": "查看更新說明",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -1099,6 +1099,7 @@ export interface Dict {
   'updater.reinstallReadyGeneric': string;
   'updater.reinstallReadyVersion': string;
   'updater.restartAnyway': string;
+  'updater.tryAgain': string;
   'updater.upToDate': string;
   'updater.viewVersionFeatures': string;
 

--- a/apps/web/src/styles/workspace/mention-home.css
+++ b/apps/web/src/styles/workspace/mention-home.css
@@ -539,6 +539,24 @@
   background: color-mix(in srgb, var(--text-strong) 88%, var(--brand, #87ea5c));
 }
 
+/* Destructive override for restart-safety denials; mirrors the app-menu
+   UpdateDialog danger action. */
+.updater-popup__button--danger {
+  border-color: color-mix(in srgb, #c1583c 38%, var(--border-soft));
+  color: #a74631;
+  background: color-mix(in srgb, #c1583c 8%, var(--bg-elevated));
+}
+
+.updater-popup__button--danger:hover:not(:disabled) {
+  background: color-mix(in srgb, #c1583c 13%, var(--bg-elevated));
+}
+
+/* Warning states add a third action; stack the pills so the destructive
+   option sits apart from the safe defaults. */
+.updater-popup__actions:has(.updater-popup__button--danger) {
+  grid-template-columns: 1fr;
+}
+
 @media (max-width: 560px) {
   .updater-popup {
     width: calc(100vw - var(--entry-rail-width, 56px) - 18px);

--- a/apps/web/tests/components/UpdaterPopup.test.tsx
+++ b/apps/web/tests/components/UpdaterPopup.test.tsx
@@ -58,6 +58,38 @@ function payloadDownloadedStatus(overrides: Partial<OpenDesignHostUpdaterStatusS
   });
 }
 
+function installerOpenedStatus(): OpenDesignHostUpdaterStatusSnapshot {
+  return downloadedStatus({
+    installResult: {
+      dryRun: true,
+      openedAt: '2026-05-19T00:00:00.000Z',
+      path: '/tmp/open-design-updater/Open Design Beta.dmg',
+    },
+  });
+}
+
+// Preflight denials arrive as a successful install whose status carries the
+// desktop preflight error (see apps/desktop/src/main/update-preflight.ts).
+function blockedStatus(activeRunCount = 2): OpenDesignHostUpdaterStatusSnapshot {
+  return downloadedStatus({
+    error: {
+      code: 'active-runs-blocked',
+      details: { activeRunCount },
+      message: `OpenDesign is still working on ${activeRunCount} active tasks.`,
+    },
+  });
+}
+
+function unknownStatus(): OpenDesignHostUpdaterStatusSnapshot {
+  return downloadedStatus({
+    error: {
+      code: 'active-runs-unknown',
+      details: { activeRunCount: null },
+      message: 'OpenDesign could not confirm whether tasks are still running.',
+    },
+  });
+}
+
 describe('UpdaterPopup', () => {
   let restoreHost: (() => void) | null = null;
 
@@ -601,5 +633,185 @@ describe('UpdaterPopup', () => {
 
     expect(await screen.findByTestId('entry-nav-updater')).toBeTruthy();
     expect(screen.queryByTestId('updater-popup')).toBeNull();
+  });
+
+  it('requires an explicit Restart anyway override when active runs block the restart', async () => {
+    const install = vi.fn()
+      .mockResolvedValueOnce(blockedStatus())
+      .mockResolvedValueOnce(installerOpenedStatus());
+    const quit = vi.fn(async () => ({ ok: true as const }));
+    restoreHost = installMockOpenDesignHost({
+      host: {
+        updater: {
+          install,
+          quit,
+          status: vi.fn(async () => downloadedStatus()),
+        },
+      },
+    });
+
+    render(<UpdaterPopup />);
+
+    fireEvent.click(await screen.findByTestId('entry-nav-updater'));
+    fireEvent.click(screen.getByTestId('updater-install-button'));
+
+    const warning = await screen.findByRole('dialog', { name: 'OpenDesign is still working' });
+    expect(warning.textContent).toContain('2 active tasks are still running');
+    expect(install).toHaveBeenCalledTimes(1);
+    expect(install).toHaveBeenCalledWith({ payload: { source: 'updater-prompt' } });
+    expect(quit).not.toHaveBeenCalled();
+    // The denial swaps the normal install action for the override set, so the
+    // user cannot loop through the same doomed non-forced install button.
+    expect(screen.queryByTestId('updater-install-button')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Restart anyway' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restart anyway' }));
+    await waitFor(() => expect(install).toHaveBeenNthCalledWith(2, { payload: { force: true, source: 'updater-prompt' } }));
+    await waitFor(() => expect(quit).toHaveBeenCalledWith({ payload: { force: true, source: 'updater-prompt' } }));
+    expect(quit).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers a non-forced Try again retry when the restart preflight is unknown', async () => {
+    const install = vi.fn()
+      .mockResolvedValueOnce(unknownStatus())
+      .mockResolvedValueOnce(installerOpenedStatus());
+    const quit = vi.fn(async () => ({ ok: true as const }));
+    restoreHost = installMockOpenDesignHost({
+      host: {
+        updater: {
+          install,
+          quit,
+          status: vi.fn(async () => downloadedStatus()),
+        },
+      },
+    });
+
+    render(<UpdaterPopup />);
+
+    fireEvent.click(await screen.findByTestId('entry-nav-updater'));
+    fireEvent.click(screen.getByTestId('updater-install-button'));
+
+    const warning = await screen.findByRole('dialog', { name: 'OpenDesign is still working' });
+    expect(warning.textContent).toContain('could not confirm whether tasks are still running');
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Restart anyway' })).toBeTruthy();
+    expect(quit).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+    await waitFor(() => expect(install).toHaveBeenNthCalledWith(2, { payload: { source: 'updater-prompt' } }));
+    await waitFor(() => expect(quit).toHaveBeenCalledWith({ payload: { source: 'updater-prompt' } }));
+  });
+
+  it('stays in the unknown warning across repeated retries without forcing or looping', async () => {
+    const install = vi.fn(async () => unknownStatus());
+    const quit = vi.fn(async () => ({ ok: true as const }));
+    restoreHost = installMockOpenDesignHost({
+      host: {
+        updater: {
+          install,
+          quit,
+          status: vi.fn(async () => downloadedStatus()),
+        },
+      },
+    });
+
+    render(<UpdaterPopup />);
+
+    fireEvent.click(await screen.findByTestId('entry-nav-updater'));
+    fireEvent.click(screen.getByTestId('updater-install-button'));
+    await screen.findByRole('dialog', { name: 'OpenDesign is still working' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+    await waitFor(() => expect(install).toHaveBeenCalledTimes(2));
+    expect(await screen.findByRole('dialog', { name: 'OpenDesign is still working' })).toBeTruthy();
+    expect(install).toHaveBeenNthCalledWith(2, { payload: { source: 'updater-prompt' } });
+    expect(quit).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Restart anyway' })).toBeTruthy();
+  });
+
+  it('keeps Later safe from blocked and unknown denials without installer side effects', async () => {
+    const install = vi.fn()
+      .mockResolvedValueOnce(blockedStatus())
+      .mockResolvedValueOnce(unknownStatus());
+    const quit = vi.fn(async () => ({ ok: true as const }));
+    restoreHost = installMockOpenDesignHost({
+      host: {
+        updater: {
+          install,
+          quit,
+          status: vi.fn(async () => downloadedStatus()),
+        },
+      },
+    });
+
+    render(<UpdaterPopup />);
+
+    fireEvent.click(await screen.findByTestId('entry-nav-updater'));
+    fireEvent.click(screen.getByTestId('updater-install-button'));
+    await screen.findByRole('dialog', { name: 'OpenDesign is still working' });
+    fireEvent.click(screen.getByRole('button', { name: 'Later' }));
+    expect(screen.queryByTestId('updater-popup')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('entry-nav-updater'));
+    fireEvent.click(screen.getByTestId('updater-install-button'));
+    const unknownWarning = await screen.findByRole('dialog', { name: 'OpenDesign is still working' });
+    expect(unknownWarning.textContent).toContain('could not confirm whether tasks are still running');
+    fireEvent.click(screen.getByRole('button', { name: 'Later' }));
+    expect(screen.queryByTestId('updater-popup')).toBeNull();
+
+    expect(install).toHaveBeenCalledTimes(2);
+    expect(quit).not.toHaveBeenCalled();
+  });
+
+  it('focuses the safe Later action, never Restart anyway, on a denial', async () => {
+    const install = vi.fn(async () => blockedStatus());
+    const quit = vi.fn(async () => ({ ok: true as const }));
+    restoreHost = installMockOpenDesignHost({
+      host: {
+        updater: {
+          install,
+          quit,
+          status: vi.fn(async () => downloadedStatus()),
+        },
+      },
+    });
+
+    render(<UpdaterPopup />);
+
+    fireEvent.click(await screen.findByTestId('entry-nav-updater'));
+    fireEvent.click(screen.getByTestId('updater-install-button'));
+    await screen.findByRole('dialog', { name: 'OpenDesign is still working' });
+
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Later' }));
+  });
+
+  it('offers a forced quit override when the quit handoff is denied for active runs', async () => {
+    const install = vi.fn(async () => installerOpenedStatus());
+    const quit = vi.fn()
+      .mockResolvedValueOnce({ ok: false as const, reason: 'active-runs-blocked', details: { activeRunCount: 1 } })
+      .mockResolvedValueOnce({ ok: true as const });
+    restoreHost = installMockOpenDesignHost({
+      host: {
+        updater: {
+          install,
+          quit,
+          status: vi.fn(async () => downloadedStatus()),
+        },
+      },
+    });
+
+    render(<UpdaterPopup />);
+
+    fireEvent.click(await screen.findByTestId('entry-nav-updater'));
+    fireEvent.click(screen.getByTestId('updater-install-button'));
+
+    expect(await screen.findByRole('dialog', { name: 'Could not quit' })).toBeTruthy();
+    expect(quit).toHaveBeenCalledWith({ payload: { source: 'updater-prompt' } });
+    expect(screen.getByRole('button', { name: 'Restart anyway' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Restart anyway' }));
+    await waitFor(() => expect(quit).toHaveBeenNthCalledWith(2, { payload: { force: true, source: 'updater-prompt' } }));
+    expect(install).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Fixes #7563

## Why

I claimed this community bug because the trap it describes is easy to hit and currently has no way out: when an update is ready and the desktop restart preflight denies the restart, the update-ready popup shows the warning as an error line and then returns to the normal "Install and restart" button. Pressing it again re-runs the exact same non-forced install request, hits the exact same preflight denial, and returns to the same button — an endless no-progress loop.

That trap fires in two cases: active tasks are actually running (`active-runs-blocked`), or the preflight could not determine safety within its short active-runs probe (`active-runs-unknown`, e.g. the daemon is unreachable for ~1.5s). In both, the user cannot install an already-downloaded update from the popup at all, even though the app-menu UpdateDialog has had a safe explicit override for exactly this situation. This PR gives the popup the same restart-safety semantics instead of a dead end.

## What users will see

- **Active tasks are running** and they press "Install and restart": the popup now switches to the "OpenDesign is still working" warning state with a real action set — **Later** (safe default, receives focus) and a destructive-styled **Restart anyway**. The misleading normal install button is gone from the warning state, so there is no way to loop through it.
- **The preflight is unknown** ("could not confirm whether tasks are still running"): the warning additionally offers **Try again**, a non-forced retry that re-runs the normal install path. If it is still unknown, the popup stays in the warning state with the retry still available — no automatic looping, no forced restart.
- **Restart anyway** performs the install (and quit) with the same explicit `force: true` flag the app-menu dialog uses. The desktop preflight safety gate itself is unchanged and still protects every normal install.
- If the quit handoff after a successful install is denied for the same safety reasons, the recovery state now also offers **Restart anyway** (forced quit) next to the existing non-forced "Quit OpenDesign" retry.
- Everything else is unchanged: a preflight-safe install behaves exactly as before, with the same request payload as before.

## Surface area

- [x] **UI** — UpdaterPopup warning state with a new action set (Later / Try again / Restart anyway) in the existing update-ready popup (`apps/web`); entry point is the rocket update indicator in the home top-right cluster
- [ ] **Keyboard shortcut** — none new
- [ ] **CLI / env var** — none
- [ ] **API / contract** — none; reuses the existing `openUpdaterInstaller` payload `force` flag (`parseUpdateActionRequest` already accepts it), no contract change
- [ ] **Extension point** — none
- [x] **i18n keys** — added `updater.tryAgain` to `types.ts` + all 19 locale files; all other copy reuses existing `updater.*` keys
- [ ] **New top-level dependency** — none
- [ ] **Default behavior change** — normal preflight-safe installs are byte-identical (same payload shape, no `force`); only the two denial paths gain actions
- [ ] **None**

## Screenshots

> Note: this change can only be fully exercised inside the packaged desktop app with a staged update, which I don't have in my current environment — I'll attach real before/after screenshots of the entry point (rocket indicator → popup) from a desktop run if maintainers want them; happy to run `pnpm tools-dev` QA on request. Textual map of the states:

- Before: popup always shows "Update ready" + install actions; a denial renders as an error line under it, looping back to the same install button.
- After (blocked): title "OpenDesign is still working", body "{count} active tasks are still running. Restarting now will interrupt them.", actions = Later (focused) / Restart anyway (danger).
- After (unknown): same warning title, body "OpenDesign could not confirm whether tasks are still running…", actions = Later (focused) / Try again / Restart anyway (danger).

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/UpdaterPopup.test.tsx` — 6 new regression cases (blocked override, unknown retry, repeated-unknown stability, Later safety from both denials, focus safety, forced quit override) plus preflight-denial status helpers.
- Did the test go red on `main` and green on this branch? **Yes.** With only `apps/web/src/components/UpdaterPopup.tsx` + `mention-home.css` reverted to `upstream/main` (test file kept), the 6 new tests fail and all 17 pre-existing tests still pass; with the fix restored, all 23 pass. These are component-level state-machine tests, so the red/green claim is fully falsifiable — no jsdom-blind spot involved.
- The forced path is asserted to call the installer/quit with exactly `{ payload: { force: true, source: 'updater-prompt' } }`, and the normal path keeps its exact existing payload (existing tests pin it).

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/components/UpdaterPopup.test.tsx tests/components/UpdaterPopup.rocket-indicator.test.tsx` (in `apps/web`) — 26/26 PASS
- `pnpm exec vitest run -c vitest.config.ts tests/components/UpdateDialog.test.tsx tests/lib/updater.test.ts` (in `apps/web`) — 19/19 PASS
- `pnpm --filter @open-design/web typecheck` — PASS (validates Dict parity across all 19 locales)
- `pnpm guard` — PASS
- `pnpm typecheck` — PASS
- Manual desktop QA (real preflight, real installer handoff): not executable in this environment — noted as manual QA for review; the automated suite covers the state machine.
