### PR TITLE
fix(landing-page): allow studio cards to shrink below 420px on narrow screens

### DIFF
--- a/apps/landing-page/app/pages/codex-slides/index.astro
+++ b/apps/landing-page/app/pages/codex-slides/index.astro
@@ -483,7 +483,7 @@ const studioTiles = copy.inside.map((tile, i) => ({ ...tile, src: STUDIO_SHOTS[i
   /* Studio UI screenshots carry dense product chrome, so they need a bigger
      cell than the simple deck cards — two-up instead of four-up. */
   .ha-showcase-wide {
-    grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 420px), 1fr));
   }
 
   /* ---- Scenario cards ---- */


### PR DESCRIPTION
Fixes #6097

The `.ha-showcase-wide` grid on `/codex-slides/` used a fixed 420px minimum track, which overflowed its container on phones narrower than 420px. The global `html { overflow-x: clip }` rule hides the horizontal scrollbar, so the clipping was invisible except for the content loss at the card edge.

## Fix

Wrap the `minmax` lower bound in `min(100%, 420px)` so the track shrinks to the available container width when the viewport is narrower than the cell minimum. Desktop layout is preserved.