### PR TITLE
fix web Instagram and Xiaohongshu share alignment

### DIFF
--- a/apps/web/src/styles/social-share.css
+++ b/apps/web/src/styles/social-share.css
@@ -9,6 +9,7 @@
   --social-share-brand: var(--text-muted);
   appearance: none;
   min-width: 0;
+  height: auto;
   min-height: 34px;
   border: 1px solid var(--border-soft);
   border-radius: var(--radius);
@@ -16,8 +17,10 @@
   color: var(--text);
   display: inline-flex;
   align-items: center;
+  justify-content: flex-start;
   gap: 8px;
   padding: 0 9px;
+  font: inherit;
   font-size: 13px;
   text-align: left;
   text-decoration: none;

--- a/apps/web/tests/styles/social-share.test.ts
+++ b/apps/web/tests/styles/social-share.test.ts
@@ -1,0 +1,29 @@
+import postcss, { type Declaration, type Rule } from 'postcss';
+import { describe, expect, it } from 'vitest';
+
+import { readExpandedIndexCss } from '../helpers/read-expanded-css';
+
+function declarationsFor(selector: string): Map<string, string> {
+  const root = postcss.parse(readExpandedIndexCss(), { from: 'src/index.css' });
+  const rule = root.nodes.find(
+    (node): node is Rule => node.type === 'rule' && node.selector === selector,
+  );
+
+  return new Map(
+    rule?.nodes
+      .filter((node): node is Declaration => node.type === 'decl')
+      .map((declaration) => [declaration.prop, declaration.value]),
+  );
+}
+
+describe('social share target layout', () => {
+  it('normalizes link and button targets after the global button styles', () => {
+    const declarations = declarationsFor('.social-share-button');
+
+    expect(declarations.get('height')).toBe('auto');
+    expect(declarations.get('min-height')).toBe('34px');
+    expect(declarations.get('justify-content')).toBe('flex-start');
+    expect(declarations.get('font')).toBe('inherit');
+    expect(declarations.get('font-size')).toBe('13px');
+  });
+});


### PR DESCRIPTION
Fixes #7660

## Why

Issue #7660 reports a Share-panel mismatch that reproduces in the desktop app. The social grid renders intent-based destinations as links, while Instagram and Xiaohongshu use buttons because they copy the share text before opening the destination.

A global button primitive introduced fixed height, centered content, medium weight, and a shorter line height. Those defaults affected only the two button-based destinations, leaving the final row visibly inconsistent with the eight link-based destinations above it.

## What users will see

After obtaining a public share link and opening **Share**, Instagram and 小红书 now match every other social destination: the same 34px height, left-aligned icon and label, 10px icon inset, typography, and row spacing. Share destinations and copy/open behavior are unchanged.

## Surface area

- [x] **UI** — corrects alignment in the existing social-share grid in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — existing social-share buttons now use the intended shared layout
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

The [original issue capture](https://github.com/nexu-io/open-design/issues/7660#issuecomment-5477143435) shows the misaligned final row. These headed Electron captures show the complete Share entry point after the fix.

**English**

![Aligned social share grid in the English desktop Share panel](https://github.com/user-attachments/assets/c7005cca-3da2-4378-9441-9eeec7a0a4b2)

**Simplified Chinese (`zh-CN`, matching the reported locale)**

![Aligned Instagram and Xiaohongshu options in the Chinese desktop Share panel](https://github.com/user-attachments/assets/9351a78b-e146-482e-822e-0debff9c3c5d)

## Bug fix verification

- Test path: `apps/web/tests/styles/social-share.test.ts`
- Red on `main`: yes — the test was written first and failed because `.social-share-button` did not reset the global button height.
- Green on this branch: yes — the shared rule now pins auto height with a 34px minimum, left alignment, inherited typography, and the existing 13px label size.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/styles/social-share.test.ts tests/components/SocialShareGrid.test.tsx --maxWorkers=1`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web build`
- `pnpm guard`
- `pnpm typecheck`
- Headed Electron validation in English and `zh-CN`, using production project/file/share APIs with only the external Vela publication dependency replaced by a local fixture: all 10 options measured `170×34px`, shared a 10px icon inset, identical typography, and no horizontal overflow. Instagram and 小红书 remained enabled, keyboard-focusable `<button type="button">` controls on the same row.