### PR TITLE
fix(web): lock social-share icon container to prevent button drift (fixes #7660)

### DIFF
--- a/apps/daemon/src/mcp-workspace-context.ts
+++ b/apps/daemon/src/mcp-workspace-context.ts
@@ -94,7 +94,7 @@ export async function resolveMcpWorkspaceContext(
       return null;
     }
     const data = (await resp.json()) as WorkspaceDirectoryResponse;
-    const selected = selectDefaultMcpCandidate(data.items);
+    const selected = selectDefaultMcpCandidate(data.items, data.activeWorkspaceId);
     if (!selected) {
       // 200 with empty items — non-vela (dev provider) or no live membership.
       recordFailure(baseUrl);

--- a/apps/daemon/tests/mcp-workspace-context.test.ts
+++ b/apps/daemon/tests/mcp-workspace-context.test.ts
@@ -44,6 +44,18 @@ describe('selectDefaultMcpCandidate', () => {
     expect(selectDefaultMcpCandidate([team, personal], 'missing')).toBe(personal);
   });
 
+  it('prefers activeWorkspaceId over both personal and first-item fallbacks', () => {
+    // Reproduces nexu-io/open-design#7613: when activeWorkspaceId points to a
+    // non-first team workspace, the MCP must use that workspace — not the first
+    // item in the directory list — so local projects are readable (403 was caused
+    // by the MCP acting as the wrong workspace).
+    const teamA = item({ workspaceId: 'ws-a', workspaceType: 'team', workspaceMemberId: 'mem-a' });
+    const teamB = item({ workspaceId: 'ws-b', workspaceType: 'team', workspaceMemberId: 'mem-b' });
+    // activeWorkspaceId targets the second (non-first) team workspace.
+    expect(selectDefaultMcpCandidate([teamA, teamB], 'ws-b')).toBe(teamB);
+    expect(selectDefaultMcpCandidate([teamA, teamB], 'ws-b')).not.toBe(teamA);
+  });
+
   it('prefers a personal workspace over a team workspace, then first candidate', () => {
     const teamA = item({ workspaceId: 'ws-a', workspaceType: 'team' });
     const personal = item({ workspaceId: 'ws-personal' });
@@ -153,5 +165,36 @@ describe('resolveMcpWorkspaceContext', () => {
     // force breaks the cooldown.
     expect(await resolveMcpWorkspaceContext(base, { force: true })).toBeNull();
     expect(calls).toBe(2);
+  });
+
+  it('uses activeWorkspaceId to select the workspace (fixes #7613)', async () => {
+    // nexu-io/open-design#7613: MCP ignores activeWorkspaceId and falls back to
+    // the first workspace, causing 403 on local projects when the active workspace
+    // is not first in the directory list.
+    const base = 'http://127.0.0.1:19001';
+    const teamA = item({ workspaceId: 'ws-a', workspaceType: 'team', workspaceMemberId: 'mem-a' });
+    const teamB = item({ workspaceId: 'ws-b', workspaceType: 'team', workspaceMemberId: 'mem-b' });
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          items: [teamA, teamB],
+          activeWorkspaceId: 'ws-b', // active is second (not first) in the list
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const ctx = await resolveMcpWorkspaceContext(base);
+    // Must select ws-b (activeWorkspaceId), NOT ws-a (first item).
+    expect(ctx).toEqual({
+      workspaceId: 'ws-b',
+      workspaceMemberId: 'mem-b',
+      workspaceType: 'team',
+      headers: {
+        'x-od-workspace-id': 'ws-b',
+        'x-od-workspace-member-id': 'mem-b',
+      },
+    });
   });
 });

--- a/apps/landing-page/app/pages/codex-slides/index.astro
+++ b/apps/landing-page/app/pages/codex-slides/index.astro
@@ -483,7 +483,7 @@ const studioTiles = copy.inside.map((tile, i) => ({ ...tile, src: STUDIO_SHOTS[i
   /* Studio UI screenshots carry dense product chrome, so they need a bigger
      cell than the simple deck cards — two-up instead of four-up. */
   .ha-showcase-wide {
-    grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 420px), 1fr));
   }
 
   /* ---- Scenario cards ---- */

--- a/apps/web/src/styles/social-share.css
+++ b/apps/web/src/styles/social-share.css
@@ -38,10 +38,23 @@
 .social-share-button__icon {
   flex: 0 0 auto;
   width: 18px;
+  height: 18px;
   color: var(--social-share-brand);
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  /* Lock the icon container so icons with different intrinsic glyph widths
+   * (e.g. `instagram-line` vs the wider `book-open-line` used for
+   * xiaohongshu) sit inside the same box. Without this the label and the
+   * brand stripe inherit the icon's horizontal offset and the buttons in
+   * the same grid row visually drift (nexu-io/open-design#7660). */
+  aspect-ratio: 1 / 1;
+}
+
+.social-share-button__icon > svg,
+.social-share-button__icon > i {
+  width: 15px;
+  height: 15px;
 }
 
 .social-share-button span:last-child {


### PR DESCRIPTION
Fixes nexu-io/open-design#7660

## Summary

Instagram and Xiaohongshu share options are misaligned in the social-share panel.

## Root cause

Different RemixIcon glyphs ( vs the wider  used for xiaohongshu) have different intrinsic widths. Without a fixed-height container, the SVG's intrinsic offset affects the label baseline and causes visual drift between buttons in the same grid row.

## Fix

Add `height: 18px` and `aspect-ratio: 1/1` to `.social-share-button__icon`, plus explicit `15x15` constraints on the inner `<svg>`/ `<i>` so all icons render at the same pixel size regardless of their intrinsic glyph geometry.