### PR TITLE
feat(skills): add image-led-page for dispatcher-generated page imagery

### DIFF
--- a/skills/image-led-page/SKILL.md
+++ b/skills/image-led-page/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: image-led-page
+en_name: "Image-Led Page"
+description: |
+  Build a page whose imagery is generated rather than borrowed: plan an image
+  manifest, generate every asset through the OpenDesign media dispatcher, place
+  them in the layout, then verify the result against the failures that
+  generated imagery actually produces. Use when a landing page, marketing site,
+  or product page needs real hero photography, product screenshots, portraits,
+  or illustration as page content instead of placeholder services, stock URLs,
+  or hand-rolled SVG stand-ins.
+triggers:
+  - "image-led page"
+  - "landing page with generated images"
+  - "generate the images for my page"
+  - "replace the placeholder images"
+  - "page with real product shots"
+  - "hero photography for my site"
+od:
+  mode: prototype
+  surface: web
+  platform: desktop
+  scenario: marketing
+  category: web-artifacts
+  craft:
+    requires:
+      - typography
+      - color
+      - anti-ai-slop
+  design_system:
+    requires: false
+  example_prompt: |
+    Build the launch page for my product and generate its hero shot, two
+    product screenshots, and three portraits through the media dispatcher
+    instead of leaving placeholder images.
+---
+
+# Image-Led Page
+
+A page carried by real imagery, generated in-product.
+
+Design skills reach for whatever image tool the environment happens to expose
+and fall back to a placeholder photo service when they find none. Inside
+OpenDesign there is always one: the media dispatcher the agent already holds as
+`"$OD_NODE_BIN" "$OD_BIN" media generate`. This skill makes that the default
+path and closes the chain around it — manifest, generate, place, verify —
+carrying the checks that catch what generated imagery actually gets wrong.
+
+## When to use this
+
+Use it when images are **page content**: the hero, the product screenshot, the
+portrait next to a quote, the texture behind a section.
+
+Do not use it for:
+
+| Instead | Use |
+|---|---|
+| Product photos from a customer's reference shots | `ecommerce-image-workflow` |
+| Reference comps *of* sections for a coding model to rebuild | `imagegen-frontend-web` |
+| A brand-guidelines board or identity system | `brandkit` |
+| A layout with no photographic content at all | `frontend-design` alone |
+
+## Step 1 — Plan the manifest before generating anything
+
+Write the full image list first, as a table, and show it to the user before
+spending a single generation. Each row: slot id, role on the page, aspect,
+and what must be recognisable in it.
+
+A typical marketing page needs six to nine images. If the plan needs more than
+about twelve, the page is probably using imagery as filler — cut the slots that
+carry no information rather than generating decoration.
+
+Reuse the active project's `imageAspect` metadata when it is set; otherwise
+pick per slot (hero `16:9`, portrait `1:1`, phone frame `9:16`).
+
+## Step 2 — Write prompts against one style block
+
+Compose the style block **once** from whatever brand truth exists — the
+project's design system, an uploaded logo, or the user's stated direction —
+covering palette, material, lighting, and mood. Append it **verbatim** to every
+prompt in the manifest. Identical wording across prompts is what makes a set
+look like one set; paraphrasing it per image is the most common reason a page's
+images drift apart.
+
+Then add the slot-specific subject. For any image that shows a screen or
+carries a brand mark, quote the exact strings:
+
+```text
+The word "ACME" appears as the logo in the top-left. All interface labels are
+in German. No other brand names appear anywhere in the image.
+```
+
+Without that lock the model supplies a plausible product name of its own, and
+a screenshot captioned as your product ships showing someone else's. Read
+`references/pitfalls.md` before writing the first prompt.
+
+## Step 3 — Generate through the dispatcher
+
+Do not call provider APIs, MCP image tools, or placeholder services. Use the
+unified dispatcher so the run stays inside the project's configured model,
+credentials, and file handling.
+
+```bash
+# POSIX bash. One slot per invocation; wait for each before starting the next.
+out=$("$OD_NODE_BIN" "$OD_BIN" media generate \
+  --project "$OD_PROJECT_ID" \
+  --surface image \
+  --model "<imageModel from metadata>" \
+  --aspect "<slot aspect>" \
+  --output "assets/<slot-id>.png" \
+  --prompt "<subject + verbatim style block>")
+ec=$?
+if [ "$ec" -ne 0 ]; then echo "$out" >&2; exit "$ec"; fi
+
+last=$(printf '%s\n' "$out" | tail -1)
+task_id=$(printf '%s\n' "$last" |
+  python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('taskId',''))" 2>/dev/null)
+since=$(printf '%s\n' "$last" |
+  python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('nextSince',0))" 2>/dev/null)
+since="${since:-0}"
+
+while [ -n "$task_id" ]; do
+  out=$("$OD_NODE_BIN" "$OD_BIN" media wait "$task_id" --since "$since")
+  ec=$?
+  last=$(printf '%s\n' "$out" | tail -1)
+  since=$(printf '%s\n' "$last" |
+    python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('nextSince',0))" 2>/dev/null)
+  since="${since:-0}"
+  if [ "$ec" -eq 0 ]; then
+    task_id=""
+  elif [ "$ec" -ne 2 ]; then
+    echo "$out" >&2
+    exit "$ec"
+  fi
+done
+
+printf '%s\n' "$last"
+```
+
+The final line is JSON containing `{"file": {"name": "...", ...}}`. Record the
+returned filename against its slot — the name you asked for is not guaranteed
+to be the name you get.
+
+If a slot fails, regenerate that slot alone. Do not restart the set.
+
+## Step 4 — Look at every image before placing it
+
+Open each generated file and check it, one at a time. This step is not
+optional and cannot be delegated to the linter, which never sees inside a
+raster image.
+
+- Is the brand name in the image the right one?
+- Is any rendered text spelled correctly and in the right language?
+- Are numbers, ratings, certificates, or metrics visible that nobody verified?
+  Treat them as false claims and regenerate without them.
+- Are hands, faces, and product geometry plausible?
+
+Delete and regenerate anything that fails. A wrong image that reaches the
+layout is far more expensive to find later, when it reads as intentional.
+
+## Step 5 — Place them as content
+
+Give every image a real job in the layout: it establishes the product, proves a
+claim, or gives a person a face. An image that could be swapped for a grey box
+without changing the page is decoration — cut it and reclaim the space.
+
+Requirements at placement time:
+
+- Text over an image needs full opacity **and** a scrim or plate. Photographs
+  have bright and dark regions; protect against both.
+- `width`/`height` attributes on every `<img>` so the layout does not reflow.
+- Descriptive `alt` on content images; `alt=""` on purely atmospheric ones.
+- No `ad`, `ads`, `banner`, or `sponsor` in file names, classes, or ids —
+  content blockers hide those by name, and the page then renders empty for
+  users who run one while looking correct in every test you can run.
+
+## Step 6 — Verify
+
+Run the linter first; it costs seconds and needs no model call:
+
+```bash
+"$OD_NODE_BIN" "$OD_BIN" lint index.html --fail-on p0
+```
+
+Exit `1` means findings at or above the threshold; `--json` gives a
+machine-readable envelope. Fix P0 findings before anything else.
+
+Then work `references/checklist.md` top to bottom. The linter reads markup —
+it cannot see contrast, an unreadable button, a cropped screenshot, or a
+mislabelled photograph.
+
+## Hard rules
+
+- Plan the manifest and show it before generating.
+- One style block, appended verbatim to every prompt.
+- Quote exact brand and interface text for anything showing a screen.
+- Generate through `"$OD_NODE_BIN" "$OD_BIN" media generate` only — never a
+  provider API, never a placeholder photo service, never a hand-rolled SVG
+  "screenshot".
+- Open and inspect every generated image before it enters the layout.
+- Never let a generated image assert a number, rating, or certification.
+- Run `od lint` and `references/checklist.md` before handoff.
+- Do not emit an `<artifact>` tag.

