### PR TITLE
fix(daemon): record agent CLI version in run diagnostics

### DIFF
--- a/apps/daemon/src/runtimes/detection.ts
+++ b/apps/daemon/src/runtimes/detection.ts
@@ -7,7 +7,11 @@ import {
   mergeFallbackModelMetadata,
   rememberLiveModels,
 } from './models.js';
-import { applyAgentLaunchEnv, resolveAgentLaunch } from './launch.js';
+import {
+  applyAgentLaunchEnv,
+  resolveAgentLaunch,
+  type AgentLaunchResolution,
+} from './launch.js';
 import { spawnEnvForAgent } from './env.js';
 import { probeAgentAuthStatus } from './auth.js';
 import { agentCapabilities } from './capabilities.js';
@@ -91,11 +95,12 @@ export function getDetectedRuntimeVersions(
 export async function ensureDetectedRuntimeVersions(
   agentId: string | null | undefined,
   configuredAgentEnv: Record<string, string> = {},
+  launch?: AgentLaunchResolution,
 ): Promise<DetectedRuntimeVersions | null> {
   if (!agentId) return null;
   const def = AGENT_DEFS.find((candidate) => candidate.id === agentId);
   if (!def) return null;
-  const context = runtimeVersionProbeContext(def, configuredAgentEnv);
+  const context = runtimeVersionProbeContext(def, configuredAgentEnv, launch);
   if (!context) return null;
   const remembered = getDetectedRuntimeVersions(agentId);
   if (
@@ -137,11 +142,12 @@ export async function ensureDetectedRuntimeVersions(
 export async function ensureDetectedRuntimeCapabilities(
   agentId: string | null | undefined,
   configuredAgentEnv: Record<string, string> = {},
+  launch?: AgentLaunchResolution,
 ): Promise<RuntimeCapabilityMap | null> {
   if (!agentId) return null;
   const def = AGENT_DEFS.find((candidate) => candidate.id === agentId);
   if (!def) return null;
-  const context = runtimeVersionProbeContext(def, configuredAgentEnv);
+  const context = runtimeVersionProbeContext(def, configuredAgentEnv, launch);
   if (!context) return null;
   const remembered = agentCapabilities.get(agentId);
   if (
@@ -394,8 +400,9 @@ type RuntimeVersionProbeContext = {
 function runtimeVersionProbeContext(
   def: RuntimeAgentDef,
   configuredEnv: Record<string, string>,
+  capturedLaunch?: AgentLaunchResolution,
 ): RuntimeVersionProbeContext | null {
-  const launch = resolveAgentLaunch(def, configuredEnv);
+  const launch = capturedLaunch ?? resolveAgentLaunch(def, configuredEnv);
   if (!launch.selectedPath || !launch.launchPath) return null;
   const probeEnv = applyAgentLaunchEnv(
     spawnEnvForAgent(

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -12748,10 +12748,18 @@ export async function startServer({
           })()
         : [];
     try {
-      // Optional argv flags are gated on the `--help` capability map, which used
-      // to be filled only by `GET /api/agents`. Probe it here so a daemon that
-      // has never served that route still builds the same argv as one that has.
-      await ensureDetectedRuntimeCapabilities(def.id, configuredAgentEnv);
+      // Freeze the selected CLI version on the Run and populate the optional
+      // argv capability map before spawn. Probe both in parallel so a daemon
+      // that has never served `GET /api/agents` has the same provenance and
+      // argv behavior as one whose detection cache is already warm.
+      const [runtimeVersions] = await Promise.all([
+        ensureDetectedRuntimeVersions(def.id, configuredAgentEnv),
+        ensureDetectedRuntimeCapabilities(def.id, configuredAgentEnv),
+      ]);
+      if (!run.preflightAgentCliVersion && runtimeVersions?.agentCliVersion) {
+        run.preflightAgentCliVersion = runtimeVersions.agentCliVersion;
+        design.runs.persistState(run);
+      }
       args = def.buildArgs(
         composed,
         promptImagePaths,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -12753,9 +12753,17 @@ export async function startServer({
       // that has never served `GET /api/agents` has the same provenance and
       // argv behavior as one whose detection cache is already warm.
       const [runtimeVersions] = await Promise.all([
-        ensureDetectedRuntimeVersions(def.id, configuredAgentEnv),
-        ensureDetectedRuntimeCapabilities(def.id, configuredAgentEnv),
+        ensureDetectedRuntimeVersions(def.id, configuredAgentEnv, agentLaunch),
+        ensureDetectedRuntimeCapabilities(def.id, configuredAgentEnv, agentLaunch),
       ]);
+      if (run.cancelRequested || design.runs.isTerminal(run.status)) {
+        lifecycle.mark('launch_preflight_end');
+        antigravityModelLockRelease?.();
+        antigravityModelLockRelease = null;
+        cleanupPromptFile();
+        cleanupOdNextRunInputProjection();
+        return;
+      }
       if (!run.preflightAgentCliVersion && runtimeVersions?.agentCliVersion) {
         run.preflightAgentCliVersion = runtimeVersions.agentCliVersion;
         design.runs.persistState(run);

--- a/apps/daemon/tests/runtimes/run-runtime-version-provenance.test.ts
+++ b/apps/daemon/tests/runtimes/run-runtime-version-provenance.test.ts
@@ -1,11 +1,46 @@
 import type { Server } from 'node:http';
 import { randomUUID } from 'node:crypto';
-import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { access, chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const promptFileInterleave = vi.hoisted(() => ({
+  afterPrepare: null as null | (() => Promise<void>),
+  onCleanup: null as null | (() => void),
+}));
+
+vi.mock('../../src/runtimes/prompt-file.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/runtimes/prompt-file.js')>();
+  return {
+    ...actual,
+    preparePromptFileForAgent: async (
+      ...args: Parameters<typeof actual.preparePromptFileForAgent>
+    ) => {
+      const prepared = await actual.preparePromptFileForAgent(...args);
+      await promptFileInterleave.afterPrepare?.();
+      if (!promptFileInterleave.onCleanup) return prepared;
+      return {
+        path: prepared?.path ?? '',
+        cleanup: async () => {
+          try {
+            await prepared?.cleanup();
+          } finally {
+            promptFileInterleave.onCleanup?.();
+          }
+        },
+      };
+    },
+  };
+});
 
 import { startServer } from '../../src/server.js';
+import {
+  forgetUnusableExecutables,
+  rememberUnusableExecutable,
+} from '../../src/runtimes/executables.js';
+import { resolveAgentLaunch } from '../../src/runtimes/launch.js';
+import { getAgentDef } from '../../src/runtimes/registry.js';
 
 type StartedServer = {
   url: string;
@@ -31,7 +66,7 @@ type RunStatus = {
 describe('run runtime version provenance', () => {
   const originalEnv = snapshotEnv();
   let started: StartedServer | null = null;
-  let binDir: string | null = null;
+  const tempDirs: string[] = [];
 
   afterEach(async () => {
     await Promise.resolve(started?.shutdown?.());
@@ -39,13 +74,18 @@ describe('run runtime version provenance', () => {
       await new Promise<void>((resolve) => started?.server.close(() => resolve()));
     }
     started = null;
-    if (binDir) await rm(binDir, { recursive: true, force: true });
-    binDir = null;
+    while (tempDirs.length > 0) {
+      await rm(tempDirs.pop() as string, { recursive: true, force: true });
+    }
+    promptFileInterleave.afterPrepare = null;
+    promptFileInterleave.onCleanup = null;
+    forgetUnusableExecutables('opencode');
+    vi.restoreAllMocks();
     restoreEnv(originalEnv);
   });
 
   it('freezes a non-Codex CLI version into terminal execution diagnostics', async () => {
-    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-run-version-bin-'));
+    const binDir = await createTempDir(tempDirs, 'od-run-version-bin-');
     const fakeOpenCode = await writeSuccessfulOpenCode(binDir);
 
     disableTelemetry();
@@ -70,6 +110,114 @@ describe('run runtime version provenance', () => {
       definition: 'runtime CLI version observed during preflight',
     });
   });
+
+  it('keeps provenance bound to the launch captured before executable fallback changes', async () => {
+    const candidateADir = await createTempDir(tempDirs, 'od-run-version-a-');
+    const candidateBDir = await createTempDir(tempDirs, 'od-run-version-b-');
+    const candidateAMarker = path.join(candidateADir, 'run.marker');
+    const candidateBMarker = path.join(candidateBDir, 'run.marker');
+    const candidateA = await writeOpenCodeFixture(candidateADir, {
+      binName: 'opencode-cli',
+      version: 'opencode-cli candidate-a',
+      runMarker: candidateAMarker,
+    });
+    const candidateB = await writeOpenCodeFixture(candidateBDir, {
+      binName: 'opencode-cli',
+      version: 'opencode-cli candidate-b',
+      runMarker: candidateBMarker,
+    });
+    process.env.PATH = [candidateADir, candidateBDir, originalEnv.PATH ?? '']
+      .filter(Boolean)
+      .join(path.delimiter);
+    process.env.OD_AGENT_HOME = candidateADir;
+    delete process.env.OPENCODE_BIN;
+
+    disableTelemetry();
+    started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'opencode',
+      agentCliEnv: { opencode: {} },
+      telemetry: { metrics: false, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const gate = createGate();
+    promptFileInterleave.afterPrepare = gate.wait;
+    const { projectId, conversationId } = await createProject(started.url);
+    const runId = await createRun(started.url, projectId, conversationId);
+    await gate.entered;
+
+    const def = getAgentDef('opencode');
+    expect(def).toBeTruthy();
+    const launchBeforeFallback = resolveAgentLaunch(def!, {});
+    expect(samePath(launchBeforeFallback.selectedPath, candidateA)).toBe(true);
+
+    // Full agent detection publishes this same state when candidate A fails
+    // while the run is between launch capture and its version preflight.
+    rememberUnusableExecutable('opencode', launchBeforeFallback.selectedPath!);
+    expect(samePath(resolveAgentLaunch(def!, {}).selectedPath, candidateB)).toBe(true);
+    gate.release();
+
+    const run = await waitForRun(started.url, runId);
+    expect(run.status, JSON.stringify(run)).toBe('succeeded');
+    expect(await pathExists(candidateAMarker)).toBe(true);
+    expect(await pathExists(candidateBMarker)).toBe(false);
+    expect(run.executionDiagnostics?.environment?.agentCliVersion?.value).toBe(
+      'opencode-cli candidate-a',
+    );
+  });
+
+  it('does not mutate or build a canceled run after a delayed version probe', async () => {
+    const binDir = await createTempDir(tempDirs, 'od-run-version-cancel-');
+    const probeStarted = path.join(binDir, 'probe-started.marker');
+    const probeRelease = path.join(binDir, 'probe-release.marker');
+    const probeFinished = path.join(binDir, 'probe-finished.marker');
+    const runMarker = path.join(binDir, 'run.marker');
+    const fakeOpenCode = await writeOpenCodeFixture(binDir, {
+      binName: 'opencode-delayed',
+      version: 'opencode-cli delayed',
+      runMarker,
+      versionGate: {
+        started: probeStarted,
+        release: probeRelease,
+        finished: probeFinished,
+      },
+    });
+
+    disableTelemetry();
+    started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'opencode',
+      agentCliEnv: { opencode: { OPENCODE_BIN: fakeOpenCode } },
+      telemetry: { metrics: false, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const def = getAgentDef('opencode');
+    expect(def).toBeTruthy();
+    const buildArgs = vi.spyOn(def!, 'buildArgs');
+    const cleanupReached = deferred();
+    promptFileInterleave.onCleanup = cleanupReached.resolve;
+
+    const { projectId, conversationId } = await createProject(started.url);
+    const runId = await createRun(started.url, projectId, conversationId);
+    await waitForFile(probeStarted);
+
+    const cancelResponse = await fetch(
+      `${started.url}/api/runs/${encodeURIComponent(runId)}/cancel`,
+      { method: 'POST' },
+    );
+    expect(cancelResponse.status).toBe(200);
+    await writeFile(probeRelease, 'release', 'utf8');
+    await waitForFile(probeFinished);
+    await cleanupReached.promise;
+
+    const run = await waitForRun(started.url, runId);
+    expect(run.status).toBe('canceled');
+    expect(run.executionDiagnostics?.environment?.agentCliVersion?.state).toBe('not_collected');
+    expect(buildArgs).not.toHaveBeenCalled();
+    expect(await pathExists(runMarker)).toBe(false);
+  });
 });
 
 function snapshotEnv(): Record<string, string | undefined> {
@@ -80,6 +228,9 @@ function snapshotEnv(): Record<string, string | undefined> {
     OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
     POSTHOG_KEY: process.env.POSTHOG_KEY,
     POSTHOG_HOST: process.env.POSTHOG_HOST,
+    PATH: process.env.PATH,
+    OD_AGENT_HOME: process.env.OD_AGENT_HOME,
+    OPENCODE_BIN: process.env.OPENCODE_BIN,
   };
 }
 
@@ -100,43 +251,136 @@ function disableTelemetry(): void {
 }
 
 async function writeSuccessfulOpenCode(dir: string): Promise<string> {
+  return writeOpenCodeFixture(dir, {
+    binName: 'opencode-version',
+    version: 'opencode-cli 9.8.7',
+  });
+}
+
+type OpenCodeFixtureOptions = {
+  binName: string;
+  version: string;
+  runMarker?: string;
+  versionGate?: {
+    started: string;
+    release: string;
+    finished: string;
+  };
+};
+
+async function writeOpenCodeFixture(
+  dir: string,
+  options: OpenCodeFixtureOptions,
+): Promise<string> {
+  const script = path.join(dir, `${options.binName}.cjs`);
+  const source = [
+    "const fs = require('node:fs');",
+    `const version = ${JSON.stringify(options.version)};`,
+    `const runMarker = ${JSON.stringify(options.runMarker ?? null)};`,
+    `const versionGate = ${JSON.stringify(options.versionGate ?? null)};`,
+    'const args = process.argv.slice(2);',
+    'const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));',
+    'async function main() {',
+    "  if (args.includes('--version')) {",
+    '    if (versionGate) {',
+    "      fs.writeFileSync(versionGate.started, 'started');",
+    '      while (!fs.existsSync(versionGate.release)) await sleep(20);',
+    "      fs.writeFileSync(versionGate.finished, 'finished');",
+    '    }',
+    '    console.log(version);',
+    '    return;',
+    '  }',
+    "  if (args.includes('--help')) {",
+    "    console.log('Usage: opencode');",
+    '    return;',
+    '  }',
+    "  if (args[0] === 'models') {",
+    "    console.log('test/provider');",
+    '    return;',
+    '  }',
+    "  if (runMarker) fs.writeFileSync(runMarker, 'ran');",
+    "  console.log('{\"type\":\"step_start\"}');",
+    "  console.log('{\"type\":\"text\",\"part\":{\"text\":\"completed\"}}');",
+    "  console.log('{\"type\":\"step_finish\",\"part\":{\"tokens\":{\"input\":1,\"output\":1}}}');",
+    '}',
+    'main().catch((error) => {',
+    '  console.error(error);',
+    '  process.exitCode = 1;',
+    '});',
+    '',
+  ].join('\n');
+  await writeFile(script, source, 'utf8');
+
   const windows = process.platform === 'win32';
-  const bin = path.join(dir, windows ? 'opencode-version.cmd' : 'opencode-version');
-  const source = windows
-    ? [
-        '@echo off',
-        'if "%1"=="--version" (',
-        '  echo opencode-cli 9.8.7',
-        '  exit /b 0',
-        ')',
-        'if "%1"=="models" (',
-        '  echo test/provider',
-        '  exit /b 0',
-        ')',
-        'echo {"type":"step_start"}',
-        'echo {"type":"text","part":{"text":"completed"}}',
-        'echo {"type":"step_finish","part":{"tokens":{"input":1,"output":1}}}',
-        'exit /b 0',
-        '',
-      ].join('\r\n')
-    : [
-        '#!/bin/sh',
-        'if [ "$1" = "--version" ]; then',
-        '  echo "opencode-cli 9.8.7"',
-        '  exit 0',
-        'fi',
-        'if [ "$1" = "models" ]; then',
-        '  echo "test/provider"',
-        '  exit 0',
-        'fi',
-        'echo \'{"type":"step_start"}\'',
-        'echo \'{"type":"text","part":{"text":"completed"}}\'',
-        'echo \'{"type":"step_finish","part":{"tokens":{"input":1,"output":1}}}\'',
-        '',
-      ].join('\n');
-  await writeFile(bin, source, 'utf8');
+  const bin = path.join(dir, windows ? `${options.binName}.cmd` : options.binName);
+  const launcher = windows
+    ? `@echo off\r\n"${process.execPath}" "${script}" %*\r\n`
+    : `#!/bin/sh\nexec ${shellQuote(process.execPath)} ${shellQuote(script)} "$@"\n`;
+  await writeFile(bin, launcher, 'utf8');
   if (!windows) await chmod(bin, 0o755);
   return bin;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+async function createTempDir(dirs: string[], prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  dirs.push(dir);
+  return dir;
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function createGate(): {
+  entered: Promise<void>;
+  wait: () => Promise<void>;
+  release: () => void;
+} {
+  const entered = deferred();
+  const released = deferred();
+  return {
+    entered: entered.promise,
+    wait: async () => {
+      entered.resolve();
+      await released.promise;
+    },
+    release: released.resolve,
+  };
+}
+
+function samePath(left: string | null, right: string): boolean {
+  if (!left) return false;
+  const normalize = (value: string) => {
+    const resolved = path.resolve(value);
+    return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+  };
+  return normalize(left) === normalize(right);
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForFile(filePath: string): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 10_000) {
+    if (await pathExists(filePath)) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`file did not appear: ${filePath}`);
 }
 
 async function putConfig(url: string, patch: Record<string, unknown>): Promise<void> {
@@ -173,6 +417,15 @@ async function createAndWaitForRun(
   projectId: string,
   conversationId: string,
 ): Promise<RunStatus> {
+  const runId = await createRun(url, projectId, conversationId);
+  return waitForRun(url, runId);
+}
+
+async function createRun(
+  url: string,
+  projectId: string,
+  conversationId: string,
+): Promise<string> {
   const response = await fetch(`${url}/api/runs`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
@@ -188,7 +441,7 @@ async function createAndWaitForRun(
   });
   expect(response.status).toBe(202);
   const body = await response.json() as { runId: string };
-  return waitForRun(url, body.runId);
+  return body.runId;
 }
 
 async function waitForRun(url: string, runId: string): Promise<RunStatus> {

--- a/apps/daemon/tests/runtimes/run-runtime-version-provenance.test.ts
+++ b/apps/daemon/tests/runtimes/run-runtime-version-provenance.test.ts
@@ -1,0 +1,206 @@
+import type { Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { startServer } from '../../src/server.js';
+
+type StartedServer = {
+  url: string;
+  server: Server;
+  shutdown?: () => Promise<void> | void;
+};
+
+type RunStatus = {
+  id: string;
+  status: string;
+  error?: string | null;
+  errorCode?: string | null;
+  executionDiagnostics?: {
+    environment?: {
+      agentCliVersion?: {
+        state: string;
+        value?: string;
+      };
+    };
+  };
+};
+
+describe('run runtime version provenance', () => {
+  const originalEnv = snapshotEnv();
+  let started: StartedServer | null = null;
+  let binDir: string | null = null;
+
+  afterEach(async () => {
+    await Promise.resolve(started?.shutdown?.());
+    if (started?.server) {
+      await new Promise<void>((resolve) => started?.server.close(() => resolve()));
+    }
+    started = null;
+    if (binDir) await rm(binDir, { recursive: true, force: true });
+    binDir = null;
+    restoreEnv(originalEnv);
+  });
+
+  it('freezes a non-Codex CLI version into terminal execution diagnostics', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-run-version-bin-'));
+    const fakeOpenCode = await writeSuccessfulOpenCode(binDir);
+
+    disableTelemetry();
+    started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'opencode',
+      agentCliEnv: { opencode: { OPENCODE_BIN: fakeOpenCode } },
+      telemetry: { metrics: false, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const { projectId, conversationId } = await createProject(started.url);
+    const run = await createAndWaitForRun(started.url, projectId, conversationId);
+
+    expect(run.status, JSON.stringify(run)).toBe('succeeded');
+    expect(run.executionDiagnostics?.environment?.agentCliVersion).toEqual({
+      state: 'available',
+      value: 'opencode-cli 9.8.7',
+      evidence: 'computed',
+      source: 'agent-runtime',
+      complete: true,
+      definition: 'runtime CLI version observed during preflight',
+    });
+  });
+});
+
+function snapshotEnv(): Record<string, string | undefined> {
+  return {
+    LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
+    LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
+    LANGFUSE_BASE_URL: process.env.LANGFUSE_BASE_URL,
+    OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
+    POSTHOG_KEY: process.env.POSTHOG_KEY,
+    POSTHOG_HOST: process.env.POSTHOG_HOST,
+  };
+}
+
+function restoreEnv(env: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function disableTelemetry(): void {
+  delete process.env.LANGFUSE_PUBLIC_KEY;
+  delete process.env.LANGFUSE_SECRET_KEY;
+  delete process.env.LANGFUSE_BASE_URL;
+  delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+  delete process.env.POSTHOG_KEY;
+  delete process.env.POSTHOG_HOST;
+}
+
+async function writeSuccessfulOpenCode(dir: string): Promise<string> {
+  const windows = process.platform === 'win32';
+  const bin = path.join(dir, windows ? 'opencode-version.cmd' : 'opencode-version');
+  const source = windows
+    ? [
+        '@echo off',
+        'if "%1"=="--version" (',
+        '  echo opencode-cli 9.8.7',
+        '  exit /b 0',
+        ')',
+        'if "%1"=="models" (',
+        '  echo test/provider',
+        '  exit /b 0',
+        ')',
+        'echo {"type":"step_start"}',
+        'echo {"type":"text","part":{"text":"completed"}}',
+        'echo {"type":"step_finish","part":{"tokens":{"input":1,"output":1}}}',
+        'exit /b 0',
+        '',
+      ].join('\r\n')
+    : [
+        '#!/bin/sh',
+        'if [ "$1" = "--version" ]; then',
+        '  echo "opencode-cli 9.8.7"',
+        '  exit 0',
+        'fi',
+        'if [ "$1" = "models" ]; then',
+        '  echo "test/provider"',
+        '  exit 0',
+        'fi',
+        'echo \'{"type":"step_start"}\'',
+        'echo \'{"type":"text","part":{"text":"completed"}}\'',
+        'echo \'{"type":"step_finish","part":{"tokens":{"input":1,"output":1}}}\'',
+        '',
+      ].join('\n');
+  await writeFile(bin, source, 'utf8');
+  if (!windows) await chmod(bin, 0o755);
+  return bin;
+}
+
+async function putConfig(url: string, patch: Record<string, unknown>): Promise<void> {
+  const response = await fetch(`${url}/api/app-config`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  expect(response.status).toBe(200);
+}
+
+async function createProject(url: string): Promise<{
+  projectId: string;
+  conversationId: string;
+}> {
+  const projectId = `run_version_${randomUUID()}`;
+  const response = await fetch(`${url}/api/projects`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      id: projectId,
+      name: 'Run version provenance',
+      metadata: { kind: 'prototype' },
+      skipDiscoveryBrief: true,
+    }),
+  });
+  expect(response.status).toBe(200);
+  const body = await response.json() as { conversationId: string };
+  return { projectId, conversationId: body.conversationId };
+}
+
+async function createAndWaitForRun(
+  url: string,
+  projectId: string,
+  conversationId: string,
+): Promise<RunStatus> {
+  const response = await fetch(`${url}/api/runs`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      projectId,
+      conversationId,
+      assistantMessageId: `assistant_run_version_${randomUUID()}`,
+      clientRequestId: `client_run_version_${randomUUID()}`,
+      agentId: 'opencode',
+      message: 'complete the task',
+      currentPrompt: 'complete the task',
+    }),
+  });
+  expect(response.status).toBe(202);
+  const body = await response.json() as { runId: string };
+  return waitForRun(url, body.runId);
+}
+
+async function waitForRun(url: string, runId: string): Promise<RunStatus> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 10_000) {
+    const response = await fetch(`${url}/api/runs/${encodeURIComponent(runId)}`);
+    expect(response.status).toBe(200);
+    const run = await response.json() as RunStatus;
+    if (run.status === 'failed' || run.status === 'succeeded' || run.status === 'canceled') {
+      return run;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`run ${runId} did not finish`);
+}


### PR DESCRIPTION
Refs #7609 (implements the first, per-run diagnostics half only)

## Why

Runtime detection already probes the selected agent executable for its exact CLI version, but ordinary runs did not freeze that value into the run record. As a result, terminal execution diagnostics reported `agent_cli_version_not_recorded`, making version-specific regressions difficult to correlate after the run had finished.

This keeps the change focused on per-run provenance. The separate stale-runtime Settings hint proposed in #7609 is intentionally out of scope.

## What users will see

Completed runs now report the selected runtime's detected CLI version under `executionDiagnostics.environment.agentCliVersion` instead of `not_collected` when a version is available. This applies to non-Codex runtimes such as Pi and OpenCode as well as existing runtime definitions.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this changes an existing diagnostics value and adds no UI.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/runtimes/run-runtime-version-provenance.test.ts`
- Did the test go red on `main` and green on this branch? **Yes.** On `main`, the real HTTP run returned `state: "not_collected"` with `missingReason: "agent_cli_version_not_recorded"`. On this branch it returns `state: "available"` with the exact fake OpenCode version `opencode-cli 9.8.7`.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/runtimes/run-runtime-version-provenance.test.ts` — 1 passed
- `pnpm exec vitest run -c vitest.config.ts tests/runtimes/runs.test.ts` — 55 passed
- `pnpm --filter @open-design/daemon typecheck` — passed
- `pnpm --filter @open-design/daemon build` — passed
- `git diff --check` — passed
- `pnpm guard` — all checks reached before plugin-preview validation passed; the command could not complete in this partial clone because the intentionally omitted `plugins/` tree makes the preview manifest appear stale.

Local Windows note: the existing `runtime-version-provenance.test.ts` fixture resolves the locally installed Claude CLI instead of its extensionless fake executable on Windows (3 existing assertions fail with local `2.1.191` output). The new cross-platform OpenCode regression and the daemon checks above pass.