### PR TITLE
fix(web): detect ancestor-hidden slides in deck thumbnail bridge

### DIFF
--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -3230,12 +3230,27 @@ function injectDeckBridge(
     }
     return -1;
   }
+  // display and opacity do not inherit through the CSS cascade, so a
+  // getComputedStyle() call on a candidate slide never reflects an
+  // ancestor's own display:none/opacity:0 (e.g. reveal.js hides
+  // non-present slides via display:none on the PARENT <section>, one
+  // level above the slide element itself). Walk up to document.body /
+  // document.documentElement, bounded the same way transformTrack() is,
+  // so any ancestor's own hidden state is caught.
+  function isRenderedHidden(el){
+    var node = el;
+    while (node && node !== document.body && node !== document.documentElement) {
+      try {
+        var cs = window.getComputedStyle(node);
+        if (cs.display === 'none' || cs.visibility === 'hidden' || cs.opacity === '0') return true;
+      } catch (_) {}
+      node = node.parentElement;
+    }
+    return false;
+  }
   function findActiveByVisibility(list){
     for (var i=0; i<list.length; i++) {
-      try {
-        var cs = window.getComputedStyle(list[i]);
-        if (cs.display !== 'none' && cs.visibility !== 'hidden' && cs.opacity !== '0') return i;
-      } catch (_) {}
+      if (!isRenderedHidden(list[i])) return i;
     }
     return -1;
   }
