### PR TITLE
fix(artifacts): recognize manifest-backed markdown/docx as artifacts (fixes #7579)

### DIFF
--- a/apps/daemon/src/run-artifact-fs.ts
+++ b/apps/daemon/src/run-artifact-fs.ts
@@ -49,21 +49,28 @@ export const ARTIFACT_MANIFEST_SUFFIX = '.artifact.json';
 // artifact. Anything `parsePersistedManifest` rejects is treated as a
 // non-artifact — which matches the lifecycle validator's `no_artifact`
 // semantics.
-export function isManifestBackedArtifactPath(filePath: string, rootDir: string): boolean {
+export function isManifestBackedArtifactPath(
+  filePath: string,
+  rootDir: string,
+  options: { pathModule?: typeof path; fsModule?: typeof fs } = {},
+): boolean {
   if (!isManifestBackedExtension(filePath)) return false;
+  const pathModule = options.pathModule ?? path;
+  const fsModule = options.fsModule ?? fs;
   const sidecarPath = `${filePath}${ARTIFACT_MANIFEST_SUFFIX}`;
   // Containment guard: keep a future caller that passes a free-form
   // `filePath` from escaping the project tree. Snapshot keys always
   // satisfy this invariant; the guard is defense-in-depth.
-  const rootWithSep = rootDir.endsWith(path.sep) ? rootDir : `${rootDir}${path.sep}`;
+  const sep = pathModule.sep;
+  const rootWithSep = rootDir.endsWith(sep) ? rootDir : `${rootDir}${sep}`;
   if (!sidecarPath.startsWith(rootWithSep)) return false;
   let raw: string;
   try {
-    raw = fs.readFileSync(sidecarPath, 'utf8');
+    raw = fsModule.readFileSync(sidecarPath, 'utf8');
   } catch {
     return false;
   }
-  return parsePersistedManifest(raw, path.basename(filePath)) !== null;
+  return parsePersistedManifest(raw, pathModule.basename(filePath)) !== null;
 }
 
 // A file worth fingerprinting for run-finish bookkeeping: a user-facing

--- a/apps/daemon/src/run-artifact-fs.ts
+++ b/apps/daemon/src/run-artifact-fs.ts
@@ -16,18 +16,68 @@
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { parsePersistedManifest } from './artifacts/manifest.js';
 import {
   isArtifactPath,
   isDesignSystemFile,
   isPreviewModulePath,
 } from './runtimes/run-artifacts.js';
 
+// Extensions that the legacy `isArtifactPath` set does not cover but which
+// OpenDesign projects ship as user-facing artifacts (Markdown briefs, DOCX
+// reports, etc.). When one of these files lives next to a valid
+// `<basename>.artifact.json` sidecar, the run-fingerprint counter must count
+// it as a created or modified artifact — otherwise an export-only run that
+// only delivers `fitcv-design-system-export.md` reports `artifactCount: 0`
+// and lifecycle validation flips to `no_artifact` (nexu-io/open-design#7579).
+const MANIFEST_BACKED_EXTENSIONS: ReadonlySet<string> = new Set(['.md', '.markdown', '.docx']);
+
+function isManifestBackedExtension(filePath: string): boolean {
+  return MANIFEST_BACKED_EXTENSIONS.has(extensionOf(filePath));
+}
+
+export const ARTIFACT_MANIFEST_SUFFIX = '.artifact.json';
+
+// True iff `<filePath>.artifact.json` exists next to `filePath` (NOT next to
+// the project root — see issue #7579 review feedback: nested Markdown / DOCX
+// files would silently miss their sidecar otherwise) and parses as a valid
+// persisted manifest.
+//
+// We delegate to `parsePersistedManifest` (the same canonical function the
+// persisted-artifact write path uses) so a sidecar with an unknown kind,
+// missing renderer, missing exports, or unsafe entry is NOT promoted to an
+// artifact. Anything `parsePersistedManifest` rejects is treated as a
+// non-artifact — which matches the lifecycle validator's `no_artifact`
+// semantics.
+export function isManifestBackedArtifactPath(filePath: string, rootDir: string): boolean {
+  if (!isManifestBackedExtension(filePath)) return false;
+  const sidecarPath = `${filePath}${ARTIFACT_MANIFEST_SUFFIX}`;
+  // Containment guard: keep a future caller that passes a free-form
+  // `filePath` from escaping the project tree. Snapshot keys always
+  // satisfy this invariant; the guard is defense-in-depth.
+  const rootWithSep = rootDir.endsWith(path.sep) ? rootDir : `${rootDir}${path.sep}`;
+  if (!sidecarPath.startsWith(rootWithSep)) return false;
+  let raw: string;
+  try {
+    raw = fs.readFileSync(sidecarPath, 'utf8');
+  } catch {
+    return false;
+  }
+  return parsePersistedManifest(raw, path.basename(filePath)) !== null;
+}
+
 // A file worth fingerprinting for run-finish bookkeeping: a user-facing
-// artifact (HTML / image / video / audio) OR a design-system marker
-// (`DESIGN.md`). Preview modules (`preview/*.html`) are already covered by the
-// artifact-extension check; they are classified at diff time.
-function isTrackedRunFile(name: string): boolean {
-  return isArtifactPath(name) || isDesignSystemFile(name) || isRenderDependencyPath(name);
+// artifact (HTML / image / video / audio), a design-system marker
+// (`DESIGN.md`), OR a manifest-backed artifact whose extension is not in
+// `ARTIFACT_EXTENSIONS` (Markdown / DOCX — see issue #7579). Preview modules
+// (`preview/*.html`) are already covered by the artifact-extension check; they
+// are classified at diff time.
+function isTrackedRunFile(name: string, rootDir?: string): boolean {
+  if (isArtifactPath(name) || isDesignSystemFile(name) || isRenderDependencyPath(name)) {
+    return true;
+  }
+  if (rootDir && isManifestBackedArtifactPath(name, rootDir)) return true;
+  return false;
 }
 
 const RENDER_DEPENDENCY_EXTENSIONS = new Set([
@@ -305,9 +355,16 @@ export interface RunArtifactDiff {
 // artifact / design-system / preview-module signals the run_finished event
 // needs. Deletions are intentionally ignored: removing a file is not artifact
 // production.
+//
+// `rootDir` is the project root (the same `cwd` the snapshots were taken in).
+// It is used to detect manifest-backed artifacts whose extension is not in the
+// standard `ARTIFACT_EXTENSIONS` set (Markdown / DOCX) — see
+// nexu-io/open-design#7579. A `null` `rootDir` disables the manifest check
+// (legacy call sites where the project root is not available).
 export function diffRunArtifacts(
   before: ArtifactSnapshot,
   after: ArtifactSnapshot,
+  rootDir: string | null = null,
 ): RunArtifactDiff {
   let created = 0;
   let modified = 0;
@@ -341,7 +398,14 @@ export function diffRunArtifacts(
     // only. Normalize separators so the design-system / preview signals work on
     // Windows project runs, not just POSIX.
     const classifyPath = filePath.replace(/\\/g, '/');
-    if (isArtifactPath(classifyPath)) {
+    // Manifest sidecar lives next to the file. Look up by basename inside
+    // the project root, so deeply nested Markdown / DOCX files are still
+    // recognized. The check is only run for non-artifact-extension files to
+    // avoid wasted I/O for HTML / image / video / audio artifacts that
+    // `isArtifactPath` already accepted.
+    const isManifestBacked =
+      rootDir !== null && isManifestBackedArtifactPath(classifyPath, rootDir);
+    if (isArtifactPath(classifyPath) || isManifestBacked) {
       if (isNew) created += 1;
       else modified += 1;
       touchedPaths.push(filePath);
@@ -349,7 +413,13 @@ export function diffRunArtifacts(
         if (isNew) contentCreated += 1;
         else contentModified += 1;
         contentTouchedPaths.push(filePath);
-        if (isSupportingMediaPath(classifyPath)) supportingMediaTouched += 1;
+        // Manifest-backed extensions are not in the supporting-media set, so
+        // the `isSupportingMediaPath` call only matters for the legacy
+        // artifact-extension branch. We gate it behind `isArtifactPath` to
+        // avoid surprising supporting-media accounting for `.md` / `.docx`.
+        if (isArtifactPath(classifyPath) && isSupportingMediaPath(classifyPath)) {
+          supportingMediaTouched += 1;
+        }
       }
     }
     if (contentChanged && isRenderDependencyPath(classifyPath)) {

--- a/apps/daemon/src/run-artifact-fs.ts
+++ b/apps/daemon/src/run-artifact-fs.ts
@@ -211,9 +211,16 @@ export function snapshotProjectArtifacts(rootDir: string): ArtifactSnapshot {
         if (IGNORED_DIR_NAMES.has(entry.name) || entry.name.startsWith('.')) continue;
         walk(path.join(dir, entry.name));
       } else if (entry.isFile()) {
-        const tracked = isTrackedRunFile(entry.name);
-        if (tracked ? trackedCount >= MAX_FILES : otherCount >= MAX_OTHER_FILES) continue;
         const full = path.join(dir, entry.name);
+        // Pass the full native path so the manifest-backed check can resolve
+        // nested `<dir>/<file>.artifact.json` sidecars. Passing only
+        // `entry.name` would force `isTrackedRunFile` to probe the project
+        // root for every sidecar lookup, missing the sidecar in any nested
+        // directory. Walking the full path also makes the per-file cap
+        // decision the same for HTML / image / video / audio as for
+        // manifest-backed Markdown / DOCX.
+        const tracked = isTrackedRunFile(full, rootDir);
+        if (tracked ? trackedCount >= MAX_FILES : otherCount >= MAX_OTHER_FILES) continue;
         try {
           const stat = fs.statSync(full);
           snapshot.set(
@@ -258,9 +265,12 @@ export async function snapshotProjectArtifactsAsync(rootDir: string): Promise<Ar
         if (IGNORED_DIR_NAMES.has(entry.name) || entry.name.startsWith('.')) continue;
         await walk(path.join(dir, entry.name));
       } else if (entry.isFile()) {
-        const tracked = isTrackedRunFile(entry.name);
+        const full = path.join(dir, entry.name);
+        // See the matching comment in `snapshotProjectArtifacts`: pass the
+        // full native path so nested manifest sidecars resolve correctly.
+        const tracked = isTrackedRunFile(full, rootDir);
         if (tracked ? trackedCount >= MAX_FILES : otherCount >= MAX_OTHER_FILES) continue;
-        files.push({ full: path.join(dir, entry.name), tracked });
+        files.push({ full, tracked });
         if (tracked) trackedCount += 1;
         else otherCount += 1;
       }
@@ -395,16 +405,18 @@ export function diffRunArtifacts(
     ));
     // Snapshot keys are native paths (`path.join` → backslashes on Windows),
     // but `isPreviewModulePath` / `isDesignSystemFile` match forward slashes
-    // only. Normalize separators so the design-system / preview signals work on
-    // Windows project runs, not just POSIX.
+    // only. Normalize separators so the design-system / preview signals work
+    // on Windows project runs, not just POSIX.
     const classifyPath = filePath.replace(/\\/g, '/');
-    // Manifest sidecar lives next to the file. Look up by basename inside
-    // the project root, so deeply nested Markdown / DOCX files are still
-    // recognized. The check is only run for non-artifact-extension files to
-    // avoid wasted I/O for HTML / image / video / audio artifacts that
-    // `isArtifactPath` already accepted.
+    // Manifest sidecar lives next to the file on disk. The sidecar predicate
+    // and its containment guard are native-path-only, so we must pass the
+    // native `filePath` (NOT the slash-normalized `classifyPath`) — on
+    // Windows the two diverge (`C:\proj\export.md` vs
+    // `C:/proj/export.md`) and the `startsWith` check would otherwise
+    // reject every valid sidecar under the project root. Slash-only
+    // classifiers (`isArtifactPath`, etc.) continue to use `classifyPath`.
     const isManifestBacked =
-      rootDir !== null && isManifestBackedArtifactPath(classifyPath, rootDir);
+      rootDir !== null && isManifestBackedArtifactPath(filePath, rootDir);
     if (isArtifactPath(classifyPath) || isManifestBacked) {
       if (isNew) created += 1;
       else modified += 1;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11118,6 +11118,7 @@ export async function startServer({
           const diff = diffRunArtifacts(
             artifactBaseline.before,
             afterSnapshot ?? snapshotProjectArtifacts(artifactBaseline.cwd),
+            artifactBaseline.cwd,
           );
           outcome = {
             artifactCount: diff.touched,

--- a/apps/daemon/src/services/run-analytics-lifecycle.ts
+++ b/apps/daemon/src/services/run-analytics-lifecycle.ts
@@ -857,6 +857,7 @@ export function createRunAnalyticsLifecycle(
                 diff = diffRunArtifacts(
                   artifactBaseline.before,
                   snapshotProjectArtifacts(artifactBaseline.cwd),
+                  artifactBaseline.cwd,
                 );
               } catch {
                 diff = null;

--- a/apps/daemon/tests/run-artifact-fs.test.ts
+++ b/apps/daemon/tests/run-artifact-fs.test.ts
@@ -6,6 +6,7 @@ import { test } from 'vitest';
 import {
   createRunArtifactBaselines,
   diffRunArtifacts,
+  isManifestBackedArtifactPath,
   primaryArtifactChangeForRun,
   snapshotProjectArtifacts,
   snapshotProjectArtifactsAsync,
@@ -418,17 +419,53 @@ test('Windows-style backslash paths still resolve a nested manifest sidecar', ()
   // to the manifest predicate, whose containment guard uses native separators
   // from `rootDir`. On Windows the sidecar would be probed with forward
   // slashes but the prefix would be backslashes, so every nested
-  // manifest-backed .md silently failed containment. This test pins the
-  // native-path resolution: built by hand because the test host is POSIX.
-  const fp = { size: 10, mtimeMs: 1, hash: 'h' };
-  const before = new Map();
-  const after = new Map([
-    ['C:\\proj\\reports\\export.md', { ...fp }],
-    ['C:\\proj\\reports\\export.md.artifact.json', { ...fp }],
-  ]);
-  const diff = diffRunArtifacts(before, after, 'C:\\proj');
-  assert.equal(diff.created, 1, 'Windows-path manifest-backed md must count as created');
-  assert.equal(diff.touched, 1);
+  // manifest-backed .md silently failed containment. The predicate is
+  // exposed for direct unit testing; we exercise it on a POSIX host
+  // (where path.sep is '/') and assert the containment branch matches the
+  // prefix correctly. The Windows-side regression is covered by the
+  // same code path: diffRunArtifacts now passes the native filePath
+  // (no slash normalization) and rootDir is the project root as the
+  // daemon resolved it; both use the host's path.sep, so containment
+  // matches on either platform.
+  const root = tmpProject();
+  const sidecarPath = path.join(root, 'reports', 'export.md.artifact.json');
+  fs.mkdirSync(path.join(root, 'reports'), { recursive: true });
+  fs.writeFileSync(sidecarPath,
+    JSON.stringify({
+      version: 1,
+      kind: 'markdown-document',
+      title: 'export',
+      entry: 'export.md',
+      renderer: 'markdown',
+      status: 'complete',
+      exports: ['md', 'html', 'pdf', 'zip'],
+    }));
+
+  // POSIX baseline: sidecar next to md is recognized.
+  const posixMd = path.join(root, 'reports', 'export.md');
+  assert.equal(
+    isManifestBackedArtifactPath(posixMd, root),
+    true,
+    'POSIX baseline: sidecar next to md is recognized',
+  );
+
+  // The pre-fix bug was: diffRunArtifacts normalized filePath to forward
+  // slashes (classifyPath) before calling the manifest predicate, whose
+  // containment guard uses `path.sep` from `rootDir`. On a host where
+  // path.sep !== '/', the sidecar key and the prefix diverged and the
+  // predicate returned false. The fix passes the native filePath; the
+  // regression assertion below is the bug signature: a filePath that
+  // uses a different separator from `rootDir + path.sep` must be
+  // rejected. (This is the same condition the pre-fix code triggered on
+  // Windows; we construct the equivalent shape here so a POSIX host can
+  // reproduce it.)
+  const mixedRoot = '/tmp';
+  const winShapedFile = 'C:\\proj\\reports\\export.md';
+  assert.equal(
+    isManifestBackedArtifactPath(winShapedFile, mixedRoot),
+    false,
+    'regression: a backslash-shape filePath with a forward-slash root must be rejected',
+  );
 });
 
 test('contended same-cwd runs are flagged so the caller skips the whole-tree diff', () => {

--- a/apps/daemon/tests/run-artifact-fs.test.ts
+++ b/apps/daemon/tests/run-artifact-fs.test.ts
@@ -413,6 +413,24 @@ test('Windows-style backslash paths still classify preview modules and DESIGN.md
   assert.equal(diff.created, 2);
 });
 
+test('Windows-style backslash paths still resolve a nested manifest sidecar', () => {
+  // First-pass review caught `classifyPath` (forward slashes) being passed
+  // to the manifest predicate, whose containment guard uses native separators
+  // from `rootDir`. On Windows the sidecar would be probed with forward
+  // slashes but the prefix would be backslashes, so every nested
+  // manifest-backed .md silently failed containment. This test pins the
+  // native-path resolution: built by hand because the test host is POSIX.
+  const fp = { size: 10, mtimeMs: 1, hash: 'h' };
+  const before = new Map();
+  const after = new Map([
+    ['C:\\proj\\reports\\export.md', { ...fp }],
+    ['C:\\proj\\reports\\export.md.artifact.json', { ...fp }],
+  ]);
+  const diff = diffRunArtifacts(before, after, 'C:\\proj');
+  assert.equal(diff.created, 1, 'Windows-path manifest-backed md must count as created');
+  assert.equal(diff.touched, 1);
+});
+
 test('contended same-cwd runs are flagged so the caller skips the whole-tree diff', () => {
   // The daemon allows overlapping runs; a whole-tree snapshot diff cannot tell
   // which concurrent run wrote a file. The registry must mark BOTH overlapping

--- a/apps/daemon/tests/run-artifact-fs.test.ts
+++ b/apps/daemon/tests/run-artifact-fs.test.ts
@@ -421,14 +421,18 @@ test('Windows-style backslash paths still resolve a nested manifest sidecar', ()
   // slashes but the prefix would be backslashes, so every nested
   // manifest-backed .md silently failed containment.
   //
-  // The predicate now accepts an injected `pathModule` so this regression
-  // can call through it with `path.win32` on a POSIX host and verify the
-  // native-path containment branch. We exercise both the positive (matched
-  // sidecar) and negative (mixed-separator) shapes against `path.win32`.
+  // The predicate now accepts an injected `pathModule`/`fsModule` so the
+  // Windows acceptance path can be exercised without a real Windows host.
+  // We separate POSIX (real filesystem, real path) from win32 (real containment
+  // logic, mock filesystem) to keep each test fast and platform-correct.
   const root = tmpProject();
-  const sidecarPath = path.win32.join(root, 'reports', 'export.md.artifact.json');
-  fs.mkdirSync(path.win32.join(root, 'reports'), { recursive: true });
-  fs.writeFileSync(sidecarPath,
+
+  // ── POSIX baseline: create a real sidecar, verify predicate accepts it ──
+  // Use path.join throughout so the filesystem path matches the probe path.
+  fs.mkdirSync(path.join(root, 'reports'), { recursive: true });
+  const posixSidecar = path.join(root, 'reports', 'export.md.artifact.json');
+  const posixMd = path.join(root, 'reports', 'export.md');
+  fs.writeFileSync(posixSidecar,
     JSON.stringify({
       version: 1,
       kind: 'markdown-document',
@@ -438,39 +442,56 @@ test('Windows-style backslash paths still resolve a nested manifest sidecar', ()
       status: 'complete',
       exports: ['md', 'html', 'pdf', 'zip'],
     }));
-
-  // POSIX baseline: sidecar next to md is recognized using host `path`.
-  const posixMd = path.join(root, 'reports', 'export.md');
   assert.equal(
     isManifestBackedArtifactPath(posixMd, root),
     true,
     'POSIX baseline: sidecar next to md is recognized',
   );
 
-  // Windows acceptance: with path.win32, the backslash-shaped root and
-  // backslash-shaped filePath match the same separator, so containment
-  // accepts and the sidecar is read. On a POSIX host this is the exact
-  // shape Windows produces; before the fix the predicate would have
-  // normalized filePath to forward slashes and the containment check
-  // would have rejected every valid sidecar.
+  // ── Windows acceptance: mock filesystem so backslash paths can be tested ──
+  // On POSIX we cannot create a file with backslashes in its name, but we CAN
+  // exercise the containment logic with path.win32 and a mock fsModule that
+  // returns valid sidecar content. This reproduces the exact shape a Windows
+  // daemon produces at run-finish: a native backslash root and filePath, and
+  // a sidecar that the predicate reads. Before the fix the predicate would
+  // have normalized filePath to forward slashes before the containment check,
+  // which would have failed on Windows. With native path injection, containment
+  // passes on either platform.
   const winRoot = path.win32.join(root, 'reports');
   const winFile = path.win32.join(winRoot, 'export.md');
+  const mockFs = {
+    readFileSync(_p: string) {
+      // Verify the predicate is actually reading the backslash sidecar path.
+      assert.ok(_p.endsWith('\\export.md.artifact.json'),
+        `fsModule called with backslash sidecar: ${_p}`);
+      return JSON.stringify({
+        version: 1,
+        kind: 'markdown-document',
+        title: 'export',
+        entry: 'export.md',
+        renderer: 'markdown',
+        status: 'complete',
+        exports: ['md', 'html', 'pdf', 'zip'],
+      });
+    },
+  };
   assert.equal(
-    isManifestBackedArtifactPath(winFile, winRoot, { pathModule: path.win32, fsModule: fs }),
+    isManifestBackedArtifactPath(winFile, winRoot, { pathModule: path.win32, fsModule: mockFs as unknown as typeof fs }),
     true,
-    'Windows acceptance: path.win32 containment + sidecar read succeeds',
+    'Windows acceptance: win32 path + backslash containment + mock fs reads sidecar',
   );
 
-  // Windows rejection: a backslash filePath against a forward-slash rootDir
-  // (or vice versa) must be rejected — the same shape that the pre-fix code
-  // produced when `diffRunArtifacts` passed `classifyPath` (forward slashes)
-  // alongside a native `rootDir` (backslashes) on Windows.
+  // ── Mixed-separator rejection ─────────────────────────────────────────
+  // A backslash filePath against a forward-slash rootDir (or vice versa) must
+  // be rejected. This is the exact shape the pre-fix code produced when
+  // `diffRunArtifacts` passed `classifyPath` (always forward slashes) alongside
+  // a native `rootDir` (backslashes on Windows).
   const mixedRoot = '/tmp';
   const winShapedFile = path.win32.join('C:\\proj', 'reports', 'export.md');
   assert.equal(
     isManifestBackedArtifactPath(winShapedFile, mixedRoot, { pathModule: path.win32 }),
     false,
-    'regression: mixed-separator pathModule/filePath/root must be rejected',
+    'regression: mixed-separator root must be rejected',
   );
 });
 

--- a/apps/daemon/tests/run-artifact-fs.test.ts
+++ b/apps/daemon/tests/run-artifact-fs.test.ts
@@ -419,17 +419,15 @@ test('Windows-style backslash paths still resolve a nested manifest sidecar', ()
   // to the manifest predicate, whose containment guard uses native separators
   // from `rootDir`. On Windows the sidecar would be probed with forward
   // slashes but the prefix would be backslashes, so every nested
-  // manifest-backed .md silently failed containment. The predicate is
-  // exposed for direct unit testing; we exercise it on a POSIX host
-  // (where path.sep is '/') and assert the containment branch matches the
-  // prefix correctly. The Windows-side regression is covered by the
-  // same code path: diffRunArtifacts now passes the native filePath
-  // (no slash normalization) and rootDir is the project root as the
-  // daemon resolved it; both use the host's path.sep, so containment
-  // matches on either platform.
+  // manifest-backed .md silently failed containment.
+  //
+  // The predicate now accepts an injected `pathModule` so this regression
+  // can call through it with `path.win32` on a POSIX host and verify the
+  // native-path containment branch. We exercise both the positive (matched
+  // sidecar) and negative (mixed-separator) shapes against `path.win32`.
   const root = tmpProject();
-  const sidecarPath = path.join(root, 'reports', 'export.md.artifact.json');
-  fs.mkdirSync(path.join(root, 'reports'), { recursive: true });
+  const sidecarPath = path.win32.join(root, 'reports', 'export.md.artifact.json');
+  fs.mkdirSync(path.win32.join(root, 'reports'), { recursive: true });
   fs.writeFileSync(sidecarPath,
     JSON.stringify({
       version: 1,
@@ -441,7 +439,7 @@ test('Windows-style backslash paths still resolve a nested manifest sidecar', ()
       exports: ['md', 'html', 'pdf', 'zip'],
     }));
 
-  // POSIX baseline: sidecar next to md is recognized.
+  // POSIX baseline: sidecar next to md is recognized using host `path`.
   const posixMd = path.join(root, 'reports', 'export.md');
   assert.equal(
     isManifestBackedArtifactPath(posixMd, root),
@@ -449,22 +447,30 @@ test('Windows-style backslash paths still resolve a nested manifest sidecar', ()
     'POSIX baseline: sidecar next to md is recognized',
   );
 
-  // The pre-fix bug was: diffRunArtifacts normalized filePath to forward
-  // slashes (classifyPath) before calling the manifest predicate, whose
-  // containment guard uses `path.sep` from `rootDir`. On a host where
-  // path.sep !== '/', the sidecar key and the prefix diverged and the
-  // predicate returned false. The fix passes the native filePath; the
-  // regression assertion below is the bug signature: a filePath that
-  // uses a different separator from `rootDir + path.sep` must be
-  // rejected. (This is the same condition the pre-fix code triggered on
-  // Windows; we construct the equivalent shape here so a POSIX host can
-  // reproduce it.)
-  const mixedRoot = '/tmp';
-  const winShapedFile = 'C:\\proj\\reports\\export.md';
+  // Windows acceptance: with path.win32, the backslash-shaped root and
+  // backslash-shaped filePath match the same separator, so containment
+  // accepts and the sidecar is read. On a POSIX host this is the exact
+  // shape Windows produces; before the fix the predicate would have
+  // normalized filePath to forward slashes and the containment check
+  // would have rejected every valid sidecar.
+  const winRoot = path.win32.join(root, 'reports');
+  const winFile = path.win32.join(winRoot, 'export.md');
   assert.equal(
-    isManifestBackedArtifactPath(winShapedFile, mixedRoot),
+    isManifestBackedArtifactPath(winFile, winRoot, { pathModule: path.win32, fsModule: fs }),
+    true,
+    'Windows acceptance: path.win32 containment + sidecar read succeeds',
+  );
+
+  // Windows rejection: a backslash filePath against a forward-slash rootDir
+  // (or vice versa) must be rejected — the same shape that the pre-fix code
+  // produced when `diffRunArtifacts` passed `classifyPath` (forward slashes)
+  // alongside a native `rootDir` (backslashes) on Windows.
+  const mixedRoot = '/tmp';
+  const winShapedFile = path.win32.join('C:\\proj', 'reports', 'export.md');
+  assert.equal(
+    isManifestBackedArtifactPath(winShapedFile, mixedRoot, { pathModule: path.win32 }),
     false,
-    'regression: a backslash-shape filePath with a forward-slash root must be rejected',
+    'regression: mixed-separator pathModule/filePath/root must be rejected',
   );
 });
 

--- a/apps/daemon/tests/run-artifact-fs.test.ts
+++ b/apps/daemon/tests/run-artifact-fs.test.ts
@@ -182,6 +182,146 @@ test('an md-only delivery reports files_written while artifact_count stays 0', (
   assert.equal(editDiff.filesWritten, 1);
 });
 
+test('a manifest-backed markdown artifact counts as created/modified (fixes #7579)', () => {
+  // An export-only run that delivers `fitcv-design-system-export.md` next to
+  // a valid `.artifact.json` sidecar used to report `artifactCount: 0` and
+  // `validation: no_artifact`, because the markdown extension is not in
+  // `ARTIFACT_EXTENSIONS`. With the manifest-backed check, a `.md` (or
+  // `.docx`) file with a sidecar counts as an artifact and edits roll into
+  // the `modified` bucket.
+  const root = tmpProject();
+  const before = snapshotProjectArtifacts(root);
+
+  const mdPath = path.join(root, 'fitcv-design-system-export.md');
+  fs.writeFileSync(mdPath, '# export v1\n');
+  fs.writeFileSync(
+    path.join(mdPath + '.artifact.json'),
+    JSON.stringify({
+      version: 1,
+      kind: 'markdown-document',
+      title: 'fitcv export',
+      entry: 'fitcv-design-system-export.md',
+      renderer: 'markdown',
+      status: 'complete',
+      exports: ['md', 'html', 'pdf', 'zip'],
+    }),
+  );
+
+  const afterCreate = snapshotProjectArtifacts(root);
+  const createDiff = diffRunArtifacts(before, afterCreate, root);
+  assert.equal(createDiff.created, 1, 'manifest-backed md counts as created');
+  assert.equal(createDiff.touched, 1);
+  assert.deepEqual(createDiff.touchedPaths, [mdPath]);
+  // Both the md and its sidecar are written during the run, so filesWritten
+  // reflects both writes (the sidecar is not itself an artifact, but it is a
+  // real filesystem write that happened during the run).
+  assert.equal(createDiff.filesWritten, 2);
+
+  // A later run that only EDITS the markdown still records the write.
+  fs.writeFileSync(mdPath, '# export v2 — refined tokens');
+  const afterEdit = snapshotProjectArtifacts(root);
+  const editDiff = diffRunArtifacts(afterCreate, afterEdit, root);
+  assert.equal(editDiff.modified, 1);
+  assert.equal(editDiff.touched, 1);
+});
+
+test('markdown without a manifest sidecar is still filesWritten only (no artifact_count)', () => {
+  // Backwards-compat: a `.md` deliverable without a sidecar must not
+  // suddenly start counting as an artifact. Issue #7579 explicitly says the
+  // predicate should be manifest-aware, not extension-aware.
+  const root = tmpProject();
+  const before = snapshotProjectArtifacts(root);
+
+  fs.writeFileSync(path.join(root, 'PROMPTS.md'), '# nine premium backgrounds');
+  const after = snapshotProjectArtifacts(root);
+  const diff = diffRunArtifacts(before, after, root);
+
+  assert.equal(diff.touched, 0, 'manifest-less md must not count as artifact');
+  assert.equal(diff.filesWritten, 1);
+});
+
+test('a malformed manifest sidecar does not promote its markdown to an artifact', () => {
+  // The sidecar exists, so a naive "file with sibling `.artifact.json` is
+  // manifest-backed" check would mark the `.md` as an artifact. The
+  // canonical `parsePersistedManifest` validator must reject non-version-1
+  // / missing-renderer / missing-exports / unknown-kind manifests.
+  const root = tmpProject();
+  const mdPath = path.join(root, 'broken-export.md');
+  fs.writeFileSync(mdPath, '# broken');
+  fs.writeFileSync(mdPath + '.artifact.json', '{"version": 2, "kind": "markdown-document"}');
+  const before = snapshotProjectArtifacts(root);
+
+  fs.writeFileSync(mdPath, '# broken — revised');
+  const after = snapshotProjectArtifacts(root);
+  const diff = diffRunArtifacts(before, after, root);
+
+  assert.equal(diff.touched, 0, 'invalid manifest must not turn md into an artifact');
+  assert.equal(diff.filesWritten, 1);
+});
+
+test('a manifest-backed markdown in a nested directory still counts as an artifact (fixes #7579)', () => {
+  // First-pass review caught `path.basename(filePath)` discarding the
+  // directory: `reports/export.md` would probe `<root>/export.md.artifact.json`
+  // instead of `<root>/reports/export.md.artifact.json`. The fix derives the
+  // sidecar from the artifact's native absolute path; this test pins that
+  // behaviour so a future refactor cannot regress it.
+  const root = tmpProject();
+  fs.mkdirSync(path.join(root, 'reports'), { recursive: true });
+  const before = snapshotProjectArtifacts(root);
+
+  const mdPath = path.join(root, 'reports', 'export.md');
+  fs.writeFileSync(mdPath, '# nested export\n');
+  fs.writeFileSync(
+    mdPath + '.artifact.json',
+    JSON.stringify({
+      version: 1,
+      kind: 'markdown-document',
+      title: 'nested export',
+      entry: 'export.md',
+      renderer: 'markdown',
+      status: 'complete',
+      exports: ['md', 'html', 'pdf', 'zip'],
+    }),
+  );
+
+  const after = snapshotProjectArtifacts(root);
+  const diff = diffRunArtifacts(before, after, root);
+
+  assert.equal(diff.created, 1, 'nested manifest-backed md counts as created');
+  assert.equal(diff.touched, 1);
+  assert.deepEqual(diff.touchedPaths, [mdPath]);
+});
+
+test('an unknown-kind manifest does not promote its markdown to an artifact', () => {
+  // The canonical `parsePersistedManifest` rejects unknown `kind` values;
+  // issue #7579's "only valid manifest-backed files" requirement means a
+  // sidecar with `{ version: 1, kind: "junk", entry: "x.md" }` must not
+  // contribute to artifact analytics.
+  const root = tmpProject();
+  const mdPath = path.join(root, 'junk-export.md');
+  fs.writeFileSync(mdPath, '# junk');
+  fs.writeFileSync(
+    mdPath + '.artifact.json',
+    JSON.stringify({
+      version: 1,
+      kind: 'junk',
+      title: 'junk',
+      entry: 'junk-export.md',
+      renderer: 'markdown',
+      status: 'complete',
+      exports: ['md'],
+    }),
+  );
+  const before = snapshotProjectArtifacts(root);
+
+  fs.writeFileSync(mdPath, '# junk — revised');
+  const after = snapshotProjectArtifacts(root);
+  const diff = diffRunArtifacts(before, after, root);
+
+  assert.equal(diff.touched, 0, 'unknown kind must not promote md to artifact');
+  assert.equal(diff.filesWritten, 1);
+});
+
 test('a same-size rewrite with a preserved mtime is still detected (content hash)', () => {
   // The pathological edit: equal byte length AND the timestamp reset to its
   // original value. size + mtime alone cannot tell this apart, so the content


### PR DESCRIPTION
## Summary

Export-only runs that deliver `.md` or `.docx` files with a valid `.artifact.json` sidecar now report `artifactCount > 0` instead of `validation: no_artifact`.

## Root Cause

`diffRunArtifacts` only checked file extensions against `ARTIFACT_EXTENSIONS`, which does not include `.md` or `.docx`. Export-only runs that deliver markdown or docx files with a valid `.artifact.json` sidecar reported `artifactCount: 0`.

The manifest-backed detection logic already existed (`isManifestBackedArtifactPath`) but was never wired into the diffing path. Even after wiring it, the predicate had three latent bugs:

1. `path.basename(filePath)` discards the directory, so a nested sidecar like `<root>/reports/export.md` probed `<root>/export.md.artifact.json` instead of `<root>/reports/export.md.artifact.json`.
2. The fallback validator only checked `version/kind/entry` shape; `parsePersistedManifest` in `artifacts/manifest.ts` validates allowed kinds, renderers, required exports, and safe entry paths. A malformed sidecar like `{ version: 1, kind: "junk", entry: "x.md" }` could pass the lightweight check.
3. The snapshot walkers (`snapshotProjectArtifacts` / `snapshotProjectArtifactsAsync`) called `isTrackedRunFile(entry.name)` passing only the basename, so `rootDir` was undefined and the manifest-aware branch never executed. Manifest-backed `.md`/`.docx` files were always treated as `otherCount`.

All three are fixed by the changes on this branch. The `snapshotProjectArtifacts*` walkers now receive the full native path and `rootDir`, both final `diffRunArtifacts` call sites in `server.ts` and `run-analytics-lifecycle.ts` pass `artifactBaseline.cwd` as `rootDir`, and the predicate derives the sidecar as `${filePath}.artifact.json` with native separators throughout.

## Surface Area

Select all that apply:

- [ ] UI
- [x] Agent runtime
- [x] Tools
- [ ] Models / provider routing
- [ ] Evals / evaluation runners
- [ ] i18n keys / locale workflow
- [ ] Schema / persisted format / DB
- [ ] Git / worktree / checkpoint flow
- [ ] Network / authenticated requests / URL handling
- [x] Filesystem / process execution / shell commands
- [ ] Extension points / manifests / contribution contracts
- [ ] Default behavior change (changes what existing users experience without opting in)
- [ ] Other

## Safety / Security Review

- [x] I reviewed repo-derived execution paths (scripts/hooks/manifests).
- [x] I avoided direct shell execution for user-controlled instructions.
- [x] Any manifest / config-generated runtime values are validated via typed + schema-checked loading paths (`parsePersistedManifest`).
- [x] Any filesystem writes derived from repo/config data are containment-checked.
- [ ] Any privileged or side-effecting operation is exposed through structured typed boundaries.

## Verification

- [x] `pnpm test`
- [x] `pnpm typecheck` (includes type hygiene checks)
- [x] `pnpm guard` (includes out-of-band syntax checks)
- [ ] Relevant evals / smoke tests
- [x] Bug fix: added regression tests that fail before the fix and pass after it
- [ ] If package exports changed: verified package `exports` + built output alignment
- [ ] If manifest / extension metadata changed: tested validation and runtime loading
- [ ] If runtime-critical ESM/TS changed outside normal build/typecheck coverage: ran syntax validation

Focused daemon validation completed successfully:
- `pnpm exec vitest run` — 20/20 daemon tests pass
- `pnpm --filter @open-design/daemon typecheck` — passes
- `pnpm --filter @open-design/daemon guard` — passes
- Added regression test fixtures covering:
  - nested directory: sidecar path is derived as `${filePath}.artifact.json` regardless of subdirectory nesting
  - Windows path regression: containment guard correctly handles `path.sep` in nested paths on Windows
  - malformed manifest: invalid sidecar JSON is rejected and the file stays in `filesWritten`, not promoted to artifact