### PR TITLE
test(e2e): cover grid card menu overflow near the viewport bottom (#6916)

### DIFF
--- a/e2e/ui/home-hero-rail.test.ts
+++ b/e2e/ui/home-hero-rail.test.ts
@@ -723,6 +723,60 @@ test('[P1] last project list row keeps its overflow menu inside the viewport', a
   expect((menuBox?.y ?? 0) + (menuBox?.height ?? 0)).toBeLessThan(triggerBox?.y ?? 0);
 });
 
+test('[P1] bottom-row project card keeps its overflow menu inside the viewport', async ({ page }) => {
+  // Grid is the default view (RecentProjectsStrip.tsx `useState<'grid' | 'list'>('grid')`),
+  // and the card menu shares one render site with the list rows, so a regression in the
+  // placement effect surfaces here first. The list-row case above covers the other layout.
+  const recentProjects = Array.from({ length: 6 }, (_, index) => ({
+    id: `recent-card-menu-${index + 1}`,
+    name: `Card Project ${index + 1}`,
+    skillId: null,
+    designSystemId: null,
+    createdAt: Date.now() - (index + 1) * 10_000,
+    updatedAt: Date.now() - (index + 1) * 5_000,
+    metadata: { kind: 'prototype', nameSource: 'user' },
+  }));
+  const lastProject = recentProjects.at(-1)!;
+
+  await page.setViewportSize({ width: 1280, height: 500 });
+  await page.route('**/api/projects', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({ json: { projects: recentProjects } });
+      return;
+    }
+    await route.continue();
+  });
+  await gotoEntryHome(page);
+
+  const lastCard = page.locator(`[data-project-id="${lastProject.id}"]`);
+  await expect(lastCard).toBeVisible();
+  await page.evaluate((projectId) => {
+    const scroller = document.querySelector<HTMLElement>('.entry-main--scroll');
+    const card = document.querySelector<HTMLElement>(`[data-project-id="${projectId}"]`);
+    const trigger = card?.querySelector<HTMLElement>('.recent-projects__card-more');
+    if (!scroller || !card || !trigger) {
+      throw new Error('Recent project card-menu fixture is missing');
+    }
+
+    const desiredTop = scroller.getBoundingClientRect().bottom - 60;
+    scroller.scrollTop += trigger.getBoundingClientRect().top - desiredTop;
+  }, lastProject.id);
+
+  await lastCard.hover();
+  const trigger = lastCard.getByRole('button', { name: /more actions/i });
+  await trigger.click();
+
+  const menu = lastCard.getByRole('menu');
+  await expect(menu).toBeVisible();
+  await expect(menu.getByRole('menuitem', { name: 'Delete' })).toBeInViewport();
+
+  const triggerBox = await trigger.boundingBox();
+  const menuBox = await menu.boundingBox();
+  expect(triggerBox).not.toBeNull();
+  expect(menuBox).not.toBeNull();
+  expect((menuBox?.y ?? 0) + (menuBox?.height ?? 0)).toBeLessThan(triggerBox?.y ?? 0);
+});
+
 test('[P1] home left rail expands and collapses from the shell controls', async ({ page }) => {
   await gotoEntryHome(page);
 


### PR DESCRIPTION
Adds the grid/card regression case for #6916. Test-only — no runtime change.

<!-- No Fixes/Closes link on purpose: #6971 shipped the production fix for #6916.
     This PR only adds the missing regression witness, so it should not auto-close
     the issue on merge. -->

## Why

**#6916's actual scenario — the grid view — has no regression test.** The fix that shipped covers it, but only the list view is guarded, so the bug could silently come back in the layout it was reported against.

In detail: #6971 shipped the production fix and it is view-agnostic: `RecentProjectsStrip` has a single `.recent-projects__card-menu` render site (`apps/web/src/components/RecentProjectsStrip.tsx:1928`) shared by both layouts, and the `useLayoutEffect` at `:642`, keyed on `menuOpenId`, drives placement for whichever view is showing.

Its regression coverage, however, is list-view only. On current `main`, `e2e/ui/home-hero-rail.test.ts:674` has `[P1] last project list row keeps its overflow menu inside the viewport`, and that is the only `toBeInViewport` assertion in the file (`:717`). Grid is the default view (`RecentProjectsStrip.tsx:420`, `useState<'grid' | 'list'>('grid')`) and is the layout #6916 reports, so the reported scenario itself had no witness.

When #6917 was closed in favour of #6971, the note there was that its grid/card scenario was complementary and should be retained in the final coverage. This restores that half.

## What users will see

**Nothing.** This adds one Playwright case and touches no runtime code, so there is no user-visible change in either the web app or the desktop build.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal refactor, docs, tests, or translation update only

## What the test does

Mirrors the existing list-row case so the two read as a pair: mocks `/api/projects` with six projects, scrolls the last card's trigger to within 60px of the `.entry-main--scroll` bottom, opens the menu, then asserts `Delete` is in the viewport and that the menu's bottom edge sits above the trigger's top edge. The only structural difference is that it does not switch to List view.

## Verification

Ran red/green against the placement rule rather than assuming it:

- With `.recent-projects__card-menu[data-placement='up']` (`apps/web/src/styles/home/recent-projects.css:507-510`) removed: **2 failed** — the new case fails on the menu-above-trigger assertion, and the existing list-row case fails with it, confirming both exercise the same protection.
- With the rule restored: **2 passed** (36.6s, then 27.9s on a re-run).

`cd e2e && pnpm exec playwright test -c playwright.config.ts ui/home-hero-rail.test.ts --workers=1 -g "overflow menu inside the viewport"`

## Bug fix verification

Not a bug fix — the fix for #6916 shipped in #6971. This PR supplies the regression witness that fix was missing, and the red/green above is against the shipped CSS rule rather than against `main`: removing `[data-placement='up']` turns the new case red, restoring it turns it green.

## A note on my earlier comment in #6916

I previously said on the issue that a PR already covered this and asked people not to duplicate it. That reference was wrong — the PR number I cited does not exist, and I have corrected the record on the issue. This is me writing the test I mistakenly told others was already written.
