### PR TITLE
fix(daemon): pass activeWorkspaceId to workspace selector (fixes #7613)

### DIFF
--- a/apps/daemon/src/mcp-workspace-context.ts
+++ b/apps/daemon/src/mcp-workspace-context.ts
@@ -94,7 +94,7 @@ export async function resolveMcpWorkspaceContext(
       return null;
     }
     const data = (await resp.json()) as WorkspaceDirectoryResponse;
-    const selected = selectDefaultMcpCandidate(data.items);
+    const selected = selectDefaultMcpCandidate(data.items, data.activeWorkspaceId ?? undefined);
     if (!selected) {
       // 200 with empty items — non-vela (dev provider) or no live membership.
       recordFailure(baseUrl);

--- a/apps/daemon/tests/mcp-workspace-context.test.ts
+++ b/apps/daemon/tests/mcp-workspace-context.test.ts
@@ -44,6 +44,18 @@ describe('selectDefaultMcpCandidate', () => {
     expect(selectDefaultMcpCandidate([team, personal], 'missing')).toBe(personal);
   });
 
+  it('prefers activeWorkspaceId over both personal and first-item fallbacks', () => {
+    // Reproduces nexu-io/open-design#7613: when activeWorkspaceId points to a
+    // non-first team workspace, the MCP must use that workspace — not the first
+    // item in the directory list — so local projects are readable (403 was caused
+    // by the MCP acting as the wrong workspace).
+    const teamA = item({ workspaceId: 'ws-a', workspaceType: 'team', workspaceMemberId: 'mem-a' });
+    const teamB = item({ workspaceId: 'ws-b', workspaceType: 'team', workspaceMemberId: 'mem-b' });
+    // activeWorkspaceId targets the second (non-first) team workspace.
+    expect(selectDefaultMcpCandidate([teamA, teamB], 'ws-b')).toBe(teamB);
+    expect(selectDefaultMcpCandidate([teamA, teamB], 'ws-b')).not.toBe(teamA);
+  });
+
   it('prefers a personal workspace over a team workspace, then first candidate', () => {
     const teamA = item({ workspaceId: 'ws-a', workspaceType: 'team' });
     const personal = item({ workspaceId: 'ws-personal' });
@@ -153,5 +165,36 @@ describe('resolveMcpWorkspaceContext', () => {
     // force breaks the cooldown.
     expect(await resolveMcpWorkspaceContext(base, { force: true })).toBeNull();
     expect(calls).toBe(2);
+  });
+
+  it('uses activeWorkspaceId to select the workspace (fixes #7613)', async () => {
+    // nexu-io/open-design#7613: MCP ignores activeWorkspaceId and falls back to
+    // the first workspace, causing 403 on local projects when the active workspace
+    // is not first in the directory list.
+    const base = 'http://127.0.0.1:19001';
+    const teamA = item({ workspaceId: 'ws-a', workspaceType: 'team', workspaceMemberId: 'mem-a' });
+    const teamB = item({ workspaceId: 'ws-b', workspaceType: 'team', workspaceMemberId: 'mem-b' });
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          items: [teamA, teamB],
+          activeWorkspaceId: 'ws-b', // active is second (not first) in the list
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const ctx = await resolveMcpWorkspaceContext(base);
+    // Must select ws-b (activeWorkspaceId), NOT ws-a (first item).
+    expect(ctx).toEqual({
+      workspaceId: 'ws-b',
+      workspaceMemberId: 'mem-b',
+      workspaceType: 'team',
+      headers: {
+        'x-od-workspace-id': 'ws-b',
+        'x-od-workspace-member-id': 'mem-b',
+      },
+    });
   });
 });


### PR DESCRIPTION
Fixes nexu-io/open-design#7613

## Summary

nexus-io/open-design#7613: MCP server ignores the activeWorkspaceId returned by /api/workspace/directory and always falls back to candidates[0], causing 403 WORKSPACE_PROJECT_PERMISSION_DENIED on local projects when the active workspace is not first in the directory list.

## Root cause

resolveMcpWorkspaceContext() calls selectDefaultMcpCandidate() without passing activeWorkspaceId. The preferredId parameter already existed in selectDefaultMcpCandidate() but was never populated.

## Fix

Pass data.activeWorkspaceId ?? undefined to selectDefaultMcpCandidate(). The function's existing fallback chain (preferred → personal → first-item) already handles all cases correctly once the active ID is provided.

Type coercion: WorkspaceDirectoryResponse.activeWorkspaceId is typed as string | null, but selectDefaultMcpCandidate declares preferredId?: string. Use data.activeWorkspaceId ?? undefined so the call typechecks under exactOptionalPropertyTypes.

## Testing

- Unit test: selectDefaultMcpCandidate with two team workspaces, activeWorkspaceId pointing to the second one — verifies the second workspace is selected, not the first
- Integration test: resolveMcpWorkspaceContext with mock fetch returning activeWorkspaceId: 'ws-b' — verifies the resolved context uses ws-b's headers

## Scope

This PR is scoped to the daemon MCP workspace-selection fix only (fixes #7613). The social-share icon drift fix has its own dedicated PR.