### PR TITLE
fix(daemon): keep OD Next clarifications resumable after a restart drops the source Run snapshot

### DIFF
--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -1014,6 +1014,32 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
     | { kind: 'continuation'; value: ClarificationContinuation };
 
   /**
+   * A source Run restored from durable state may miss its applied snapshot
+   * id: `durableRunState` historically never serialized the field, so any
+   * daemon restart dropped it while the task record kept its locked snapshot.
+   * The `applied_plugin_snapshots` row keeps `run_id` FK-linked to the source
+   * Run across restarts; that link is the ownership witness authorizing this
+   * one-time backfill. A Run whose field is set must never be touched — the
+   * caller treats it as a genuine mismatch.
+   */
+  function recoverSourceRunSnapshotId(
+    task: StrategyTaskExecutionRecord,
+    sourceRun: ChatRun,
+  ): boolean {
+    if (sourceRun.appliedPluginSnapshotId) return false;
+    const linkedSnapshot = db
+      .prepare(
+        `SELECT id FROM applied_plugin_snapshots
+          WHERE id = ? AND run_id = ? AND project_id = ?`,
+      )
+      .get(task.snapshotId, sourceRun.id, task.projectId);
+    if (!linkedSnapshot) return false;
+    sourceRun.appliedPluginSnapshotId = task.snapshotId;
+    design.runs.persistState(sourceRun);
+    return true;
+  }
+
+  /**
    * Resolve only an explicit daemon-issued task handle. Conversation order is
    * never an ownership signal: an ordinary follow-up in a conversation that
    * happens to contain an awaiting strategy task must stay an ordinary Run.
@@ -1182,7 +1208,17 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       || sourceRun.projectId !== task.projectId
       || sourceRun.conversationId !== task.conversationId
       || sourceRun.agentId !== task.selectedAgentId
-      || sourceRun.appliedPluginSnapshotId !== task.snapshotId
+    ) {
+      return {
+        kind: 'error',
+        status: 409,
+        code: 'STRATEGY_TASK_SOURCE_RUN_INVALID',
+        message: 'strategy clarification source Run is unavailable or does not match the locked task',
+      };
+    }
+    if (
+      sourceRun.appliedPluginSnapshotId !== task.snapshotId
+      && !recoverSourceRunSnapshotId(task, sourceRun)
     ) {
       return {
         kind: 'error',

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -523,6 +523,9 @@ function durableRunState(run) {
     assistantMessageId: run.assistantMessageId,
     clientRequestId: run.clientRequestId,
     requestFingerprint: run.requestFingerprint,
+    ...(typeof run.appliedPluginSnapshotId === 'string'
+      ? { appliedPluginSnapshotId: run.appliedPluginSnapshotId }
+      : {}),
     ...(run.strategyRolloutDecision
       ? { strategyRolloutDecision: run.strategyRolloutDecision }
       : {}),
@@ -789,6 +792,10 @@ export function createChatRunService({
       requestFingerprint:
         typeof state.requestFingerprint === 'string' ? state.requestFingerprint : null,
       agentId: typeof state.agentId === 'string' ? state.agentId : null,
+      appliedPluginSnapshotId:
+        typeof state.appliedPluginSnapshotId === 'string' && state.appliedPluginSnapshotId
+          ? state.appliedPluginSnapshotId
+          : null,
       projectMetadata: null,
       events,
       nextEventId: events.reduce((max, record) => Math.max(max, record.id), 0) + 1,

--- a/apps/daemon/tests/run-create-workspace-gate.test.ts
+++ b/apps/daemon/tests/run-create-workspace-gate.test.ts
@@ -25,6 +25,7 @@ import {
 import {
   createSnapshot,
   linkSnapshotToProject,
+  linkSnapshotToRun,
 } from '../src/plugins/snapshots.js';
 import { createAuthorizeProjectRequest } from '../src/collab/project-request-authority.js';
 import { resolveOptionalLocalWorkspaceRequestAuthority } from '../src/collab/workspace-resource-mutation.js';
@@ -306,6 +307,7 @@ function createRunsServiceStub() {
           || run.projectId === filters.projectId,
       ),
     statusBody: (run: any) => ({ ...run }),
+    persistState: () => {},
     stream: (run: any, req: any, res: any) => {
       res.status(req.method === 'GET' ? 200 : 202).json({
         runId: run.id,
@@ -834,6 +836,153 @@ describe('POST /api/runs — workspace mutation gate', () => {
       expect(response.status).toBe(409);
       await expect(response.json()).resolves.toMatchObject({
         error: { code: 'STRATEGY_TASK_AGENT_MISMATCH' },
+      });
+      expect(createdRunCount).toBe(0);
+    },
+  );
+
+  it.each(['/api/runs', '/api/chat'])(
+    'recovers a restart-cleared source Run snapshot via the linked snapshot row through %s',
+    async (route) => {
+      // See recoverSourceRunSnapshotId: `durableRunState()` never serialized
+      // `appliedPluginSnapshotId`, so a daemon restart restored the source Run
+      // without the field while the task record kept its locked snapshot.
+      const baseUrl = await startServer();
+      const snapshot = seedAwaitingClarificationTask();
+      linkSnapshotToRun(
+        openDatabase(tempDir!),
+        snapshot.snapshotId,
+        'run-strategy-request',
+      );
+      // Simulate a source Run restored from a pre-fix durable state.json.
+      runsServiceStub?.seed({
+        id: 'run-strategy-request',
+        projectId: PERSONAL_PROJECT,
+        conversationId: 'conversation-strategy',
+        assistantMessageId: 'assistant-strategy-request',
+        agentId: 'codex',
+        pluginId: 'od-next-strategy',
+        odNextTaskInputSnapshot: {
+          taskExecutionId: 'task-strategy-clarification',
+          snapshotDir: path.join(tempDir!, 'strategy-input-fixture'),
+          manifestSha256: 'd'.repeat(64),
+        },
+        status: 'succeeded',
+      });
+
+      const response = await fetch(`${baseUrl}${route}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          taskExecutionId: 'task-strategy-clarification',
+          projectId: PERSONAL_PROJECT,
+          conversationId: 'conversation-strategy',
+          agentId: 'codex',
+          userMessageId: 'user-strategy-answer',
+          assistantMessageId: 'assistant-strategy-answer',
+          clientRequestId: 'client-strategy-answer',
+          message: 'Desktop workspace',
+          currentPrompt: 'Desktop workspace',
+        }),
+      });
+      const responseText = await response.text();
+      expect(response.status, responseText).toBe(202);
+      expect(lastCreatedRun.appliedPluginSnapshotId).toBe(snapshot.snapshotId);
+    },
+  );
+
+  it.each(['/api/runs', '/api/chat'])(
+    'rejects a snapshot-less source Run whose snapshot row is not linked to it through %s',
+    async (route) => {
+      const baseUrl = await startServer();
+      seedAwaitingClarificationTask();
+      // No `linkSnapshotToRun`: the snapshot row keeps `run_id = null`, so the
+      // ownership witness fails.
+      runsServiceStub?.seed({
+        id: 'run-strategy-request',
+        projectId: PERSONAL_PROJECT,
+        conversationId: 'conversation-strategy',
+        assistantMessageId: 'assistant-strategy-request',
+        agentId: 'codex',
+        pluginId: 'od-next-strategy',
+        status: 'succeeded',
+      });
+
+      const response = await fetch(`${baseUrl}${route}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          taskExecutionId: 'task-strategy-clarification',
+          projectId: PERSONAL_PROJECT,
+          conversationId: 'conversation-strategy',
+          agentId: 'codex',
+          userMessageId: 'user-strategy-answer',
+          assistantMessageId: 'assistant-strategy-answer',
+          clientRequestId: 'client-strategy-answer',
+          message: 'Desktop workspace',
+          currentPrompt: 'Desktop workspace',
+        }),
+      });
+      expect(response.status).toBe(409);
+      await expect(response.json()).resolves.toMatchObject({
+        error: { code: 'STRATEGY_TASK_SOURCE_RUN_INVALID' },
+      });
+      expect(createdRunCount).toBe(0);
+    },
+  );
+
+  it.each(['/api/runs', '/api/chat'])(
+    'rejects a source Run locked to a different snapshot through %s',
+    async (route) => {
+      const baseUrl = await startServer();
+      const snapshot = seedAwaitingClarificationTask();
+      const driftedSnapshot = createSnapshot(openDatabase(tempDir!), {
+        projectId: PERSONAL_PROJECT,
+        conversationId: 'conversation-strategy',
+        runId: null,
+        pluginId: 'od-next-strategy',
+        pluginVersion: '2.0.0',
+        manifestSourceDigest: 'strategy-manifest',
+        strategy: snapshot.strategy,
+        taskKind: 'new-generation',
+        inputs: {},
+        resolvedContext: { items: [] },
+        capabilitiesGranted: ['prompt:inject'],
+        capabilitiesRequired: ['prompt:inject'],
+        assetsStaged: [],
+        connectorsRequired: [],
+        connectorsResolved: [],
+        mcpServers: [],
+      });
+      runsServiceStub?.seed({
+        id: 'run-strategy-request',
+        projectId: PERSONAL_PROJECT,
+        conversationId: 'conversation-strategy',
+        assistantMessageId: 'assistant-strategy-request',
+        agentId: 'codex',
+        pluginId: 'od-next-strategy',
+        appliedPluginSnapshotId: driftedSnapshot.snapshotId,
+        status: 'succeeded',
+      });
+
+      const response = await fetch(`${baseUrl}${route}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          taskExecutionId: 'task-strategy-clarification',
+          projectId: PERSONAL_PROJECT,
+          conversationId: 'conversation-strategy',
+          agentId: 'codex',
+          userMessageId: 'user-strategy-answer',
+          assistantMessageId: 'assistant-strategy-answer',
+          clientRequestId: 'client-strategy-answer',
+          message: 'Desktop workspace',
+          currentPrompt: 'Desktop workspace',
+        }),
+      });
+      expect(response.status).toBe(409);
+      await expect(response.json()).resolves.toMatchObject({
+        error: { code: 'STRATEGY_TASK_SOURCE_RUN_INVALID' },
       });
       expect(createdRunCount).toBe(0);
     },

--- a/apps/daemon/tests/run-durable-snapshot-id.test.ts
+++ b/apps/daemon/tests/run-durable-snapshot-id.test.ts
@@ -1,0 +1,52 @@
+// A daemon restart (including the `.12 → .13` app update) must not erase the
+// snapshot a succeeded OD Next source Run was locked to. `appliedPluginSnapshotId`
+// has to round-trip through the durable `<runsLogDir>/<runId>/state.json`, or
+// the clarification continuation guard rejects a source Run that its task
+// record still correctly pins.
+
+import { describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { createChatRunService } from '../src/runtimes/runs.js';
+
+function makeRunService(runsLogDir: string) {
+  return createChatRunService({
+    createSseResponse: () => ({ send: vi.fn(() => true), end: vi.fn(), cleanup: vi.fn() }),
+    createSseErrorPayload: (code: string, message: string) => ({ error: { code, message } }),
+    shutdownGraceMs: 10,
+    ttlMs: 60_000,
+    // runs.ts is `@ts-nocheck`, so its option type for runsLogDir collapses
+    // to the `null` default instead of `string | null`.
+    runsLogDir: runsLogDir as any,
+  });
+}
+
+describe('durable run state keeps appliedPluginSnapshotId across a restart', () => {
+  it('serializes and restores appliedPluginSnapshotId through state.json', () => {
+    const runsLogDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-run-durable-snapshot-'));
+    try {
+      const runs = makeRunService(runsLogDir);
+      const run = runs.create({
+        projectId: 'p-durable-snapshot',
+        conversationId: 'c-durable-snapshot',
+        appliedPluginSnapshotId: 'snapshot-durable-1',
+      });
+      run.status = 'succeeded';
+      runs.persistState(run);
+
+      const state = JSON.parse(
+        fs.readFileSync(path.join(runsLogDir, run.id, 'state.json'), 'utf8'),
+      ) as Record<string, unknown>;
+      expect(state.appliedPluginSnapshotId).toBe('snapshot-durable-1');
+
+      // Fresh service over the same runsLogDir simulates the post-restart
+      // daemon: the run only exists on disk until get() hydrates it.
+      const restored = makeRunService(runsLogDir).get(run.id);
+      expect(restored?.appliedPluginSnapshotId).toBe('snapshot-durable-1');
+    } finally {
+      fs.rmSync(runsLogDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes #7567

## Why

A daemon restart — which is what the `0.21.1-prerelease.12` → `.13` update performs — permanently broke every OD Next task waiting on a clarification. `durableRunState()` never serialized `appliedPluginSnapshotId`, so the restored source Run no longer carried the field while the task record kept its locked snapshot. The clarification continuation guard then rejected the still-valid source Run with `STRATEGY_TASK_SOURCE_RUN_INVALID`, and no restart repaired it because the persisted run state stayed incomplete. I hit this while investigating #7567.

## What users will see

A clarification question that was asked before an app update or restart can be answered afterwards, instead of failing with "strategy clarification source Run is unavailable or does not match the locked task". The continuation is still created with the task's locked agent, snapshot, route, and native session; a source Run that genuinely mismatches the locked task keeps failing exactly as before.

## Surface area

- [x] **None** — daemon-internal bug fix and tests only (no UI, CLI, contract, or dependency changes)

## Bug fix verification

- Test path: `apps/daemon/tests/run-create-workspace-gate.test.ts` (clarification continuation acceptance, missing-witness rejection, snapshot-drift rejection — both `/api/runs` and `/api/chat`) and `apps/daemon/tests/run-durable-snapshot-id.test.ts` (durable run state round-trip for `appliedPluginSnapshotId`).
- Did the test go red on `main` and green on this branch? Yes. On `main` the acceptance tests returned 409 `STRATEGY_TASK_SOURCE_RUN_INVALID`, and the round-trip test failed because `state.json` lacked `appliedPluginSnapshotId`.
- Scope note: the issue's requested packaged-Windows regression test is covered at the daemon level, because the defect is the `state.json` serialization gap and the round-trip test reproduces that exact mechanism platform-agnostically through the public HTTP seam. The empty failed assistant message on an unrecoverable preflight failure (issue item 4) is out of scope: that shell is written by the web app, its behavior is unchanged here, and recoverable resumes no longer leave one behind.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/run-create-workspace-gate.test.ts tests/run-durable-snapshot-id.test.ts` — 71 passed.
- `pnpm --filter @open-design/daemon typecheck` — clean.
- `pnpm --filter @open-design/daemon test` — 9683 passed; the 8 failures (`connection-test`, `proxy-routes`, `media/tasks-routes`, one Claude-auth diagnostic in `chat-route`) fail identically on unmodified `main` in this environment (proxy/auth env vars) and are unrelated.
- `pnpm guard` — passed.
