### PR TITLE
fix(daemon): tolerate empty poll results in media wait

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -2043,11 +2043,28 @@ async function pollUntilDoneOrBudget(daemonUrl, taskId, sinceStart, options = {}
       await flushStreamsAndExit(4);
     }
     let snap;
+    let rawText = '';
     try {
-      snap = await resp.json();
+      rawText = await resp.text();
+      if (!rawText || !rawText.trim()) {
+        console.error('wait returned empty response; still running — retrying');
+        await new Promise((r) => setTimeout(r, 200));
+        continue;
+      }
+      snap = JSON.parse(rawText);
     } catch {
-      console.error('daemon returned non-JSON for /wait');
-      await flushStreamsAndExit(4);
+      console.error('daemon returned non-JSON for /wait; still running — retrying');
+      await new Promise((r) => setTimeout(r, 200));
+      continue;
+    }
+    if (!snap || typeof snap !== 'object') {
+      console.error('wait returned empty/ambiguous result; still running — retrying');
+      await new Promise((r) => setTimeout(r, 200));
+      continue;
+    }
+    if (typeof snap.status !== 'string' || !snap.status.trim()) {
+      console.error('wait returned ambiguous status; still running — retrying');
+      snap.status = 'running';
     }
     lastSnapshot = snap;
     if (Array.isArray(snap.progress)) {

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -2049,11 +2049,28 @@ async function pollUntilDoneOrBudget(daemonUrl, taskId, sinceStart, options = {}
       await flushStreamsAndExit(4);
     }
     let snap;
+    let rawText = '';
     try {
-      snap = await resp.json();
+      rawText = await resp.text();
+      if (!rawText || !rawText.trim()) {
+        console.error('wait returned empty response; still running — retrying');
+        await new Promise((r) => setTimeout(r, 200));
+        continue;
+      }
+      snap = JSON.parse(rawText);
     } catch {
-      console.error('daemon returned non-JSON for /wait');
-      await flushStreamsAndExit(4);
+      console.error('daemon returned non-JSON for /wait; still running — retrying');
+      await new Promise((r) => setTimeout(r, 200));
+      continue;
+    }
+    if (!snap || typeof snap !== 'object') {
+      console.error('wait returned empty/ambiguous result; still running — retrying');
+      await new Promise((r) => setTimeout(r, 200));
+      continue;
+    }
+    if (typeof snap.status !== 'string' || !snap.status.trim()) {
+      console.error('wait returned ambiguous status; still running — retrying');
+      snap.status = 'running';
     }
     lastSnapshot = snap;
     if (Array.isArray(snap.progress)) {

--- a/apps/daemon/src/prompts/media-contract.ts
+++ b/apps/daemon/src/prompts/media-contract.ts
@@ -413,6 +413,14 @@ both well within your shell tool's timeout. Progress lines stream to stderr as
 they arrive, so the user sees live status in chat throughout the loop instead of
 waiting silently for a single multi-minute call.
 
+**Empty or ambiguous poll results are not failures.** An empty stdout,
+whitespace-only, or non-JSON handoff from \`media wait\` is \`unknown\` — do NOT
+narrate failure. Re-run \`"$OD_NODE_BIN" "$OD_BIN" media wait <taskId> --since <n>\`
+with the same \`since\`. If the live poll stays ambiguous, recover via
+\`GET /api/projects/<projectId>/media/tasks?includeDone=true\` and only report
+\`failed\`/\`interrupted\` when \`status\` is explicitly that; treat \`done\` with a
+file as success even when earlier polls were empty.
+
 **Always write your shell invocation as the full generate+wait loop above**, even
 for image models. \`flux-pro-ultra\` routinely takes 60–180s; \`sora-2\` and
 \`veo-3-fal\` take longer. In the wait loop, exit 2 means "keep polling, not an error."

--- a/apps/daemon/src/prompts/media-contract.ts
+++ b/apps/daemon/src/prompts/media-contract.ts
@@ -431,6 +431,14 @@ both well within your shell tool's timeout. Progress lines stream to stderr as
 they arrive, so the user sees live status in chat throughout the loop instead of
 waiting silently for a single multi-minute call.
 
+**Empty or ambiguous poll results are not failures.** An empty stdout,
+whitespace-only, or non-JSON handoff from \`media wait\` is \`unknown\` — do NOT
+narrate failure. Re-run \`"$OD_NODE_BIN" "$OD_BIN" media wait <taskId> --since <n>\`
+with the same \`since\`. If the live poll stays ambiguous, recover via
+\`GET /api/projects/<projectId>/media/tasks?includeDone=true\` and only report
+\`failed\`/\`interrupted\` when \`status\` is explicitly that; treat \`done\` with a
+file as success even when earlier polls were empty.
+
 **Always write your shell invocation as the full generate+wait loop above**, even
 for image models. \`flux-pro-ultra\` routinely takes 60–180s; \`sora-2\` and
 \`veo-3-fal\` take longer. In the wait loop, exit 2 means "keep polling, not an error."

--- a/apps/daemon/src/prompts/media-contract.ts
+++ b/apps/daemon/src/prompts/media-contract.ts
@@ -410,19 +410,59 @@ last=\$(printf '%s\\n' "\$out" | tail -1)
 task_id=\$(printf '%s\\n' "\$last" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('taskId',''))" 2>/dev/null)
 since=\$(printf '%s\\n' "\$last" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('nextSince',0))" 2>/dev/null)
 since="\${since:-0}"
-while [ -n "\$task_id" ]; do
+if [ -z "\$task_id" ]; then printf '%s\\n' "\$last"; exit 0; fi
+ambiguous=0
+lookups=0
+while :; do
   out=\$("$OD_NODE_BIN" "$OD_BIN" media wait "\$task_id" --since "\$since")
   ec=\$?
   last=\$(printf '%s\\n' "\$out" | tail -1)
-  since=\$(printf '%s\\n' "\$last" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('nextSince',\$since))" 2>/dev/null)
-  since="\${since:-0}"
-  if [ "\$ec" -eq 0 ]; then
-    task_id=""
-  elif [ "\$ec" -ne 2 ]; then
-    echo "\$out" >&2; exit "\$ec"
+  status=\$(printf '%s\\n' "\$last" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status','') if isinstance(d,dict) else '')" 2>/dev/null)
+  ns=\$(printf '%s\\n' "\$last" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('nextSince','') if isinstance(d,dict) else '')" 2>/dev/null)
+  # Keep the previous cursor whenever the line does not parse as a status object.
+  if [ -n "\$ns" ]; then since="\$ns"; fi
+  if [ "\$status" = "failed" ] || [ "\$status" = "interrupted" ]; then
+    echo "\$last" >&2; exit 5
+  fi
+  if [ "\$status" = "done" ]; then
+    has_file=\$(printf '%s\\n' "\$last" | python3 -c "import sys,json; d=json.load(sys.stdin); print('yes' if isinstance(d,dict) and d.get('file') else 'no')" 2>/dev/null)
+    if [ "\$has_file" = "yes" ]; then break; fi
+    ambiguous=\$((ambiguous+1))
+  elif [ -z "\$status" ]; then
+    if [ "\$ec" -ne 0 ] && [ "\$ec" -ne 2 ]; then echo "\$out" >&2; exit "\$ec"; fi
+    ambiguous=\$((ambiguous+1))
+  else
+    ambiguous=0
+  fi
+  # Bounded recovery: only after repeated ambiguous results, look the task up by ID.
+  if [ "\$ambiguous" -ge 3 ] && [ "\$lookups" -lt 3 ]; then
+    ambiguous=0
+    lookups=\$((lookups+1))
+    recovered=\$(python3 -c 'import json,os,sys,urllib.request
+base=(os.environ.get("OD_DAEMON_URL") or "http://127.0.0.1:7456").rstrip("/")
+pid=os.environ.get("OD_PROJECT_ID","")
+url=base+"/api/projects/"+pid+"/media/tasks?includeDone=true"
+try:
+    with urllib.request.urlopen(url,timeout=10) as r:
+        tasks=json.load(r).get("tasks",[])
+except Exception:
+    tasks=[]
+tid=sys.argv[1]
+for t in tasks:
+    if str(t.get("taskId",""))==tid:
+        if t.get("status")=="done" and t.get("file"):
+            print(json.dumps({"file":t["file"]}))
+        elif t.get("status") in ("failed","interrupted"):
+            print(json.dumps({"status":t["status"],"error":t.get("error",{})}))
+        break' "\$task_id" 2>/dev/null)
+    if [ -n "\$recovered" ]; then
+      last="\$recovered"
+      rstatus=\$(printf '%s\\n' "\$last" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status','done'))" 2>/dev/null)
+      if [ -z "\$rstatus" ] || [ "\$rstatus" = "done" ]; then break; fi
+      echo "\$last" >&2; exit 5
+    fi
   fi
 done
-# At this point ec is 0 (done) or 5 (failed). Final result on the last stdout line of \$out.
 printf '%s\\n' "\$last"
 \`\`\`
 

--- a/apps/daemon/tests/media-wait-empty-tolerance.test.ts
+++ b/apps/daemon/tests/media-wait-empty-tolerance.test.ts
@@ -1,0 +1,127 @@
+// Regression for #6257: Polling layer must tolerate empty/early poll results and recover.
+// Before fix, POST /wait returning empty/whitespace/non-JSON or ambiguous status caused exit 4 (failure).
+// After fix, those are treated as still-running (exit 2/0 eventually) and the task completes when daemon returns done.
+// This test simulates poll responses without a Fal.ai key, as required by dispatch.
+
+import { spawn } from 'node:child_process';
+import http from 'node:http';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const daemonRoot = fileURLToPath(new URL('..', import.meta.url));
+const cliEntry = fileURLToPath(new URL('../src/cli.ts', import.meta.url));
+
+let server: http.Server | undefined;
+let baseUrl = '';
+let callCount = 0;
+let sequence: Array<{ status: number; body: string | null }> = [];
+
+beforeEach(async () => {
+  callCount = 0;
+  sequence = [];
+  server = http.createServer((req, res) => {
+    if (req.method === 'POST' && (req.url ?? '').includes('/media/tasks/')) {
+      const idx = callCount++;
+      req.resume();
+      const entry = sequence[idx] ?? sequence[sequence.length - 1];
+      const status = entry?.status ?? 200;
+      const body = entry?.body ?? '';
+      if (body === null) {
+        res.writeHead(status, { 'content-type': 'application/json' });
+        res.end('');
+        return;
+      }
+      res.writeHead(status, { 'content-type': 'application/json' });
+      res.end(body);
+      return;
+    }
+    res.writeHead(404, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not found' }));
+  });
+  await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', () => resolve()));
+  const addr = server.address() as { port: number };
+  baseUrl = `http://127.0.0.1:${addr.port}`;
+});
+
+afterEach(async () => {
+  if (server) await new Promise<void>((r) => server!.close(() => r()));
+  server = undefined;
+});
+
+function runMediaWait(taskId: string, timeoutMs = 15000): Promise<{ code: number; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ['--import', 'tsx', cliEntry, 'media', 'wait', taskId, '--daemon-url', baseUrl], {
+      cwd: daemonRoot,
+      env: { ...process.env, OD_PROJECT_ID: 'p1' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (c) => (stdout += c));
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (c) => (stderr += c));
+    child.on('error', reject);
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`timeout waiting for media wait; stdout=${stdout} stderr=${stderr} calls=${callCount}`));
+    }, timeoutMs);
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolve({ code: code ?? -1, stdout, stderr });
+    });
+    child.stdin.end();
+  });
+}
+
+describe('media wait tolerates empty/ambiguous poll results (#6257)', () => {
+  it('empty body then done: retries and exits 0', async () => {
+    const done = JSON.stringify({ status: 'done', file: { name: 'clip.mp4', size: 123, kind: 'video' }, nextSince: 1 });
+    sequence = [
+      { status: 200, body: '' },
+      { status: 200, body: done },
+    ];
+    const { code, stdout, stderr } = await runMediaWait('task-empty-then-done');
+    expect(callCount).toBeGreaterThanOrEqual(2);
+    expect(code, `expected exit 0 after empty retry; stderr:\n${stderr}\nstdout:\n${stdout}`).toBe(0);
+    const lastLine = stdout.trim().split('\n').pop() ?? '';
+    const parsed = JSON.parse(lastLine);
+    expect(parsed.file.name).toBe('clip.mp4');
+  });
+
+  it('whitespace + non-JSON then done: retries and exits 0', async () => {
+    const done = JSON.stringify({ status: 'done', file: { name: 'out.mp4', size: 456, kind: 'video' } });
+    sequence = [
+      { status: 200, body: '   \n' },
+      { status: 200, body: 'not-json{' },
+      { status: 200, body: done },
+    ];
+    const { code, stdout, stderr } = await runMediaWait('task-whitespace-then-done');
+    expect(callCount).toBeGreaterThanOrEqual(3);
+    expect(code, `stderr:\n${stderr}\nstdout:\n${stdout}`).toBe(0);
+    const last = stdout.trim().split('\n').pop()!;
+    expect(JSON.parse(last).file.name).toBe('out.mp4');
+  });
+
+  it('ambiguous status {} then running then done: does not fail, eventually done', async () => {
+    const running = JSON.stringify({ status: 'running', progress: [], nextSince: 1 });
+    const done = JSON.stringify({ status: 'done', file: { name: 'final.mp4', size: 789, kind: 'video' } });
+    sequence = [
+      { status: 200, body: JSON.stringify({ progress: [], nextSince: 0 }) },
+      { status: 200, body: running },
+      { status: 200, body: done },
+    ];
+    const { code, stdout } = await runMediaWait('task-ambiguous-then-done');
+    expect(callCount).toBeGreaterThanOrEqual(2);
+    expect(code).toBe(0);
+    const last = stdout.trim().split('\n').pop()!;
+    expect(JSON.parse(last).file.name).toBe('final.mp4');
+  });
+
+  it('still reports explicit failed status as failure (exit 5) not masked by tolerance', async () => {
+    const failed = JSON.stringify({ status: 'failed', error: { message: 'provider boom', status: 5 } });
+    sequence = [{ status: 200, body: failed }];
+    const { code } = await runMediaWait('task-failed');
+    expect(code).toBe(5);
+  });
+});

