### PR TITLE
test(e2e): wait for onboarding app load

### DIFF
--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -138,8 +138,7 @@ test('[P0] Cloud status loading does not block signed-out Local CLI or BYOK setu
   });
 
   await seedOnboardingConfig(page, config);
-  await page.goto('/onboarding', { waitUntil: 'domcontentloaded' });
-  await expect(connectLandingHeading(page)).toBeVisible();
+  await gotoOnboarding(page);
 
   await expect(cloudPrimaryButton(page)).toBeDisabled();
   await expect(page.getByRole('button', { name: /Local (coding )?agent/i })).toBeEnabled();
@@ -163,8 +162,7 @@ test('[P0] delayed active Cloud login stays out of Local setup and resumes after
   });
 
   await seedOnboardingConfig(page, config);
-  await page.goto('/onboarding', { waitUntil: 'domcontentloaded' });
-  await expect(connectLandingHeading(page)).toBeVisible();
+  await gotoOnboarding(page);
 
   await page.getByRole('button', { name: /Local (coding )?agent/i }).click();
   const localPanel = page.locator('.onboarding-view__setup-panel');


### PR DESCRIPTION
## Why

While diagnosing the unrelated `UI P0 (entry-settings)` failure that blocked #7541, I found the same onboarding cluster failing repeatedly on unrelated PR #7594. The two affected P0 cases navigate with `waitUntil: 'domcontentloaded'` and immediately assert the rendered onboarding heading, unlike the rest of this file, which waits for the dynamic app loading shell to clear.

The retained Playwright artifacts show only `Loading OpenDesign…` in the DOM at the assertion timeout. In the retry trace, the dynamic chunk containing `EntryView` is still pending. That means these tests can spend their entire 10-second assertion window waiting for the app bundle on a slow hosted runner; the delayed Cloud-status mocks are not the cause.

This change routes both affected cases through the existing `gotoOnboarding` helper. That helper waits for the loading shell to clear, dismisses the privacy dialog, and confirms the same landing heading before each scenario continues. No product code or timeout is changed.

## What users will see

Nothing. This is a test-only stability fix; product behavior is unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: there is no UI behavior change. The failure artifacts referenced below capture the loading shell that remained visible when the original assertions timed out.

## Bug fix verification

- Test path: `e2e/ui/amr-onboarding.test.ts`
- Existing red specs:
  - `[P0] Cloud status loading does not block signed-out Local CLI or BYOK setup`
  - `[P0] delayed active Cloud login stays out of Local setup and resumes after Back`
- Hosted red evidence:
  - #7541: https://github.com/nexu-io/open-design/actions/runs/33204147032/job/98961186101
  - #7594, both cases: https://github.com/nexu-io/open-design/actions/runs/33257483371/job/99113787780
  - #7594, repeated delayed-login failure: https://github.com/nexu-io/open-design/actions/runs/33258753741/job/99119863460
- Did the test go red on `main` and green on this branch? The main-derived hosted failures above provide the red evidence. A local green run could not reach the test body because this machine's isolated tools-dev web runtime exceeded the independent 120-second Playwright warmup budget before and after the patch. The hosted `UI P0 (entry-settings)` job on this PR is therefore the relevant green verification.
- The patch covers every direct `/onboarding` navigation in this file that omitted the existing loading-shell wait; no adjacent product defect was found in this failure cluster.

## Validation

- `pnpm --filter @open-design/e2e typecheck` — passed
- `pnpm guard` — passed
- `pnpm typecheck` — passed (landing-page emitted existing hints; 0 errors)
- `git diff --check` — passed
- Targeted Playwright command — attempted against both affected cases before and after the patch; blocked during worker fixture setup by `Playwright web warmup timed out after 120000ms`, before either test body ran. This is not counted as a test pass.

A human maintainer with Actions write access: please independently inspect the hosted `UI P0 (entry-settings)` result and retained trace for this PR, then reply with the verified outcome. Automated or AI-assisted triage is useful, but this runner-sensitive fix needs explicit human re-verification.
