### PR TITLE
fix daemon automation CLI ReferenceError before subcommand dispatch

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -11174,13 +11174,11 @@ function splitCommaSeparatedIds(value) {
   return out;
 }
 
-const splitAutomationIds = splitCommaSeparatedIds;
-
 function automationContextFromFlags(flags) {
-  const skillIds = splitAutomationIds(flags.skill);
-  const pluginIds = splitAutomationIds(flags.plugin);
-  const mcpServerIds = splitAutomationIds(flags.mcp);
-  const connectorIds = splitAutomationIds(flags.connector);
+  const skillIds = splitCommaSeparatedIds(flags.skill);
+  const pluginIds = splitCommaSeparatedIds(flags.plugin);
+  const mcpServerIds = splitCommaSeparatedIds(flags.mcp);
+  const connectorIds = splitCommaSeparatedIds(flags.connector);
   const context = {
     ...(skillIds.length > 0 ? { skillIds } : {}),
     ...(pluginIds.length > 0 ? { pluginIds } : {}),
@@ -11716,7 +11714,7 @@ async function runAutomation(args) {
         enabled: !flags.disabled,
       };
       const context = automationContextFromFlags(flags);
-      const skillIds = splitAutomationIds(flags.skill);
+      const skillIds = splitCommaSeparatedIds(flags.skill);
       if (skillIds.length > 0) body.skillId = skillIds[0];
       if (context) body.context = context;
       if (flags.agent) body.agentId = String(flags.agent);
@@ -11767,7 +11765,7 @@ async function runAutomation(args) {
       if (flags.enabled) patch.enabled = true;
       const context = automationContextFromFlags(flags);
       if (context) {
-        const skillIds = splitAutomationIds(flags.skill);
+        const skillIds = splitCommaSeparatedIds(flags.skill);
         if (skillIds.length > 0) patch.skillId = skillIds[0];
         patch.context = context;
       }

--- a/apps/daemon/tests/cli-startup.test.ts
+++ b/apps/daemon/tests/cli-startup.test.ts
@@ -20,7 +20,21 @@ describe('CLI startup boundaries', () => {
     ['config', ['config', 'get', 'apiProtocol', '--daemon-url', 'http://127.0.0.1:9']],
     ['diagnostics', ['diagnostics', 'export', '--daemon-url', 'http://127.0.0.1:9']],
     ['amr', ['amr', 'status', '--daemon-url', 'http://127.0.0.1:9']],
-  ])('initializes flag constants before dispatching od %s', async (_name, args) => {
+    ['automation create', [
+      'automation', 'create',
+      '--name', 'nightly',
+      '--prompt', 'refresh the board',
+      '--schedule', 'daily:03:00',
+      '--skill', 'alpha,beta',
+      '--daemon-url', 'http://127.0.0.1:9',
+    ]],
+    ['automation update', [
+      'automation', 'update', 'routine-1',
+      '--name', 'nightly',
+      '--skill', 'alpha,beta',
+      '--daemon-url', 'http://127.0.0.1:9',
+    ]],
+  ])('initializes module-level bindings before dispatching od %s', async (_name, args) => {
     let output = '';
     try {
       const result = await execFileAsync(
@@ -42,6 +56,7 @@ describe('CLI startup boundaries', () => {
     expect(output).not.toContain('CONFIG_STRING_FLAGS');
     expect(output).not.toContain('DIAGNOSTICS_STRING_FLAGS');
     expect(output).not.toContain('AMR_STRING_FLAGS');
+    expect(output).not.toContain('splitAutomationIds');
   });
 
   it('keeps od daemon start alive until SIGTERM and reports the actual listening port', async () => {


### PR DESCRIPTION
Fixes #7611

## Why

Hit this while driving OD headlessly through the `od` CLI: `od automation create` and `od automation update` are both completely unusable, on every flag path, with

```
ReferenceError: Cannot access 'splitAutomationIds' before initialization
```

The cause is a temporal dead zone. `cli.ts` dispatches its subcommand from the top level:

```js
const first = argv.find((a) => !a.startsWith('-'));
if (first && SUBCOMMAND_MAP[first]) {
  ...
  await SUBCOMMAND_MAP[first](rest);
```

That runs at roughly line 850, about 10,300 lines before the module body reaches

```js
const splitAutomationIds = splitCommaSeparatedIds;
```

`splitCommaSeparatedIds` is a function declaration, so it hoists and is callable. The `const` alias does not hoist, so it is still in its dead zone when the dispatched handler calls `automationContextFromFlags`. Every `automation create` / `automation update` invocation goes through that function, so both commands throw before they issue a request. Observed stack:

```
ReferenceError: Cannot access 'splitAutomationIds' before initialization
    at automationContextFromFlags (apps/daemon/src/cli.ts:11180:20)
    at Object.runAutomation (apps/daemon/src/cli.ts:11768:23)
    at async <anonymous> (apps/daemon/src/cli.ts:854:3)
```

This is the same class of bug as the already-guarded `CONFIG_STRING_FLAGS` / `DIAGNOSTICS_STRING_FLAGS` / `AMR_STRING_FLAGS` cases — a module-level binding that is only initialized after the top-level dispatch has already run.

## What users will see

`od automation create` and `od automation update` work again instead of crashing with a `ReferenceError`. `--skill`, `--plugin`, `--mcp` and `--connector` accept comma-separated ids as documented.

No new flags, no changed flag semantics, no changed output format.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [x] **CLI / env var** — no *new* subcommand or flag; this repairs the existing `od automation create` / `od automation update` commands. Flagged so reviewers scope to the CLI.
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

n/a — not a UI change.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/cli-startup.test.ts`

Rather than add a new file, this extends the existing `it.each` table in `CLI startup boundaries`, which already covers exactly this failure mode for `doctor` / `config` / `diagnostics` / `amr`. Two rows were added for `automation create` and `automation update`, plus a `splitAutomationIds` assertion so the alias cannot be reintroduced. The test name was generalized from "initializes flag constants" to "initializes module-level bindings", since the table now covers a function alias as well as flag-constant sets.

- Did the test go red on `main` and green on this branch? **yes**

Red before the source change, with the real defect rather than an incidental failure:

```
FAIL tests/cli-startup.test.ts > CLI startup boundaries >
  initializes module-level bindings before dispatching od automation create
FAIL tests/cli-startup.test.ts > CLI startup boundaries >
  initializes module-level bindings before dispatching od automation update

ReferenceError: Cannot access 'splitAutomationIds' before initialization
Tests  2 failed | 4 passed
```

Green after:

```
Test Files  1 passed (1)
     Tests  13 passed (13)
```

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/daemon run build` — pass
- `apps/daemon` targeted suites — `cli-startup.test.ts` (13 passed), plus `automation-ingestions`, `automation-proposals`, `automation-routine-evolution`, `automation-templates`, `routines`, `routine-routes`, `routine-schedule-claims` (73 passed across 7 files)
- Manual, against a real daemon started with `pnpm tools-dev run web` and `OD_DAEMON_URL` pointed at the port it reported:

```
$ od automation create --name x --prompt y --schedule "daily:03:00"
[automation] created routine-aaec37f9-…
routine-aaec37f9-…	x	daily:03:00:UTC	new-project	enabled	2026-08-31T03:00:00.000Z
```

  and confirming the repaired path actually builds the context correctly, not merely that it stops throwing:

```
$ od automation update <id> --skill alpha,beta --plugin p1 --mcp m1 --connector c1 --json
"context": {
  "skillIds": ["alpha", "beta"],
  "pluginIds": ["p1"],
  "mcpServerIds": ["m1"],
  "connectorIds": ["c1"]
}
```

  The routine created during verification was deleted afterwards.

## Note on the approach

The alias was dropped rather than converted to a hoisted `function` wrapper. `splitCommaSeparatedIds` is already called directly elsewhere in `cli.ts` (in the run CLI's `--skill` handling), the alias added no behavior, and removing it means there is no second binding that can fall back into a dead zone. Happy to switch to a `function splitAutomationIds(...)` wrapper instead if you would rather keep the automation-specific name.