--- a/skills/image-led-page/references/checklist.md
+++ b/skills/image-led-page/references/checklist.md
@@ -1,0 +1,33 @@
+# Pre-handoff checklist
+
+Run top to bottom. `od lint` covers none of this — it reads markup, not
+pixels, not cascade outcomes.
+
+## Images
+
+- [ ] Every slot in the manifest exists in the page, and every image in the
+      page is in the manifest.
+- [ ] Each image opened and inspected: correct brand name, correct spelling,
+      correct language, plausible geometry.
+- [ ] No unverified number, rating, or certification is visible in any image.
+- [ ] Every `<img>` has `width` and `height`; content images have descriptive
+      `alt`, atmospheric ones `alt=""`.
+- [ ] Images resized and compressed; transparency-bearing files still PNG.
+
+## Text over imagery
+
+- [ ] Text on photographs is fully opaque and backed by a scrim or plate.
+- [ ] Body text meets at least 4.5:1 against its actual background; muted
+      tokens are not sitting on photographs, textures, or tinted panels.
+- [ ] Every button on a coloured surface checked visually, header included
+      (see pitfall 3).
+
+## Robustness
+
+- [ ] Rendered at mobile and desktop widths, and the produced screenshots are
+      the widths that were requested.
+- [ ] No `ad`, `ads`, `banner`, or `sponsor` token in any filename, class, or
+      id.
+- [ ] If the page travels as a single file: opened from an empty directory
+      with every image still rendering.
+- [ ] `od lint index.html --fail-on p0` exits 0.

