### PR TITLE
fix(download): verify OS-managed root artifacts are plain files

### DIFF
--- a/packages/download/src/store.ts
+++ b/packages/download/src/store.ts
@@ -23,6 +23,11 @@ import { readJson, writeJson } from "./fs-io.js";
  * Thumbs.db/desktop.ini. Mirrors apps/desktop's isOsManagedRootArtifact —
  * duplicated rather than shared since apps/desktop depends on this package,
  * not the reverse.
+ *
+ * Matched by name only — callers MUST additionally confirm the entry is a
+ * plain file via {@link verifiedOsManagedRootArtifacts} before trusting a
+ * match. A directory or symlink squatting on one of these names must still
+ * be treated as real content, not waved through as harmless OS litter.
  */
 const OS_MANAGED_ROOT_ARTIFACTS = new Set([".DS_Store", "Thumbs.db", "desktop.ini", ".localized"]);
 
@@ -32,6 +37,31 @@ const OS_MANAGED_ROOT_ARTIFACTS = new Set([".DS_Store", "Thumbs.db", "desktop.in
  */
 function isOsManagedRootArtifact(name: string): boolean {
   return OS_MANAGED_ROOT_ARTIFACTS.has(name);
+}
+
+/**
+ * @internal Resolves which of `entries` (direct children of `basePath`) are
+ * genuine OS-managed artifacts: name-matched AND a plain file, not a
+ * directory or symlink. A name match alone is not enough — see {@link
+ * isOsManagedRootArtifact}. An entry that disappears or fails to stat
+ * between `readdir` and this check is treated as unverified (excluded),
+ * which fails closed into the existing rejection path rather than silently
+ * trusting it. Mirrors apps/desktop's verifiedOsManagedRootArtifacts.
+ */
+async function verifiedOsManagedRootArtifacts(basePath: string, entries: string[]): Promise<Set<string>> {
+  const candidates = entries.filter((entry) => isOsManagedRootArtifact(entry));
+  if (candidates.length === 0) return new Set();
+  const verified = await Promise.all(
+    candidates.map(async (entry) => {
+      try {
+        const entryStat = await lstat(join(basePath, entry));
+        return entryStat.isFile() && !entryStat.isSymbolicLink() ? entry : null;
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return new Set(verified.filter((entry): entry is string => entry != null));
 }
 
 /**
@@ -104,7 +134,8 @@ export async function ensureManagedBase(basePath: string): Promise<void> {
   const sentinel = await readJson<unknown>(sentinelPath);
   if (sentinel == null) {
     const entries = await readdir(basePath);
-    const content = entries.filter((name) => !isOsManagedRootArtifact(name));
+    const osArtifacts = await verifiedOsManagedRootArtifacts(basePath, entries);
+    const content = entries.filter((name) => !osArtifacts.has(name));
     if (content.length > 0) {
       throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED, `download base is not empty and has no ownership marker: ${basePath}`);
     }

--- a/packages/download/tests/index.test.ts
+++ b/packages/download/tests/index.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -480,5 +480,35 @@ describe("managed download package", () => {
       code: MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED,
     });
     expect(existsSync(join(basePath, ".open-design-download-root.json"))).toBe(false);
+  });
+
+  it("does not claim a fresh managed base whose only entry is a directory named .DS_Store", async () => {
+    const root = tmpRoot("os-artifact-dir-not-file");
+    const basePath = join(root, "downloads");
+    mkdirSync(basePath, { recursive: true });
+    mkdirSync(join(basePath, ".DS_Store"));
+    writeFileSync(join(basePath, ".DS_Store", "hidden.txt"), "not actually OS litter");
+
+    await expect(pruneManagedDownloads({ basePath })).rejects.toMatchObject({
+      code: MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED,
+    });
+    expect(existsSync(join(basePath, ".open-design-download-root.json"))).toBe(false);
+    expect(existsSync(join(basePath, ".DS_Store", "hidden.txt"))).toBe(true);
+  });
+
+  const symlinkOsArtifactIt = process.platform === "win32" ? it.skip : it;
+  symlinkOsArtifactIt("does not extend the OS-artifact allowance to a symlink named .DS_Store", async () => {
+    const root = tmpRoot("os-artifact-symlink-not-file");
+    const basePath = join(root, "downloads");
+    const outsideTarget = join(root, "outside.txt");
+    mkdirSync(basePath, { recursive: true });
+    writeFileSync(outsideTarget, "outside content");
+    symlinkSync(outsideTarget, join(basePath, ".DS_Store"));
+
+    await expect(pruneManagedDownloads({ basePath })).rejects.toMatchObject({
+      code: MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED,
+    });
+    expect(existsSync(join(basePath, ".open-design-download-root.json"))).toBe(false);
+    expect(existsSync(outsideTarget)).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #7602

## Why

Follow-up from #7267's review: that PR fixed the same name-only OS-artifact matching defect in `apps/desktop/src/main/updater/store.ts` (a directory or symlink named `.DS_Store`/`Thumbs.db`/`desktop.ini`/`.localized` was silently treated as harmless OS litter with no `lstat` check, letting it bypass the empty-root claim check). `packages/download/src/store.ts`'s `ensureManagedBase()` has the identical pattern via its own duplicated constant/predicate - it was flagged once already as #7266 (merged via #7268), but that merge only ported the plain-file case, not the type verification. Since `apps/desktop` depends on `packages/download` (not the reverse), the fix needs its own local implementation here.

## What users will see

No visible change. A fresh managed-download base whose only entry happens to be a directory or symlink named `.DS_Store` (etc.) is now correctly rejected as not-empty/not-owned instead of being silently claimed - closing a corruption-hiding edge case, not changing any normal user-facing flow.

## Surface area

- [x] **None** - internal refactor, docs, tests, or translation update only

## Bug fix verification

- Test path: `packages/download/tests/index.test.ts` - new cases `"does not claim a fresh managed base whose only entry is a directory named .DS_Store"` and `"does not extend the OS-artifact allowance to a symlink named .DS_Store"`.
- Did the test go red on `main` and green on this branch? **Yes.** Both cases reproduce the original name-only-match bug against unpatched `ensureManagedBase()` (a fresh base containing only a directory/symlink named `.DS_Store` was wrongly claimed as empty and owned); both pass after adding `verifiedOsManagedRootArtifacts()`.

## Validation

- `pnpm --filter @open-design/download test` - 21/21 passing (19 pre-existing + 2 new).
- `pnpm --filter @open-design/download typecheck` - clean.
- Independently re-reviewed by a second AI agent (Codex on `gpt-5.6-terra`), which re-ran the tests/typecheck itself and confirmed no blocking issues; it flagged the same `readdir`/`lstat`/sentinel-write TOCTOU window that #7267's original fix also carries - a pre-existing limitation shared with the reference implementation, not something either fix addresses.

Note for reviewers: `ensureManagedBase()` only consults this allowlist at its one call site (the fresh-claim branch) - unlike `apps/desktop`'s `ensureOwnedUpdateRoot()`, this package has no separate "unexpected root entries" check on an already-owned base, so both regression tests target the fresh-claim path (the actual site of the defect).