### PR TITLE
fix(daemon,web): forward pure plugin applies and honor persisted capability grants

### DIFF
--- a/apps/daemon/src/plugins/apply.ts
+++ b/apps/daemon/src/plugins/apply.ts
@@ -34,7 +34,7 @@ import {
   type PluginProjectMetadataPatch,
   type TrustTier,
 } from '@open-design/contracts';
-import { resolveCapabilitiesGranted, requiredCapabilities } from './trust.js';
+import { requiredCapabilities } from './trust.js';
 import {
   deriveAutoOAuthPrompts,
   mergeAutoOAuthPrompts,
@@ -144,7 +144,8 @@ export function applyPlugin(input: ApplyInput): ApplyComputed {
   const { resolved: connectorsResolved, required: connectorsRequired } =
     resolveConnectorBindings(manifest, input.connectorProbe);
   const required = requiredCapabilities(manifest);
-  const granted = resolveCapabilitiesGranted({ manifest, trust });
+  // Persisted grants are authoritative; recomputing defaults here would undo revocations.
+  const granted = Array.from(new Set([...(input.plugin.capabilitiesGranted ?? []), 'prompt:inject']));
   const taskKind = (manifest.od?.taskKind ?? 'new-generation') as AppliedPluginSnapshot['taskKind'];
 
   // Spec §23.3.3: when the plugin omits `od.pipeline`, fall back to

--- a/apps/daemon/src/plugins/trust.ts
+++ b/apps/daemon/src/plugins/trust.ts
@@ -91,6 +91,7 @@ const KNOWN_TOP_LEVEL_CAPABILITIES = new Set<string>([
   'bash',
   'network',
   'connector',
+  'pipeline:*',
   // Plan §3.K3 / spec §10.3.5 — plugin-bundled React component
   // surfaces require an explicit capability so a restricted plugin
   // cannot smuggle arbitrary UI through the GenUI layer.

--- a/apps/daemon/tests/plugins-apply.test.ts
+++ b/apps/daemon/tests/plugins-apply.test.ts
@@ -103,11 +103,28 @@ describe('applyPlugin', () => {
     expect(result.result.appliedPlugin.query).toBe('生成一份关于 {{topic}} 的简报。');
   });
 
-  it('grants trusted defaults plus required caps for a trusted plugin', () => {
-    const result = applyPlugin({ plugin: pluginFixture(), inputs: { topic: 'design' }, registry: REGISTRY });
-    for (const cap of TRUSTED_DEFAULT_CAPABILITIES) {
-      expect(result.result.capabilitiesGranted).toContain(cap);
-    }
+  it('uses persisted capabilitiesGranted for a restricted plugin', () => {
+    const capabilitiesGranted = ['pipeline:*', 'prompt:inject'];
+    const result = applyPlugin({
+      plugin: pluginFixture({ trust: 'restricted', capabilitiesGranted }),
+      inputs: { topic: 'design' },
+      registry: REGISTRY,
+    });
+
+    expect(result.result.capabilitiesGranted).toEqual(capabilitiesGranted);
+    expect(result.result.appliedPlugin.capabilitiesGranted).toEqual(capabilitiesGranted);
+  });
+
+  it('does not resurrect a persisted capability revoked from a trusted plugin', () => {
+    const capabilitiesGranted = TRUSTED_DEFAULT_CAPABILITIES.filter((cap) => cap !== 'pipeline:*');
+    const result = applyPlugin({
+      plugin: pluginFixture({ capabilitiesGranted }),
+      inputs: { topic: 'design' },
+      registry: REGISTRY,
+    });
+
+    expect(result.result.capabilitiesGranted).not.toContain('pipeline:*');
+    expect(result.result.appliedPlugin.capabilitiesGranted).not.toContain('pipeline:*');
   });
 
   it('emits skill+atom items in resolvedContext.items', () => {

--- a/apps/daemon/tests/plugins-dod-e2e.test.ts
+++ b/apps/daemon/tests/plugins-dod-e2e.test.ts
@@ -223,11 +223,12 @@ describe('Plan §8 e2e — daemon-side anchors', () => {
       '---\nname: connector-plugin\ndescription: requires slack\n---\n# Connector\n',
     );
     // Install as restricted (the GitHub-style default for non-local
-    // sources). We simulate that by overriding sourceKind via the
-    // already-installed registry record.
+    // sources). Simulate that tier and its persisted default grants on
+    // the already-installed registry record.
     await installLocal(folder);
-    db.prepare('UPDATE installed_plugins SET trust = ? WHERE id = ?')
-      .run('restricted', 'connector-plugin');
+    db.prepare(
+      'UPDATE installed_plugins SET trust = ?, capabilities_granted = ? WHERE id = ?',
+    ).run('restricted', JSON.stringify(['prompt:inject']), 'connector-plugin');
     const plugin = getInstalledPlugin(db, 'connector-plugin')!;
 
     // Apply via the resolver — restricted + missing capability →

--- a/apps/daemon/tests/plugins-trust.test.ts
+++ b/apps/daemon/tests/plugins-trust.test.ts
@@ -85,6 +85,13 @@ describe('validateCapabilityList', () => {
     ]);
   });
 
+  it('accepts exact pipeline:* for a persisted grant', () => {
+    expect(validateCapabilityList(['pipeline:*'])).toEqual({
+      accepted: ['pipeline:*'],
+      rejected: [],
+    });
+  });
+
   it('rejects unknown shapes without dropping good entries', () => {
     const { accepted, rejected } = validateCapabilityList([
       'fs:read',

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -8267,6 +8267,8 @@ export function ProjectView({
           sessionMode: runSessionMode,
           appliedPluginSnapshotId:
             meta?.appliedPluginSnapshotId ?? meta?.appliedPluginSnapshot?.snapshotId ?? null,
+          pluginId: meta?.appliedPluginSnapshot?.pluginId,
+          pluginInputs: meta?.appliedPluginSnapshot?.inputs,
           research: meta?.research,
           mediaExecution: mediaExecutionPolicyForProjectMetadata(project.metadata),
           model: daemonByokOpenCode ? config.model : choice?.model ?? null,
@@ -8482,6 +8484,8 @@ export function ProjectView({
           sessionMode: runSessionMode,
           appliedPluginSnapshotId:
             meta?.appliedPluginSnapshotId ?? meta?.appliedPluginSnapshot?.snapshotId ?? null,
+          pluginId: meta?.appliedPluginSnapshot?.pluginId,
+          pluginInputs: meta?.appliedPluginSnapshot?.inputs,
           research: meta?.research,
           mediaExecution: mediaExecutionPolicyForProjectMetadata(project.metadata),
           model: config.model,

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -343,6 +343,8 @@ export interface DaemonStreamOptions {
   research?: ResearchOptions;
   context?: RunContextSelection;
   appliedPluginSnapshotId?: string | null;
+  pluginId?: string;
+  pluginInputs?: Record<string, unknown>;
   mediaExecution?: MediaExecutionPolicy;
   titleGeneration?: { enabled?: boolean };
   locale?: string;
@@ -737,6 +739,8 @@ export async function streamViaDaemon({
   research,
   context,
   appliedPluginSnapshotId,
+  pluginId,
+  pluginInputs,
   mediaExecution,
   titleGeneration,
   locale,
@@ -781,7 +785,11 @@ export async function streamViaDaemon({
     ...(byokProvider ? { byokProvider } : {}),
     ...(byokMediaDefaults ? { byokMediaDefaults } : {}),
     locale,
-    ...(appliedPluginSnapshotId ? { appliedPluginSnapshotId } : {}),
+    ...(appliedPluginSnapshotId
+      ? { appliedPluginSnapshotId }
+      : pluginId
+        ? { pluginId, ...(pluginInputs ? { pluginInputs } : {}) }
+        : {}),
     ...(context ? { context } : {}),
     ...(research ? { research } : {}),
     ...(mediaExecution ? { mediaExecution } : {}),

--- a/apps/web/tests/providers/sse.test.ts
+++ b/apps/web/tests/providers/sse.test.ts
@@ -460,6 +460,36 @@ describe('streamViaDaemon', () => {
     expect(body.appliedPluginSnapshotId).toBe('snap-plugin-1');
   });
 
+  it('forwards the plugin identity when the applied snapshot id is empty', async () => {
+    const handlers = createDaemonHandlers();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/runs') return jsonResponse({ runId: 'run-1' });
+      if (url === '/api/runs/run-1/events') {
+        return sseResponse('event: end\ndata: {"code":0,"status":"succeeded"}\n\n');
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await streamViaDaemon({
+      agentId: 'mock',
+      history: [{ id: '1', role: 'user', content: 'use the plugin' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+      appliedPluginSnapshotId: '',
+      pluginId: 'plugin-alpha',
+      pluginInputs: { tone: 'warm' },
+    });
+
+    const [, createRunInit] = fetchMock.mock.calls[0] as unknown as [RequestInfo | URL, RequestInit];
+    const body = JSON.parse(String(createRunInit.body));
+    expect(body.pluginId).toBe('plugin-alpha');
+    expect(body.pluginInputs).toEqual({ tone: 'warm' });
+    expect(body).not.toHaveProperty('appliedPluginSnapshotId');
+  });
+
   it('drops prior assistant turns from another agent when composing daemon transcript', async () => {
     const handlers = createDaemonHandlers();
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -132,6 +132,8 @@ export interface ChatRequest {
   research?: ResearchOptions;
   context?: RunContextSelection;
   appliedPluginSnapshotId?: string | null;
+  pluginId?: string;
+  pluginInputs?: Record<string, unknown>;
   /**
    * Run-scoped media execution policy. Omitted means current OpenDesign
    * behavior: media generation is enabled and OD may execute its configured


### PR DESCRIPTION
Fixes #6186

## Why

Pure plugin applies return `snapshotId: ""` on existing projects and the web send path forwarded only that empty id, so selected plugins were dropped; restricted pipeline plugins also required `pipeline:*` which the trust endpoint rejected, and `applyPlugin` recomputed defaults instead of honoring `capabilitiesGranted`.

## What users will see

In an existing project, attaching a plugin and sending now correctly persists and pins the plugin snapshot even when pure apply has no id; `od plugin trust <id> --capabilities pipeline:*` is accepted and subsequent applies honor the stored grant without resurrecting revoked capabilities.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. No visual change.

## Bug fix verification

- Test path that reproduces the bug:
  - `apps/daemon/tests/plugins-trust.test.ts` — `accepts exact pipeline:* for a persisted grant`
  - `apps/daemon/tests/plugins-apply.test.ts` — `uses persisted capabilitiesGranted for a restricted plugin` and `does not resurrect a persisted capability revoked from a trusted plugin`
- Did the test go red on `main` and green on this branch? yes

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/plugins-trust.test.ts tests/plugins-apply.test.ts tests/plugins-dod-e2e.test.ts`
- `pnpm --filter @open-design/web test tests/providers/sse.test.ts tests/ProjectView.run-isolation.test.tsx`
- `pnpm typecheck` (contracts/web/daemon) and `git diff --check` clean

