### PR TITLE
fix(pack): allow Windows desktop evals to run for 60 seconds

### DIFF
--- a/tools/pack/src/win/lifecycle.ts
+++ b/tools/pack/src/win/lifecycle.ts
@@ -64,6 +64,7 @@ import type {
 
 const PACKAGED_CONFIG_PATH_ENV = "OD_PACKAGED_CONFIG_PATH";
 const UPDATE_ACTION_TIMEOUT_MS = 10 * 60 * 1000;
+export const WIN_DESKTOP_EVAL_TIMEOUT_MS = 60_000;
 
 function desktopStamp(config: ToolPackConfig): SidecarStamp {
   return {
@@ -524,7 +525,7 @@ async function requestDesktopEval(
     return await requestJsonIpc<DesktopEvalResult>(
       ipc,
       { input: { expression }, type: SIDECAR_MESSAGES.EVAL },
-      { timeoutMs: 5000 },
+      { timeoutMs: WIN_DESKTOP_EVAL_TIMEOUT_MS },
     );
   } catch (error) {
     return {

--- a/tools/pack/tests/win-lifecycle-timeouts.test.ts
+++ b/tools/pack/tests/win-lifecycle-timeouts.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { WIN_DESKTOP_EVAL_TIMEOUT_MS } from "../src/win/lifecycle.js";
+
+describe("Windows packaged lifecycle timeout contracts", () => {
+  it("keeps desktop eval at the release smoke budget of exactly 60 seconds", () => {
+    expect(WIN_DESKTOP_EVAL_TIMEOUT_MS).toBe(60_000);
+  });
+});


### PR DESCRIPTION
Fixes #6285

## Why
Packaged Windows smoke timed out because the desktop eval budget was 5s while the first packaged load needs up to 60s. Raise the timeout to match the documented 60s smoke budget.

## What users will see
Windows packaged `inspect --expr` no longer aborts after 5s. Long first evaluations can run up to 60s; other evals unchanged.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

N/A

## Bug fix verification

- Test path: `tools/pack/tests/win-lifecycle-timeouts.test.ts`
- Did the test go red on `main` and green on this branch? yes

## Validation

- `git diff --check` clean
- `tools-pack` contract test `win-lifecycle-timeouts.test.ts` locks 60_000