### PR TITLE
fix(daemon): honor active workspace in MCP bridge

### DIFF
--- a/apps/daemon/src/mcp-workspace-context.ts
+++ b/apps/daemon/src/mcp-workspace-context.ts
@@ -94,7 +94,10 @@ export async function resolveMcpWorkspaceContext(
       return null;
     }
     const data = (await resp.json()) as WorkspaceDirectoryResponse;
-    const selected = selectDefaultMcpCandidate(data.items);
+    const selected = selectDefaultMcpCandidate(
+      data.items,
+      data.activeWorkspaceId ?? undefined,
+    );
     if (!selected) {
       // 200 with empty items — non-vela (dev provider) or no live membership.
       recordFailure(baseUrl);

--- a/apps/daemon/tests/mcp-workspace-context.test.ts
+++ b/apps/daemon/tests/mcp-workspace-context.test.ts
@@ -91,6 +91,44 @@ describe('resolveMcpWorkspaceContext', () => {
     expect(fetchMock).toHaveBeenCalledWith(`${base}/api/workspace/directory`, expect.anything());
   });
 
+  it('uses the active workspace across multiple team memberships', async () => {
+    const base = 'http://127.0.0.1:19003';
+    const first = item({
+      workspaceId: 'ws-team-a',
+      workspaceName: 'Team A',
+      workspaceType: 'team',
+      workspaceMemberId: 'mem-a',
+    });
+    const active = item({
+      workspaceId: 'ws-team-b',
+      workspaceName: 'Team B',
+      workspaceType: 'team',
+      workspaceMemberId: 'mem-b',
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            items: [first, active],
+            activeWorkspaceId: active.workspaceId,
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+
+    expect(await resolveMcpWorkspaceContext(base)).toEqual({
+      workspaceId: active.workspaceId,
+      workspaceMemberId: active.workspaceMemberId,
+      workspaceType: 'team',
+      headers: {
+        'x-od-workspace-id': active.workspaceId,
+        'x-od-workspace-member-id': active.workspaceMemberId,
+      },
+    });
+  });
+
   it('returns null on a directory outage (non-200)', async () => {
     vi.stubGlobal(
       'fetch',


### PR DESCRIPTION
Fixes #7613

## Why

A multi-workspace account can have a valid active workspace that is not the first entry in `/api/workspace/directory`. The MCP stdio bridge currently ignores the response's `activeWorkspaceId`, selects its personal/first fallback instead, and then sends that different workspace identity on project and artifact requests. Valid projects in the active workspace can consequently appear missing or fail with `WORKSPACE_PROJECT_PERMISSION_DENIED`.

This is the narrow current-source fix confirmed in the issue. It is separate from #6929's explicit `OD_MCP_WORKSPACE_ID` override and does not aggregate catalogs across memberships.

## What users will see

After reconnecting MCP, project and artifact tools use the workspace last selected in Open Design when that workspace is still an active membership. Multi-workspace users no longer get an empty project list or a misleading workspace-permission error solely because the active workspace was not first in directory order.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — no UI surface changes.

## Bug fix verification

- Test path: `apps/daemon/tests/mcp-workspace-context.test.ts` (`uses the active workspace across multiple team memberships`).
- Red on `main`: yes — the bridge selected the first Team workspace (`ws-team-a`) instead of the active second Team workspace (`ws-team-b`).
- Green on this branch: yes — the focused file passes 11/11 tests and asserts the active workspace id, member id, type, and both request headers.

## Validation

- `corepack pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/mcp-workspace-context.test.ts` — 11 passed
- `corepack pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/mcp` — 26 files / 347 tests passed
- `corepack pnpm --filter @open-design/daemon typecheck` — passed
- `corepack pnpm --filter @open-design/daemon build` — passed
- `corepack pnpm guard` — passed
- `git diff --check` — passed

Live two-team account QA was not repeated locally; the issue reporter supplied that end-to-end verification, while this change adds the current-source regression requested in the issue.
