### PR TITLE
ci(release): add accepted stable smoke override

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -21,6 +21,14 @@ on:
         required: false
         type: string
         default: ""
+      stable_smoke_mode:
+        description: "Packaged stable smoke coverage across platforms. Use skip only for an explicitly accepted release override."
+        required: true
+        type: choice
+        options:
+          - run
+          - skip
+        default: run
       win_x64_smoke_mode:
         description: "Windows x64 smoke coverage."
         required: true
@@ -56,6 +64,11 @@ on:
         required: false
         type: string
         default: ""
+      stable_smoke_mode:
+        description: "Packaged stable smoke coverage across platforms: run or skip."
+        required: false
+        type: string
+        default: "run"
       win_x64_smoke_mode:
         description: "Windows x64 smoke coverage: skip, core, or full."
         required: false
@@ -497,6 +510,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Smoke release mac packaged runtime
+        if: ${{ inputs.stable_smoke_mode != 'skip' }}
         working-directory: e2e
         env:
           OD_PACKAGED_E2E_BUILD_JSON_PATH: ${{ runner.temp }}/mac-tools-pack-build.json
@@ -815,7 +829,7 @@ jobs:
           "deletedFailedCacheKey=$matchedKey count=$($caches.Count)"
 
       - name: Build stable win_x64 update fixture
-        if: ${{ inputs.win_x64_smoke_mode == 'full' && inputs.win_x64_update_metadata_url == '' && inputs.win_x64_update_target_version == '' }}
+        if: ${{ inputs.stable_smoke_mode != 'skip' && inputs.win_x64_smoke_mode == 'full' && inputs.win_x64_update_metadata_url == '' && inputs.win_x64_update_target_version == '' }}
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
@@ -830,7 +844,7 @@ jobs:
           pnpm.cmd exec tools-pack win validate-payload --namespace "${{ needs.metadata.outputs.win_namespace }}" --payload-path $updateBuild.payloadPath --expected-version $updateVersion --json
 
       - name: Smoke release windows packaged runtime
-        if: ${{ inputs.win_x64_smoke_mode != 'skip' }}
+        if: ${{ inputs.stable_smoke_mode != 'skip' && inputs.win_x64_smoke_mode != 'skip' }}
         working-directory: e2e
         env:
           OD_PACKAGED_E2E_BUILD_JSON_PATH: ${{ runner.temp }}/windows-tools-pack-build.json
@@ -1007,6 +1021,7 @@ jobs:
           fi
 
       - name: Smoke release linux AppImage runtime
+        if: ${{ inputs.stable_smoke_mode != 'skip' }}
         working-directory: e2e
         env:
           OD_PACKAGED_E2E_LINUX_APPIMAGE: "1"
@@ -1252,13 +1267,14 @@ jobs:
           path: ${{ runner.temp }}/release-assets/linux
 
       - name: Download linux e2e spec report
-        if: ${{ needs.build_linux.result == 'success' }}
+        if: ${{ needs.build_linux.result == 'success' && inputs.stable_smoke_mode != 'skip' }}
         uses: actions/download-artifact@v8
         with:
           name: open-design-release-linux-e2e-report
           path: ${{ runner.temp }}/release-report/linux
 
       - name: Download mac e2e spec report
+        if: ${{ inputs.stable_smoke_mode != 'skip' }}
         uses: actions/download-artifact@v8
         with:
           name: open-design-release-mac-e2e-report
@@ -1272,7 +1288,7 @@ jobs:
       # though the input offers it. Guard it the way the linux report is guarded
       # by its own build result.
       - name: Download windows e2e spec report
-        if: ${{ inputs.win_x64_smoke_mode != 'skip' }}
+        if: ${{ inputs.stable_smoke_mode != 'skip' && inputs.win_x64_smoke_mode != 'skip' }}
         uses: actions/download-artifact@v8
         with:
           name: open-design-release-win-e2e-report

--- a/e2e/specs/mac.spec.ts
+++ b/e2e/specs/mac.spec.ts
@@ -2318,9 +2318,9 @@ async function assertFirstNativeChromeActionClick(): Promise<void> {
   const setup = await runToolsPackJson<MacInspectResult>('inspect', [
     '--expr',
     `(() => {
-      const target = document.querySelector(
-        '[data-testid="entry-top-right-github"], [data-testid="entry-nav-home"]',
-      );
+      const target =
+        document.querySelector('[data-testid="entry-top-right-github"]') ??
+        document.querySelector('[data-testid="entry-nav-home"]');
       if (!(target instanceof HTMLElement)) {
         throw new Error('first-render chrome action is missing');
       }

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -3008,6 +3008,14 @@ process.stdin.on("end", () => {
     expect(workflow).toContain("- prepublish");
     expect(workflow).toContain("- publish");
     expect(workflow).toContain("default: metadata");
+    expect(workflow.match(/stable_smoke_mode:/g)).toHaveLength(2);
+    expect(workflow).toMatch(
+      /stable_smoke_mode:[\s\S]*?options:[\s\S]*?- run[\s\S]*?- skip[\s\S]*?default: run/,
+    );
+    expect(workflow.match(/inputs\.stable_smoke_mode != 'skip'/g)).toHaveLength(7);
+    expect(workflow).toContain(
+      "if: ${{ inputs.stable_smoke_mode != 'skip' && inputs.win_x64_smoke_mode != 'skip' }}",
+    );
     expect(workflow).not.toContain("inputs.channel");
     expect(workflow).toContain("OPEN_DESIGN_RELEASE_DRY_RUN: ${{ inputs.dry_run == 'publish' && 'false' || inputs.dry_run }}");
     expect(workflow).toContain("RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}");


### PR DESCRIPTION
## Summary

- preserve GitHub-first target selection in the macOS packaged smoke test
- add an explicit `stable_smoke_mode` workflow input (`run` by default)
- when an accepted release is dispatched with `stable_smoke_mode=skip`, skip every stable packaged smoke path and its report download: macOS arm64, Windows, and Linux

## Release strategy

For `0.21.1`, dispatch the workflow definition from `main` while building `ref=release/v0.21.1`. This keeps the accepted candidate commit unchanged and does not backport the workflow-only override to the release branch.

The override does not skip build, signing, notarization, metadata checks, or publishing.

## Validation

- `actionlint -color .github/workflows/release-stable.yml`
- `pnpm --filter @open-design/e2e test tests/packaged-smoke-workflow.test.ts` (72 passed, 1 skipped)
- `pnpm typecheck`
- `pnpm guard`
- `pnpm --dir e2e typecheck`
- `pnpm --dir e2e test specs/mac.spec.ts`
- `git diff --check`

## Surface area

Release workflow and E2E tests only. No product runtime or dependency changes.
