### PR TITLE
test(e2e): wait for the app shell before asserting the onboarding landing

### DIFF
--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -139,6 +139,7 @@ test('[P0] Cloud status loading does not block signed-out Local CLI or BYOK setu
 
   await seedOnboardingConfig(page, config);
   await page.goto('/onboarding', { waitUntil: 'domcontentloaded' });
+  await waitForLoadingToClear(page);
   await expect(connectLandingHeading(page)).toBeVisible();
 
   await expect(cloudPrimaryButton(page)).toBeDisabled();
@@ -164,6 +165,7 @@ test('[P0] delayed active Cloud login stays out of Local setup and resumes after
 
   await seedOnboardingConfig(page, config);
   await page.goto('/onboarding', { waitUntil: 'domcontentloaded' });
+  await waitForLoadingToClear(page);
   await expect(connectLandingHeading(page)).toBeVisible();
 
   await page.getByRole('button', { name: /Local (coding )?agent/i }).click();


### PR DESCRIPTION
Fixes #7669.

Two `[P0]` tests in `e2e/ui/amr-onboarding.test.ts` assert the landing heading
immediately after

```ts
await page.goto('/onboarding', { waitUntil: 'domcontentloaded' });
```

`domcontentloaded` fires before the lazily-imported App chunk mounts, so the only
budget covering that mount is the 10s `expect` timeout. Every other test in the
file calls `waitForLoadingToClear(page)` first, which is why only these two are
affected: on a slow runner the `Loading OpenDesign…` shell is still mounted and
the heading does not exist yet.

```
Error: expect(locator).toBeVisible() failed
Locator: getByRole('heading', { name: /Sign in to OpenDesign|登录 OpenDesign/i })
Error: element(s) not found
```

### Not a regression in any one PR

Four approved PRs with disjoint file sets are red on this, and which of the two
tests fails varies by run — `:132` on #7552, #7460 and #7257, `:152` on #6056.
`Validate workspace` fails only as an aggregator reporting `ui_p0=failure`, so
for #7552, #7460 and #6056 this is the sole root failure.

### Change

Two lines, using the helper the rest of the file already uses:

```diff
   await page.goto('/onboarding', { waitUntil: 'domcontentloaded' });
+  await waitForLoadingToClear(page);
   await expect(connectLandingHeading(page)).toBeVisible();
```

`waitForLoadingToClear` waits on the app-shell placeholder, not on the Cloud
status request, so both tests still prove exactly what they exist to prove: the
landing renders while Cloud status is unresolved. Its `.catch(() => {})` means a
shell that never clears still fails at the assertion rather than passing, so this
does not weaken either test.

### Verification

The failure is timing-dependent, so an unthrottled local pass proves nothing —
unpatched, this machine passes in 43.7s. Reproduced deterministically over CDP
(40ms latency, 8 Mbps, `Emulation.setCPUThrottlingRate: 6`):

| run | result |
| --- | --- |
| throttled, without this change | the CI failure above; shell clears at 31.5s, assertion gives up at 10s |
| throttled, with this change | passes (1.2m) |
| unthrottled, with this change | passes (42.6s) |
