### PR TITLE
fix(e2e): align packaged chrome smoke with signed-out home

### DIFF
--- a/e2e/specs/mac.spec.ts
+++ b/e2e/specs/mac.spec.ts
@@ -2318,9 +2318,11 @@ async function assertFirstNativeChromeActionClick(): Promise<void> {
   const setup = await runToolsPackJson<MacInspectResult>('inspect', [
     '--expr',
     `(() => {
-      const target = document.querySelector('[data-testid="entry-top-right-github"]');
+      const target = document.querySelector(
+        '[data-testid="entry-top-right-github"], [data-testid="entry-nav-home"]',
+      );
       if (!(target instanceof HTMLElement)) {
-        throw new Error('first-render GitHub chrome action is missing');
+        throw new Error('first-render chrome action is missing');
       }
       window[${JSON.stringify(probeKey)}]?.cleanup?.();
       const probe = { clickCount: 0 };


### PR DESCRIPTION
## Summary

- keep the native packaged chrome click probe on the GitHub action when the top-right cluster exists
- fall back to the always-present Home rail action on the signed-out first-launch surface
- preserve fail-fast behavior when neither real chrome action is available

## Release blocker

The 0.21.1 prerelease.18 and stable run 33364950749 both failed the macOS arm64 P0 smoke before product assertions because the probe required `entry-top-right-github`. The signed-out product contract intentionally omits that cluster, and component tests assert it is absent.

## Validation

- `pnpm --dir e2e typecheck`
- `pnpm --dir e2e test specs/mac.spec.ts`
- `pnpm guard`
