### PR TITLE
fix OpenRouter retired model diagnostics

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -897,6 +897,7 @@ export function isSmokeOkReply(text: unknown): boolean {
 }
 
 function isLikelyModelErrorText(text: string): boolean {
+  if (/no (?:available )?endpoints? found for\b/i.test(text)) return true;
   return (
     /model/i.test(text) &&
     /(not found|not exist|does not exist|unknown|invalid|unsupported|not supported|not have access|no access|issue with the selected model)/i.test(
@@ -1060,7 +1061,13 @@ function classifyProviderHttpFailure(
   detailText: string,
   secrets: string[],
 ): { kind: ConnectionTestKind; detail: string } {
-  const redactedDetail = redactSecrets(detailText.slice(0, 240), secrets);
+  let providerDetail = detailText;
+  try {
+    providerDetail = extractProviderErrorDetail(JSON.parse(detailText), detailText);
+  } catch {
+    // Keep non-JSON upstream bodies verbatim.
+  }
+  const redactedDetail = redactSecrets(providerDetail.slice(0, 240), secrets);
   const override = providerHttpErrorOverride(
     protocol,
     hostname,

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -1070,6 +1070,45 @@ describe('POST /api/test/connection provider mode', () => {
     expect(body.status).toBe(404);
   });
 
+  it('maps OpenRouter no-endpoints 404 responses to not_found_model', async () => {
+    vi.stubGlobal(
+      'fetch',
+      passThroughOrUpstream(() =>
+        jsonResponse(
+          {
+            error: {
+              message: 'No endpoints found for anthropic/claude-3.7-sonnet.',
+            },
+          },
+          { status: 404 },
+        ),
+      ),
+    );
+
+    const res = await realFetch(`${baseUrl}/api/test/connection`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        mode: 'provider',
+        protocol: 'openai',
+        baseUrl: 'https://openrouter.ai/api/v1',
+        apiKey: 'sk-or-test',
+        model: 'anthropic/claude-3.7-sonnet',
+      }),
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(body).toMatchObject({
+      ok: false,
+      kind: 'not_found_model',
+      status: 404,
+      model: 'anthropic/claude-3.7-sonnet',
+    });
+    expect(body.detail).toBe(
+      'No endpoints found for anthropic/claude-3.7-sonnet.',
+    );
+  });
+
   it('maps an ambiguous 404 to invalid_base_url', async () => {
     vi.stubGlobal(
       'fetch',

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -212,14 +212,18 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     protocol: 'openai',
     baseUrl: 'https://openrouter.ai/api/v1',
     preferredModels: [
-      'anthropic/claude-3.7-sonnet',
-      'anthropic/claude-3.5-sonnet',
+      'anthropic/claude-sonnet-4.6',
+      'anthropic/claude-sonnet-4.5',
       'google/gemini-2.5-flash',
       'google/gemini-2.5-pro',
       'openai/gpt-4o',
       'openai/o3-mini',
       'deepseek/deepseek-chat',
       'deepseek/deepseek-r1',
+    ],
+    retiredModels: [
+      'anthropic/claude-3.7-sonnet',
+      'anthropic/claude-3.5-sonnet',
     ],
   },
   {
@@ -732,41 +736,41 @@ export function loadConfig(): AppConfig {
         merged.apiProviderBaseUrl = knownProvider?.baseUrl ?? null;
       }
 
-      // Migration v2: replace model ids that were previously shipped as
-      // provider defaults but have since been retired. Apply it to every saved
-      // BYOK slot so switching protocols/providers cannot restore a stale id.
-      if (parsedMigrationVersion < 2) {
-        const activeProtocol = merged.apiProtocol ?? inferApiProtocol(
-          merged.model,
-          merged.baseUrl,
-        );
-        migratedConfig = migrateRetiredKnownProviderModel(activeProtocol, merged)
-          || migratedConfig;
-        for (const [protocol, apiConfig] of Object.entries(
-          merged.apiProtocolConfigs ?? {},
-        )) {
-          if (!apiConfig) continue;
-          migratedConfig = migrateRetiredKnownProviderModel(
-            protocol as ApiProtocol,
-            apiConfig,
-          ) || migratedConfig;
-        }
-        for (const [draftKey, draft] of Object.entries(
-          merged.byokProviderConfigDrafts ?? {},
-        )) {
-          const separator = draftKey.indexOf(':');
-          if (separator <= 0) continue;
-          migratedConfig = migrateRetiredKnownProviderModel(
-            draftKey.slice(0, separator) as ApiProtocol,
-            draft.apiConfig,
-          ) || migratedConfig;
-        }
-      }
       const persistedAccent = normalizeAccentColor(parsed.accentColor);
       if (persistedAccent != null && LEGACY_DEFAULT_ACCENT_COLORS.includes(persistedAccent)) {
         merged.accentColor = DEFAULT_CONFIG.accentColor;
       }
       merged.configMigrationVersion = CONFIG_MIGRATION_VERSION;
+    }
+
+    // Retired provider defaults are data updates rather than config schema
+    // changes. Apply them on every read so adding one does not require bumping
+    // the migration version, and cover every saved BYOK slot so switching
+    // protocols/providers cannot restore a stale id.
+    const activeProtocol = merged.apiProtocol ?? inferApiProtocol(
+      merged.model,
+      merged.baseUrl,
+    );
+    migratedConfig = migrateRetiredKnownProviderModel(activeProtocol, merged)
+      || migratedConfig;
+    for (const [protocol, apiConfig] of Object.entries(
+      merged.apiProtocolConfigs ?? {},
+    )) {
+      if (!apiConfig) continue;
+      migratedConfig = migrateRetiredKnownProviderModel(
+        protocol as ApiProtocol,
+        apiConfig,
+      ) || migratedConfig;
+    }
+    for (const [draftKey, draft] of Object.entries(
+      merged.byokProviderConfigDrafts ?? {},
+    )) {
+      const separator = draftKey.indexOf(':');
+      if (separator <= 0) continue;
+      migratedConfig = migrateRetiredKnownProviderModel(
+        draftKey.slice(0, separator) as ApiProtocol,
+        draft.apiConfig,
+      ) || migratedConfig;
     }
 
     const downgradedUnsupportedChatProtocol =

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -83,6 +83,20 @@ describe('KNOWN_PROVIDERS', () => {
 
     expect(defaultKnownProviderModel(ollamaCloud)).toBe('gpt-oss:120b');
   });
+
+  it('defaults OpenRouter to a live model and records retired defaults', () => {
+    const openRouter = KNOWN_PROVIDERS.find(
+      (provider) => provider.label === 'OpenRouter',
+    );
+
+    expect(defaultKnownProviderModel(openRouter)).toBe(
+      'anthropic/claude-sonnet-4.6',
+    );
+    expect(openRouter?.retiredModels).toEqual([
+      'anthropic/claude-3.7-sonnet',
+      'anthropic/claude-3.5-sonnet',
+    ]);
+  });
 });
 
 vi.stubGlobal('localStorage', {
@@ -1060,6 +1074,25 @@ describe('loadConfig', () => {
     expect(
       config.byokProviderConfigDrafts?.[`openai:${moonshotBaseUrl}`]?.apiConfig.model,
     ).toBe('kimi-k2.6');
+    expect(config.configMigrationVersion).toBe(3);
+  });
+
+  it('migrates the retired OpenRouter default from migration version 3', () => {
+    const openRouterBaseUrl = 'https://openrouter.ai/api/v1';
+    const persisted: Partial<AppConfig> = {
+      mode: 'api',
+      apiProtocol: 'openai',
+      apiKey: 'sk-or-test',
+      baseUrl: openRouterBaseUrl,
+      model: 'anthropic/claude-3.7-sonnet',
+      apiProviderBaseUrl: openRouterBaseUrl,
+      configMigrationVersion: 3,
+    };
+    store.set('open-design:config', JSON.stringify(persisted));
+
+    const config = loadConfig();
+
+    expect(config.model).toBe('anthropic/claude-sonnet-4.6');
     expect(config.configMigrationVersion).toBe(3);
   });
 


### PR DESCRIPTION
Plane: https://plane.powerformer.net/open-design/browse/OPEND-2456/

## Why

While reproducing OPEND-2456 with a real OpenRouter credential, the shipped OpenRouter default `anthropic/claude-3.7-sonnet` returned an upstream 404 because the model no longer has endpoints. Open Design classified that response as an invalid Base URL, so users with a correct key and untouched preset were told to repair the wrong setting.

This PR keeps the bug fix scoped to the OpenRouter preset and provider-error classification. Other provider-account issues found during the wider BYOK regression are listed below rather than folded into this change.

## What users will see

- New OpenRouter configurations default to `anthropic/claude-sonnet-4.6`.
- Existing configurations saved with the retired 3.7/3.5 Sonnet defaults migrate to the live default when loaded.
- If OpenRouter returns `No endpoints found for ...`, the connection test reports a model-not-found error instead of claiming the Base URL is invalid.
- Ambiguous 404 responses continue to use the existing invalid-Base-URL diagnosis.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this changes the existing preset value and error diagnosis without adding or rearranging UI. The full existing UI flow was exercised against live providers as described below.

## Bug fix verification

- Red specs:
  - `apps/daemon/tests/connection-test.test.ts` — reproduces OpenRouter's exact `No endpoints found` 404 at the daemon HTTP boundary.
  - `apps/web/tests/state/config.test.ts` — reproduces a migration-version-3 config carrying the retired OpenRouter default.
- Red on `main`, green on this branch: yes. Before the source fix, the HTTP-boundary case classified the payload as `invalid_base_url`, and a current-version config retained the retired model; both assertions pass on this branch.
- Live reproduction on `main`: the untouched OpenRouter preset selected the retired model and returned the user-visible invalid-Base-URL error. On this branch, the same UI configuration fetched the live model catalog, connected, saved, and completed a real chat turn.

## Adjacent issues

Kept out of this focused fix: stale xAI recommendations, NVIDIA's 120B default exceeding the 12-second smoke timeout, MiniMax regional preset/key mismatch, and account/upstream failures observed for Zhipu, MiMo, and Volcengine. Each needs its own provider-specific red spec and policy decision.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/daemon exec vitest run tests/connection-test.test.ts` — 159 passed
- `pnpm --filter @open-design/web exec vitest run tests/state/config.test.ts` — 73 passed
- Package typechecks for `@open-design/daemon` and `@open-design/web`
- Real UI → connection test → save → chat regression passed for OpenRouter, OpenAI, Google Gemini, xAI, NVIDIA, SiliconFlow CN, Moonshot/Kimi, and MiniMax International. Credentials were held only in an isolated temporary data root and removed after the run.
