### PR TITLE
fix(daemon): fail OD Next runs on blocked verdicts and blank output

### DIFF
--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -2,7 +2,7 @@
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
-import { strategyTaskProvesDelivery, todoSnapshotHasUnfinishedWork } from '@open-design/contracts';
+import { strategyTaskProvesDelivery, strategyTaskVerdictRefutesSuccess, todoSnapshotHasUnfinishedWork } from '@open-design/contracts';
 import {
   collectProcessTreePids,
   listProcessSnapshots,
@@ -1313,9 +1313,16 @@ export function createChatRunService({
 
   const commitFinish = (run, status, code: number | null = null, signal: string | null = null) => {
     if (TERMINAL_RUN_STATUSES.has(run.status)) return;
-    if (beforeFinish) beforeFinish(run, status, code, signal);
+    // A terminal strategy verdict that is not `completed` (blocked/canceled task)
+    // outranks a clean agent process exit (#7564): the task never delivered, so the
+    // physical run must not be persisted (or projected) as succeeded.
+    const effectiveStatus =
+      status === 'succeeded' && strategyTaskVerdictRefutesSuccess(run.strategyTask)
+        ? 'failed'
+        : status;
+    if (beforeFinish) beforeFinish(run, effectiveStatus, code, signal);
     const terminalAt = Date.now();
-    run.status = status;
+    run.status = effectiveStatus;
     run.exitCode = code;
     run.signal = signal;
     run.updatedAt = terminalAt;
@@ -1339,7 +1346,7 @@ export function createChatRunService({
     // Commit the terminal Run snapshot before exposing its terminal event. The
     // optional outbox hook is local-only and synchronous by contract.
     persistState(run);
-    finalizeTerminalLocally(run, status, terminalAt);
+    finalizeTerminalLocally(run, effectiveStatus, terminalAt);
     // Release run-scoped resources the starter registered (e.g. the minted
     // tool-token grant + agent event-sink entries). This runs on EVERY
     // terminal path — including a startup throw that never reached the child
@@ -1357,7 +1364,7 @@ export function createChatRunService({
     emit(run, 'end', {
       code,
       signal,
-      status,
+      status: effectiveStatus,
       terminalAt,
       resumable: run.resumable ?? false,
       endedWithUnfinishedWork: run.endedWithUnfinishedWork,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -14195,7 +14195,10 @@ export async function startServer({
         const decodedAt = Date.now();
         if (emitTitleFilteredGuardedTextDelta(ev.delta)) {
           noteFirstTokenAt(decodedAt);
-          agentProducedOutput = true;
+          // A whitespace-only delta is not substantive output: a run whose entire
+          // response is blank must still hit the close-time empty-output guard
+          // (#7564) instead of being classified as a produced-output success.
+          if (ev.delta.trim().length > 0) agentProducedOutput = true;
         }
         return;
       }
@@ -15737,13 +15740,25 @@ export async function startServer({
           }
           run.strategyTask = projectStrategyTask(transition.result.task, run.id);
           if (transition.result.action === 'blocked') {
-            const signal = rolloutStopSignalForBlockedContinuation(
+            const rolloutSignal = rolloutStopSignalForBlockedContinuation(
               transition.result.reasonCodes,
             );
-            const stopMode = signal ? stopModeForOdNextSignal(signal) : null;
-            if (signal && stopMode) {
-              latchOdNextRolloutForRun(run, stopMode, signal);
+            const stopMode = rolloutSignal ? stopModeForOdNextSignal(rolloutSignal) : null;
+            if (rolloutSignal && stopMode) {
+              latchOdNextRolloutForRun(run, stopMode, rolloutSignal);
             }
+            // The strategy verdict is terminal for this task. A clean agent process exit
+            // must not publish a false success on top of it (#7564): surface the blocked
+            // reason codes as an explicit, actionable failure instead. Mirrors the
+            // blockAutomaticContinuation handling above.
+            if (!run.cancelRequested && !design.runs.isTerminal(run.status)) {
+              send('error', createSseErrorPayload(
+                'AGENT_EXECUTION_FAILED',
+                `OD Next task blocked: ${transition.result.reasonCodes.join(', ') || 'protocol violation'}. The run produced no usable deliverable; review the blocked reason and retry the task.`,
+                { retryable: false },
+              ));
+            }
+            return finishWithRetryDecision('failed', code ?? 1, signal ?? null);
           }
           if (transition.start && transition.prepared?.kind === 'ready') {
             const nextRun = transition.prepared.run;

--- a/apps/daemon/tests/blank-output-empty-output-guard.test.ts
+++ b/apps/daemon/tests/blank-output-empty-output-guard.test.ts
@@ -1,0 +1,181 @@
+// Regression (#7564): a whitespace-only text_delta must not count as produced
+// output, or the close-time empty-output guard is defeated.
+//
+// Bug: sendAgentEvent marked `agentProducedOutput = true` for ANY non-empty
+// delta string it forwarded, including pure whitespace ("\n"). A codex run
+// (json-event-stream → trackingSubstantiveOutput = true) whose ENTIRE answer
+// is blank therefore passes the empty-output guard at close time and, with a
+// clean exit 0, classifies 'succeeded'.
+//
+// A/B: the ONLY difference between the two runs below is the agent_message
+// text ('Real answer.' vs '\n'). Both exit 0.
+//   - control (real text): 'succeeded' proves the healthy path is unaffected.
+//   - blank ("\n"): INVARIANT 'failed' — on current code it is 'succeeded'.
+
+import type { Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+type StartedServer = {
+  url: string;
+  server: Server;
+  shutdown?: () => Promise<void> | void;
+};
+
+type RunStatus = {
+  id: string;
+  status: string;
+  exitCode: number | null;
+  error: string | null;
+  errorCode: string | null;
+  failureCategory: string | null;
+  eventsLogPath: string;
+};
+
+describe('blank output must not defeat the empty-output guard (#7564)', () => {
+  const originalEnv = {
+    POSTHOG_KEY: process.env.POSTHOG_KEY,
+    POSTHOG_HOST: process.env.POSTHOG_HOST,
+    LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
+    LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
+    LANGFUSE_BASE_URL: process.env.LANGFUSE_BASE_URL,
+    OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
+    OD_NEXT_STRATEGY_ROLLOUT: process.env.OD_NEXT_STRATEGY_ROLLOUT,
+  };
+  let started: StartedServer | null = null;
+  let binDir: string | null = null;
+
+  afterEach(async () => {
+    await Promise.resolve(started?.shutdown?.());
+    if (started?.server) {
+      await new Promise<void>((resolve) => started?.server.close(() => resolve()));
+    }
+    started = null;
+    if (binDir) await rm(binDir, { recursive: true, force: true });
+    binDir = null;
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it('a run whose entire answer is whitespace-only must fail, not succeed', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-blank-output-codex-bin-'));
+    const controlBin = await writeBlankCodex(binDir, 'codex-control', { text: 'Real answer.' });
+    const blankBin = await writeBlankCodex(binDir, 'codex-blank', { text: '\n' });
+
+    delete process.env.POSTHOG_KEY;
+    delete process.env.POSTHOG_HOST;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_BASE_URL;
+    delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+    delete process.env.OD_NEXT_STRATEGY_ROLLOUT;
+
+    started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+
+    // A/B control: a real agent_message with a clean exit is a success.
+    await putConfig(started.url, {
+      agentId: 'codex',
+      agentCliEnv: { codex: { CODEX_BIN: controlBin, CODEX_HOME: binDir } },
+      telemetry: { metrics: false, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+    const controlRun = await createAndWaitForRun(started.url);
+    expect(controlRun.exitCode).toBe(0);
+    expect(controlRun.status).toBe('succeeded');
+
+    // The bug: the same healthy close shape, but the whole answer is "\n".
+    // INVARIANT: a whitespace-only response is not substantive output; the
+    // close-time empty-output guard must classify the run 'failed'.
+    await putConfig(started.url, {
+      agentId: 'codex',
+      agentCliEnv: { codex: { CODEX_BIN: blankBin, CODEX_HOME: binDir } },
+      telemetry: { metrics: false, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+    const blankRun = await createAndWaitForRun(started.url);
+    expect(blankRun.status).toBe('failed');
+    expect(blankRun.failureCategory).toBe('empty_output');
+  });
+});
+
+async function writeBlankCodex(
+  dir: string,
+  name: string,
+  opts: { text: string },
+): Promise<string> {
+  const bin = path.join(dir, name);
+  await writeFile(bin, `#!/usr/bin/env node
+const fs = require('node:fs');
+function w(s) { fs.writeSync(1, s); }
+if (process.argv.includes('--version')) { w('codex-cli 0.147.0\\n'); process.exit(0); }
+if (process.argv.includes('--help')) { w('Usage: codex exec [--sandbox MODE]\\n'); process.exit(0); }
+w(JSON.stringify({ type: 'thread.started', thread_id: 'thread-${name}' }) + '\\n');
+w(JSON.stringify({ type: 'turn.started' }) + '\\n');
+w(JSON.stringify({ type: 'item.completed', item: { id: 'answer', type: 'agent_message', text: ${JSON.stringify(opts.text)} } }) + '\\n');
+w(JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 } }) + '\\n');
+setTimeout(() => process.exit(0), 5);
+`, 'utf8');
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+async function putConfig(url: string, patch: Record<string, unknown>): Promise<void> {
+  const response = await fetch(`${url}/api/app-config`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  expect(response.status).toBe(200);
+}
+
+async function createAndWaitForRun(url: string): Promise<RunStatus> {
+  const projectId = `blank_output_${randomUUID()}`;
+  const projectResponse = await fetch(`${url}/api/projects`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      id: projectId,
+      name: 'Blank output empty-output guard repro',
+      metadata: { kind: 'prototype' },
+      skipDiscoveryBrief: true,
+    }),
+  });
+  expect(projectResponse.status).toBe(200);
+  const projectBody = await projectResponse.json() as { conversationId: string };
+  const runResponse = await fetch(`${url}/api/runs`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-od-analytics-device-id': 'blank-output-codex-test',
+      'x-od-analytics-session-id': 'blank-output-codex-session',
+      'x-od-analytics-client-type': 'web',
+    },
+    body: JSON.stringify({
+      projectId,
+      conversationId: projectBody.conversationId,
+      assistantMessageId: `assistant_blank_output_${randomUUID()}`,
+      clientRequestId: `client_blank_output_${randomUUID()}`,
+      agentId: 'codex',
+      message: 'reproduce blank output false success',
+      currentPrompt: 'reproduce blank output false success',
+    }),
+  });
+  expect(runResponse.status).toBe(202);
+  const body = await runResponse.json() as { runId: string };
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 10_000) {
+    const response = await fetch(`${url}/api/runs/${encodeURIComponent(body.runId)}`);
+    expect(response.status).toBe(200);
+    const run = await response.json() as RunStatus;
+    if (['failed', 'succeeded', 'canceled'].includes(run.status)) return run;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`run ${body.runId} did not finish`);
+}

--- a/apps/daemon/tests/od-next-automatic-simple-server.test.ts
+++ b/apps/daemon/tests/od-next-automatic-simple-server.test.ts
@@ -2123,6 +2123,51 @@ describe('OD Next automatic production through the real server', () => {
     });
   });
 
+  it('fails the run when a terminal blocked strategy verdict meets a clean agent exit', async () => {
+    const fixture = await createFixture('repair');
+    // Replace the strategy fixture CLI with one that answers in plain prose:
+    // no machine blocks, no plan, no runtime state, exit 0.
+    const bin = path.join(binDir!, 'codex-prose-only');
+    await writeFile(bin, `#!/usr/bin/env node
+const argv = process.argv.slice(2);
+if (argv.includes('--version')) { console.log('codex-cli 0.147.0'); process.exit(0); }
+if (argv.includes('--help')) { console.log('Usage: codex exec [--sandbox MODE]'); process.exit(0); }
+console.log(JSON.stringify({ type: 'thread.started', thread_id: 'thread-prose-only' }));
+console.log(JSON.stringify({ type: 'turn.started' }));
+console.log(JSON.stringify({ type: 'item.completed', item: { id: 'answer', type: 'agent_message', text: 'I could not finish the prototype.' } }));
+console.log(JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 } }));
+setTimeout(() => process.exit(0), 5);
+`);
+    await chmod(bin, 0o755);
+    const configResponse = await fetch(`${started!.url}/api/app-config`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        agentId: 'codex',
+        agentCliEnv: { codex: { CODEX_BIN: bin, CODEX_HOME: binDir! } },
+        telemetry: { metrics: false, content: false, artifactManifest: false },
+        privacyDecisionAt: Date.now(),
+      }),
+    });
+    expect(configResponse.status).toBe(200);
+
+    queueFixtureIds(fixture);
+    const created = await postRun(
+      started!.url,
+      createRunRequest(fixture, 'Update the existing operator header.'),
+    );
+    const terminal = await waitForRunTerminal(started!.url, created.runId as string);
+
+    expect(terminal.status).toBe('failed');
+    expect(terminal.errorCode).toBe('AGENT_EXECUTION_FAILED');
+    expect(terminal.error ?? '').toContain('od_next_protocol_runtime_state_missing');
+    expect(terminal.strategyTask).toMatchObject({
+      taskExecutionId: fixture.taskExecutionId,
+      outcome: 'blocked',
+      terminal: true,
+    });
+  });
+
   it('fails a mapped Run before live Skill staging when its frozen package row is missing', async () => {
     const fixture = await createFixture('repair');
     const body = createRunRequest(fixture, 'Do not fall back to a live Skill.');

--- a/apps/daemon/tests/runtimes/runs-strategy-verdict-gate.test.ts
+++ b/apps/daemon/tests/runtimes/runs-strategy-verdict-gate.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createChatRunService } from '../../src/runtimes/runs.js';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-08-29T00:00:00.000Z'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function createRuns() {
+  return createChatRunService({
+    createSseResponse: () => ({
+      send: vi.fn(() => true),
+      end: vi.fn(),
+      cleanup: vi.fn(),
+    }),
+    createSseErrorPayload: (code: string, message: string) => ({ error: { code, message } }),
+    shutdownGraceMs: 10,
+    ttlMs: 60_000,
+  });
+}
+
+function createRun(runs: ReturnType<typeof createChatRunService>, strategyTask?: unknown) {
+  const run = runs.create({
+    projectId: 'project-1',
+    conversationId: 'conv-1',
+    agentId: 'amr',
+  }) as any;
+  if (strategyTask !== undefined) run.strategyTask = strategyTask;
+  return run;
+}
+
+describe('chat run completion gate on strategy verdict', () => {
+  it('downgrades a clean exit to failed when the terminal strategy verdict refutes success', () => {
+    const runs = createRuns();
+    const run = createRun(runs, {
+      taskExecutionId: 't1',
+      outcome: 'blocked',
+      terminal: true,
+    });
+    runs.finish(run, 'succeeded', 0, null);
+    expect(run.status).toBe('failed');
+  });
+
+  it('downgrades a clean exit to failed for a terminal canceled task', () => {
+    const runs = createRuns();
+    const run = createRun(runs, {
+      taskExecutionId: 't1',
+      outcome: 'canceled',
+      terminal: true,
+    });
+    runs.finish(run, 'succeeded', 0, null);
+    expect(run.status).toBe('failed');
+  });
+
+  it('keeps a succeeded close when there is no strategy task', () => {
+    const runs = createRuns();
+    const run = createRun(runs);
+    runs.finish(run, 'succeeded', 0, null);
+    expect(run.status).toBe('succeeded');
+  });
+
+  it('keeps a succeeded close when the terminal strategy task completed', () => {
+    const runs = createRuns();
+    const run = createRun(runs, {
+      taskExecutionId: 't1',
+      outcome: 'completed',
+      terminal: true,
+    });
+    runs.finish(run, 'succeeded', 0, null);
+    expect(run.status).toBe('succeeded');
+  });
+
+  it('keeps a succeeded close for a non-terminal clarification task', () => {
+    const runs = createRuns();
+    const run = createRun(runs, {
+      taskExecutionId: 't1',
+      outcome: 'clarification_required',
+      terminal: false,
+    });
+    runs.finish(run, 'succeeded', 0, null);
+    expect(run.status).toBe('succeeded');
+  });
+});

--- a/packages/contracts/src/api/run-completeness.ts
+++ b/packages/contracts/src/api/run-completeness.ts
@@ -153,3 +153,20 @@ export function strategyTaskProvesDelivery(
 ): boolean {
   return strategyTask?.terminal === true && strategyTask.outcome === 'completed';
 }
+
+/**
+ * True when a strategy task's terminal verdict refutes a `succeeded` run
+ * classification. The mirror of `strategyTaskProvesDelivery`: any terminal
+ * outcome other than `completed` (a blocked or canceled task) means the task
+ * never delivered its work, so a clean agent process exit must not be allowed
+ * to persist the run as succeeded (#7564). Non-terminal outcomes (e.g. a
+ * clarification prompt still in flight) say nothing about delivery and are
+ * deliberately ignored here.
+ */
+export function strategyTaskVerdictRefutesSuccess(
+  strategyTask: { outcome?: unknown; terminal?: unknown } | null | undefined,
+): boolean {
+  return strategyTask?.terminal === true
+    && typeof strategyTask.outcome === 'string'
+    && strategyTask.outcome !== 'completed';
+}

--- a/packages/contracts/tests/run-completeness.test.ts
+++ b/packages/contracts/tests/run-completeness.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   eventsEndedWithUnfinishedWork,
   isTodoWriteToolName,
+  strategyTaskVerdictRefutesSuccess,
   todoSnapshotHasUnfinishedWork,
   todoStatusIsUnfinished,
 } from '../src/api/run-completeness';
@@ -59,6 +60,44 @@ describe('isTodoWriteToolName', () => {
     }
     expect(isTodoWriteToolName('Write')).toBe(false);
     expect(isTodoWriteToolName(undefined)).toBe(false);
+  });
+});
+
+describe('strategyTaskVerdictRefutesSuccess', () => {
+  it('is true for a terminal outcome other than completed', () => {
+    expect(
+      strategyTaskVerdictRefutesSuccess({ terminal: true, outcome: 'blocked' }),
+    ).toBe(true);
+    expect(
+      strategyTaskVerdictRefutesSuccess({ terminal: true, outcome: 'canceled' }),
+    ).toBe(true);
+  });
+
+  it('is false for a terminal completed outcome (proves delivery)', () => {
+    expect(
+      strategyTaskVerdictRefutesSuccess({ terminal: true, outcome: 'completed' }),
+    ).toBe(false);
+  });
+
+  it('is false for non-terminal outcomes', () => {
+    expect(
+      strategyTaskVerdictRefutesSuccess({
+        terminal: false,
+        outcome: 'clarification_required',
+      }),
+    ).toBe(false);
+    expect(
+      strategyTaskVerdictRefutesSuccess({ terminal: false, outcome: 'plan_ready' }),
+    ).toBe(false);
+  });
+
+  it('is false for missing or malformed strategy tasks', () => {
+    expect(strategyTaskVerdictRefutesSuccess(null)).toBe(false);
+    expect(strategyTaskVerdictRefutesSuccess(undefined)).toBe(false);
+    expect(
+      strategyTaskVerdictRefutesSuccess({ terminal: true, outcome: 42 }),
+    ).toBe(false);
+    expect(strategyTaskVerdictRefutesSuccess({ outcome: 'blocked' })).toBe(false);
   });
 });
 


### PR DESCRIPTION
Fixes #7564

## Why

OD Next prototype runs could be persisted as `succeeded` even when they produced nothing or were terminally blocked. `classifyChatRunCloseStatus` derived the physical run status from the close shape alone, so a blocked strategy verdict computed afterwards could never change it. A second hole fed the same symptom: a whitespace-only `text_delta` counted as output, so the close-time empty-output guard never fired and the blank response was never retried.

## What users will see

A prototype run whose response was blank, or whose task was terminally blocked, now shows a failed run carrying the blocked reason codes and an actionable error, instead of a "completed" run with discovery/plan/generate all ticked and no deliverable on disk. A blank response is classified `empty_output` and flows into the existing automatic retry policy. Runs that genuinely delivered (canonical entry resolved, `deliverableValid === true`, outcome `completed`) behave exactly as before, as do clarification prompts and non-strategy chat runs.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

The contract change is a single exported pure predicate, `strategyTaskVerdictRefutesSuccess` in `packages/contracts/src/api/run-completeness.ts`, mirroring `strategyTaskProvesDelivery`. No SSE event or DTO shape changes: the blocked branch reuses the existing `error` SSE event and the `AGENT_EXECUTION_FAILED` code. It is emitted `retryable: false` on purpose, because the task verdict is sticky and retrying the same task cannot unblock it, unlike the retryable `empty_output` path.

## Screenshots

Not applicable — daemon/contracts behavior change with no visual surface.

## Bug fix verification

- Test path that reproduces the bug:
  - `apps/daemon/tests/od-next-automatic-simple-server.test.ts` — a terminal blocked strategy verdict with a clean agent exit (prose-only turn, exit 0) now fails the run with `AGENT_EXECUTION_FAILED` and the `od_next_protocol_runtime_state_missing` reason code.
  - `apps/daemon/tests/runtimes/runs-strategy-verdict-gate.test.ts` — the `commitFinish` persistence gate: terminal blocked/canceled downgrade, with no-task, completed-task and non-terminal clarification controls staying `succeeded`.
  - `apps/daemon/tests/blank-output-empty-output-guard.test.ts` — HTTP-boundary A/B: `'Real answer.'` → `succeeded`; `"\n"` → `failed` with `failureCategory: 'empty_output'`.
- Did the test go red on `main` and green on this branch? yes (all three).

## Validation

- `pnpm guard` — pass
- `pnpm --filter @open-design/contracts exec tsc -p tsconfig.json --noEmit` and `pnpm --filter @open-design/daemon typecheck` — pass
- `pnpm --filter @open-design/contracts exec vitest run tests/run-completeness.test.ts` — 12 passed
- daemon `tests/od-next-automatic-simple-server.test.ts` — 32 passed
- daemon `tests/runtimes/runs.test.ts tests/run-retry-policy.test.ts tests/run-failure-classification.test.ts tests/chat-route.test.ts` — 285 passed, one pre-existing `chat-route` failure on `main` reproduced with the patch stashed
- focused regression sweep (`retry-*`, `deliverable`, `strategy`, `chat-run*`) — 89 + 39 passed
- `git diff --check` — pass
- Out of scope: ACP (`acp-json-rpc`) and plain-stream runs without a strategy verdict are unchanged; a plain-stream blank-output guard would be a follow-up.

