### PR TITLE
fix(chat): hide OpenCode compaction lifecycle

### DIFF
--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -479,7 +479,8 @@ export function attachAcpSession({
     if (
       name !== 'assistant_message_lifecycle' &&
       name !== 'model_step_lifecycle' &&
-      name !== 'model_retry'
+      name !== 'model_retry' &&
+      name !== 'opencode_compaction'
     ) {
       return false;
     }

--- a/apps/daemon/src/runtimes/chat-run-messages.ts
+++ b/apps/daemon/src/runtimes/chat-run-messages.ts
@@ -376,6 +376,7 @@ const TRANSIENT_ACP_PERSISTED_STATUS_LABELS = new Set([
   'tool_call',
   'tool_call_update',
   'session_update',
+  'opencode_compaction',
 ]);
 
 export function daemonAgentPayloadToPersistedAgentEvent(data: unknown): PersistedAgentEvent | null {

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -476,6 +476,49 @@ test('attachAcpSession forwards ACP status message details', () => {
   assert.equal(status?.detail, 'Compacting conversation history after a context-length error');
 });
 
+test('attachAcpSession records OpenCode compaction lifecycle as diagnostic observability', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'describe the project',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'opencode_compaction',
+    phase: 'requested',
+    status: 'running',
+    reason: 'automatic',
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const agentPayloads = events
+    .filter((entry) => entry.event === 'agent')
+    .map((entry) => entry.payload as Record<string, unknown>);
+  assert.equal(
+    agentPayloads.some(
+      (payload) => payload.type === 'status' && payload.label === 'opencode_compaction',
+    ),
+    false,
+  );
+  const diagnostic = agentPayloads.find(
+    (payload) => payload.type === 'diagnostic' && payload.name === 'opencode_compaction',
+  );
+  assert.ok(diagnostic);
+  assert.equal(diagnostic.source, 'amr-opencode');
+  assert.equal(diagnostic.phase, 'requested');
+  assert.equal(diagnostic.status, 'running');
+  assert.equal(diagnostic.reason, 'automatic');
+  assert.equal(typeof diagnostic.elapsedMs, 'number');
+});
+
 test('attachAcpSession suppresses split duplicate DSML artifact text and preserves trailing prose', () => {
   const child = new FakeAcpChild();
   const events: Array<{ event: string; payload: unknown }> = [];

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -497,6 +497,24 @@ test('attachAcpSession records OpenCode compaction lifecycle as diagnostic obser
     status: 'running',
     reason: 'automatic',
   });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: 'Answer after compaction' },
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'post-compaction-tool',
+    kind: 'read',
+    title: 'Read after compaction',
+    status: 'pending',
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call_update',
+    toolCallId: 'post-compaction-tool',
+    status: 'completed',
+    rawOutput: 'continuation output',
+  });
+  assert.equal(child.stdin.writableEnded, false);
   writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
 
   const agentPayloads = events
