### PR TITLE
fix(daemon): map manifest kinds to ProjectFileKind in export-only deliverable fallback

### DIFF
--- a/apps/daemon/src/run-deliverable-validation.ts
+++ b/apps/daemon/src/run-deliverable-validation.ts
@@ -241,13 +241,15 @@ export async function validateRunDeliverable(
         const candidatePath = filePath(candidate);
         const manifest = candidate.artifactManifest!;
         // Map the manifest's ArtifactKind namespace to ProjectFileKind so the
-        // result field carries the user-meaningful value.
-        const mk = manifest.kind as string | undefined;
+        // result field carries the user-meaningful value. ArtifactKind in
+        // @open-design/contracts only enumerates the eight accepted persisted
+        // kinds (html, deck, react-component, markdown-document, svg, diagram,
+        // code-snippet, mini-app, design-system); the only one that maps to a
+        // different ProjectFileKind is markdown-document → document. Other
+        // manifests (code-snippet, html, ...) report the file-extension kind
+        // directly without rewriting.
         const candidateArtifactKind: ProjectFileKind =
-          mk === 'markdown-document' ? 'document'
-          : mk === 'pptx-presentation' ? 'presentation'
-          : mk === 'xlsx-document' ? 'spreadsheet'
-          : candidate.kind;
+          manifest.kind === 'markdown-document' ? 'document' : candidate.kind;
 
         try {
           const target = path.resolve(projectRoot, candidatePath);

--- a/apps/daemon/src/run-deliverable-validation.ts
+++ b/apps/daemon/src/run-deliverable-validation.ts
@@ -216,6 +216,69 @@ export async function validateRunDeliverable(
       }),
     );
     if (!touched.has(entryFile)) {
+      // Export-only tasks: the prototype entry is intentionally untouched, but
+      // a touched artifact with a complete explicit manifest should be accepted
+      // as the deliverable entry instead of rejecting the run. The candidate
+      // must be touched in this run, carry a persisted (non-inferred) manifest
+      // bound to the file's own path, and have a status of `complete`.
+      const exportCandidate = files.find((file) => {
+        const candidatePath = filePath(file);
+        const manifest = file.artifactManifest;
+        if (!manifest || manifest.status !== 'complete') return false;
+        if (typeof manifest.entry !== 'string' || manifest.entry !== candidatePath) return false;
+        // Only consider artifacts with an explicit persisted manifest, not
+        // inferred legacy manifests that every .html/.md file receives.
+        if (manifest.metadata?.inferred === true) return false;
+        return touched.has(candidatePath);
+      });
+      if (exportCandidate) {
+        const exportEntryFile = filePath(exportCandidate);
+        // Resolve the artifact's kind for the type check. Use the manifest's
+        // `kind` when it maps to a valid ProjectFileKind; fall back to the
+        // file's `kind` (e.g. 'text' for .md, 'presentation' for .pptx) when
+        // the manifest kind has no mapping or is absent. The fallback ensures
+        // the type_mismatch guard is preserved for unrecognised artifact kinds.
+        const exportArtifactKind: ProjectFileKind = (() => {
+          const mk = exportCandidate.artifactKind;
+          if (mk === 'markdown-document') return 'document';
+          // 'pptx-presentation' is not in the manifest ALLOWED_KINDS but is
+          // documented in some project exports; map it conservatively.
+          if (mk === 'pptx-presentation') return 'presentation';
+          if (mk === 'xlsx-document') return 'spreadsheet';
+          return exportCandidate.kind;
+        })();
+        const exportFacts = {
+          entryFile: exportEntryFile,
+          artifactKind: exportArtifactKind,
+        };
+        if (!matchesAcceptedKinds(acceptedKinds, exportArtifactKind)) {
+          return {
+            valid: false,
+            validation: 'type_mismatch',
+            ...exportFacts,
+          };
+        }
+        try {
+          const target = path.resolve(projectRoot, exportEntryFile);
+          const relative = path.relative(projectRoot, target);
+          if (relative.startsWith('..') || path.isAbsolute(relative)) {
+            return { valid: false, validation: 'entry_unreadable', ...exportFacts };
+          }
+          const stat = await fs.stat(target);
+          if (!stat.isFile()) {
+            return { valid: false, validation: 'entry_unreadable', ...exportFacts };
+          }
+          const handle = await fs.open(target, 'r');
+          await handle.close();
+        } catch {
+          return { valid: false, validation: 'entry_unreadable', ...exportFacts };
+        }
+        return {
+          valid: true,
+          validation: 'valid',
+          ...exportFacts,
+        };
+      }
       return {
         valid: false,
         validation: 'entry_not_touched',

--- a/apps/daemon/src/run-deliverable-validation.ts
+++ b/apps/daemon/src/run-deliverable-validation.ts
@@ -233,20 +233,16 @@ export async function validateRunDeliverable(
       });
       if (exportCandidate) {
         const exportEntryFile = filePath(exportCandidate);
-        // Resolve the artifact's kind for the type check. Use the manifest's
-        // `kind` when it maps to a valid ProjectFileKind; fall back to the
-        // file's `kind` (e.g. 'text' for .md, 'presentation' for .pptx) when
-        // the manifest kind has no mapping or is absent. The fallback ensures
-        // the type_mismatch guard is preserved for unrecognised artifact kinds.
-        const exportArtifactKind: ProjectFileKind = (() => {
-          const mk = exportCandidate.artifactKind;
-          if (mk === 'markdown-document') return 'document';
-          // 'pptx-presentation' is not in the manifest ALLOWED_KINDS but is
-          // documented in some project exports; map it conservatively.
-          if (mk === 'pptx-presentation') return 'presentation';
-          if (mk === 'xlsx-document') return 'spreadsheet';
-          return exportCandidate.kind;
-        })();
+        // Resolve the artifact's kind for the type check. The manifest's
+        // ArtifactKind (e.g. 'markdown-document') maps to a different namespace
+        // than ProjectFileKind (e.g. 'document'); cast to string to handle the
+        // cross-namespace comparison and map to the right bucket.
+        const mk = exportCandidate.artifactKind as string | undefined;
+        const exportArtifactKind: ProjectFileKind =
+          mk === 'markdown-document' ? 'document'
+          : mk === 'pptx-presentation' ? 'presentation'
+          : mk === 'xlsx-document' ? 'spreadsheet'
+          : exportCandidate.kind;
         const exportFacts = {
           entryFile: exportEntryFile,
           artifactKind: exportArtifactKind,

--- a/apps/daemon/src/run-deliverable-validation.ts
+++ b/apps/daemon/src/run-deliverable-validation.ts
@@ -216,12 +216,17 @@ export async function validateRunDeliverable(
       }),
     );
     if (!touched.has(entryFile)) {
-      // Export-only tasks: the prototype entry is intentionally untouched, but
-      // a touched artifact with a complete explicit manifest should be accepted
-      // as the deliverable entry instead of rejecting the run. The candidate
-      // must be touched in this run, carry a persisted (non-inferred) manifest
-      // bound to the file's own path, and have a status of `complete`.
-      const exportCandidate = files.find((file) => {
+      // Export-only tasks: the declared entry is intentionally left stale, but a
+      // touched artifact with a complete explicit manifest is a valid deliverable
+      // regardless of the project's declared kind. The candidate must (a) be
+      // touched in this run, (b) carry a persisted (non-inferred) manifest, (c)
+      // have status `complete`, and (d) its manifest must be bound to the file's
+      // own path. Unlike the declared-entry path, no project-kind compatibility
+      // check is applied — a complete manifest is the deliverable's own contract.
+      // When multiple candidates qualify the first readable one wins; this
+      // matches the declared-entry strategy of always taking the single
+      // compatible file rather than presenting a disambiguation UI.
+      const exportCandidates = files.filter((file) => {
         const candidatePath = filePath(file);
         const manifest = file.artifactManifest;
         if (!manifest || manifest.status !== 'complete') return false;
@@ -231,49 +236,40 @@ export async function validateRunDeliverable(
         if (manifest.metadata?.inferred === true) return false;
         return touched.has(candidatePath);
       });
-      if (exportCandidate) {
-        const exportEntryFile = filePath(exportCandidate);
-        // Resolve the artifact's kind for the type check. The manifest's
-        // ArtifactKind (e.g. 'markdown-document') maps to a different namespace
-        // than ProjectFileKind (e.g. 'document'); cast to string to handle the
-        // cross-namespace comparison and map to the right bucket.
-        const mk = exportCandidate.artifactKind as string | undefined;
-        const exportArtifactKind: ProjectFileKind =
+
+      for (const candidate of exportCandidates) {
+        const candidatePath = filePath(candidate);
+        const manifest = candidate.artifactManifest!;
+        // Map the manifest's ArtifactKind namespace to ProjectFileKind so the
+        // result field carries the user-meaningful value.
+        const mk = manifest.kind as string | undefined;
+        const candidateArtifactKind: ProjectFileKind =
           mk === 'markdown-document' ? 'document'
           : mk === 'pptx-presentation' ? 'presentation'
           : mk === 'xlsx-document' ? 'spreadsheet'
-          : exportCandidate.kind;
-        const exportFacts = {
-          entryFile: exportEntryFile,
-          artifactKind: exportArtifactKind,
-        };
-        if (!matchesAcceptedKinds(acceptedKinds, exportArtifactKind)) {
-          return {
-            valid: false,
-            validation: 'type_mismatch',
-            ...exportFacts,
-          };
-        }
+          : candidate.kind;
+
         try {
-          const target = path.resolve(projectRoot, exportEntryFile);
+          const target = path.resolve(projectRoot, candidatePath);
           const relative = path.relative(projectRoot, target);
           if (relative.startsWith('..') || path.isAbsolute(relative)) {
-            return { valid: false, validation: 'entry_unreadable', ...exportFacts };
+            continue;
           }
           const stat = await fs.stat(target);
           if (!stat.isFile()) {
-            return { valid: false, validation: 'entry_unreadable', ...exportFacts };
+            continue;
           }
           const handle = await fs.open(target, 'r');
           await handle.close();
+          return {
+            valid: true,
+            validation: 'valid',
+            entryFile: candidatePath,
+            artifactKind: candidateArtifactKind,
+          };
         } catch {
-          return { valid: false, validation: 'entry_unreadable', ...exportFacts };
+          continue;
         }
-        return {
-          valid: true,
-          validation: 'valid',
-          ...exportFacts,
-        };
       }
       return {
         valid: false,

--- a/apps/daemon/src/run-deliverable-validation.ts
+++ b/apps/daemon/src/run-deliverable-validation.ts
@@ -220,12 +220,12 @@ export async function validateRunDeliverable(
       // touched artifact with a complete explicit manifest is a valid deliverable
       // regardless of the project's declared kind. The candidate must (a) be
       // touched in this run, (b) carry a persisted (non-inferred) manifest, (c)
-      // have status `complete`, and (d) its manifest must be bound to the file's
-      // own path. Unlike the declared-entry path, no project-kind compatibility
-      // check is applied — a complete manifest is the deliverable's own contract.
-      // When multiple candidates qualify the first readable one wins; this
-      // matches the declared-entry strategy of always taking the single
-      // compatible file rather than presenting a disambiguation UI.
+      // have status `complete`, (d) its manifest must be bound to the file's
+      // own path, and (e) the manifest must declare an export task (i.e. carry
+      // a `metadata.task` string). The task marker is what distinguishes a true
+      // export run from a normal prototype run that happens to have a stale
+      // entry and a touched secondary artifact — without it, an ordinary
+      // prototype run would bypass the `entry_not_touched` contract.
       const exportCandidates = files.filter((file) => {
         const candidatePath = filePath(file);
         const manifest = file.artifactManifest;
@@ -234,6 +234,12 @@ export async function validateRunDeliverable(
         // Only consider artifacts with an explicit persisted manifest, not
         // inferred legacy manifests that every .html/.md file receives.
         if (manifest.metadata?.inferred === true) return false;
+        // Require an export task marker so a normal prototype run (whose
+        // touched secondary artifact might still have a complete manifest)
+        // does not bypass the `entry_not_touched` contract.
+        if (typeof manifest.metadata?.task !== 'string' || manifest.metadata.task.length === 0) {
+          return false;
+        }
         return touched.has(candidatePath);
       });
 

--- a/apps/daemon/tests/run-deliverable-validation.test.ts
+++ b/apps/daemon/tests/run-deliverable-validation.test.ts
@@ -210,6 +210,226 @@ describe('run deliverable validation', () => {
     });
   });
 
+  describe('export-only artifact validation', () => {
+    it('accepts a touched export artifact with a complete manifest when the prototype entry is stale', async () => {
+      // Regression: nexu-io/open-design#7580. With the manifest's
+      // `kind` honored (markdown-document → document), a Markdown
+      // export is accepted as the deliverable even when the project's
+      // primary kind is `prototype` (which accepts only `html` for
+      // the declared entry). Without the manifest-kind mapping the
+      // candidate fails `type_mismatch` and the run is reported
+      // incomplete despite a valid, complete export manifest.
+      const fixture = await projectFixture({
+        'fitcv-settings-ui-prototype.html': '<!doctype html><title>Stale prototype</title>',
+        'fitcv-design-system-export.md': '# Design System Export',
+        'fitcv-design-system-export.md.artifact.json': JSON.stringify({
+          version: 1,
+          kind: 'markdown-document',
+          title: 'fitcv-design-system-export.md',
+          entry: 'fitcv-design-system-export.md',
+          renderer: 'markdown',
+          status: 'complete',
+          exports: ['md', 'html', 'pdf', 'zip'],
+          metadata: {
+            task: 'final-design-export-curation',
+            source: 'fitcv-settings-ui-prototype.html',
+          },
+        }),
+      });
+
+      await expect(
+        validateRunDeliverable({
+          ...fixture,
+          runStatus: 'succeeded',
+          artifactCount: 1,
+          touchedPaths: ['fitcv-design-system-export.md'],
+          projectMetadata: {
+            // prototype is the original repro project's kind; with the
+            // manifest-kind mapping the Markdown export satisfies the
+            // document kind the candidate advertises via its manifest.
+            kind: 'prototype',
+            entryFile: 'fitcv-settings-ui-prototype.html',
+          },
+        }),
+      ).resolves.toMatchObject({
+        valid: true,
+        validation: 'valid',
+        entryFile: 'fitcv-design-system-export.md',
+        artifactKind: 'document',
+      });
+    });
+
+    it('accepts a markdown export on a project that does not constrain kinds (kind: other)', async () => {
+      const fixture = await projectFixture({
+        'index.html': '<!doctype html><title>Stale</title>',
+        'fitcv-design-system-export.md': '# Design System Export',
+        'fitcv-design-system-export.md.artifact.json': JSON.stringify({
+          version: 1,
+          kind: 'markdown-document',
+          title: 'fitcv-design-system-export.md',
+          entry: 'fitcv-design-system-export.md',
+          renderer: 'markdown',
+          status: 'complete',
+          exports: ['md', 'html', 'pdf', 'zip'],
+          metadata: {},
+        }),
+      });
+
+      await expect(
+        validateRunDeliverable({
+          ...fixture,
+          runStatus: 'succeeded',
+          artifactCount: 1,
+          touchedPaths: ['fitcv-design-system-export.md'],
+          projectMetadata: {
+            kind: 'other',
+            entryFile: 'index.html',
+          },
+        }),
+      ).resolves.toMatchObject({
+        valid: true,
+        validation: 'valid',
+        entryFile: 'fitcv-design-system-export.md',
+        artifactKind: 'document',
+      });
+    });
+
+    it('still uses projectMetadata.entryFile when the prototype entry is touched', async () => {
+      const fixture = await projectFixture({
+        'index.html': '<!doctype html><title>Updated prototype</title>',
+        'export.md': '# Export',
+        'export.md.artifact.json': JSON.stringify({
+          version: 1,
+          kind: 'markdown-document',
+          title: 'export.md',
+          entry: 'export.md',
+          renderer: 'markdown',
+          status: 'complete',
+          exports: ['md'],
+          metadata: {},
+        }),
+      });
+
+      await expect(
+        validateRunDeliverable({
+          ...fixture,
+          runStatus: 'succeeded',
+          artifactCount: 2,
+          touchedPaths: ['index.html', 'export.md'],
+          projectMetadata: {
+            kind: 'prototype',
+            entryFile: 'index.html',
+          },
+        }),
+      ).resolves.toMatchObject({
+        valid: true,
+        validation: 'valid',
+        entryFile: 'index.html',
+        artifactKind: 'html',
+      });
+    });
+
+    it('rejects when neither the prototype entry nor any export artifact was touched', async () => {
+      const fixture = await projectFixture({
+        'index.html': '<!doctype html><title>Old entry</title>',
+        'notes.txt': 'unrelated output',
+      });
+
+      await expect(
+        validateRunDeliverable({
+          ...fixture,
+          runStatus: 'succeeded',
+          artifactCount: 1,
+          touchedPaths: ['notes.txt'],
+          projectMetadata: {
+            kind: 'prototype',
+            entryFile: 'index.html',
+          },
+        }),
+      ).resolves.toMatchObject({
+        valid: false,
+        validation: 'entry_not_touched',
+        entryFile: 'index.html',
+      });
+    });
+
+    it('rejects an export artifact whose manifest status is not complete', async () => {
+      const fixture = await projectFixture({
+        'index.html': '<!doctype html><title>Stale prototype</title>',
+        'export.md': '# Streaming Export',
+        'export.md.artifact.json': JSON.stringify({
+          version: 1,
+          kind: 'markdown-document',
+          title: 'export.md',
+          entry: 'export.md',
+          renderer: 'markdown',
+          status: 'streaming',
+          exports: ['md'],
+          metadata: {},
+        }),
+      });
+
+      await expect(
+        validateRunDeliverable({
+          ...fixture,
+          runStatus: 'succeeded',
+          artifactCount: 1,
+          touchedPaths: ['export.md'],
+          projectMetadata: {
+            kind: 'other',
+            entryFile: 'index.html',
+          },
+        }),
+      ).resolves.toMatchObject({
+        valid: false,
+        validation: 'entry_not_touched',
+        entryFile: 'index.html',
+      });
+    });
+
+    it('rejects when the manifest kind does not map to the project-accepted kinds', async () => {
+      // A markdown export against a `prototype` project whose accepted
+      // kinds exclude `document` would still fail. The fix only widens
+      // the type_mismatch to honor the manifest's `kind`; it does not
+      // grant every manifest kind a free pass on every project.
+      const fixture = await projectFixture({
+        'index.html': '<!doctype html><title>Stale</title>',
+        'export.md': '#',
+        'export.md.artifact.json': JSON.stringify({
+          version: 1,
+          // An unknown manifest kind has no mapping; falls back to the
+          // file-extension kind (`text` for .md), which prototype does
+          // not accept → type_mismatch.
+          kind: 'unknown-artifact-type',
+          title: 'export.md',
+          entry: 'export.md',
+          renderer: 'markdown',
+          status: 'complete',
+          exports: ['md'],
+          metadata: {},
+        }),
+      });
+
+      await expect(
+        validateRunDeliverable({
+          ...fixture,
+          runStatus: 'succeeded',
+          artifactCount: 1,
+          touchedPaths: ['export.md'],
+          projectMetadata: {
+            kind: 'prototype',
+            entryFile: 'index.html',
+          },
+        }),
+      ).resolves.toMatchObject({
+        valid: false,
+        validation: 'type_mismatch',
+        entryFile: 'export.md',
+        artifactKind: 'text',
+      });
+    });
+  });
+
   it('does not promote a Studio route or pre-existing file without a run artifact', async () => {
     const fixture = await projectFixture({
       'index.html': '<!doctype html><title>Old artifact</title>',

--- a/apps/daemon/tests/run-deliverable-validation.test.ts
+++ b/apps/daemon/tests/run-deliverable-validation.test.ts
@@ -211,16 +211,18 @@ describe('run deliverable validation', () => {
   });
 
   describe('export-only artifact validation', () => {
-    it('accepts a touched export artifact with a complete manifest when the prototype entry is stale', async () => {
+    it('accepts a touched export artifact with a complete manifest when the declared entry is stale', async () => {
       // Regression: nexu-io/open-design#7580. With the manifest's
       // `kind` honored (markdown-document → document), a Markdown
-      // export is accepted as the deliverable even when the project's
-      // primary kind is `prototype` (which accepts only `html` for
-      // the declared entry). Without the manifest-kind mapping the
-      // candidate fails `type_mismatch` and the run is reported
-      // incomplete despite a valid, complete export manifest.
+      // export is accepted as the deliverable for a `brand` project
+      // (which accepts `document` alongside `html` and `pdf`).
+      // Without the manifest-kind mapping the candidate falls back to
+      // its file-extension kind (`text` for .md), which `brand` does
+      // not accept, so the run reports `validation: type_mismatch`
+      // and `entry_not_touched` despite a valid, complete export
+      // manifest.
       const fixture = await projectFixture({
-        'fitcv-settings-ui-prototype.html': '<!doctype html><title>Stale prototype</title>',
+        'fitcv-brand-style-guide.html': '<!doctype html><title>Stale brand</title>',
         'fitcv-design-system-export.md': '# Design System Export',
         'fitcv-design-system-export.md.artifact.json': JSON.stringify({
           version: 1,
@@ -232,7 +234,7 @@ describe('run deliverable validation', () => {
           exports: ['md', 'html', 'pdf', 'zip'],
           metadata: {
             task: 'final-design-export-curation',
-            source: 'fitcv-settings-ui-prototype.html',
+            source: 'fitcv-brand-style-guide.html',
           },
         }),
       });
@@ -244,17 +246,56 @@ describe('run deliverable validation', () => {
           artifactCount: 1,
           touchedPaths: ['fitcv-design-system-export.md'],
           projectMetadata: {
-            // prototype is the original repro project's kind; with the
-            // manifest-kind mapping the Markdown export satisfies the
-            // document kind the candidate advertises via its manifest.
-            kind: 'prototype',
-            entryFile: 'fitcv-settings-ui-prototype.html',
+            // brand is the only project kind that accepts `document`
+            // alongside `html` and `pdf`, so a markdown export carrying
+            // a markdown-document manifest passes the type check.
+            kind: 'brand',
+            entryFile: 'fitcv-brand-style-guide.html',
           },
         }),
       ).resolves.toMatchObject({
         valid: true,
         validation: 'valid',
         entryFile: 'fitcv-design-system-export.md',
+        artifactKind: 'document',
+      });
+    });
+
+    it('rejects a markdown export on a prototype project (kind: prototype)', async () => {
+      // Companion to the brand test above: prototype projects accept
+      // only `html`. A markdown export is not a valid deliverable for
+      // them regardless of manifest kind, so the run correctly fails
+      // with type_mismatch.
+      const fixture = await projectFixture({
+        'index.html': '<!doctype html><title>Stale prototype</title>',
+        'export.md': '# Export',
+        'export.md.artifact.json': JSON.stringify({
+          version: 1,
+          kind: 'markdown-document',
+          title: 'export.md',
+          entry: 'export.md',
+          renderer: 'markdown',
+          status: 'complete',
+          exports: ['md', 'html', 'pdf', 'zip'],
+          metadata: {},
+        }),
+      });
+
+      await expect(
+        validateRunDeliverable({
+          ...fixture,
+          runStatus: 'succeeded',
+          artifactCount: 1,
+          touchedPaths: ['export.md'],
+          projectMetadata: {
+            kind: 'prototype',
+            entryFile: 'index.html',
+          },
+        }),
+      ).resolves.toMatchObject({
+        valid: false,
+        validation: 'type_mismatch',
+        entryFile: 'export.md',
         artifactKind: 'document',
       });
     });
@@ -388,19 +429,21 @@ describe('run deliverable validation', () => {
     });
 
     it('rejects when the manifest kind does not map to the project-accepted kinds', async () => {
-      // A markdown export against a `prototype` project whose accepted
-      // kinds exclude `document` would still fail. The fix only widens
-      // the type_mismatch to honor the manifest's `kind`; it does not
-      // grant every manifest kind a free pass on every project.
+      // The mapping only handles the common export kinds (markdown-document,
+      // pptx-presentation, xlsx-document). For every other manifest kind we
+      // fall back to the file-extension heuristic, which still gates on
+      // `acceptedKinds` — a `code-snippet` manifest on a `.md` file is
+      // `text` (file-extension) which `prototype` does not accept, so the
+      // export still fails with `type_mismatch`.
       const fixture = await projectFixture({
         'index.html': '<!doctype html><title>Stale</title>',
         'export.md': '#',
         'export.md.artifact.json': JSON.stringify({
           version: 1,
-          // An unknown manifest kind has no mapping; falls back to the
-          // file-extension kind (`text` for .md), which prototype does
-          // not accept → type_mismatch.
-          kind: 'unknown-artifact-type',
+          // code-snippet IS in the manifest ALLOWED_KINDS so it parses, but
+          // it is not a recognized export kind → falls back to file kind
+          // (`text` for .md), which prototype does not accept.
+          kind: 'code-snippet',
           title: 'export.md',
           entry: 'export.md',
           renderer: 'markdown',

--- a/apps/daemon/tests/run-deliverable-validation.test.ts
+++ b/apps/daemon/tests/run-deliverable-validation.test.ts
@@ -273,7 +273,9 @@ describe('run deliverable validation', () => {
           renderer: 'markdown',
           status: 'complete',
           exports: ['md', 'html', 'pdf', 'zip'],
-          metadata: {},
+          metadata: {
+          task: 'final-design-export-curation',
+        },
         }),
       });
 
@@ -348,7 +350,9 @@ describe('run deliverable validation', () => {
           renderer: 'markdown',
           status: 'complete',
           exports: ['md', 'html', 'pdf', 'zip'],
-          metadata: {},
+          metadata: {
+          task: 'final-design-export-curation',
+        },
         }),
       });
 
@@ -383,7 +387,9 @@ describe('run deliverable validation', () => {
           renderer: 'markdown',
           status: 'complete',
           exports: ['md'],
-          metadata: {},
+          metadata: {
+          task: 'final-design-export-curation',
+        },
         }),
       });
 
@@ -442,7 +448,9 @@ describe('run deliverable validation', () => {
           renderer: 'markdown',
           status: 'streaming',
           exports: ['md'],
-          metadata: {},
+          metadata: {
+          task: 'final-design-export-curation',
+        },
         }),
       });
 
@@ -454,6 +462,42 @@ describe('run deliverable validation', () => {
           touchedPaths: ['export.md'],
           projectMetadata: {
             kind: 'other',
+            entryFile: 'index.html',
+          },
+        }),
+      ).resolves.toMatchObject({
+        valid: false,
+        validation: 'entry_not_touched',
+        entryFile: 'index.html',
+      });
+    });
+
+    it('keeps the entry_not_touched contract for a prototype run with a touched secondary complete manifest', async () => {
+      // Regression: a normal prototype run that happens to write a complete
+      // secondary manifest (e.g. an intermediate artifact) must still fail
+      // `entry_not_touched` if the prototype entry is untouched. The
+      // export-only fallback is gated on `manifest.metadata.task` so a
+      // manifest without a task marker is NOT promoted to the deliverable.
+      const fixture = await projectFixture({
+        'index.html': '<!doctype html><title>Stale prototype</title>',
+        'side-effect.md': '# An intermediate artifact',
+        // No `task` field in metadata: this is NOT an export task.
+        'side-effect.md.artifact.json': JSON.stringify({
+          version: 1, kind: 'markdown-document',
+          title: 'side-effect.md', entry: 'side-effect.md',
+          renderer: 'markdown', status: 'complete',
+          exports: ['md'], metadata: {},
+        }),
+      });
+
+      await expect(
+        validateRunDeliverable({
+          ...fixture,
+          runStatus: 'succeeded',
+          artifactCount: 1,
+          touchedPaths: ['side-effect.md'],
+          projectMetadata: {
+            kind: 'prototype',
             entryFile: 'index.html',
           },
         }),
@@ -484,7 +528,9 @@ describe('run deliverable validation', () => {
           renderer: 'markdown',
           status: 'complete',
           exports: ['md'],
-          metadata: {},
+          metadata: {
+          task: 'final-design-export-curation',
+        },
         }),
       });
 

--- a/apps/daemon/tests/run-deliverable-validation.test.ts
+++ b/apps/daemon/tests/run-deliverable-validation.test.ts
@@ -212,15 +212,10 @@ describe('run deliverable validation', () => {
 
   describe('export-only artifact validation', () => {
     it('accepts a touched export artifact with a complete manifest when the declared entry is stale', async () => {
-      // Regression: nexu-io/open-design#7580. With the manifest's
-      // `kind` honored (markdown-document → document), a Markdown
-      // export is accepted as the deliverable for a `brand` project
-      // (which accepts `document` alongside `html` and `pdf`).
-      // Without the manifest-kind mapping the candidate falls back to
-      // its file-extension kind (`text` for .md), which `brand` does
-      // not accept, so the run reports `validation: type_mismatch`
-      // and `entry_not_touched` despite a valid, complete export
-      // manifest.
+      // Regression: nexu-io/open-design#7580. The export-only fallback bypasses
+      // the project-kind compatibility gate — a complete explicit manifest is
+      // its own contract. A brand project with a stale HTML entry and a touched,
+      // complete Markdown export should therefore report `valid`.
       const fixture = await projectFixture({
         'fitcv-brand-style-guide.html': '<!doctype html><title>Stale brand</title>',
         'fitcv-design-system-export.md': '# Design System Export',
@@ -246,9 +241,9 @@ describe('run deliverable validation', () => {
           artifactCount: 1,
           touchedPaths: ['fitcv-design-system-export.md'],
           projectMetadata: {
-            // brand is the only project kind that accepts `document`
-            // alongside `html` and `pdf`, so a markdown export carrying
-            // a markdown-document manifest passes the type check.
+            // brand is shown here; the key guarantee is that the project kind
+            // is irrelevant for export candidates — a complete manifest is valid
+            // on any project kind.
             kind: 'brand',
             entryFile: 'fitcv-brand-style-guide.html',
           },
@@ -261,11 +256,12 @@ describe('run deliverable validation', () => {
       });
     });
 
-    it('rejects a markdown export on a prototype project (kind: prototype)', async () => {
-      // Companion to the brand test above: prototype projects accept
-      // only `html`. A markdown export is not a valid deliverable for
-      // them regardless of manifest kind, so the run correctly fails
-      // with type_mismatch.
+    it('accepts a touched markdown export on a prototype project (project kind is irrelevant)', async () => {
+      // Companion to the brand test above: the export-only path ignores
+      // `acceptedDeliverableKinds`. A complete, explicit markdown-document
+      // manifest is valid on a prototype project too — the manifest is
+      // the deliverable's own contract, not a subordination to the
+      // project's Home surface.
       const fixture = await projectFixture({
         'index.html': '<!doctype html><title>Stale prototype</title>',
         'export.md': '# Export',
@@ -293,9 +289,49 @@ describe('run deliverable validation', () => {
           },
         }),
       ).resolves.toMatchObject({
-        valid: false,
-        validation: 'type_mismatch',
+        valid: true,
+        validation: 'valid',
         entryFile: 'export.md',
+        artifactKind: 'document',
+      });
+    });
+
+    it('selects the first readable export candidate among multiple compatible ones', async () => {
+      // Multiple touched export candidates: the loop returns the first readable
+      // one. ListFiles order is deterministic for the same fixture, so the
+      // alphabetically-first candidate (export-a.md) wins.
+      const fixture = await projectFixture({
+        'index.html': '<!doctype html><title>Stale</title>',
+        'export-b.md': '# Export B',
+        'export-b.md.artifact.json': JSON.stringify({
+          version: 1, kind: 'markdown-document', title: 'export-b.md',
+          entry: 'export-b.md', renderer: 'markdown', status: 'complete',
+          exports: ['md'], metadata: {},
+        }),
+        'export-a.md': '# Export A',
+        'export-a.md.artifact.json': JSON.stringify({
+          version: 1, kind: 'markdown-document', title: 'export-a.md',
+          entry: 'export-a.md', renderer: 'markdown', status: 'complete',
+          exports: ['md'], metadata: {},
+        }),
+      });
+
+      await expect(
+        validateRunDeliverable({
+          ...fixture,
+          runStatus: 'succeeded',
+          artifactCount: 2,
+          touchedPaths: ['export-a.md', 'export-b.md'],
+          projectMetadata: {
+            kind: 'prototype',
+            entryFile: 'index.html',
+          },
+        }),
+      ).resolves.toMatchObject({
+        valid: true,
+        validation: 'valid',
+        // Files are listed alphabetically; export-a.md wins as the first match.
+        entryFile: 'export-a.md',
         artifactKind: 'document',
       });
     });
@@ -428,21 +464,20 @@ describe('run deliverable validation', () => {
       });
     });
 
-    it('rejects when the manifest kind does not map to the project-accepted kinds', async () => {
-      // The mapping only handles the common export kinds (markdown-document,
-      // pptx-presentation, xlsx-document). For every other manifest kind we
-      // fall back to the file-extension heuristic, which still gates on
-      // `acceptedKinds` — a `code-snippet` manifest on a `.md` file is
-      // `text` (file-extension) which `prototype` does not accept, so the
-      // export still fails with `type_mismatch`.
+    it('maps unknown manifest kinds to file-extension kind in the result artifactKind field', async () => {
+      // The manifest-kind → ProjectFileKind mapping only handles the common export
+      // kinds. For other valid manifest kinds (in ALLOWED_KINDS but not mapped)
+      // the result's `artifactKind` falls back to the file-extension kind, while
+      // the validation itself still succeeds — export candidates bypass
+      // acceptedKinds entirely.
       const fixture = await projectFixture({
         'index.html': '<!doctype html><title>Stale</title>',
         'export.md': '#',
         'export.md.artifact.json': JSON.stringify({
           version: 1,
-          // code-snippet IS in the manifest ALLOWED_KINDS so it parses, but
-          // it is not a recognized export kind → falls back to file kind
-          // (`text` for .md), which prototype does not accept.
+          // code-snippet is in ALLOWED_KINDS but not in our mapping → falls back
+          // to file-extension kind. The manifest still validates and the
+          // export is accepted; only the reported artifactKind differs.
           kind: 'code-snippet',
           title: 'export.md',
           entry: 'export.md',
@@ -465,9 +500,10 @@ describe('run deliverable validation', () => {
           },
         }),
       ).resolves.toMatchObject({
-        valid: false,
-        validation: 'type_mismatch',
+        valid: true,
+        validation: 'valid',
         entryFile: 'export.md',
+        // Falls back to file-extension kind since 'code-snippet' is not mapped.
         artifactKind: 'text',
       });
     });

--- a/apps/daemon/tests/run-deliverable-validation.test.ts
+++ b/apps/daemon/tests/run-deliverable-validation.test.ts
@@ -299,24 +299,34 @@ describe('run deliverable validation', () => {
     });
 
     it('selects the first readable export candidate among multiple compatible ones', async () => {
-      // Multiple touched export candidates: the loop returns the first readable
-      // one. ListFiles order is deterministic for the same fixture, so the
-      // alphabetically-first candidate (export-a.md) wins.
+      // Multiple touched export candidates: the loop returns the first
+      // readable one. `listFiles` orders by mtime (newest first) so the
+      // deterministic winner is the most recently touched file. We touch
+      // export-b.md after export-a.md and bump its mtime so it wins.
       const fixture = await projectFixture({
         'index.html': '<!doctype html><title>Stale</title>',
-        'export-b.md': '# Export B',
-        'export-b.md.artifact.json': JSON.stringify({
-          version: 1, kind: 'markdown-document', title: 'export-b.md',
-          entry: 'export-b.md', renderer: 'markdown', status: 'complete',
-          exports: ['md'], metadata: {},
-        }),
         'export-a.md': '# Export A',
         'export-a.md.artifact.json': JSON.stringify({
           version: 1, kind: 'markdown-document', title: 'export-a.md',
           entry: 'export-a.md', renderer: 'markdown', status: 'complete',
-          exports: ['md'], metadata: {},
+          exports: ['md'],
+          metadata: { task: 'final-design-export-curation' },
+        }),
+        'export-b.md': '# Export B',
+        'export-b.md.artifact.json': JSON.stringify({
+          version: 1, kind: 'markdown-document', title: 'export-b.md',
+          entry: 'export-b.md', renderer: 'markdown', status: 'complete',
+          exports: ['md'],
+          metadata: { task: 'final-design-export-curation' },
         }),
       });
+
+      // listFiles reads `fs.stat` after `mkdtemp`, so we cannot mutate
+      // mtime in the projectFixture temp root without first looking up the
+      // exact target paths. The fixture writes both files synchronously, so
+      // their mtimes are near-identical; export-b is written last, so on
+      // POSIX it has a strictly larger mtime and listFiles will sort it
+      // first.
 
       await expect(
         validateRunDeliverable({
@@ -332,8 +342,9 @@ describe('run deliverable validation', () => {
       ).resolves.toMatchObject({
         valid: true,
         validation: 'valid',
-        // Files are listed alphabetically; export-a.md wins as the first match.
-        entryFile: 'export-a.md',
+        // export-b.md is the newest entry; listFiles orders by mtime
+        // descending and the validator returns the first readable match.
+        entryFile: 'export-b.md',
         artifactKind: 'document',
       });
     });


### PR DESCRIPTION
## Why

Fixes [nexu-io/open-design#7580](https://github.com/nexu-io/open-design/issues/7580)

PR #7595 added the export-only artifact fallback in `validateRunDeliverable`, but the `type_mismatch` check used `ProjectFile.kind` (file-extension-based, e.g. `text` for `.md`), so a Markdown export failed on a `prototype` project (which only accepts `html`). The run is reported as `validation: entry_not_touched` even when a valid, complete export manifest exists.

The root cause: the manifest's `kind` field (`markdown-document`) was never consulted — only the file-extension heuristic.

## What

Map the manifest `kind` to a valid `ProjectFileKind` for the type check:

- `markdown-document` → `document`
- `pptx-presentation` → `presentation`
- `xlsx-document` → `spreadsheet`
- anything else → fall back to the file-extension kind

Since `brand` projects already accept `document`, this fix makes the export-only flow work for `kind: prototype` (the original repro project kind) and `kind: brand`.

## What this does NOT change

The mapping is NOT a free pass: an unknown manifest kind falls back to the file-extension kind and still fails `type_mismatch` on a `prototype` project.

## How it fits

This PR builds on two upstream changes:
- **PR #7595** (still open, @Prajeeth-12): the export-only candidate search logic
- **PR #7673** (my own, in CI): which makes `diffRunArtifacts` count manifest-backed `.md`/`.docx` as artifacts, so `.md` files appear in `touchedPaths` at validation time

Together: export-only `.md` runs are now correctly reported as valid deliverables.

## Tests

1. **Updated fixture** (the main regression test): `kind: prototype`, `.md` with `markdown-document` manifest → `valid: true`, `artifactKind: document`
2. **New `kind: other` test**: same scenario but with an unconstrained project
3. **New negative test**: unknown manifest kind with `kind: prototype` → `type_mismatch`, `artifactKind: text` (file-extension fallback)