--- a/skills/image-led-page/references/pitfalls.md
+++ b/skills/image-led-page/references/pitfalls.md
@@ -1,0 +1,118 @@
+# Pitfalls
+
+Failure modes that generated imagery produces reliably. Each one has shipped
+in a finished-looking page. They are listed in the order they tend to bite.
+
+## 1. The model renames your product
+
+**Symptom.** A generated UI screenshot comes back polished, well-composed, and
+carrying a product name nobody chose — a plausible neighbour of the real one.
+The page ships advertising someone else's brand.
+
+**Why.** A prompt that says "a dashboard for a monitoring product" leaves the
+logotype undetermined, and an image model never renders an empty logo slot.
+
+**Fix.** Quote every string that must appear, and forbid the rest:
+
+```text
+The word "ACME" appears as the logo. All labels are in German.
+No other brand name appears anywhere in the image.
+```
+
+The one exception is a screen belonging to a fictional customer inside your
+product — there a foreign name is correct, so say which name.
+
+## 2. A generated screenshot invents facts
+
+**Symptom.** The hero shot shows `99.98% uptime`, four-and-a-half stars, or an
+ISO badge. Nobody wrote those; the model filled the composition.
+
+**Why.** Dashboards, review cards, and packaging are dense with numbers in the
+training data, so the model produces numbers.
+
+**Fix.** Either name the exact figures in the prompt because they are true, or
+instruct the image to carry no numerals, ratings, or certification marks at
+all. Reject and regenerate anything that arrives with an unverified claim —
+including one that happens to be flattering.
+
+## 3. Navigation specificity eats the header button
+
+**Symptom.** Every button on the page is fine except the one in the header,
+which is white text on its own light background, or the reverse.
+
+**Why.** `.nav a { color: var(--muted) }` and `.btn-primary { color: #fff }`
+have the same specificity, so source order decides. The nav rule usually comes
+later. Nothing in the markup looks wrong and the linter has nothing to flag.
+
+**Fix.** Bind the exception explicitly and check it visually:
+
+```css
+.nav a.btn-primary { color: #fff; }
+```
+
+Check every button that sits on a coloured surface, not only the header — this
+is a cascade problem, and headers are just where it surfaces most.
+
+## 4. Relative asset paths vanish in single-file contexts
+
+**Symptom.** The page is perfect in its own folder and image-less everywhere
+else — pasted into a canvas, deployed as one file, mailed to a reviewer.
+
+**Why.** `assets/hero.png` resolves against the document's location. Move the
+document and the images stay behind.
+
+**Fix.** For any context where the HTML travels alone, inline the images as
+`data:` URIs. Then prove it: copy the file into an empty directory, open it
+there, and confirm every image still renders.
+
+## 5. A screenshot taken from the wrong directory lies
+
+**Symptom.** A verification screenshot shows the page in Times New Roman with
+browser-default colours. The obvious conclusion — the fonts and tokens are
+broken — is wrong.
+
+**Why.** The check copy was written somewhere convenient (a temp directory)
+instead of beside the original, so its relative stylesheet link resolved to
+nothing. The page was never broken; the screenshot was.
+
+**Fix.** Write check copies **into the same directory as the page**, named so
+they are obvious (`_check-1.html`), and delete them afterwards. Before
+reporting any styling defect from a screenshot, confirm the stylesheet
+actually loaded.
+
+## 6. The screenshot is not the width you asked for
+
+**Symptom.** A mobile screenshot looks like a narrow desktop layout, or content
+is cropped at the right edge with no error.
+
+**Why.** Headless browsers do not always honour very small window widths, and
+they report success either way.
+
+**Fix.** Read the produced image's actual pixel width before drawing
+conclusions from it. If it does not match the request, the shot is not evidence
+about mobile.
+
+## 7. Exit code 0 is not proof of a finished file
+
+**Symptom.** A build step reports success. The page is half-written: a
+truncated section, three of nine images placed, no closing tag.
+
+**Why.** Agents and CLIs report their own process status, not whether the
+artifact they were asked for is complete.
+
+**Fix.** Assert on the artifact. Does it end with `</html>`? Does it reference
+every slot in the manifest? Does `od lint` parse it? Those are the checks that
+answer the question the exit code only appears to answer.
+
+## 8. Generated images are far too heavy to ship
+
+**Symptom.** A nine-image page weighs 20 MB. It looks fine on the machine that
+built it.
+
+**Why.** Image models return large lossless files. That is the right default
+for a source asset and the wrong one for a web page.
+
+**Fix.** Before handoff, resize to the largest dimension the layout actually
+uses and convert to a lossy format — keeping PNG only where transparency is
+load-bearing, since flattening a cut-out onto JPEG gives it a white box. Then
+update the references in the markup to the new filenames.


