### PR TITLE
fix(daemon): exclude host-flushed ACP results from completion diagnostics

### DIFF
--- a/apps/daemon/src/agent-protocol/acp/emission-provenance.ts
+++ b/apps/daemon/src/agent-protocol/acp/emission-provenance.ts
@@ -1,0 +1,24 @@
+/** Out-of-band origin of an ACP bridge emission, never part of its payload. */
+export interface AcpEmissionMeta {
+  hostSynthesized?: boolean;
+}
+
+const hostSynthesizedEmissions = new WeakSet<object>();
+
+/**
+ * Retain host provenance on the live payload identity even when a consumer only
+ * stores { event, data }. Weak references neither retain transcripts nor add
+ * fields to SSE, persisted JSON, or Langfuse. Deserialized legacy events have
+ * no provenance and keep the existing pairing behavior.
+ */
+export function withAcpEmissionProvenance<T extends object>(
+  payload: T,
+  meta?: AcpEmissionMeta,
+): T {
+  if (meta?.hostSynthesized === true) hostSynthesizedEmissions.add(payload);
+  return payload;
+}
+
+export function isHostSynthesizedAcpEmission(payload: object): boolean {
+  return hostSynthesizedEmissions.has(payload);
+}

--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -63,6 +63,7 @@ import {
 import { buildAcpSessionNewParams, buildPromptBlocks, type AcpMcpServerInput } from './session-params.js';
 import { withholdStdioMcpServersForBuild } from './stdio-mcp.js';
 import { createVelaChildEvidenceConsumer } from '../../runtimes/vela-child-evidence.js';
+import { withAcpEmissionProvenance, type AcpEmissionMeta } from './emission-provenance.js';
 
 const NON_DISPLAYABLE_ACP_SESSION_UPDATES = new Set([
   'usage_update',
@@ -84,9 +85,7 @@ const NON_DISPLAYABLE_ACP_SESSION_UPDATES = new Set([
  * exclude these; consumers that build the transcript still want them, which is
  * why the pair is emitted rather than dropped.
  */
-export interface AcpEmissionMeta {
-  hostSynthesized?: boolean;
-}
+export type { AcpEmissionMeta } from './emission-provenance.js';
 
 /**
  * Options for `attachAcpSession`. All fields except `child`, `prompt`, and
@@ -315,7 +314,7 @@ export function attachAcpSession({
     // ids (paths, tokens, JWTs) never leak into Langfuse span ids or
     // metadata.toolCallId.
     const telemetryToolCallId = acpTelemetryToolCallId(toolCallId);
-    send('agent', {
+    send('agent', withAcpEmissionProvenance({
       type: 'tool_use',
       id: telemetryToolCallId,
       name: st.name,
@@ -323,15 +322,15 @@ export function attachAcpSession({
       // Wall-clock start of the first ACP frame for this toolCallId so analytics
       // can compute real duration even though tool_use is emitted at terminal.
       startedAt: st.firstSeenAt,
-    }, meta);
-    send('agent', {
+    }, meta), meta);
+    send('agent', withAcpEmissionProvenance({
       type: 'tool_result',
       toolUseId: telemetryToolCallId,
       // Bash/execute stdout can dump private files (cat .env). Langfuse only
       // lexically masks Bash, so redact before the canonical transcript ships.
       content: acpSafeToolResultContent(st.name, st.resultContent),
       isError,
-    }, meta);
+    }, meta), meta);
     // Concrete only on terminal tool_result for a real (non-think) tool.
     emittedConcreteToolEvent = true;
   };

--- a/apps/daemon/src/run-diagnostics.ts
+++ b/apps/daemon/src/run-diagnostics.ts
@@ -5,6 +5,7 @@ import type {
   TrackingAmrOpenCodeLastToolStatus,
 } from '@open-design/contracts/analytics';
 import { redactSecrets } from './redact.js';
+import { isHostSynthesizedAcpEmission } from './agent-protocol/acp/emission-provenance.js';
 
 export interface RunEventForDiagnostics {
   event: string;
@@ -45,11 +46,10 @@ export interface RunDiagnosticsAnalytics {
   first_token_seen: boolean;
   user_visible_output_seen: boolean;
   tool_call_seen: boolean;
-  // True when every committed tool_use received a matching tool_result — paired
-  // by id where the runtime supplies one, by count for degraded events that emit
-  // a null id on both sides. A stall with `tool_call_seen && !tool_result_sent`
-  // is the tool-result-not-delivered root cause (a tool_use whose result never
-  // came back — including a still-outstanding tool in a parallel turn).
+  // Legacy name: every tool_use in the terminal attempt has a matching observed
+  // tool_result (by id, or count for idless streams). Known host-synthesized
+  // results are display cleanup, not agent-confirmed completion. Even a real
+  // result only proves observation, not delivery back to the model or run success.
   tool_result_sent: boolean;
   // True when an approval/permission gate fired. Only ACP runtimes surface this
   // (via an `acp_approval_request` diagnostic); stream/CLI runtimes bypass gates.
@@ -182,6 +182,13 @@ export function summarizeRunToolProgress(
   let toolCallSeen = false;
 
   for (const event of events) {
+    if (event.event === 'start') {
+      outstandingToolUseIds.clear();
+      idlessToolUses = 0;
+      idlessToolResults = 0;
+      toolCallSeen = false;
+      continue;
+    }
     const data = event.data && typeof event.data === 'object'
       ? event.data as Record<string, unknown>
       : {};
@@ -190,7 +197,9 @@ export function summarizeRunToolProgress(
       if (typeof data.id === 'string') outstandingToolUseIds.add(data.id);
       else idlessToolUses += 1;
     }
-    if (data.type === 'tool_result') {
+    // A host-flushed tool_use still witnesses an actual open ACP tool; only
+    // its manufactured result must be excluded from completion evidence.
+    if (data.type === 'tool_result' && !isHostSynthesizedAcpEmission(data)) {
       if (typeof data.toolUseId === 'string') {
         outstandingToolUseIds.delete(data.toolUseId);
       } else {

--- a/apps/daemon/tests/acp-tool-completion-diagnostics.test.ts
+++ b/apps/daemon/tests/acp-tool-completion-diagnostics.test.ts
@@ -1,0 +1,200 @@
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { attachAcpSession } from '../src/agent-protocol/acp/session.js';
+import {
+  summarizeRunDiagnosticsForAnalytics,
+  summarizeRunToolProgress,
+  type RunEventForDiagnostics,
+} from '../src/run-diagnostics.js';
+import { classifyRunFailure } from '../src/run-failure-classification.js';
+
+class InMemoryAcpChild extends EventEmitter {
+  stdin = new PassThrough();
+  stdout = new PassThrough();
+  stderr = new PassThrough();
+  kill() { return true; }
+}
+
+const sessions: ReturnType<typeof attachAcpSession>[] = [];
+afterEach(() => {
+  for (const session of sessions.splice(0)) session.abort();
+  vi.useRealTimers();
+});
+
+function startAttempt(events: RunEventForDiagnostics[] = []) {
+  vi.useFakeTimers();
+  const child = new InMemoryAcpChild();
+  events.push({ event: 'start', data: {} });
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'Synthetic diagnostics fixture',
+    stageTimeoutMs: 100,
+    // Like the daemon transcript path, retain payloads without copying the
+    // bridge's out-of-band metadata into the public event record.
+    send: (event, data) => events.push({ event, data }),
+  });
+  sessions.push(session);
+  const frame = (value: unknown) => child.stdout.write(JSON.stringify(value) + '\n');
+  frame({ id: 1, result: {} });
+  frame({ id: 2, result: { sessionId: 'fixture-session' } });
+  const tool = (id: string, status: string, kind = 'execute') => frame({
+    method: 'session/update',
+    params: { update: { sessionUpdate: 'tool_call_update', toolCallId: id, kind, status } },
+  });
+  return { events, session, frame, tool };
+}
+
+function failureStage(events: RunEventForDiagnostics[]) {
+  const error = events.slice().reverse().find(({ event }) => event === 'error')?.data as
+    { message?: string } | undefined;
+  return classifyRunFailure({
+    result: 'failed',
+    status: { status: 'failed', error: error?.message ?? 'ACP response timed out', exitCode: 1, signal: null },
+    errorCode: 'AGENT_EXIT_1',
+    agentId: 'amr',
+    events,
+  })?.failure_stage;
+}
+
+function expectOutstanding(events: RunEventForDiagnostics[]) {
+  expect(summarizeRunToolProgress(events)).toEqual({
+    toolCallSeen: true, toolResultSent: false, hasOutstandingTool: true,
+  });
+  expect(summarizeRunDiagnosticsForAnalytics({ events })).toMatchObject({
+    tool_call_seen: true, tool_result_sent: false,
+  });
+  expect(failureStage(events)).toBe('tool_outstanding');
+}
+
+function toolEvents(events: RunEventForDiagnostics[]) {
+  return events.filter(({ data }) => (data as { type?: string })?.type?.startsWith('tool_'));
+}
+
+describe('ACP tool completion diagnostics', () => {
+  it.each([
+    ['execute', 'pending'], ['execute', 'in_progress'], ['write', 'pending'],
+  ])('keeps %s / %s outstanding after a host timeout flush', async (kind, status) => {
+    const attempt = startAttempt();
+    attempt.tool('open-tool', status, kind);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(attempt.events.some(({ event }) => event === 'error')).toBe(true);
+    expect(toolEvents(attempt.events)).toHaveLength(2);
+    expect(toolEvents(attempt.events)[1]?.data).toMatchObject({ type: 'tool_result', isError: true });
+    expectOutstanding(attempt.events);
+  });
+
+  it('keeps a pending tool outstanding when the agent reports an SSE disconnect', () => {
+    const attempt = startAttempt();
+    attempt.tool('open-tool', 'pending', 'write');
+    attempt.frame({
+      id: 3,
+      error: {
+        code: -32603,
+        message: 'SSE stream disconnected',
+        data: {
+          kind: 'opencode_prompt_error', runtime: 'opencode', phase: 'event_stream',
+          lastEventType: 'tool_call_update', lastToolKind: 'write', lastToolStatus: 'pending',
+        },
+      },
+    });
+    expect(attempt.session.hasFatalError()).toBe(true);
+    // The chat close handler adds this verdict before classifying the run.
+    attempt.events.push({
+      event: 'diagnostic', data: { type: 'runtime_close', rpc_close_reason: 'fatal_rpc_error' },
+    });
+    expect(toolEvents(attempt.events)).toHaveLength(2);
+    expectOutstanding(attempt.events);
+  });
+
+  it.each(['completed', 'failed'])('retains agent-confirmed %s results', async (status) => {
+    const attempt = startAttempt();
+    attempt.tool('real-tool', 'in_progress');
+    attempt.tool('real-tool', status);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(summarizeRunToolProgress(attempt.events)).toEqual({
+      toolCallSeen: true, toolResultSent: true, hasOutstandingTool: false,
+    });
+    expect(failureStage(attempt.events)).toBe('post_tool_resume');
+    expect(toolEvents(attempt.events)).toHaveLength(2);
+  });
+
+  it('does not let a completed parallel tool hide a host-flushed tool', async () => {
+    const attempt = startAttempt();
+    attempt.tool('real-tool', 'completed');
+    attempt.tool('open-tool', 'in_progress');
+    await vi.advanceTimersByTimeAsync(100);
+    expect(toolEvents(attempt.events)).toHaveLength(4);
+    expectOutstanding(attempt.events);
+  });
+
+  it('ignores late terminals and duplicate flushes after the failure verdict', async () => {
+    const attempt = startAttempt();
+    attempt.tool('open-tool', 'pending');
+    await vi.advanceTimersByTimeAsync(100);
+    const count = attempt.events.length;
+    attempt.tool('open-tool', 'completed');
+    attempt.session.abort();
+    attempt.session.abort();
+    expect(attempt.events).toHaveLength(count);
+    expectOutstanding(attempt.events);
+  });
+
+  it.each([true, false])('isolates reused tool ids across attempts (first completed: %s)', async (firstCompleted) => {
+    const first = startAttempt();
+    first.tool('reused-tool', firstCompleted ? 'completed' : 'pending');
+    await vi.advanceTimersByTimeAsync(100);
+    const second = startAttempt(first.events);
+    second.tool('reused-tool', firstCompleted ? 'pending' : 'completed');
+    await vi.advanceTimersByTimeAsync(100);
+    if (firstCompleted) expectOutstanding(second.events);
+    else {
+      expect(summarizeRunToolProgress(second.events).toolResultSent).toBe(true);
+      expect(failureStage(second.events)).toBe('post_tool_resume');
+    }
+  });
+
+  it('does not carry an earlier outstanding tool into a tool-free attempt', async () => {
+    const first = startAttempt();
+    first.tool('previous-tool', 'pending');
+    await vi.advanceTimersByTimeAsync(100);
+    const second = startAttempt(first.events);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(summarizeRunToolProgress(second.events)).toEqual({
+      toolCallSeen: false, toolResultSent: false, hasOutstandingTool: false,
+    });
+    expect(failureStage(second.events)).toBe('first_token_wait');
+  });
+
+  it('keeps a best-effort clean flush distinct from confirmed tool completion', () => {
+    const attempt = startAttempt();
+    attempt.tool('open-tool', 'pending');
+    attempt.frame({ id: 3, result: { stopReason: 'end_turn' } });
+    expect(attempt.session.completedSuccessfully()).toBe(true);
+    expect(toolEvents(attempt.events)[1]?.data).toMatchObject({ isError: false });
+    expectOutstanding(attempt.events);
+  });
+
+  it('does not serialize provenance or reinterpret unmarked legacy pairs', async () => {
+    const attempt = startAttempt();
+    attempt.tool('open-tool', 'pending');
+    await vi.advanceTimersByTimeAsync(100);
+    const serialized = JSON.stringify(attempt.events);
+    expect(serialized).not.toContain('hostSynthesized');
+    expect(serialized).not.toContain('host_flush');
+    // Persistence has no completion provenance contract. Existing records keep
+    // their legacy behavior; this change must not guess their origin from text.
+    expect(summarizeRunToolProgress(JSON.parse(serialized)).toolResultSent).toBe(true);
+    expectOutstanding(attempt.events);
+  });
+
+  it('preserves idless pairing and does not trust payload-supplied provenance', () => {
+    const events = [
+      { event: 'agent', data: { type: 'tool_use', id: null } },
+      { event: 'agent', data: { type: 'tool_result', toolUseId: null, hostSynthesized: true } },
+    ];
+    expect(summarizeRunToolProgress(events)).toEqual({
+      toolCallSeen: true, toolResultSent: true, hasOutstandingTool: false,
+    });
+  });
+});

--- a/apps/daemon/tests/runtimes/acp-stall-last-progress-age.test.ts
+++ b/apps/daemon/tests/runtimes/acp-stall-last-progress-age.test.ts
@@ -196,6 +196,15 @@ describe('ACP stall progress age', () => {
     // the failure path really did synthesize its terminal pair. Without this the
     // progress-age assertion below could pass simply because no tool existed.
     expect(finished.tool_call_count).toBeGreaterThanOrEqual(1);
+    expect(finished.tool_call_seen).toBe(true);
+    expect(finished.tool_result_sent).toBe(false);
+    expect(finished.failure_stage).toBe('tool_outstanding');
+
+    // Provenance stays in memory; the display transcript still has its pair.
+    const transcript = readFileSync(run.eventsLogPath, 'utf8');
+    expect(transcript).toContain('"type":"tool_result"');
+    expect(transcript).not.toContain('hostSynthesized');
+    expect(transcript).not.toContain('host_flush');
 
     // Same terminal fingerprint as the tool-free stall: an ACP stage timeout,
     // named as such. Flushing an open tool must not reclassify the failure.


### PR DESCRIPTION
## Why

The AMR reliability audit reproduced a diagnostic error in the daemon's ACP shutdown path: a tool still pending or in progress received a host-generated `tool_use`/`tool_result` pair, and pairing alone reported `tool_result_sent=true` and `post_tool_resume`. This sends investigation toward agent resumption even though no agent tool terminal was observed.

Keep the display cleanup, but exclude its result from completion evidence. The existing trusted `hostSynthesized` metadata now also associates the live payload with a private WeakSet; diagnostics can recover that provenance without adding serialized fields. Tool pairing resets at each `start`, consistent with failure classification's terminal-attempt boundary.

## What users will see

Tool cards and error handling stay unchanged in both UI and CLI. Live failure telemetry reports `tool_outstanding` when the host closes an unfinished tool, including when another parallel tool really completed. This fixes diagnosis only: it does not make the failed user task succeed or change timeouts, executors, process termination, retries, model selection, admission policy, or SLO denominators.

`tool_result_sent` keeps its legacy name. A true value means matching observed tool results, not proof of delivery back to the model or overall task success. Unmarked/non-ACP and deserialized legacy events retain existing pairing; historical/restart-recovered records cannot recover this in-memory provenance. No public contract or persistence migration is introduced, and existing event-buffer limits remain unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new subcommand, flag, or env var
- [ ] **API / contract** — new endpoint, SSE event, or changed `packages/contracts` shape
- [ ] **Extension point** — skills, design systems/templates, craft, or protocol
- [ ] **i18n keys** — new translation keys
- [ ] **New top-level dependency** — root dependency addition
- [ ] **Default behavior change** — changed user-facing defaults or schema
- [x] **None** — internal diagnostics and regression tests only

UI/CLI parity is not applicable: no capability or interaction is added. Both continue through the existing daemon APIs.

## Screenshots

Not applicable; no visible UI change. The HTTP regression checks that the persisted display transcript still contains its tool result without provenance fields.

## Bug fix verification

- Red spec: [acp-tool-completion-diagnostics.test.ts](https://github.com/Siri-Ray/open-design/blob/1d949488afbfcb1317365e0848dca2154587b0df/apps/daemon/tests/acp-tool-completion-diagnostics.test.ts), plus the open-tool case in [runtimes/acp-stall-last-progress-age.test.ts](https://github.com/Siri-Ray/open-design/blob/1d949488afbfcb1317365e0848dca2154587b0df/apps/daemon/tests/runtimes/acp-stall-last-progress-age.test.ts).
- On main `49cc51058fd76ec825fcd6a9f684f8d3a138fca3`, before source edits: 7/10 narrow cases failed because `tool_result_sent` was true and no tool remained outstanding. The real HTTP/PostHog case separately failed with expected false / received true. Agent-confirmed terminal controls passed.
- Expanded coverage: completed/failed agent terminals; execute pending/in-progress and write pending on timeout; structured SSE disconnect plus host close metadata; parallel tools; late terminal after verdict; repeated flush; clean best-effort flush; attempt isolation/reused IDs; idless legacy pairing; serialization/privacy and untrusted payload provenance.
- Only synthetic in-memory frames and the existing fake ACP CLI are used. No production trace, original user prompt/tool input, identity, or credential is included.

## Validation

- `corepack pnpm install --frozen-lockfile`: passed; no manifest/lock changes.
- `corepack pnpm guard`: passed.
- `corepack pnpm typecheck`: passed across the workspace. The initial pass caught a test-only `findLast` target-lib mismatch; replaced it with a compatible lookup, then the full command passed.
- Daemon Vitest: **303 passed across 7 files** (`acp-tool-completion-diagnostics`, `run-diagnostics`, `run-failure-classification`, `acp`, `amr-acp-integration`, `runtimes/acp-stall-last-progress-age`, `services/run-analytics-lifecycle`). Narrow matrix repeated after the compatibility edit: **14 passed**. This is the selected package suite, not the full daemon test inventory.
- The expanded SSE fixture initially omitted host close metadata and therefore reached the unknown/finalize fallback. The fixture now includes the actual runtime close/error-code shape; no classifier policy was changed to accommodate it.
- Existing `mocks/bin/vela` recording replay through `attachAcpSession`: clean completion, text and usage observed, no error; no provider calls. The generic recording renderer emits text rather than tool terminals, so the dedicated regressions provide tool coverage.
- `git diff --check`: passed.
- Environment: Node 24.16.0, pnpm 10.33.2. The terminal package warns that it pins Node 24.18.0; all listed checks passed.
- Remote CI and review are tracked on this PR separately from local results. Not merged or deployed.

## Adjacent issues and delivery limits

The underlying Bash/tool timeout and SSE/provider disconnect causes are outside this PR. No changes to the admission/report work or `run-failure-classification.ts`. No success-count claims, historical telemetry rewrite, merge, release, deployment, or production-data modification.
