### PR TITLE
chore(pack): bump Vela CLI to 0.0.34

### DIFF
--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -9,6 +9,6 @@
   # 1. Temporarily set the consuming `hash = lib.fakeHash;`
   # 2. Run the relevant nix build/flake check
   # 3. Copy the expected hash printed by Nix into the matching field below
-  daemonHash = "sha256-ujXjphrP9TvyLvIFaiplOfWMhQEbMsy74KkCmqALkus=";
-  webHash = "sha256-OfTksoOcxLu6OairFxQEYLQomj1JFCDEA3maKiH+9bQ=";
+  daemonHash = "sha256-SFvveAQJlyx5Qt2WX7SKN68++PK7utORa70+n0fSXdw=";
+  webHash = "sha256-0SrHy95pJUoY10+Vanh4aD6HCNrp4W14VdRyhrHqjAo=";
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -930,8 +930,8 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       '@powerformer/vela-cli':
-        specifier: 0.0.33
-        version: 0.0.33
+        specifier: 0.0.34
+        version: 0.0.34
 
   tools/release:
     dependencies:
@@ -2705,33 +2705,33 @@ packages:
   '@posthog/types@1.374.2':
     resolution: {integrity: sha512-ZghQSFMi+HFJNPvPjBoyY/jWQ+q6mSQVtWQxOHMSbBidUZjsyYbxYxBFbHy2qWLNe4mEpX+Wqir2Q4I/4AVvJQ==}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.33':