### PR DESCRIPTION
## Why

I build image-heavy marketing pages inside OpenDesign, and kept ending up
hand-wiring the same sequence every time: decide what imagery the page needs,
generate it, place it, then check the things that actually go wrong with
generated pictures. None of that is written down in the catalogue, so it gets
rebuilt (or forgotten) per run.

The pain is narrower than it sounds. `skills/ecommerce-image-workflow` is the
only entry under `skills/` that calls the media dispatcher, and it is scoped to
product photography reproduced from a customer's reference shots. The general
design skills take a different route: `skills/taste-skill` instructs the agent
to use "ANY image-gen tool available in the environment (`generate_image`, MCP
image tool, IDE-integrated gen, OpenAI image tools, etc.)" and, failing that,
to fall back to `picsum.photos` seeds. The built-in dispatcher is not on that
list. So a page built inside OpenDesign can ship with placeholder photography
while `media generate` sits unused a command away.

The second half is verification. `od lint` has been available as a CLI since
0.20.0 and is referenced by no skill in the catalogue — worth wiring into a
workflow that produces artifacts.

## What users will see

A new skill, **Image-Led Page**, in Integrations → Skills (category
`web-artifacts`, marketing scenario). Ask for a landing page with real hero
photography or product screenshots and the agent now plans an image manifest,
shows it before spending generations, produces each slot through
`media generate`, places them, and runs `od lint` plus a pre-handoff checklist
instead of reaching for a placeholder service.

Nothing existing changes. The PR is additive: three new files, no edits.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [x] **Extension point** — new entry under `skills/`
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

No UI surface — the entry renders in the existing Integrations → Skills list.

## Bug fix verification

Not a bug fix.

## Validation

- `pnpm guard` → exit 0. Relevant checks named explicitly in the output:
  `Product-neutrality check passed` and `Craft reference check passed: 242
  references across 99 manifests resolve or are explicitly planned` (this
  skill's `craft.requires: [typography, color, anti-ai-slop]` is among them).
- `pnpm typecheck` → exit 0.
- Frontmatter verified against the running daemon rather than by inspection:
  staged the folder into `USER_SKILLS_DIR` and read the parsed entry back from
  `GET /api/skills` → `mode prototype | surface web | platform desktop |
  category web-artifacts`, triggers intact.
- `od lint` verified end-to-end against a deliberately non-compliant page:
  3 findings (P0 2 · P2 1), exit 1 — confirming the Step 6 command and its
  documented exit semantics.
- The dispatcher generate/wait block is carried over unchanged from
  `skills/ecommerce-image-workflow`, deliberately, so both skills fail the same
  way if that contract moves.

## Adjacent issues (not fixed here)

Two things surfaced while writing this. Both are outside this PR's scope and I
did not touch them:

1. **`od.mode: utility` is not a mode the daemon knows.** `SkillMode` in
   `apps/daemon/src/skills.ts` is `image | video | audio | deck | design-system
   | template | prototype`, and `normalizeMode` falls through to
   `inferMode(body, description)` for anything else. The five skills that
   declare `mode: utility` today (`chat-motion-overlay`,
   `export-download-debugging`, `library-curator`, `pptx-html-fidelity-audit`,
   `pr-feedback-quality-gate`) are therefore categorised heuristically from
   their prose. I hit this because I authored this skill as `utility` first and
   the daemon returned `mode: image`. Happy to file it separately.

2. **`normalizePlatform` reads prose.** This skill was classified
   `platform: mobile` because its aspect-ratio example mentions a phone frame.
   Declaring `platform: desktop` explicitly fixes it, but the inference is easy
   to trip.