--- a/apps/daemon/tests/media-wait-loop-recovery.test.ts
+++ b/apps/daemon/tests/media-wait-loop-recovery.test.ts
@@ -1,0 +1,165 @@
+// Regression for #6257 at the loop/CLI-output seam. The Windows failure was
+// the CLI's final stdout line being dropped at the named-pipe handoff: `media
+// wait` exited 0 with nothing on stdout, and the generate+wait loop that
+// MEDIA_GENERATION_CONTRACT ships treated that as completion. The HTTP-body
+// tolerance covered by media-wait-empty-tolerance.test.ts never reaches this
+// boundary, so these tests run the loop text itself against a stub CLI and a
+// stub project task-list endpoint.
+
+import { spawn } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import http from 'node:http';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { MEDIA_GENERATION_CONTRACT } from '../src/prompts/media-contract.js';
+
+const BASH_FENCE = /```bash\n([\s\S]*?)```/g;
+
+function generateWaitLoop(): string {
+  const blocks = [...MEDIA_GENERATION_CONTRACT.matchAll(BASH_FENCE)].map((match) => match[1] ?? '');
+  const loop = blocks.find(
+    (block) => block.includes('media generate') && block.includes('media wait') && block.includes('while'),
+  );
+  if (!loop) throw new Error('generate+wait loop not found in MEDIA_GENERATION_CONTRACT');
+  return loop;
+}
+
+// Stand-in for `od media ...`: `generate` hands off a task, and each `wait`
+// replays the next line of $STUB_RESPONSES. `empty` reproduces the Windows
+// handoff — exit 0 with no stdout line at all.
+const STUB_CLI = `#!/usr/bin/env bash
+echo "$*" >> "$STUB_LOG"
+if [ "$1" = "media" ] && [ "$2" = "generate" ]; then
+  echo '{"taskId":"t1","status":"running","nextSince":0}'
+  exit 0
+fi
+count=$(cat "$STUB_COUNT" 2>/dev/null || echo 0)
+count=$((count + 1))
+echo "$count" > "$STUB_COUNT"
+line=$(sed -n "$count"p "$STUB_RESPONSES" 2>/dev/null)
+kind=$(printf '%s' "$line" | cut -d: -f1)
+value=$(printf '%s' "$line" | cut -d: -f2)
+case "$kind" in
+  empty) exit 0 ;;
+  running) printf '{"taskId":"t1","status":"running","nextSince":%s}\\n' "$value"; exit 0 ;;
+  done) printf '{"status":"done","file":{"name":"%s","size":10,"kind":"video"}}\\n' "$value"; exit 0 ;;
+  failed) echo '{"status":"failed","error":{"message":"boom"}}'; exit 5 ;;
+esac
+exit 0
+`;
+
+let server: http.Server | undefined;
+let baseUrl = '';
+let taskListRequests = 0;
+let taskListBody: unknown = { tasks: [] };
+const tempDirs: string[] = [];
+
+beforeEach(async () => {
+  taskListRequests = 0;
+  taskListBody = { tasks: [] };
+  server = http.createServer((req, res) => {
+    if (req.method === 'GET' && (req.url ?? '').includes('/media/tasks')) {
+      taskListRequests += 1;
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(taskListBody));
+      return;
+    }
+    res.writeHead(404, { 'content-type': 'application/json' });
+    res.end('{}');
+  });
+  await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', () => resolve()));
+  const address = server.address() as { port: number };
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterEach(async () => {
+  if (server) await new Promise<void>((resolve) => server!.close(() => resolve()));
+  server = undefined;
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function runGenerateWaitLoop(responses: string[]): Promise<{
+  code: number;
+  stdout: string;
+  stderr: string;
+  calls: string[];
+}> {
+  const dir = mkdtempSync(path.join(tmpdir(), 'od-media-loop-'));
+  tempDirs.push(dir);
+  const stub = path.join(dir, 'stub.sh');
+  writeFileSync(stub, STUB_CLI);
+  const responsesPath = path.join(dir, 'responses');
+  writeFileSync(responsesPath, responses.map((line) => `${line}\n`).join(''));
+  const logPath = path.join(dir, 'calls.log');
+  writeFileSync(logPath, '');
+  const countPath = path.join(dir, 'count');
+
+  const child = spawn('bash', ['-c', generateWaitLoop()], {
+    cwd: dir,
+    env: {
+      ...process.env,
+      OD_NODE_BIN: 'bash',
+      OD_BIN: stub,
+      OD_PROJECT_ID: 'p1',
+      OD_DAEMON_URL: baseUrl,
+      STUB_LOG: logPath,
+      STUB_COUNT: countPath,
+      STUB_RESPONSES: responsesPath,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (chunk) => (stdout += chunk));
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk) => (stderr += chunk));
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`loop never terminated; stdout=${stdout} stderr=${stderr}`));
+    }, 15_000);
+    child.on('error', reject);
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolve({
+        code: code ?? -1,
+        stdout,
+        stderr,
+        calls: readFileSync(logPath, 'utf8').trim().split('\n').filter(Boolean),
+      });
+    });
+  });
+}
+
+function lastStdoutLine(stdout: string): string {
+  return stdout.trim().split('\n').pop() ?? '';
+}
+
+describe('generate+wait loop recovers a lost final stdout line (#6257)', () => {
+  it('recovers the file from the project task list when a wait exits 0 with empty stdout', async () => {
+    taskListBody = {
+      tasks: [{ taskId: 't1', status: 'done', file: { name: 'recovered.mp4', size: 321, kind: 'video' } }],
+    };
+    const result = await runGenerateWaitLoop(['empty', 'empty', 'empty']);
+    expect(result.code, `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`).toBe(0);
+    expect(JSON.parse(lastStdoutLine(result.stdout)).file.name).toBe('recovered.mp4');
+    expect(taskListRequests).toBeGreaterThanOrEqual(1);
+  });
+
+  it('keeps the previous --since cursor when a wait line does not parse', async () => {
+    const result = await runGenerateWaitLoop(['running:7', 'empty', 'done:final.mp4']);
+    expect(result.code, `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`).toBe(0);
+    const waits = result.calls.filter((call) => call.startsWith('media wait'));
+    expect(waits.at(-1)).toContain('--since 7');
+    expect(JSON.parse(lastStdoutLine(result.stdout)).file.name).toBe('final.mp4');
+  });
+
+  it('still terminates on an explicit failed status', async () => {
+    const result = await runGenerateWaitLoop(['failed']);
+    expect(result.code).toBe(5);
+  });
+});

