### PR TITLE
test(e2e): await app readiness in delayed Cloud onboarding

### DIFF
--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -138,8 +138,7 @@ test('[P0] Cloud status loading does not block signed-out Local CLI or BYOK setu
   });
 
   await seedOnboardingConfig(page, config);
-  await page.goto('/onboarding', { waitUntil: 'domcontentloaded' });
-  await expect(connectLandingHeading(page)).toBeVisible();
+  await gotoOnboarding(page);
 
   await expect(cloudPrimaryButton(page)).toBeDisabled();
   await expect(page.getByRole('button', { name: /Local (coding )?agent/i })).toBeEnabled();
@@ -163,8 +162,7 @@ test('[P0] delayed active Cloud login stays out of Local setup and resumes after
   });
 
   await seedOnboardingConfig(page, config);
-  await page.goto('/onboarding', { waitUntil: 'domcontentloaded' });
-  await expect(connectLandingHeading(page)).toBeVisible();
+  await gotoOnboarding(page);
 
   await page.getByRole('button', { name: /Local (coding )?agent/i }).click();
   const localPanel = page.locator('.onboarding-view__setup-panel');


### PR DESCRIPTION
Fixes #7655

## Why

Repeated `UI P0 (entry-settings)` failures are blocking the unrelated #7544 and #7647 changes even after reruns. Both cases fail before their Cloud/Local behavior assertions: the browser still displays `Loading OpenDesign…` when the default 10-second sign-in-heading assertion expires.

These two direct navigations skipped the existing `gotoOnboarding` helper. That helper waits for the dynamic App loading shell to clear, handles the privacy banner, and then asserts the same landing heading. Reuse it in both cases without changing product code, Cloud-status mocks, assertion timeouts, or CI routing.

Related: #7596 independently proposes the same two-call-site fix. This PR is based on current main and adds completed local slow-chunk red/green verification; #7596's CI was still `action_required` when inspected. The implementation overlaps; these are alternatives, not patches that need to land together.

## What users will see

No product behavior changes. Contributors' onboarding checks wait for the app to mount before checking that slow Cloud status does not block Local CLI/BYOK setup.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: test-only change. Both controlled pre-fix failure snapshots contain only `Loading OpenDesign…` and the alert node, matching the hosted artifacts.

## Bug fix verification

Existing red specs: [`e2e/ui/amr-onboarding.test.ts`](https://github.com/nexu-io/open-design/blob/e0d0faa37495f951c6fc28847b492ae5067f6258/e2e/ui/amr-onboarding.test.ts#L132):

- `[P0] Cloud status loading does not block signed-out Local CLI or BYOK setup`
- `[P0] delayed active Cloud login stays out of Local setup and resumes after Back`

Fixed specs: [branch version](https://github.com/Siri-Ray/open-design/blob/3498118a00b736a730ee846dd2f6206eed385977/e2e/ui/amr-onboarding.test.ts#L132).

Hosted failures:

- [#7544, attempt 6](https://github.com/nexu-io/open-design/actions/runs/33153909692/job/99444599440)
- [#7647, attempt 2](https://github.com/nexu-io/open-design/actions/runs/33373914519/job/99444248270)

**Red on main / green on this branch: yes, under the same controlled slow-chunk condition.**

| Run | Result |
| --- | --- |
| Main `e0d0faa37495f951c6fc28847b492ae5067f6258`, ordinary local run | 2 passed |
| Same main, dynamic App chunk delayed 15 seconds | 2 failed at the original heading assertions; both snapshots show the loading shell |
| Two-call-site fix, same 15-second chunk delay | 2 passed, no retries |

The delay was a temporary diagnosis probe registered in this file's existing `beforeEach`:

```ts
await page.route(/\/_next\/static\/chunks\/.*EntryView.*\.js/, async (route) => {
  await new Promise((resolve) => setTimeout(resolve, 15_000));
  await route.continue().catch(() => {});
});
```

This matches the dynamic App chunk observed in both retained CI traces. The probe was removed before final validation and is not part of this PR. The original Cloud-status gates, Local/BYOK assertions, and Back/resume behavior remain intact; this does not wait for network idle or release the gated status early.

## Validation

- `corepack pnpm guard` — passed.
- `corepack pnpm typecheck` — passed across the workspace (existing Node 24.18.0 vs local 24.16.0 engine warnings and landing-page hints only).
- `git diff --check` — passed.
- Controlled slow-chunk red/green comparison — 2 failed on main, 2 passed with the fix, retries disabled.
- `CI=1 OD_PLAYWRIGHT_WORKERS=2 corepack pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group entry-settings` — exit 0: **86 passed, 1 flaky, 0 failed, 0 skipped** in 9.3 minutes. Both changed cases passed on their first attempts.

A separate unchanged reload test initially raised `page.evaluate: Execution context was destroyed` inside the status mock, then passed on retry. Tracked in #7657; this PR does not claim to fix it. The full non-visual pool was not run locally.

Targeted command (used for all three comparison runs):

```sh
CI=1 corepack pnpm -C e2e exec playwright test -c playwright.config.ts ui/amr-onboarding.test.ts --grep 'Cloud status loading|delayed active Cloud login' --workers=1 --retries=0 --trace=on
```
