### PR TITLE
fix(daemon): count manifest-backed artifacts in run snapshots

### DIFF
--- a/apps/daemon/src/run-artifact-fs.ts
+++ b/apps/daemon/src/run-artifact-fs.ts
@@ -21,6 +21,7 @@ import {
   isDesignSystemFile,
   isPreviewModulePath,
 } from './runtimes/run-artifacts.js';
+import { parsePersistedManifest } from './artifacts/manifest.js';
 
 // A file worth fingerprinting for run-finish bookkeeping: a user-facing
 // artifact (HTML / image / video / audio) OR a design-system marker
@@ -28,6 +29,39 @@ import {
 // artifact-extension check; they are classified at diff time.
 function isTrackedRunFile(name: string): boolean {
   return isArtifactPath(name) || isDesignSystemFile(name) || isRenderDependencyPath(name);
+}
+
+// Manifest-backed artifacts: `create_artifact` persists a manifest sidecar
+// next to the artifact file as `<file>.artifact.json`, and the manifest layer
+// (`artifacts/manifest.ts`) accepts entry kinds the extension whitelist above
+// does not — most importantly Markdown exports (`markdown-document`). A file
+// with a valid sidecar therefore counts as a tracked run artifact even though
+// its extension is not renderable, while the sidecar itself is metadata and
+// never tracked. See #7579: a manifest-backed `.md` export was invisible to
+// the snapshot/diff, so finalization reported `artifactCount: 0` →
+// `no_artifact`.
+const MANIFEST_SIDECAR_SUFFIX = '.artifact.json';
+
+function isManifestSidecarPath(name: string): boolean {
+  return name.toLowerCase().endsWith(MANIFEST_SIDECAR_SUFFIX);
+}
+
+function manifestSidecarFor(fullPath: string): string {
+  return fullPath + MANIFEST_SIDECAR_SUFFIX;
+}
+
+// Valid = parses through the same manifest layer `create_artifact` writes with
+// (`parsePersistedManifest`), so a stray or malformed sidecar never widens
+// tracking to arbitrary unmanifested files.
+function hasValidManifestSidecar(fullPath: string): boolean {
+  if (isManifestSidecarPath(fullPath)) return false;
+  let raw: string;
+  try {
+    raw = fs.readFileSync(manifestSidecarFor(fullPath), 'utf8');
+  } catch {
+    return false;
+  }
+  return parsePersistedManifest(raw, path.basename(fullPath)) !== null;
 }
 
 const RENDER_DEPENDENCY_EXTENSIONS = new Set([
@@ -64,6 +98,11 @@ export interface ArtifactFingerprint {
   // pathological "same byte length AND preserved mtime" rewrite that size+mtime
   // alone would miss. Large media skip hashing to bound run-finish cost.
   hash: string | null;
+  // True when the file is tracked because of a valid `.artifact.json` sidecar
+  // rather than its extension. `diffRunArtifacts` counts these as artifacts
+  // even though `isArtifactPath` rejects the extension (e.g. Markdown
+  // exports). Extension-classified files never set this.
+  manifestBacked?: boolean;
 }
 
 // Files larger than this are not content-hashed (cost bound). Artifacts that
@@ -160,19 +199,21 @@ export function snapshotProjectArtifacts(rootDir: string): ArtifactSnapshot {
       if (entry.isDirectory()) {
         if (IGNORED_DIR_NAMES.has(entry.name) || entry.name.startsWith('.')) continue;
         walk(path.join(dir, entry.name));
-      } else if (entry.isFile()) {
-        const tracked = isTrackedRunFile(entry.name);
-        if (tracked ? trackedCount >= MAX_FILES : otherCount >= MAX_OTHER_FILES) continue;
+      } else if (entry.isFile() && !isManifestSidecarPath(entry.name)) {
         const full = path.join(dir, entry.name);
+        const tracked = isTrackedRunFile(entry.name);
+        const manifestBacked = !tracked && hasValidManifestSidecar(full);
+        if (tracked ? trackedCount >= MAX_FILES : otherCount >= MAX_OTHER_FILES) continue;
         try {
           const stat = fs.statSync(full);
+          const fingerprint = tracked || manifestBacked
+            ? fingerprintFile(full, stat.size, stat.mtimeMs)
+            : statOnlyFingerprint(stat.size, stat.mtimeMs);
           snapshot.set(
             full,
-            tracked
-              ? fingerprintFile(full, stat.size, stat.mtimeMs)
-              : statOnlyFingerprint(stat.size, stat.mtimeMs),
+            manifestBacked ? { ...fingerprint, manifestBacked } : fingerprint,
           );
-          if (tracked) trackedCount += 1;
+          if (tracked || manifestBacked) trackedCount += 1;
           else otherCount += 1;
         } catch {
           // Race (file removed mid-walk) or permission error — skip.
@@ -191,7 +232,7 @@ export function snapshotProjectArtifacts(rootDir: string): ArtifactSnapshot {
 // and SSE traffic while a large project is scanned.
 export async function snapshotProjectArtifactsAsync(rootDir: string): Promise<ArtifactSnapshot> {
   const snapshot: ArtifactSnapshot = new Map();
-  const files: Array<{ full: string; tracked: boolean }> = [];
+  const files: Array<{ full: string; tracked: boolean; manifestBacked: boolean }> = [];
   let trackedCount = 0;
   let otherCount = 0;
   const walk = async (dir: string): Promise<void> => {
@@ -207,11 +248,13 @@ export async function snapshotProjectArtifactsAsync(rootDir: string): Promise<Ar
       if (entry.isDirectory()) {
         if (IGNORED_DIR_NAMES.has(entry.name) || entry.name.startsWith('.')) continue;
         await walk(path.join(dir, entry.name));
-      } else if (entry.isFile()) {
+      } else if (entry.isFile() && !isManifestSidecarPath(entry.name)) {
+        const full = path.join(dir, entry.name);
         const tracked = isTrackedRunFile(entry.name);
+        const manifestBacked = !tracked && hasValidManifestSidecar(full);
         if (tracked ? trackedCount >= MAX_FILES : otherCount >= MAX_OTHER_FILES) continue;
-        files.push({ full: path.join(dir, entry.name), tracked });
-        if (tracked) trackedCount += 1;
+        files.push({ full, tracked: tracked || manifestBacked, manifestBacked });
+        if (tracked || manifestBacked) trackedCount += 1;
         else otherCount += 1;
       }
     }
@@ -230,14 +273,15 @@ export async function snapshotProjectArtifactsAsync(rootDir: string): Promise<Ar
       const index = nextIndex;
       if (index >= files.length) return;
       nextIndex += 1;
-      const { full, tracked } = files[index]!;
+      const { full, tracked, manifestBacked } = files[index]!;
       try {
         const stat = await fs.promises.stat(full);
+        const fingerprint = tracked
+          ? await fingerprintFileAsync(full, stat.size, stat.mtimeMs)
+          : statOnlyFingerprint(stat.size, stat.mtimeMs);
         fingerprints[index] = [
           full,
-          tracked
-            ? await fingerprintFileAsync(full, stat.size, stat.mtimeMs)
-            : statOnlyFingerprint(stat.size, stat.mtimeMs),
+          manifestBacked ? { ...fingerprint, manifestBacked: true } : fingerprint,
         ];
       } catch {
         fingerprints[index] = null;
@@ -341,7 +385,9 @@ export function diffRunArtifacts(
     // only. Normalize separators so the design-system / preview signals work on
     // Windows project runs, not just POSIX.
     const classifyPath = filePath.replace(/\\/g, '/');
-    if (isArtifactPath(classifyPath)) {
+    // Manifest-backed files count as artifacts despite a non-renderable
+    // extension; the manifest sidecar was validated at snapshot time.
+    if (isArtifactPath(classifyPath) || fingerprint.manifestBacked === true) {
       if (isNew) created += 1;
       else modified += 1;
       touchedPaths.push(filePath);

--- a/apps/daemon/tests/run-artifact-fs.test.ts
+++ b/apps/daemon/tests/run-artifact-fs.test.ts
@@ -317,3 +317,103 @@ test('a no-op turn (no file writes) reports zero', () => {
     filesWritten: 0,
   });
 });
+
+// #7579: `create_artifact` writes a `<file>.artifact.json` manifest sidecar,
+// and the manifest layer accepts non-renderable kinds such as Markdown
+// exports. The snapshot/diff must count such files as artifacts instead of
+// reporting artifactCount: 0 → no_artifact at finalization.
+const validMdManifest = (entry: string): string =>
+  JSON.stringify({
+    version: 1,
+    kind: 'markdown-document',
+    renderer: 'markdown',
+    entry,
+    exports: ['md'],
+    title: entry,
+  });
+
+test('a manifest-backed Markdown export counts as a run artifact', async () => {
+  const root = tmpProject();
+  const doc = path.join(root, 'fitcv-design-system-export.md');
+
+  const before = snapshotProjectArtifacts(root);
+  fs.writeFileSync(doc, '# export');
+  fs.writeFileSync(
+    `${doc}.artifact.json`,
+    validMdManifest('fitcv-design-system-export.md'),
+  );
+  const after = snapshotProjectArtifacts(root);
+  const afterAsync = await snapshotProjectArtifactsAsync(root);
+
+  assert.deepEqual(after, afterAsync, 'async snapshot must agree with the sync one');
+  assert.equal(
+    after.get(doc)?.manifestBacked,
+    true,
+    'the .md is tracked as manifest-backed',
+  );
+  assert.equal(
+    after.get(`${doc}.artifact.json`),
+    undefined,
+    'the sidecar itself is metadata, not a tracked artifact',
+  );
+  assert.deepEqual(diffRunArtifacts(before, after), {
+    created: 1,
+    modified: 0,
+    touched: 1,
+    filesWritten: 1,
+    designSystemCreated: false,
+    previewModuleCount: 0,
+    touchedPaths: [doc],
+    contentCreated: 1,
+    contentModified: 0,
+    contentTouched: 1,
+    contentTouchedPaths: [doc],
+    renderDependencyTouched: 0,
+    renderDependencyTouchedPaths: [],
+    supportingMediaTouched: 0,
+  });
+});
+
+test('a Markdown file without a valid manifest sidecar stays untracked', () => {
+  const root = tmpProject();
+  fs.writeFileSync(path.join(root, 'notes.md'), 'no sidecar here');
+  fs.writeFileSync(path.join(root, 'broken.md'), 'sidecar is not JSON');
+  fs.writeFileSync(`${path.join(root, 'broken.md')}.artifact.json`, '{not json');
+  fs.writeFileSync(path.join(root, 'stale.md'), 'sidecar has an unknown version');
+  fs.writeFileSync(
+    `${path.join(root, 'stale.md')}.artifact.json`,
+    JSON.stringify({ ...JSON.parse(validMdManifest('stale.md')), version: 99 }),
+  );
+
+  const snapshot = snapshotProjectArtifacts(root);
+  for (const fingerprint of snapshot.values()) {
+    assert.equal(
+      fingerprint.manifestBacked,
+      undefined,
+      'unmanifested or invalidly manifested .md must not be manifest-backed',
+    );
+  }
+
+  const diff = diffRunArtifacts(new Map(), snapshot);
+  assert.equal(diff.touched, 0);
+});
+
+test('an edit to a manifest-backed Markdown export counts as modified', async () => {
+  const root = tmpProject();
+  const doc = path.join(root, 'report.md');
+  fs.writeFileSync(doc, '# report v1');
+  fs.writeFileSync(`${doc}.artifact.json`, validMdManifest('report.md'));
+  const before = snapshotProjectArtifacts(root);
+
+  fs.writeFileSync(doc, '# report v2 — substantially revised');
+  const after = await snapshotProjectArtifactsAsync(root);
+
+  const diff = diffRunArtifacts(before, after);
+  assert.equal(diff.created, 0);
+  assert.equal(
+    diff.modified,
+    1,
+    'edit-only turns must still report >0 for manifest-backed files',
+  );
+  assert.equal(diff.touched, 1);
+});


### PR DESCRIPTION
Fixes #7579

## What

Run-finish snapshot/diff now also tracks files carrying a valid
`<file>.artifact.json` manifest sidecar, in addition to the renderable
extension whitelist. The sidecar itself stays metadata and is never counted.

The async snapshot path checks sidecars with asynchronous filesystem reads, and
the final manifest-backed classification is applied before either snapshot
budget is enforced.

## Why

`create_artifact` persists manifest-backed outputs of kinds the extension
whitelist does not cover, most importantly Markdown exports
(`markdown-document`). The snapshot in `run-artifact-fs.ts` filtered by
extension only, so a valid manifest-backed `.md` was invisible to the diff and
finalization reported `artifactCount: 0` -> `no_artifact` even though the file
and its manifest were in project storage.

## What users will see

Manifest-backed Markdown and other non-renderable exports now count as written
artifacts during run finalization, so a run that creates one is not incorrectly
reported as producing no artifact. Ordinary files and malformed sidecars keep
their existing behavior.

## Surface area

- [x] Daemon run-finalization bookkeeping
- [ ] Web UI
- [ ] CLI/API contract
- [ ] Persistent data format

## Bug-fix verification

Before this change, a valid manifest-backed `.md` file was omitted from the
snapshot and the finalization path could report `artifactCount: 0`. The
regression tests now cover the red-to-green seam, including created and edited
Markdown exports, malformed sidecars, both snapshot implementations, and the
two file-budget boundaries.

## Testing

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/run-artifact-fs.test.ts` (19/19 pass)
- `pnpm --filter @open-design/daemon exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @open-design/daemon exec tsc -p tsconfig.tests.json --noEmit`