-    resolution: {integrity: sha512-94BxQyh00an5Cvkrg3PbrtsciH2qPnB910fk4Hqmduai3GrTyWZHNjYdkRfiNgf7qZvheSSm4wmQPhJgwrUC1A==}
+  '@powerformer/vela-cli-darwin-arm64@0.0.34':
+    resolution: {integrity: sha512-+WMTKgnkBjCZtZ7tVXpjKBjLb9Ti/xgYuI/ukDTpqe4JZUn7K83SrX57tHfUA+aG85h6XbzdTJl3PP38KJOUcQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@powerformer/vela-cli-darwin-x64@0.0.33':
-    resolution: {integrity: sha512-t29x7b2yc/PBROLAr0FyDPcqhbBXINeLfQorAQr7ij4lkmFFqSmWrEAh/um7xOADzPUYjCUko/UWLeEHKMXbiA==}
+  '@powerformer/vela-cli-darwin-x64@0.0.34':
+    resolution: {integrity: sha512-dPQtJTGYqFAyJ4h1KpLsM+gJJ1pbBidQKr93Nq3AaiIK39A1b2UDweVdWu7bCnhgSEkGRyj+/kaoTK0gwJirhQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@powerformer/vela-cli-linux-arm64@0.0.33':
-    resolution: {integrity: sha512-+DHifD5ylfjfsaWCo0NuPwl+D0lxkOs+apDCaxrj4EkSABkzjryrh2yIBncopZbz3GmDw+43AKNfTyDx6yr4fg==}
+  '@powerformer/vela-cli-linux-arm64@0.0.34':
+    resolution: {integrity: sha512-NTet6TIZXneO33ySfXnylciA2C83xzsSS3KXElEqYh9cICzEBdN5yeDrI+5rOEaV47wZVqwa7Ih2rDpLEcfV+A==}
     cpu: [arm64]
     os: [linux]
 
-  '@powerformer/vela-cli-linux-x64@0.0.33':
-    resolution: {integrity: sha512-uBAeeTUEUaLMe5DtO1RjfiH7egvljfUJoUEkGOqle2O83wX2zulXkQzDhh+br5EvKsZo9RtSHzCcsiRPaNeo/g==}
+  '@powerformer/vela-cli-linux-x64@0.0.34':
+    resolution: {integrity: sha512-VYyf4iDcWgGEuYIRyFwCY58HD+s0KD/zhSWArptqoOFxxTp4Wk06IW8tAsrBhGWWl4FBIopMcbJz94nkQS4Bcg==}
     cpu: [x64]
     os: [linux]
 
-  '@powerformer/vela-cli-win32-x64@0.0.33':
-    resolution: {integrity: sha512-J2pHEpQ2LeTW0zgkJ/XEa9mpZh3NJKia0r28P/d+KGKpSozcJecE5+/NUfArThNnRUKi8NxPSEqs9PWdrz3BCg==}
+  '@powerformer/vela-cli-win32-x64@0.0.34':
+    resolution: {integrity: sha512-HzvSR52enek60t9TLkXdZYmP0j+im5Pa1kO4yyh7i3CgOsAM/BGw5EN6M4TJly+hYUYzyiOqf7JABID6YJiiAw==}
     cpu: [x64]
     os: [win32]
 
-  '@powerformer/vela-cli@0.0.33':
-    resolution: {integrity: sha512-ypqsOqRpj/DxO8WAvM89eeWJOsOMb+bRloZb4JNW3QTNX5TmDmA61H3wM9wX0vCd95JAmPg3mxJH6xrWnKVCcg==}
+  '@powerformer/vela-cli@0.0.34':
+    resolution: {integrity: sha512-D5X/y18HLR+i/3tS2VpTPQxb2aqhfpc6FZYkiAWg23SSdxPjIVeghjx/8efPmk0HNU9T5swLO0YTaf5r4a5hSQ==}
     hasBin: true
 
   '@preact/signals-core@1.14.2':
@@ -9198,28 +9198,28 @@ snapshots:
 
   '@posthog/types@1.374.2': {}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.33':
+  '@powerformer/vela-cli-darwin-arm64@0.0.34':
     optional: true
 
-  '@powerformer/vela-cli-darwin-x64@0.0.33':
+  '@powerformer/vela-cli-darwin-x64@0.0.34':
     optional: true
 
-  '@powerformer/vela-cli-linux-arm64@0.0.33':
+  '@powerformer/vela-cli-linux-arm64@0.0.34':
     optional: true
 
-  '@powerformer/vela-cli-linux-x64@0.0.33':
+  '@powerformer/vela-cli-linux-x64@0.0.34':
     optional: true
 
-  '@powerformer/vela-cli-win32-x64@0.0.33':
+  '@powerformer/vela-cli-win32-x64@0.0.34':
     optional: true
 
-  '@powerformer/vela-cli@0.0.33':
+  '@powerformer/vela-cli@0.0.34':
     optionalDependencies:
-      '@powerformer/vela-cli-darwin-arm64': 0.0.33
-      '@powerformer/vela-cli-darwin-x64': 0.0.33
-      '@powerformer/vela-cli-linux-arm64': 0.0.33
-      '@powerformer/vela-cli-linux-x64': 0.0.33
-      '@powerformer/vela-cli-win32-x64': 0.0.33
+      '@powerformer/vela-cli-darwin-arm64': 0.0.34
+      '@powerformer/vela-cli-darwin-x64': 0.0.34
+      '@powerformer/vela-cli-linux-arm64': 0.0.34
+      '@powerformer/vela-cli-linux-x64': 0.0.34
+      '@powerformer/vela-cli-win32-x64': 0.0.34
     optional: true
 
   '@preact/signals-core@1.14.2': {}

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -25,7 +25,7 @@
     "resedit": "1.7.2"
   },
   "optionalDependencies": {
-    "@powerformer/vela-cli": "0.0.33"
+    "@powerformer/vela-cli": "0.0.34"
   },
   "devDependencies": {
     "@types/node": "24.12.2",


### PR DESCRIPTION
## Why

Vela CLI 0.0.34 has been published. Open Design packages an exact Vela CLI version, so the tools-pack dependency and lockfile need to advance together.

## What users will see

Packaged Open Design builds will bundle Vela CLI 0.0.34 instead of 0.0.33 across supported macOS, Linux, and Windows targets.

## Surface area

- [ ] UI
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [x] Default behavior change
- [ ] None

## Screenshots

Not applicable.

## Bug fix verification

Not a bug fix.

## Validation

- pnpm install --frozen-lockfile
- pnpm --filter @open-design/tools-pack test -- tests/resources/resources.test.ts (40 files passed, 286 tests passed, 8 skipped)
- pnpm --filter @open-design/tools-pack typecheck
- git diff --check
- pnpm guard attempted; blocked by existing repository state: unallowlisted apps/landing-page/public/enhancers/cobe.js and matter.min.js, plus missing apps/telemetry-worker/package.json during the cross-app import check.