### PR TITLE
fix(daemon): pass activeWorkspaceId to workspace selector (fixes #7613)

### DIFF
--- a/apps/daemon/src/mcp-workspace-context.ts
+++ b/apps/daemon/src/mcp-workspace-context.ts
@@ -94,7 +94,7 @@ export async function resolveMcpWorkspaceContext(
       return null;
     }
     const data = (await resp.json()) as WorkspaceDirectoryResponse;
-    const selected = selectDefaultMcpCandidate(data.items, data.activeWorkspaceId);
+    const selected = selectDefaultMcpCandidate(data.items, data.activeWorkspaceId ?? undefined);
     if (!selected) {
       // 200 with empty items — non-vela (dev provider) or no live membership.
       recordFailure(baseUrl);

--- a/apps/daemon/src/mcp-workspace-context.ts
+++ b/apps/daemon/src/mcp-workspace-context.ts
@@ -94,7 +94,7 @@ export async function resolveMcpWorkspaceContext(
       return null;
     }
     const data = (await resp.json()) as WorkspaceDirectoryResponse;
-    const selected = selectDefaultMcpCandidate(data.items);
+    const selected = selectDefaultMcpCandidate(data.items, data.activeWorkspaceId);
     if (!selected) {
       // 200 with empty items — non-vela (dev provider) or no live membership.
       recordFailure(baseUrl);

--- a/apps/daemon/tests/mcp-workspace-context.test.ts
+++ b/apps/daemon/tests/mcp-workspace-context.test.ts
@@ -44,6 +44,18 @@ describe('selectDefaultMcpCandidate', () => {
     expect(selectDefaultMcpCandidate([team, personal], 'missing')).toBe(personal);
   });
 
+  it('prefers activeWorkspaceId over both personal and first-item fallbacks', () => {
+    // Reproduces nexu-io/open-design#7613: when activeWorkspaceId points to a
+    // non-first team workspace, the MCP must use that workspace — not the first
+    // item in the directory list — so local projects are readable (403 was caused
+    // by the MCP acting as the wrong workspace).
+    const teamA = item({ workspaceId: 'ws-a', workspaceType: 'team', workspaceMemberId: 'mem-a' });
+    const teamB = item({ workspaceId: 'ws-b', workspaceType: 'team', workspaceMemberId: 'mem-b' });
+    // activeWorkspaceId targets the second (non-first) team workspace.
+    expect(selectDefaultMcpCandidate([teamA, teamB], 'ws-b')).toBe(teamB);
+    expect(selectDefaultMcpCandidate([teamA, teamB], 'ws-b')).not.toBe(teamA);
+  });
+
   it('prefers a personal workspace over a team workspace, then first candidate', () => {
     const teamA = item({ workspaceId: 'ws-a', workspaceType: 'team' });
     const personal = item({ workspaceId: 'ws-personal' });
@@ -153,5 +165,36 @@ describe('resolveMcpWorkspaceContext', () => {
     // force breaks the cooldown.
     expect(await resolveMcpWorkspaceContext(base, { force: true })).toBeNull();
     expect(calls).toBe(2);
+  });
+
+  it('uses activeWorkspaceId to select the workspace (fixes #7613)', async () => {
+    // nexu-io/open-design#7613: MCP ignores activeWorkspaceId and falls back to
+    // the first workspace, causing 403 on local projects when the active workspace
+    // is not first in the directory list.
+    const base = 'http://127.0.0.1:19001';
+    const teamA = item({ workspaceId: 'ws-a', workspaceType: 'team', workspaceMemberId: 'mem-a' });
+    const teamB = item({ workspaceId: 'ws-b', workspaceType: 'team', workspaceMemberId: 'mem-b' });
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          items: [teamA, teamB],
+          activeWorkspaceId: 'ws-b', // active is second (not first) in the list
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const ctx = await resolveMcpWorkspaceContext(base);
+    // Must select ws-b (activeWorkspaceId), NOT ws-a (first item).
+    expect(ctx).toEqual({
+      workspaceId: 'ws-b',
+      workspaceMemberId: 'mem-b',
+      workspaceType: 'team',
+      headers: {
+        'x-od-workspace-id': 'ws-b',
+        'x-od-workspace-member-id': 'mem-b',
+      },
+    });
   });
 });

--- a/apps/landing-page/app/pages/codex-slides/index.astro
+++ b/apps/landing-page/app/pages/codex-slides/index.astro
@@ -483,7 +483,7 @@ const studioTiles = copy.inside.map((tile, i) => ({ ...tile, src: STUDIO_SHOTS[i
   /* Studio UI screenshots carry dense product chrome, so they need a bigger
      cell than the simple deck cards — two-up instead of four-up. */
   .ha-showcase-wide {
-    grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 420px), 1fr));
   }
 
   /* ---- Scenario cards ---- */


### PR DESCRIPTION
## Summary

nexus-io/open-design#7613: MCP server ignores the activeWorkspaceId returned by /api/workspace/directory and always falls back to , causing 403 WORKSPACE_PROJECT_PERMISSION_DENIED on local projects when the active workspace is not first in the directory list.

## Root cause

 calls  without passing . The  parameter already existed in  but was never populated.

## Fix



The function's existing fallback chain (preferred → personal → first-item) already handles all cases correctly once the active ID is provided.

## Testing

- Unit test:  with two team workspaces, activeWorkspaceId pointing to the second one — verifies the second workspace is selected, not the first
- Integration test:  with mock fetch returning  and  — verifies the resolved context uses ws-b's headers

## Workaround (for users)

None through the UI. The bundle-level patch mentioned in the issue is overwritten by every silent update.