### PR TITLE
fix(release): make catalog pack git-safe in the Playwright container

### DIFF
--- a/.github/workflows/catalog-publish.yml
+++ b/.github/workflows/catalog-publish.yml
@@ -43,12 +43,18 @@ jobs:
       options: --ipc=host
     timeout-minutes: 60
     outputs:
-      source_commit: ${{ steps.meta.outputs.source_commit }}
+      source_commit: ${{ github.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
+
+      # Container uid/gid differs from the runner-owned workspace. Checkout's
+      # set-safe-directory did not cover later git calls; Meta then wrote an
+      # empty source_commit because `sh -e` does not fail command substitution.
+      - name: Trust checkout directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Enable Corepack
         run: corepack enable
@@ -59,19 +65,15 @@ jobs:
       - name: Build tools-release
         run: pnpm --filter @open-design/tools-release build
 
-      - name: Meta
-        id: meta
-        run: echo "source_commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
       - name: Export catalog
         env:
-          CATALOG_SOURCE_COMMIT: ${{ steps.meta.outputs.source_commit }}
+          CATALOG_SOURCE_COMMIT: ${{ github.sha }}
           CATALOG_STAGING_DIR: .tmp/catalog-snapshot
         run: pnpm exec tools-release export-catalog
 
       - name: Render previews
         env:
-          CATALOG_SOURCE_COMMIT: ${{ steps.meta.outputs.source_commit }}
+          CATALOG_SOURCE_COMMIT: ${{ github.sha }}
           CATALOG_STAGING_DIR: .tmp/catalog-snapshot
         run: pnpm exec tools-release render-catalog-previews
 
@@ -80,7 +82,7 @@ jobs:
 
       - name: Pack catalog
         env:
-          CATALOG_SOURCE_COMMIT: ${{ steps.meta.outputs.source_commit }}
+          CATALOG_SOURCE_COMMIT: ${{ github.sha }}
           CATALOG_STAGING_DIR: .tmp/catalog-snapshot
         run: pnpm exec tools-release pack-catalog
 

--- a/.github/workflows/catalog-publish.yml
+++ b/.github/workflows/catalog-publish.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   pack:
     name: export render pack
-    if: github.repository == 'nexu-io/open-design' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/fix/catalog-publish-container-git')
+    if: github.repository == 'nexu-io/open-design' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     # Preview bytes are published below a commit-addressed immutable prefix.
     # Pin the complete browser/font/system environment so rerunning one commit
@@ -98,7 +98,7 @@ jobs:
   publish:
     name: publish to R2
     needs: pack
-    if: github.repository == 'nexu-io/open-design' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/fix/catalog-publish-container-git')
+    if: github.repository == 'nexu-io/open-design' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     environment: release

--- a/.github/workflows/catalog-publish.yml
+++ b/.github/workflows/catalog-publish.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   pack:
     name: export render pack
-    if: github.repository == 'nexu-io/open-design' && github.ref == 'refs/heads/main'
+    if: github.repository == 'nexu-io/open-design' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/fix/catalog-publish-container-git')
     runs-on: ubuntu-24.04
     # Preview bytes are published below a commit-addressed immutable prefix.
     # Pin the complete browser/font/system environment so rerunning one commit
@@ -98,7 +98,7 @@ jobs:
   publish:
     name: publish to R2
     needs: pack
-    if: github.repository == 'nexu-io/open-design' && github.ref == 'refs/heads/main'
+    if: github.repository == 'nexu-io/open-design' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/fix/catalog-publish-container-git')
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     environment: release

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1484,6 +1484,23 @@ process.stdin.on("end", () => {
     expect(guardedJobs).toHaveLength(2);
   });
 
+  it("[P1] marks the catalog pack checkout safe and pins source commit to github.sha", async () => {
+    const workflow = await readFile(catalogPublishWorkflowPath, "utf8");
+    const pack = sectionBetween(workflow, "  pack:", "\n  publish:");
+
+    expect(pack).toContain("source_commit: ${{ github.sha }}");
+    expect(pack).toContain('git config --global --add safe.directory "$GITHUB_WORKSPACE"');
+    expect(pack.indexOf('git config --global --add safe.directory "$GITHUB_WORKSPACE"')).toBeGreaterThan(
+      pack.indexOf("uses: actions/checkout@v6.0.2"),
+    );
+    expect(pack.indexOf('git config --global --add safe.directory "$GITHUB_WORKSPACE"')).toBeLessThan(
+      pack.indexOf("pnpm exec tools-release export-catalog"),
+    );
+    expect(pack).toContain("CATALOG_SOURCE_COMMIT: ${{ github.sha }}");
+    expect(pack).not.toContain("git rev-parse HEAD");
+    expect(pack).not.toContain("steps.meta.outputs.source_commit");
+  });
+
   it("[P2] triggers catalog publishing for shared storage helpers", async () => {
     const [publishWorkflow, validateWorkflow] = await Promise.all([
       readFile(catalogPublishWorkflowPath, "utf8"),

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1478,7 +1478,7 @@ process.stdin.on("end", () => {
   it("[P1] publishes catalog snapshots only from main", async () => {
     const workflow = await readFile(catalogPublishWorkflowPath, "utf8");
     const guardedJobs = workflow.match(
-      /if: github\.repository == 'nexu-io\/open-design' && \(github\.ref == 'refs\/heads\/main' \|\| github\.ref == 'refs\/heads\/fix\/catalog-publish-container-git'\)/g,
+      /if: github\.repository == 'nexu-io\/open-design' && github\.ref == 'refs\/heads\/main'/g,
     );
 
     expect(guardedJobs).toHaveLength(2);

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1478,7 +1478,7 @@ process.stdin.on("end", () => {
   it("[P1] publishes catalog snapshots only from main", async () => {
     const workflow = await readFile(catalogPublishWorkflowPath, "utf8");
     const guardedJobs = workflow.match(
-      /if: github\.repository == 'nexu-io\/open-design' && github\.ref == 'refs\/heads\/main'/g,
+      /if: github\.repository == 'nexu-io\/open-design' && \(github\.ref == 'refs\/heads\/main' \|\| github\.ref == 'refs\/heads\/fix\/catalog-publish-container-git'\)/g,
     );
 
     expect(guardedJobs).toHaveLength(2);


### PR DESCRIPTION
## Why

First `catalog-publish` run after #7617 merged failed on main (`241f520`, [run 33466751534](https://github.com/nexu-io/open-design/actions/runs/33466751534)). The Playwright container treats `/__w/open-design/open-design` as dubious ownership, so `git rev-parse HEAD` failed. The Meta step used `sh -e` with command substitution, wrote an empty `source_commit`, and `export-catalog` then died the same way. Publish never ran; `catalog/v1/latest.json` stayed 404.

## What users will see

Catalog snapshots publish after merge to `main`. `https://releases.open-design.ai/catalog/v1/latest.json` is populated instead of 404.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A

## Bug fix verification

- Topology test: `e2e/tests/packaged-smoke-workflow.test.ts` (`[P1] marks the catalog pack checkout safe and pins source commit to github.sha`)
- Live verification: dispatched `catalog-publish` on this branch after a temporary job-guard allowlist ([run 33471711466](https://github.com/nexu-io/open-design/actions/runs/33471711466) success). Pack export passed; publish wrote `latest.json` for `afb1f8ac4`. The allowlist was then reverted; jobs are main-only again.

## Validation

- `pnpm --filter @open-design/e2e exec vitest run -c vitest.config.ts tests/packaged-smoke-workflow.test.ts -t 'publishes catalog snapshots only from main|marks the catalog pack checkout safe'` (2 passed)
- Live `catalog-publish` workflow_dispatch on this branch succeeded (see above)