@@ -4081,6 +4096,28 @@ function injectDeckBridge(
   // For class-toggle decks the deck's own keyboard handler updates classes
   // on the slide elements; an attribute observer translates that into the
   // host counter without depending on scroll events.
+  // Deduplicated union of every slide's ancestor chain up to (not
+  // including) document.body/document.documentElement, matching
+  // isRenderedHidden()'s reach exactly. Reveal.js-style decks toggle
+  // their visibility class on that ancestor (one level above the slide
+  // element), not on the slide element itself, so the plain per-slide
+  // observation below would never fire for them.
+  function visibilityAncestors(list){
+    var result = [];
+    function add(node){
+      if (!node) return;
+      for (var i=0; i<result.length; i++) if (result[i] === node) return;
+      result.push(node);
+    }
+    for (var i=0; i<list.length; i++) {
+      var node = list[i] && list[i].parentElement;
+      while (node && node !== document.body && node !== document.documentElement) {
+        add(node);
+        node = node.parentElement;
+      }
+    }
+    return result;
+  }
   function observeSlides(){
     var list = slides();
     if (!list.length) { setTimeout(observeSlides, 150); return; }
@@ -4098,6 +4135,10 @@ function injectDeckBridge(
       // track's style too.
       var track = transformTrack(list);
       if (track) mo.observe(track, { attributes: true, attributeFilter: ['style'] });
+      var visAncestors = visibilityAncestors(list);
+      for (var v = 0; v < visAncestors.length; v++) {
+        mo.observe(visAncestors[v], { attributes: true, attributeFilter: ['class', 'style', 'hidden', 'aria-hidden'] });
+      }
     } catch (e) {}
     setTimeout(restoreInitialSlide, 100);
   }

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-ancestor-hidden.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-ancestor-hidden.test.ts
@@ -1,0 +1,191 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { buildSrcdoc } from '../../src/runtime/srcdoc';
+
+// Behavioral coverage for nexu-io/open-design#7604. Some deck-authoring
+// conventions (reveal.js is the concrete case that triggered this) hide
+// inactive slides by toggling a class on an ANCESTOR of the `.slide`
+// element rather than on `.slide` itself -- reveal.js puts `.present` /
+// `.past` / `.future` on the parent `<section>`, one level above `.slide`,
+// and its own stylesheet hides non-present sections via `display: none`.
+// `display` and `opacity` do not inherit through the CSS cascade, so the
+// `.slide` child's own `getComputedStyle()` never reflects the ancestor's
+// hidden state. The bridge's last-resort `findActiveByVisibility()`
+// heuristic only inspected the `.slide` element itself, so it always
+// reported index 0 regardless of which `<section>` was actually visible --
+// every per-slide thumbnail iframe rendered slide 1's content. The fix
+// walks the ancestor chain (bounded at document.body/documentElement,
+// matching the existing `transformTrack()` convention) and extends
+// `observeSlides()`'s MutationObserver to watch the same ancestor reach so
+// the host's live slide counter also stays in sync during manual
+// in-iframe navigation with no host request in flight.
+
+function extractDeckBridgeScript(srcdoc: string): string {
+  const match = srcdoc.match(/<script data-od-deck-bridge>([\s\S]*?)<\/script>/);
+  if (!match || !match[1]) {
+    throw new Error('deck bridge script not found in srcdoc');
+  }
+  return match[1];
+}
+
+function setupDeckBridge(bodyHtml: string) {
+  const srcdoc = buildSrcdoc(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+    deck: true,
+  });
+  const script = extractDeckBridgeScript(srcdoc);
+  const dom = new JSDOM(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+    runScripts: 'outside-only',
+    pretendToBeVisual: true,
+  });
+  const win = dom.window;
+  win.scrollTo = vi.fn() as typeof win.scrollTo;
+  const parentPostMessage = vi.fn();
+  // jsdom defaults `window.parent` to `window` itself for top-level
+  // documents; replace it with a stub that has a spied postMessage so we
+  // can observe what the bridge would send to the embedding host.
+  Object.defineProperty(win, 'parent', {
+    configurable: true,
+    value: { postMessage: parentPostMessage },
+  });
+  const evaluate = new win.Function(script);
+  evaluate.call(win);
+  // jsdom fires `load` during construction, before the bridge IIFE
+  // installs its listener. Replay it here so the test exercises the same
+  // first-paint `report()` path the real preview iframe takes.
+  win.dispatchEvent(new win.Event('load'));
+  return { dom, win, parentPostMessage };
+}
+
+function lastSlideState(parentPostMessage: ReturnType<typeof vi.fn>) {
+  const messages = parentPostMessage.mock.calls
+    .map((call) => call[0])
+    .filter((m) => m?.type === 'od:slide-state');
+  return messages.at(-1);
+}
+
+function postSlide(win: ReturnType<typeof setupDeckBridge>['win'], action: 'next' | 'prev') {
+  win.dispatchEvent(new win.window.MessageEvent('message', {
+    data: { type: 'od:slide', action },
+  }));
+}
+
+// A reveal.js-shaped deck: `.slide` sits one level inside the `<section>`
+// that actually carries the visibility state. No scroll container, no
+// `deck-stage`, no leaf-level active class, no transform track -- so
+// `activeIndex()` is forced all the way down to `findActiveByVisibility()`.
+function revealDeckHtml(presentIndex: number): string {
+  const sections = [0, 1, 2].map((i) => (
+    `<section${i === presentIndex ? ' class="present"' : ''}><div class="slide">Slide ${i + 1}</div></section>`
+  )).join('');
+  return `
+    <style>.slides > section:not(.present) { display: none; }</style>
+    <div class="reveal"><div class="slides">${sections}</div></div>
+  `;
+}
+
+describe('deck bridge — ancestor-hidden slides (#7604)', () => {
+  it('detects the active slide when a reveal.js-style ancestor toggles visibility', async () => {
+    const { win, parentPostMessage } = setupDeckBridge(revealDeckHtml(1));
+
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 350));
+
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 3 });
+  });
+
+  it('navigates via the key-simulation fallback once ancestor-hidden slides are detected correctly', async () => {
+    const { win, parentPostMessage } = setupDeckBridge(revealDeckHtml(0));
+    const sections = Array.from(win.document.querySelectorAll('.slides > section'));
+    let active = 0;
+    function paint() {
+      sections.forEach((section, index) => {
+        section.classList.toggle('present', index === active);
+      });
+    }
+    function go(index: number) {
+      active = Math.max(0, Math.min(sections.length - 1, index));
+      paint();
+    }
+    function onKey(event: KeyboardEvent) {
+      if (event.key === 'ArrowRight') go(active + 1);
+      else if (event.key === 'ArrowLeft') go(active - 1);
+    }
+    win.addEventListener('keydown', onKey, true);
+    win.document.addEventListener('keydown', onKey, true);
+    paint();
+
+    postSlide(win, 'next');
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 450));
+
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 3 });
+  });
+
+  it('updates the host counter via observeSlides when the deck navigates itself with no host request in flight', async () => {
+    const { win, parentPostMessage } = setupDeckBridge(revealDeckHtml(0));
+    const sections = Array.from(win.document.querySelectorAll('.slides > section'));
+    let active = 0;
+    function paint() {
+      sections.forEach((section, index) => {
+        section.classList.toggle('present', index === active);
+      });
+    }
+    function onKey(event: KeyboardEvent) {
+      if (event.key === 'ArrowRight') {
+        active = Math.min(sections.length - 1, active + 1);
+        paint();
+      }
+    }
+    win.addEventListener('keydown', onKey, true);
+    win.document.addEventListener('keydown', onKey, true);
+    paint();
+    // Let observeSlides() finish installing its MutationObserver before we
+    // drive the deck's own (simulated) internal navigation.
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 150));
+
+    // Simulate the deck's own internal keyboard handling directly -- no
+    // `od:slide` message is ever sent, so the only way the host can learn
+    // about this is the MutationObserver installed by observeSlides().
+    win.document.body.dispatchEvent(new win.KeyboardEvent('keydown', {
+      bubbles: true, cancelable: true, key: 'ArrowRight',
+    }));
+    win.document.body.dispatchEvent(new win.KeyboardEvent('keydown', {
+      bubbles: true, cancelable: true, key: 'ArrowRight',
+    }));
+
+    // Past the 60ms MutationObserver debounce.
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 250));
+
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 2, count: 3 });
+  });
+
+  it('does not treat a partially-opaque ancestor wrapper as hidden', async () => {
+    const { win, parentPostMessage } = setupDeckBridge(`
+      <style>
+        .slides > section:not(.present) { display: none; }
+        .fade-wrap { opacity: 0.4; }
+      </style>
+      <div class="reveal"><div class="fade-wrap"><div class="slides">
+        <section><div class="slide">One</div></section>
+        <section class="present"><div class="slide">Two</div></section>
+        <section><div class="slide">Three</div></section>
+      </div></div></div>
+    `);
+
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 350));
+
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 3 });
+  });
+
+  it('still detects a leaf-level display:none slide directly, unchanged from before', async () => {
+    const { win, parentPostMessage } = setupDeckBridge(`
+      <section class="slide" style="display:none">One</section>
+      <section class="slide">Two</section>
+      <section class="slide" style="display:none">Three</section>
+    `);
+
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 350));
+
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 3 });
+  });
+});