@@ -517,6 +535,27 @@ test('attachAcpSession records OpenCode compaction lifecycle as diagnostic obser
   assert.equal(diagnostic.status, 'running');
   assert.equal(diagnostic.reason, 'automatic');
   assert.equal(typeof diagnostic.elapsedMs, 'number');
+
+  assert.deepEqual(
+    agentPayloads
+      .filter((payload) => payload.type === 'text_delta')
+      .map((payload) => payload.delta),
+    ['Answer after compaction'],
+  );
+  assert.ok(
+    agentPayloads.some(
+      (payload) =>
+        payload.type === 'tool_use' &&
+        payload.id === acpTelemetryToolCallId('post-compaction-tool'),
+    ),
+  );
+  assert.ok(
+    agentPayloads.some(
+      (payload) =>
+        payload.type === 'tool_result' &&
+        payload.toolUseId === acpTelemetryToolCallId('post-compaction-tool'),
+    ),
+  );
 });
 
 test('attachAcpSession suppresses split duplicate DSML artifact text and preserves trailing prose', () => {

--- a/apps/daemon/tests/tool-loop-persistence.test.ts
+++ b/apps/daemon/tests/tool-loop-persistence.test.ts
@@ -113,6 +113,7 @@ describe('daemonAgentPayloadToPersistedAgentEvent — transient ACP status label
     ['tool_call'],
     ['tool_call_update'],
     ['session_update'],
+    ['opencode_compaction'],
   ])('returns null for transient status %s', (label) => {
     expect(
       persist({

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -4312,6 +4312,11 @@ function buildBlocks(events: AgentEvent[]): Block[] {
         ev.label === "requesting" ||
         ev.label === "thinking" ||
         ev.label === "empty_response" ||
+        // Vela emits OpenCode's compaction lifecycle as internal observability.
+        // Older transcripts persisted it as a generic status before the ACP
+        // adapter classified it as a diagnostic, so suppress that legacy label
+        // during history replay as well as on the live path.
+        ev.label === "opencode_compaction" ||
         // Transient ACP tool-call markers (#4618). On the live SSE path the
         // daemon normalizes these to `running` (TRANSIENT_ACP_STATUS_LABELS in
         // providers/daemon.ts), which is already skipped above; the persisted-

--- a/apps/web/tests/components/AssistantMessage.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.test.tsx
@@ -545,6 +545,27 @@ describe('AssistantMessage status badge updates (Bug A)', () => {
     expect(screen.getByText('compacting context')).toBeTruthy();
     expect(screen.getByText('Compacting conversation history after a context-length error')).toBeTruthy();
   });
+
+  it('suppresses legacy persisted OpenCode compaction lifecycle statuses', () => {
+    render(
+      <AssistantMessage
+        message={baseMessage({
+          events: [
+            { kind: 'text', text: 'Visible answer' } as ChatMessage['events'][number],
+            {
+              kind: 'status',
+              label: 'opencode_compaction',
+            } as ChatMessage['events'][number],
+          ],
+        })}
+        streaming={false}
+        projectId="proj-1"
+      />,
+    );
+
+    expect(screen.getByText('Visible answer')).toBeTruthy();
+    expect(screen.queryByText('opencode_compaction')).toBeNull();
+  });
 });
 
 describe('AssistantMessage thinking blocks', () => {


### PR DESCRIPTION
## Why

While validating Vela 0.0.34 against the TEST Link environment with a manually constrained 64K context budget, a real long-running Open Design turn exposed OpenCode's internal `opencode_compaction` lifecycle as assistant-message rows. Those raw markers were visible during streaming and remained visible after refresh because the generic ACP fallback treated an observability update as a user-facing status and persistence retained it.

This leaks provider/runtime implementation details into the product and pollutes both new and already-persisted conversations.

## What users will see

Automatic Vela/OpenCode compaction remains invisible in live and historical chat. Assistant work continues normally across compaction, and old conversations that already persisted the raw `opencode_compaction` status no longer render it. Existing human-readable `context_compaction` notices are unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No new UI entry point. Before/after evidence was captured from the isolated TEST Link + Vela 0.0.34 reproduction: the raw lifecycle rows were visible on `main`; on this branch they remained absent during the first compaction, after repeated compactions, after refresh, and when reopening the polluted pre-fix conversation.

## Bug fix verification

- Test paths: `apps/daemon/tests/acp.test.ts`, `apps/daemon/tests/tool-loop-persistence.test.ts`, and `apps/web/tests/components/AssistantMessage.test.tsx`.
- Did the test go red on `main` and green on this branch? No. The focused tests were added with the fix. The unchanged real Vela/UI reproduction was red on `main` and green on this branch.
- Real-path verification used Vela 0.0.34, its matching OpenCode runtime, TEST Link, `gpt-5.4-mini`, and a 64K context budget. The post-fix run emitted 21 `opencode_compaction` diagnostic lifecycle events across repeated automatic compactions and zero user-facing statuses with that label. The UI showed no raw marker live, after multiple cycles, after refresh, or when reopening the pre-fix transcript. The long verification run was stopped only after this evidence was complete.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/acp.test.ts tests/tool-loop-persistence.test.ts` in `apps/daemon` — 100 tests passed.
- `pnpm exec vitest run -c vitest.config.ts --maxWorkers=2 tests/components/AssistantMessage.test.tsx` in `apps/web` — 56 tests passed.
- `pnpm --filter @open-design/daemon typecheck` — passed.
- `pnpm --filter @open-design/web typecheck` — passed.
- `git diff --check` — passed.
- `pnpm guard` — reached repository checks but is currently blocked by unrelated `main` baseline issues: residual JavaScript at `apps/landing-page/public/enhancers/cobe.js` and `apps/landing-page/public/enhancers/matter.min.js`, plus the cross-app import check expecting the absent `apps/telemetry-worker/package.json`.