--- a/apps/daemon/tests/prompts/__snapshots__/system-prompt-matrix.test.ts.snap
+++ b/apps/daemon/tests/prompts/__snapshots__/system-prompt-matrix.test.ts.snap
@@ -48,7 +48,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 48046,
+    "totalChars": 48553,
   },
   "critique-enabled": {
     "sections": [
@@ -237,7 +237,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 48044,
+    "totalChars": 48551,
   },
   "memory-hooks-off": {
     "sections": [

--- a/apps/daemon/tests/prompts/__snapshots__/system-prompt-matrix.test.ts.snap
+++ b/apps/daemon/tests/prompts/__snapshots__/system-prompt-matrix.test.ts.snap
@@ -14,16 +14,14 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 62531,
+    "totalChars": 67528,
   },
   "ask-mode-full-context": {
     "sections": [
       "injection-resistance",
       "ask-mode-override",
       "personal-memory",
-      "memory-intent-gateway",
       "memory-verify-scorecard",
-      "memory-rule-proposal",
       "design-system-usage",
       "design-system-body",
       "design-system-import-mode",
@@ -36,7 +34,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 18070,
+    "totalChars": 19027,
   },
   "codex-image-dispatcher": {
     "sections": [
@@ -45,10 +43,11 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "project-metadata",
       "media-generation-contract",
       "filesystem-handoff-override",
+      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 48553,
+    "totalChars": 56511,
   },
   "critique-enabled": {
     "sections": [
@@ -66,10 +65,11 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "critique-panel",
       "active-ds-visual-direction-override",
       "filesystem-handoff-override",
+      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 60919,
+    "totalChars": 67056,
   },
   "deck-kind-no-skill": {
     "sections": [
@@ -81,10 +81,11 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "deck-framework",
       "media-dispatch-hint",
       "filesystem-handoff-override",
+      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 87419,
+    "totalChars": 95822,
   },
   "deck-kind-with-skill-seed": {
     "sections": [
@@ -96,10 +97,11 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "project-metadata",
       "media-dispatch-hint",
       "filesystem-handoff-override",
+      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 60120,
+    "totalChars": 66584,
   },
   "design-ds-fixture-fallback": {
     "sections": [
@@ -117,10 +119,11 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "media-dispatch-hint",
       "active-ds-visual-direction-override",
       "filesystem-handoff-override",
+      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 83501,
+    "totalChars": 91577,
   },
   "design-full-stack": {
     "sections": [
@@ -130,9 +133,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "shared-device-frames",
       "identity-charter",
       "personal-memory",
-      "memory-intent-gateway",
       "memory-verify-scorecard",
-      "memory-rule-proposal",
       "custom-instructions-user",
       "custom-instructions-project",
       "design-system-usage",
@@ -147,10 +148,11 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "media-dispatch-hint",
       "active-ds-visual-direction-override",
       "filesystem-handoff-override",
+      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 70255,
+    "totalChars": 74209,
   },
   "design-minimal": {
     "sections": [
@@ -162,10 +164,11 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "maybe-deck-framework",
       "media-dispatch-hint",
       "filesystem-handoff-override",
+      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 87375,
+    "totalChars": 95778,
   },
   "design-no-ds-multitarget": {
     "sections": [
@@ -177,10 +180,11 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "project-metadata",
       "media-dispatch-hint",
       "filesystem-handoff-override",
+      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 65686,
+    "totalChars": 72150,
   },
   "example-prompt": {
     "sections": [
@@ -192,10 +196,11 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "project-metadata",
       "media-dispatch-hint",
       "filesystem-handoff-override",
+      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 63933,
+    "totalChars": 70397,
   },
   "freeform-other": {
     "sections": [
@@ -208,10 +213,11 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "maybe-deck-framework",
       "media-dispatch-hint",
       "filesystem-handoff-override",
+      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 91071,
+    "totalChars": 99474,
   },
   "freeform-other-no-deck-signal": {
     "sections": [
@@ -222,10 +228,11 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "project-metadata",
       "media-dispatch-hint",
       "filesystem-handoff-override",
+      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 62856,
+    "totalChars": 69320,
   },
   "media-image": {
     "sections": [
@@ -234,10 +241,11 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "project-metadata",
       "media-generation-contract",
       "filesystem-handoff-override",
+      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 48551,
+    "totalChars": 56509,
   },
   "memory-hooks-off": {
     "sections": [
@@ -246,15 +254,15 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "direction-library",
       "identity-charter",
       "personal-memory",
-      "memory-rule-proposal",
       "deck-framework",
       "maybe-deck-framework",
       "media-dispatch-hint",
       "filesystem-handoff-override",
+      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 89603,
+    "totalChars": 97283,
   },
   "plan-mode": {
     "sections": [
@@ -266,10 +274,11 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "project-metadata",
       "media-dispatch-hint",
       "filesystem-handoff-override",
+      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 66880,
+    "totalChars": 73344,
   },
   "plugin-stages": {
     "sections": [
@@ -283,10 +292,11 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "maybe-deck-framework",
       "media-dispatch-hint",
       "filesystem-handoff-override",
+      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 87471,
+    "totalChars": 95874,
   },
   "skip-discovery-brief": {
     "sections": [
@@ -298,10 +308,11 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "project-metadata",
       "media-dispatch-hint",
       "filesystem-handoff-override",
+      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 63444,
+    "totalChars": 69908,
   },
   "slim-design-full-stack": {
     "sections": [
@@ -311,9 +322,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "slim-core-charter",
       "slim-platform-contracts",
       "personal-memory",
-      "memory-intent-gateway",
       "memory-verify-scorecard",
-      "memory-rule-proposal",
       "custom-instructions-user",
       "custom-instructions-project",
       "design-system-usage",
@@ -326,9 +335,10 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "active-skill",
       "project-metadata",
       "media-dispatch-hint",
+      "skill-write-boundary",
       "role-marker-guard",
     ],
-    "totalChars": 47995,
+    "totalChars": 50245,
   },
   "slim-freeform-no-deck-signal": {
     "sections": [
@@ -336,9 +346,10 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "slim-core-charter",
       "project-metadata",
       "media-dispatch-hint",
+      "skill-write-boundary",
       "role-marker-guard",
     ],
-    "totalChars": 38719,
+    "totalChars": 42300,
   },
 }
 `;

--- a/apps/daemon/tests/prompts/__snapshots__/system-prompt-matrix.test.ts.snap
+++ b/apps/daemon/tests/prompts/__snapshots__/system-prompt-matrix.test.ts.snap
@@ -14,14 +14,16 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 67528,
+    "totalChars": 62531,
   },
   "ask-mode-full-context": {
     "sections": [
       "injection-resistance",
       "ask-mode-override",
       "personal-memory",
+      "memory-intent-gateway",
       "memory-verify-scorecard",
+      "memory-rule-proposal",
       "design-system-usage",
       "design-system-body",
       "design-system-import-mode",
@@ -34,7 +36,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 19027,
+    "totalChars": 18070,
   },
   "codex-image-dispatcher": {
     "sections": [
@@ -43,11 +45,10 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "project-metadata",
       "media-generation-contract",
       "filesystem-handoff-override",
-      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 54086,
+    "totalChars": 48553,
   },
   "critique-enabled": {
     "sections": [
@@ -65,11 +66,10 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "critique-panel",
       "active-ds-visual-direction-override",
       "filesystem-handoff-override",
-      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 67056,
+    "totalChars": 60919,
   },
   "deck-kind-no-skill": {
     "sections": [
@@ -81,11 +81,10 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "deck-framework",
       "media-dispatch-hint",
       "filesystem-handoff-override",
-      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 95822,
+    "totalChars": 87419,
   },
   "deck-kind-with-skill-seed": {
     "sections": [
@@ -97,11 +96,10 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "project-metadata",
       "media-dispatch-hint",
       "filesystem-handoff-override",
-      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 66584,
+    "totalChars": 60120,
   },
   "design-ds-fixture-fallback": {
     "sections": [
@@ -119,11 +117,10 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "media-dispatch-hint",
       "active-ds-visual-direction-override",
       "filesystem-handoff-override",
-      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 91577,
+    "totalChars": 83501,
   },
   "design-full-stack": {
     "sections": [
@@ -133,7 +130,9 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "shared-device-frames",
       "identity-charter",
       "personal-memory",
+      "memory-intent-gateway",
       "memory-verify-scorecard",
+      "memory-rule-proposal",
       "custom-instructions-user",
       "custom-instructions-project",
       "design-system-usage",
@@ -148,11 +147,10 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "media-dispatch-hint",
       "active-ds-visual-direction-override",
       "filesystem-handoff-override",
-      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 74209,
+    "totalChars": 70255,
   },
   "design-minimal": {
     "sections": [
@@ -164,11 +162,10 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "maybe-deck-framework",
       "media-dispatch-hint",
       "filesystem-handoff-override",
-      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 95778,
+    "totalChars": 87375,
   },
   "design-no-ds-multitarget": {
     "sections": [
@@ -180,11 +177,10 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "project-metadata",
       "media-dispatch-hint",
       "filesystem-handoff-override",
-      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 72150,
+    "totalChars": 65686,
   },
   "example-prompt": {
     "sections": [
@@ -196,11 +192,10 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "project-metadata",
       "media-dispatch-hint",
       "filesystem-handoff-override",
-      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 70397,
+    "totalChars": 63933,
   },
   "freeform-other": {
     "sections": [
@@ -213,11 +208,10 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "maybe-deck-framework",
       "media-dispatch-hint",
       "filesystem-handoff-override",
-      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 99474,
+    "totalChars": 91071,
   },
   "freeform-other-no-deck-signal": {
     "sections": [
@@ -228,11 +222,10 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "project-metadata",
       "media-dispatch-hint",
       "filesystem-handoff-override",
-      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 69320,
+    "totalChars": 62856,
   },
   "media-image": {
     "sections": [
@@ -241,11 +234,10 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "project-metadata",
       "media-generation-contract",
       "filesystem-handoff-override",
-      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 54084,
+    "totalChars": 48551,
   },
   "memory-hooks-off": {
     "sections": [
@@ -254,15 +246,15 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "direction-library",
       "identity-charter",
       "personal-memory",
+      "memory-rule-proposal",
       "deck-framework",
       "maybe-deck-framework",
       "media-dispatch-hint",
       "filesystem-handoff-override",
-      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 97283,
+    "totalChars": 89603,
   },
   "plan-mode": {
     "sections": [
@@ -274,11 +266,10 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "project-metadata",
       "media-dispatch-hint",
       "filesystem-handoff-override",
-      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 73344,
+    "totalChars": 66880,
   },
   "plugin-stages": {
     "sections": [
@@ -292,11 +283,10 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "maybe-deck-framework",
       "media-dispatch-hint",
       "filesystem-handoff-override",
-      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 95874,
+    "totalChars": 87471,
   },
   "skip-discovery-brief": {
     "sections": [
@@ -308,11 +298,10 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "project-metadata",
       "media-dispatch-hint",
       "filesystem-handoff-override",
-      "skill-write-boundary",
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 69908,
+    "totalChars": 63444,
   },
   "slim-design-full-stack": {
     "sections": [
@@ -322,7 +311,9 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "slim-core-charter",
       "slim-platform-contracts",
       "personal-memory",
+      "memory-intent-gateway",
       "memory-verify-scorecard",
+      "memory-rule-proposal",
       "custom-instructions-user",
       "custom-instructions-project",
       "design-system-usage",
@@ -335,10 +326,9 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "active-skill",
       "project-metadata",
       "media-dispatch-hint",
-      "skill-write-boundary",
       "role-marker-guard",
     ],
-    "totalChars": 50245,
+    "totalChars": 47995,
   },
   "slim-freeform-no-deck-signal": {
     "sections": [
@@ -346,10 +336,9 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "slim-core-charter",
       "project-metadata",
       "media-dispatch-hint",
-      "skill-write-boundary",
       "role-marker-guard",
     ],
-    "totalChars": 42300,
+    "totalChars": 38719,
   },
 }
 `;

--- a/apps/daemon/tests/prompts/host-failure-narration.test.ts
+++ b/apps/daemon/tests/prompts/host-failure-narration.test.ts
@@ -209,6 +209,16 @@ const REGISTRY: readonly Entry[] = [
     why: 'The canonical phrasing this whole class is measured against.',
   },
 
+  {
+    file: 'apps/daemon/src/prompts/media-contract.ts',
+    match: 'narrate failure',
+    chars: [84],
+    verdict: 'suppression-rule',
+    why: 'The empty/ambiguous poll rule forbids reading a missing or non-JSON '
+      + 'wait handoff as a failure: the loop keeps the previous cursor and '
+      + 'retries instead of reporting an outage.',
+  },
+
   // ---- W84's own fix. The other three rewrites no longer trip the detector
   // at all, so they are pinned by name in the instance suite at the bottom
   // rather than carried here as registry entries. ----

--- a/packages/contracts/src/prompts/media-contract.ts
+++ b/packages/contracts/src/prompts/media-contract.ts
@@ -127,6 +127,12 @@ For long-running renders, continue with:
 when the provider task failed. Exit code \`2\` is not an error; keep polling
 with the returned \`nextSince\`.
 
+An empty, whitespace-only, or non-JSON response from \`media wait\` is not a
+failure — it is still running. Re-run \`media wait\` with the same \`--since\`
+value; if the live poll stays ambiguous, recover via
+\`GET /api/projects/:projectId/media/tasks?includeDone=true\` and only treat
+an explicit \`failed\` or \`interrupted\` status as failure.
+
 Do not emit \`<artifact>\` blocks for media. The artifact is the generated
 file written by the dispatcher, and the file viewer will render images,
 videos, and audio automatically. If generation fails, retain the actual

--- a/packages/contracts/src/prompts/media-contract.ts
+++ b/packages/contracts/src/prompts/media-contract.ts
@@ -145,6 +145,12 @@ For long-running renders, continue with:
 when the provider task failed. Exit code \`2\` is not an error; keep polling
 with the returned \`nextSince\`.
 
+An empty, whitespace-only, or non-JSON response from \`media wait\` is not a
+failure — it is still running. Re-run \`media wait\` with the same \`--since\`
+value; if the live poll stays ambiguous, recover via
+\`GET /api/projects/:projectId/media/tasks?includeDone=true\` and only treat
+an explicit \`failed\` or \`interrupted\` status as failure.
+
 Do not emit \`<artifact>\` blocks for media. The artifact is the generated
 file written by the dispatcher, and the file viewer will render images,
 videos, and audio automatically. If generation fails, retain the actual

--- a/packages/contracts/src/prompts/media-contract.ts
+++ b/packages/contracts/src/prompts/media-contract.ts
@@ -145,11 +145,13 @@ For long-running renders, continue with:
 when the provider task failed. Exit code \`2\` is not an error; keep polling
 with the returned \`nextSince\`.
 
-An empty, whitespace-only, or non-JSON response from \`media wait\` is not a
-failure — it is still running. Re-run \`media wait\` with the same \`--since\`
-value; if the live poll stays ambiguous, recover via
-\`GET /api/projects/:projectId/media/tasks?includeDone=true\` and only treat
-an explicit \`failed\` or \`interrupted\` status as failure.
+An empty stdout, whitespace-only, or non-JSON handoff from \`media wait\` is
+\`unknown\` — neither a failure nor a \`done\` result. Re-run \`media wait\` with
+the same \`--since\` value so the cursor is preserved; if the live poll stays
+ambiguous, recover via
+\`GET /api/projects/:projectId/media/tasks?includeDone=true\`. Report
+\`failed\`/\`interrupted\` only when \`status\` is explicitly that, and treat
+\`done\` with a file as success even when earlier polls were empty.
 
 Do not emit \`<artifact>\` blocks for media. The artifact is the generated
 file written by the dispatcher, and the file viewer will render images,


### PR DESCRIPTION
Fixes #6257

## Why

On Windows, a Fal.ai video task can reach `done` with a playable MP4 while Open Design narrates failure. When the `od media wait` live poll returns an empty, whitespace-only, or non-JSON result, the CLI treated it as a client error and exited 4, and the bundled media instruction passed that on as a terminal failure instead of retrying. #6257 is the motivating Windows named-pipe case.

## What users will see

Empty, whitespace-only, non-JSON, and status-less poll results from `od media wait` are no longer reported as failures — the CLI treats them as still running and retries, and only an explicit `failed` / `interrupted` status is surfaced. The media contract now documents the same rule and the `GET /api/projects/:id/media/tasks?includeDone=true` recovery lookup for a lost poll.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — CLI/contract change.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/media-wait-empty-tolerance.test.ts`
- Did the test go red on `main` and green on this branch? Yes — an empty or non-JSON `/wait` response exits 4 on `main` and is retried instead on this branch; an explicit `failed` status still exits 5.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run` on the media-wait suites (`media-wait-empty-tolerance`, `media-wait-safety-output`, `media-wait-stdout-flush`) and the `system-prompt-matrix` golden snapshot suite: all passed
- `pnpm --filter @open-design/daemon run build` (tsc) clean

@lefarcen @Siri-Ray
