### PR TITLE
fix(web): keep an exhausted subscriber's zero balance visible in the credits pill

### DIFF
--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -73,7 +73,6 @@ import {
   workspaceIdentityCacheKey,
 } from '../collab/useWorkspaceContext';
 import { canUpgradeFromPlanTier, resolvePlanLabelTier } from '../collab/team-plan';
-import { shouldShowCreditsBalance } from './entry-rail-account-state';
 import { amrPlansUrlForProfile } from '../runtime/amr-guidance';
 import { useWorkspaceInvalidation } from '../collab/workspace-events';
 import { resolveDeepSeekV4FlashCampaignAudience } from '../campaigns/deepseek-v4-flash';
@@ -622,12 +621,6 @@ export function EntryTopRightCluster({
       ? t('entry.billingTierTeam')
       : t('entry.billingTierFree');
   const balanceLabel = formatVelaBalanceUsd(balanceUsd);
-  // A subscriber's $0.00 is a healthy state (their popular models are
-  // unlimited), so the pill stays out of the way instead of alarming them.
-  const showCreditsBalance = shouldShowCreditsBalance({
-    tier: labelTier,
-    balanceUsd,
-  });
   // #5517: wordmark badge inside the menu's billing card. It names the plan
   // FAMILY, so a TEAM workspace draws the one `team` wordmark at every tier —
   // free through max — while the personal ladder keeps its per-tier glyph
@@ -837,7 +830,7 @@ export function EntryTopRightCluster({
           {context ? (
             <>
               <div className="entry-top-right-account-pill">
-          {(billing || balanceLabel) && showCreditsBalance ? (
+          {(billing || balanceLabel) ? (
             <button
               type="button"
               className="entry-top-right-credits"

--- a/apps/web/src/components/entry-rail-account-state.ts
+++ b/apps/web/src/components/entry-rail-account-state.ts
@@ -1,39 +1,6 @@
 import type { WorkspaceContextState } from '../collab/useWorkspaceContext';
-import { planUnlimitedTier } from '../runtime/amr-unlimited-models';
 
 export type EntryRailAccountFooterState = 'hidden' | 'syncing' | 'recovering' | 'sign-in';
-
-/**
- * Whether the workbench's top-right credits pill may show the wallet balance.
- *
- * A subscriber sitting at exactly $0.00 is a NORMAL state, not an alarm: on
- * Go / Plus / Pro / Max the popular models they work with every day are
- * unlimited, so the wallet only meters flagship calls and legitimately stays
- * empty. Rendering that zero permanently next to the avatar read as "you are
- * out of money" to users who are not. Product ruling: hide the money on a
- * subscribed plan whose balance is exactly zero.
- *
- * Everything else keeps it, and each exclusion is load-bearing:
- *  • free / unknown tier — zero is the number that explains why hosted models
- *    are unavailable, and an unresolved billing read must not make the pill
- *    flicker in and out as it lands;
- *  • a non-zero balance, including an OVERDRAWN one — a negative wallet is the
- *    one case the user has to act on.
- *
- * `tier` is the same resolved plan id the pill's neighbours label
- * (`resolvePlanLabelTier`), so the pill and the nameplate cannot disagree.
- */
-export function shouldShowCreditsBalance(input: {
-  tier: string | null | undefined;
-  balanceUsd: string | null | undefined;
-}): boolean {
-  if (planUnlimitedTier(input.tier) === null) return true;
-  const raw = input.balanceUsd?.trim() ?? '';
-  if (!raw) return true;
-  const amount = Number(raw);
-  if (!Number.isFinite(amount)) return true;
-  return amount !== 0;
-}
 
 export function requiresAmrReauthentication(
   amrSessionState: import('@open-design/contracts').AmrSessionState | undefined,

--- a/apps/web/tests/components/EntryNavRail.credits-zero-balance.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.credits-zero-balance.test.tsx
@@ -4,12 +4,14 @@
 // zero.
 //
 // On Go / Plus / Pro / Max the popular models the user actually works with are
-// unlimited, so the wallet only meters flagship calls. A subscriber therefore
-// sits at $0.00 as a normal, healthy state — and the pill rendered it as a
-// permanent alarm next to their avatar. Product ruling: hide the money for a
-// subscribed plan whose balance is exactly zero. Free plans keep it (zero is
-// the number that explains why hosted models are unavailable), and an
-// overdrawn wallet keeps it on every plan.
+// unlimited, but the wallet still meters flagship calls — so a subscriber at
+// exactly $0.00 can be in two different states the overview cannot tell apart:
+// a healthy wallet untouched by in-plan models, or a wallet exhausted by
+// flagship calls, which the pre-run balance gate hard-blocks (#7561). Because
+// the pill cannot distinguish them, it must not present the zero as a healthy
+// "unlimited" state by hiding it: the money stays on screen for every plan, and
+// "unlimited" is claimed only by the per-model badge backed by Vela's model
+// list. An overdrawn wallet keeps rendering its negative amount on every plan.
 
 import { cleanup, render, screen } from '@testing-library/react';
 import type { WorkspaceBillingSummary, WorkspaceCollabContext } from '@open-design/contracts';
@@ -84,20 +86,24 @@ function creditsPill(): HTMLElement | null {
 
 describe('top-right credits pill', () => {
   it.each(['go', 'plus', 'pro', 'max'])(
-    'hides the zero balance on the subscribed personal plan %s',
+    'keeps the exhausted $0.00 wallet visible on the subscribed personal plan %s',
     (tier) => {
+      // #7561: at $0.00 the composer hard-blocks metered models with
+      // "Insufficient credits", so the pill hiding the same wallet read as
+      // "Unlimited usage" to users who had just been blocked. The pill shows
+      // the wallet the composer enforces.
       renderRail({
         context: context({ planId: tier } as Partial<WorkspaceCollabContext>),
         billing: billing({ membershipTier: tier }),
         balanceUsd: '0',
       });
-      expect(creditsPill()).toBeNull();
+      expect(creditsPill()?.textContent).toContain('$0.00');
     },
   );
 
-  it('hides a zero balance written as 0.00', () => {
+  it('keeps a zero balance written as 0.00 visible', () => {
     renderRail({ balanceUsd: '0.00' });
-    expect(creditsPill()).toBeNull();
+    expect(creditsPill()?.textContent).toContain('$0.00');
   });
 
   it('keeps the balance when a subscriber still has money', () => {


### PR DESCRIPTION
Fixes #7561

## Why

A Plus user who exhausts their wallet hits two contradictory surfaces. The pre-run balance gate hard-blocks metered models at $0.00 with "Insufficient credits", but the top-right credits pill hid the same $0.00 on subscribed plans (a ruling from #7190), so the account overview still presented the healthy "unlimited subscriber" state to someone the composer had just blocked.

#7190 hid the zero because a subscriber's wallet legitimately sits at $0.00 when they only run in-plan models. But the wallet is also the only meter for flagship calls, so a zero balance is ambiguous between "healthy" and "exhausted", and the overview cannot tell the two apart from the wallet value alone — #7561 is that counterexample. The overview therefore must not derive an unlimited claim from a wallet value; "unlimited" is a per-model property (the badge backed by Vela's model list, added in #7190), not a wallet state.

## What users will see

On Go / Plus / Pro / Max, an exhausted wallet at $0.00 now shows "$0.00" in the top-right credits pill instead of the pill disappearing, matching what the account menu's billing card already showed for the same state and matching the composer's "Insufficient credits" block. Wallets with a balance, an overdrawn amount, and every free/team/unknown-tier state render exactly as before.

## Surface area

- [x] **UI** — top-right credits pill in `apps/web` (render state for subscribed plans at exactly $0.00)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — not applicable: this is the render state of an existing web-chrome pill, not a capability; no `/api/*` endpoint or `od` subcommand changes
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope.
- [x] **Default behavior change** — changes what existing users experience without opting in (a subscribed plan at exactly $0.00 now renders "$0.00" in the pill instead of hiding it)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

This environment is headless, so no screenshot is attached. The change is a text-only render state of the existing pill: before, the `entry-top-right-credits` pill is absent for a Plus wallet at $0.00; after, it renders the battery icon plus "$0.00" (unchanged markup otherwise). Reviewer-drivable before/after: `pnpm --filter @open-design/web exec vitest run tests/components/EntryNavRail.credits-zero-balance.test.tsx` goes 5-red on `main` and 12/12 green on this branch.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/EntryNavRail.credits-zero-balance.test.tsx` (go/plus/pro/max at balanceUsd "0" now expect the pill to render "$0.00").
- Did the test go red on `main` and green on this branch? yes — 5 assertions failed on a554d017 (pill absent), 12/12 pass with the fix.

## Validation

- `pnpm --filter @open-design/web typecheck` — pass (`tsc -b --noEmit`)
- `pnpm guard` — pass
- `pnpm --filter @open-design/web test` — 674 files, 7147 passed, 1 expected fail, 11 skipped
- Node note: local runs used Node 22.22.1 (the repo pins ~24); the web vitest suite, `tsc -b` and `pnpm guard` all ran to completion there.

