### PR TITLE
fix(daemon): follow OpenCode permission capability drift

### DIFF
--- a/apps/daemon/src/runtimes/opencode-permissions.ts
+++ b/apps/daemon/src/runtimes/opencode-permissions.ts
@@ -1,20 +1,28 @@
 import { agentCapabilities } from './capabilities.js';
 import type { RuntimeAgentDef } from './types.js';
 
+export const OPENCODE_AUTO_PERMISSION_FLAG = '--auto';
 export const OPENCODE_SKIP_PERMISSIONS_FLAG = '--dangerously-skip-permissions';
 export const OPENCODE_WORKSPACE_DIR_FLAG = '--dir';
 
 export const OPENCODE_PERMISSION_CAPABILITY = {
   helpArgs: ['run', '--help'],
   capabilityFlags: {
+    [OPENCODE_AUTO_PERMISSION_FLAG]: 'autoPermissionBypass',
     [OPENCODE_SKIP_PERMISSIONS_FLAG]: 'skipPermissions',
   },
 } satisfies Pick<RuntimeAgentDef, 'helpArgs' | 'capabilityFlags'>;
 
 export function appendOpenCodePermissionBypass(args: string[], agentId: string): void {
-  if (agentCapabilities.get(agentId)?.skipPermissions) {
-    args.push(OPENCODE_SKIP_PERMISSIONS_FLAG);
-  }
+  const capabilities = agentCapabilities.get(agentId);
+  // OpenCode replaced the legacy flag with --auto. Prefer the current flag if
+  // a build advertises both, while retaining the old flag for older installs.
+  const bypassFlag = capabilities?.autoPermissionBypass
+    ? OPENCODE_AUTO_PERMISSION_FLAG
+    : capabilities?.skipPermissions
+      ? OPENCODE_SKIP_PERMISSIONS_FLAG
+      : null;
+  if (bypassFlag) args.push(bypassFlag);
 }
 
 /**

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -88,7 +88,10 @@ test('opencode args pass model-supported variants without changing the default a
     (model) => model.id === 'openai/gpt-5.6-sol',
   )?.reasoningOptions, undefined);
   assert.deepEqual(opencode.helpArgs, ['run', '--help']);
-  assert.deepEqual(opencode.capabilityFlags?.['--dangerously-skip-permissions'], 'skipPermissions');
+  assert.deepEqual(opencode.capabilityFlags, {
+    '--auto': 'autoPermissionBypass',
+    '--dangerously-skip-permissions': 'skipPermissions',
+  });
   assert.equal(baseArgs.includes('-'), false);
   assert.equal(baseArgs.includes(prompt), false);
   assert.deepEqual(baseArgs, [
@@ -232,6 +235,39 @@ test('opencode passes --dangerously-skip-permissions when the help probe finds i
       '--format',
       'json',
       '--dangerously-skip-permissions',
+    ]);
+  } finally {
+    agentCapabilities.delete('opencode');
+  }
+});
+
+test('opencode prefers --auto when the help probe finds the new permission bypass', () => {
+  agentCapabilities.set('opencode', {
+    autoPermissionBypass: true,
+    skipPermissions: false,
+  });
+  try {
+    assert.deepEqual(opencode.buildArgs('design a dashboard', [], [], {}), [
+      'run',
+      '--format',
+      'json',
+      '--auto',
+    ]);
+  } finally {
+    agentCapabilities.delete('opencode');
+  }
+});
+
+test('opencode omits permission bypass when the help probe finds neither supported flag', () => {
+  agentCapabilities.set('opencode', {
+    autoPermissionBypass: false,
+    skipPermissions: false,
+  });
+  try {
+    assert.deepEqual(opencode.buildArgs('design a dashboard', [], [], {}), [
+      'run',
+      '--format',
+      'json',
     ]);
   } finally {
     agentCapabilities.delete('opencode');

--- a/apps/daemon/tests/runtimes/byok-opencode.test.ts
+++ b/apps/daemon/tests/runtimes/byok-opencode.test.ts
@@ -14,6 +14,7 @@ describe('byok-opencode runtime config', () => {
     agentCapabilities.delete('byok-opencode');
     expect(byokOpenCodeAgentDef.helpArgs).toEqual(['run', '--help']);
     expect(byokOpenCodeAgentDef.capabilityFlags).toEqual({
+      '--auto': 'autoPermissionBypass',
       '--dangerously-skip-permissions': 'skipPermissions',
     });
     expect(byokOpenCodeAgentDef.buildArgs('', [], [], {})).toEqual([
@@ -31,6 +32,39 @@ describe('byok-opencode runtime config', () => {
         '--dangerously-skip-permissions',
         '-m',
         'open-design-byok/gpt-5.5',
+      ]);
+    } finally {
+      agentCapabilities.delete('byok-opencode');
+    }
+  });
+
+  it('uses the new --auto permission bypass when the installed OpenCode advertises it', () => {
+    agentCapabilities.set('byok-opencode', {
+      autoPermissionBypass: true,
+      skipPermissions: false,
+    });
+    try {
+      expect(byokOpenCodeAgentDef.buildArgs('', [], [], {})).toEqual([
+        'run',
+        '--format',
+        'json',
+        '--auto',
+      ]);
+    } finally {
+      agentCapabilities.delete('byok-opencode');
+    }
+  });
+
+  it('omits the permission bypass when OpenCode advertises neither supported flag', () => {
+    agentCapabilities.set('byok-opencode', {
+      autoPermissionBypass: false,
+      skipPermissions: false,
+    });
+    try {
+      expect(byokOpenCodeAgentDef.buildArgs('', [], [], {})).toEqual([
+        'run',
+        '--format',
+        'json',
       ]);
     } finally {
       agentCapabilities.delete('byok-opencode');

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -1074,6 +1074,46 @@ test('detectAgents reuses the opencode configured env for byok-opencode availabi
   }
 });
 
+test('detectAgents records the new OpenCode permission capability for native and BYOK runtimes', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-opencode-capability-'));
+  try {
+    await withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], async () => {
+      const bin = join(dir, 'opencode');
+      writeFileSync(
+        bin,
+        '#!/bin/sh\n' +
+          'if [ "$1" = "--version" ]; then echo opencode-capability-test; exit 0; fi\n' +
+          'if [ "$1" = "run" ] && [ "$2" = "--help" ]; then echo "--auto" >&2; exit 0; fi\n' +
+          'if [ "$1" = "models" ]; then echo openai/gpt-5; exit 0; fi\n' +
+          'exit 0\n',
+      );
+      chmodSync(bin, 0o755);
+      process.env.PATH = '';
+      process.env.OD_AGENT_HOME = dir;
+      agentCapabilities.delete('opencode');
+      agentCapabilities.delete('byok-opencode');
+
+      const agents = await detectAgents({ opencode: { OPENCODE_BIN: bin } });
+
+      assert.equal(agents.find((agent) => agent.id === 'opencode')?.available, true);
+      assert.equal(agents.find((agent) => agent.id === 'byok-opencode')?.available, true);
+      assert.deepEqual(agentCapabilities.get('opencode'), {
+        autoPermissionBypass: true,
+        skipPermissions: false,
+      });
+      assert.deepEqual(agentCapabilities.get('byok-opencode'), {
+        autoPermissionBypass: true,
+        skipPermissions: false,
+      });
+      assert.ok(opencode.buildArgs('', [], [], {}).includes('--auto'));
+    });
+  } finally {
+    agentCapabilities.delete('opencode');
+    agentCapabilities.delete('byok-opencode');
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('detectAgents marks Cursor Agent auth ok when cursor-agent status succeeds', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'od-cursor-auth-ok-'));
   try {

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -264,9 +264,10 @@ the active-run staging implementation is in
 ### 5.6 OpenCode
 
 - OpenCode runs as `opencode run --format json` with the prompt on stdin.
-  Newer builds that advertise `--dangerously-skip-permissions` from
-  `opencode run --help` receive that flag; older builds keep the compatible
-  argv without it.
+  Builds that advertise `--auto` from `opencode run --help` receive that
+  current permission-bypass flag; older builds that advertise
+  `--dangerously-skip-permissions` receive the legacy flag. Builds that
+  advertise neither keep the compatible argv without a bypass flag.
 - The adapter discovers models with `opencode models`, parses structured JSON
   events, and captures OpenCode's `sessionID`. Follow-up turns continue the
   native session with `-s <session-id>`.
@@ -516,9 +517,10 @@ external-directory flags can widen a CLI's reach.
   Qoder and Trae use `--yolo`; Copilot uses `--allow-all-tools`; DeepSeek uses
   `--auto`. Other definitions have their own explicit headless posture (for
   example Amp's `--dangerously-allow-all`).
-- OpenCode receives `--dangerously-skip-permissions` only when its help probe
-  advertises that flag, so older compatible builds are not given an unknown
-  option.
+- OpenCode receives `--auto` when its help probe advertises the current
+  permission-bypass flag, and falls back to `--dangerously-skip-permissions`
+  for older compatible builds. If neither flag is advertised, no bypass flag
+  is added, so the CLI is not given an unknown option.
 - Codex defaults to `workspace-write` with network access on supported macOS
   and Linux hosts. Windows, WSL, or an explicit
   `OD_CODEX_SANDBOX=danger-full-access` operator override uses


### PR DESCRIPTION
Fixes #7624

## Why

I am taking the focused follow-up requested on #7624. OpenCode has renamed its non-interactive permission bypass from --dangerously-skip-permissions to --auto, but the daemon only probes for the legacy flag. On newer installations this leaves headless native and BYOK runs exposed to an interactive permission prompt with no input path.

The shared capability helper now probes both flags and preserves the exact flag advertised by the installed CLI. This keeps older OpenCode versions working while avoiding unsupported arguments on builds that expose neither flag.

## What users will see

OpenCode runs on newer CLI versions will automatically receive --auto and no longer stop at a permission prompt. Older versions continue to receive --dangerously-skip-permissions; unsupported versions receive neither optional bypass flag.

## Surface area

- [ ] UI — new page / dialog / panel / menu item / setting / empty state
- [ ] Keyboard shortcut — new or changed
- [ ] CLI / env var — new subcommand or flag
- [ ] API / contract — new endpoint, event, or contract shape
- [ ] Extension point — new skill, design system, design template, or craft entry
- [ ] i18n keys — added new translation keys
- [ ] New top-level dependency — adding any new root package dependency
- [x] Default behavior change — existing OpenCode runs now use the current advertised non-interactive bypass flag
- [ ] None — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is a daemon/runtime behavior fix.

## Bug fix verification

- Test path that reproduces the bug: apps/daemon/tests/runtimes/agent-args.test.ts, apps/daemon/tests/runtimes/byok-opencode.test.ts, and apps/daemon/tests/runtimes/env-and-detection.test.ts
- Did the test go red on main and green on this branch? Yes. The new native/BYOK assertions failed before the source change and pass on this branch.

## Validation

- Focused Vitest: 3 files, 142 tests passed
- pnpm --filter @open-design/daemon typecheck — passed
- pnpm guard — passed
- pnpm --filter @open-design/daemon test — attempted; the suite reported one unrelated existing connection-test failure under the local Node 26 environment and then hung without further progress, so it was interrupted.