### PR DESCRIPTION
Fixes #7604

## Why

I hit this myself while investigating why a reveal.js-based deck rendered every thumbnail identically to slide 1 in the rail. Filed #7604 with a diagnosis and a sanitized minimal repro, and lefarcen independently re-derived the same root cause and confirmed it as a bug with both proposed fix directions plausible. This PR implements the smaller, surgical direction (ancestor-aware visibility detection) rather than adding reveal.js-specific API integration, per the reasoning laid out in the issue.

The underlying pain: `apps/web/src/runtime/srcdoc.ts`'s `findActiveByVisibility()` (the last-resort heuristic `activeIndex()` falls back to) only ever inspected a candidate slide's own `getComputedStyle()`. `display` and `opacity` do not inherit through the CSS cascade, so a `.slide` nested inside an ancestor `<section>` that reveal.js hides via `display:none` (its `.present`/`.past`/`.future` convention) always reported itself as visible, so the heuristic always returned index 0 no matter which section was actually active.

## What users will see

Deck thumbnail rails for decks that hide inactive slides via an ancestor element (reveal.js being the concrete case) now show each slide's own content instead of N copies of slide 1. The live host slide counter also stays in sync if a user manually navigates such a deck's own UI inside the iframe with no host request in flight (a related gap in `observeSlides()`'s `MutationObserver` scope, fixed alongside the detector for the same reason).

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** - this is a bug fix to existing deck-preview runtime behavior; no new UI surface, API, or default setting.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/runtime/srcdoc-deck-bridge-ancestor-hidden.test.ts` (new file, 5 cases).
- Did the test go red on `main` and green on this branch? **Yes.** Cases 1-4 fail on unmodified `main` (all report `active: 0` instead of the correct index); case 5 (existing leaf-level `display:none` behavior) already passed and is included as a regression guard. All 5 pass after the fix.

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/runtime/srcdoc-deck-bridge-*.test.ts tests/runtime/srcdoc.test.ts` - 10 files / 96 tests, all green, zero regressions against the pre-existing suite.
- `pnpm guard` - passes.
- `pnpm --filter @open-design/web exec tsc -b --noEmit` - passes.

## Implementation notes

- `findActiveByVisibility()` now delegates to a new `isRenderedHidden(el)` helper that walks from the candidate element up to `document.body`/`document.documentElement` (same bound `transformTrack()` already uses in this file), checking each ancestor's own `display`/`visibility`/`opacity` - the same 3-signal truth table `hasComputedHiddenSibling()` already uses in this file, just evaluated at every level instead of only the leaf. Only an ancestor at *exactly* `opacity: 0` counts as hidden (no compounding across levels), so a partial-opacity cross-fade wrapper unrelated to per-slide hiding isn't misread as inactive (covered by a test case).
- `observeSlides()` gets a companion `visibilityAncestors(list)` helper (dedup idiom copied from the existing `scrollTargets()` in this file) so its `MutationObserver` also watches the same ancestor reach the detector now inspects, not just each `.slide` leaf and an optional transform-track ancestor.
- Deliberately did **not** bundle a change to widen hash-based direct-index navigation detection for reveal.js decks loaded via external `<script src>` - once the detector is fixed, `gotoIndex()`'s existing key-simulation fallback already becomes functionally correct, and confirming which navigation capability real generated decks actually enable is its own unconfirmed follow-up, not this PR's scope.
