### PR TITLE
fix(download): reject non-file OS artifact entries

### DIFF
--- a/packages/download/src/store.ts
+++ b/packages/download/src/store.ts
@@ -30,8 +30,14 @@ const OS_MANAGED_ROOT_ARTIFACTS = new Set([".DS_Store", "Thumbs.db", "desktop.in
  * @internal Whether `name` is a benign, OS-managed root artifact that should
  * never count as real content when deciding whether a directory is claimable.
  */
-function isOsManagedRootArtifact(name: string): boolean {
-  return OS_MANAGED_ROOT_ARTIFACTS.has(name);
+async function isOsManagedRootArtifact(basePath: string, name: string): Promise<boolean> {
+  if (!OS_MANAGED_ROOT_ARTIFACTS.has(name)) return false;
+  try {
+    const entry = await lstat(join(basePath, name));
+    return entry.isFile() && !entry.isSymbolicLink();
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -104,7 +110,8 @@ export async function ensureManagedBase(basePath: string): Promise<void> {
   const sentinel = await readJson<unknown>(sentinelPath);
   if (sentinel == null) {
     const entries = await readdir(basePath);
-    const content = entries.filter((name) => !isOsManagedRootArtifact(name));
+    const managedArtifacts = await Promise.all(entries.map((name) => isOsManagedRootArtifact(basePath, name)));
+    const content = entries.filter((_, index) => !managedArtifacts[index]);
     if (content.length > 0) {
       throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED, `download base is not empty and has no ownership marker: ${basePath}`);
     }

--- a/packages/download/tests/index.test.ts
+++ b/packages/download/tests/index.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -480,5 +480,28 @@ describe("managed download package", () => {
       code: MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED,
     });
     expect(existsSync(join(basePath, ".open-design-download-root.json"))).toBe(false);
+  });
+
+  it("does not ignore an OS-artifact directory in a fresh managed base", async () => {
+    const root = tmpRoot("os-artifact-directory");
+    const basePath = join(root, "downloads");
+    mkdirSync(join(basePath, ".DS_Store"), { recursive: true });
+
+    await expect(pruneManagedDownloads({ basePath })).rejects.toMatchObject({
+      code: MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED,
+    });
+    expect(existsSync(join(basePath, ".open-design-download-root.json"))).toBe(false);
+  });
+
+  it.skipIf(process.platform === "win32")("does not ignore an OS-artifact symlink in a fresh managed base", async () => {
+    const root = tmpRoot("os-artifact-symlink");
+    const basePath = join(root, "downloads");
+    mkdirSync(basePath, { recursive: true });
+    writeFileSync(join(root, "target"), "target");
+    symlinkSync(join(root, "target"), join(basePath, ".DS_Store"));
+
+    await expect(pruneManagedDownloads({ basePath })).rejects.toMatchObject({
+      code: MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED,
+    });
   });
 });


### PR DESCRIPTION
Fixes #7602

## Why

`packages/download` currently ignores entries named `.DS_Store`, `Thumbs.db`, `desktop.ini`, or `.localized` by name alone. A directory or symlink using one of those names can therefore be treated as harmless content when a fresh managed download root is claimed, allowing a non-empty directory to be claimed unexpectedly.

## What users will see

Fresh managed download roots continue to ignore genuine OS-created artifact files, while OS-artifact directories and symlinks are treated as real content and are not silently claimed.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — only for unsafe non-file entries in fresh managed download roots
- [ ] **None**

## Screenshots

Not applicable.

## Bug fix verification

- Test path that reproduces the bug: `packages/download/tests/index.test.ts` exercises fresh roots containing an OS-artifact directory and symlink.
- Did the test go red on `main` and green on this branch? The local test runner could not start because dependency installation was blocked by Windows `EPERM`; the new assertions directly exercise the changed `lstat` path and are expected to fail against the name-only implementation.

## Validation

- `git diff --check` — passed.
- `pnpm --filter @open-design/download test -- --run packages/download/tests/index.test.ts` — not run to completion: the repository requires Node 24 (host has Node 22.23.2), and pnpm dependency installation failed with `ERR_PNPM_EPERM` while importing cached packages on Windows.
- `pnpm --filter @open-design/download typecheck` — not run for the same dependency-installation limitation.
- AI assistance: Codex helped investigate the issue, implement the focused change, and draft this description; the changes and scope were reviewed against the existing code and tests.
