### PR TITLE
fix packaged mac Home readiness race

### DIFF
--- a/e2e/lib/vitest/packaged-home-first-run.ts
+++ b/e2e/lib/vitest/packaged-home-first-run.ts
@@ -89,7 +89,7 @@ function asPackagedHomeFirstRunSetupResult(
   if (
     candidate.instrumented !== true
     || typeof candidate.hrefBefore !== 'string'
-    || typeof candidate.inputTextBeforeSubmit !== 'string'
+    || candidate.inputTextBeforeSubmit !== PACKAGED_HOME_FIRST_RUN_PROMPT
     || typeof candidate.navigationEntryCountBefore !== 'number'
     || typeof candidate.performanceTimeOriginBefore !== 'number'
     || !isPackagedHomeFirstRunReadiness(candidate.readiness)
@@ -136,7 +136,10 @@ export function packagedHomeFirstRunExpression(): string {
       const prompt = ${JSON.stringify(PACKAGED_HOME_FIRST_RUN_PROMPT)};
       const stateKey = '__odPackagedHomeFirstRun';
       const existingState = globalThis[stateKey];
-      if (existingState?.instrumented === true) {
+      if (
+        existingState?.instrumented === true
+        && existingState.inputTextBeforeSubmit === prompt
+      ) {
         return {
           hrefBefore: existingState.hrefBefore,
           inputTextBeforeSubmit: existingState.inputTextBeforeSubmit,
@@ -176,9 +179,44 @@ export function packagedHomeFirstRunExpression(): string {
         return { instrumented: false, readiness };
       }
 
+      input.focus();
+      editor.setEditorState(editor.parseEditorState(JSON.stringify({
+        root: {
+          children: [{
+            children: [{
+              detail: 0,
+              format: 0,
+              mode: 'normal',
+              style: '',
+              text: prompt,
+              type: 'text',
+              version: 1,
+            }],
+            direction: null,
+            format: '',
+            indent: 0,
+            type: 'paragraph',
+            version: 1,
+            textFormat: 0,
+            textStyle: '',
+          }],
+          direction: null,
+          format: '',
+          indent: 0,
+          type: 'root',
+          version: 1,
+        },
+      })));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      const inputTextBeforeSubmit = input.textContent?.trim() ?? '';
+      const currentInput = document.querySelector('[data-testid="home-hero-input"]');
+      if (currentInput !== input || inputTextBeforeSubmit !== prompt) {
+        throw new Error('packaged first Home run prompt was not retained on the current composer');
+      }
+
       const state = {
         hrefBefore: location.href,
-        inputTextBeforeSubmit: '',
+        inputTextBeforeSubmit,
         instrumented: true,
         injectedAuthorityOutageCount: 0,
         navigationEntryCountBefore: performance.getEntriesByType('navigation').length,
@@ -192,7 +230,6 @@ export function packagedHomeFirstRunExpression(): string {
         workspaceRequestHeaders: {},
         workspaceTabClicksBeforeOutput: 0,
       };
-      globalThis[stateKey] = state;
 
       const originalFetch = globalThis.fetch.bind(globalThis);
       state.originalFetch = originalFetch;
@@ -248,37 +285,7 @@ export function packagedHomeFirstRunExpression(): string {
           state.workspaceTabClicksBeforeOutput += 1;
         }
       }, true);
-
-      input.focus();
-      editor.setEditorState(editor.parseEditorState(JSON.stringify({
-        root: {
-          children: [{
-            children: [{
-              detail: 0,
-              format: 0,
-              mode: 'normal',
-              style: '',
-              text: prompt,
-              type: 'text',
-              version: 1,
-            }],
-            direction: null,
-            format: '',
-            indent: 0,
-            type: 'paragraph',
-            version: 1,
-            textFormat: 0,
-            textStyle: '',
-          }],
-          direction: null,
-          format: '',
-          indent: 0,
-          type: 'root',
-          version: 1,
-        },
-      })));
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      state.inputTextBeforeSubmit = input.textContent?.trim() ?? '';
+      globalThis[stateKey] = state;
 
       return {
         hrefBefore: state.hrefBefore,

--- a/e2e/lib/vitest/packaged-home-first-run.ts
+++ b/e2e/lib/vitest/packaged-home-first-run.ts
@@ -30,6 +30,7 @@ export type PackagedHomeFirstRunReadiness = {
   composerContentEditable: boolean;
   composerFound: boolean;
   composerVisible: boolean;
+  lexicalEditorReady: boolean;
   loadingVisible: boolean;
   onboardingVisible: boolean;
   pathname: string;
@@ -108,6 +109,7 @@ function isPackagedHomeFirstRunReadiness(
     typeof candidate.composerContentEditable === 'boolean'
     && typeof candidate.composerFound === 'boolean'
     && typeof candidate.composerVisible === 'boolean'
+    && typeof candidate.lexicalEditorReady === 'boolean'
     && typeof candidate.loadingVisible === 'boolean'
     && typeof candidate.onboardingVisible === 'boolean'
     && typeof candidate.pathname === 'string'
@@ -155,6 +157,10 @@ export function packagedHomeFirstRunExpression(): string {
         input instanceof HTMLElement && input.getClientRects().length > 0;
       const composerContentEditable =
         input instanceof HTMLElement && input.isContentEditable;
+      const editor = input?.__lexicalEditor;
+      const lexicalEditorReady =
+        typeof editor?.parseEditorState === 'function'
+        && typeof editor?.setEditorState === 'function';
       const readiness = {
         pathname: location.pathname,
         loadingVisible:
@@ -164,8 +170,9 @@ export function packagedHomeFirstRunExpression(): string {
         composerFound: input != null,
         composerVisible,
         composerContentEditable,
+        lexicalEditorReady,
       };
-      if (!composerVisible || !composerContentEditable) {
+      if (!composerVisible || !composerContentEditable || !lexicalEditorReady) {
         return { instrumented: false, readiness };
       }
 
@@ -242,10 +249,6 @@ export function packagedHomeFirstRunExpression(): string {
         }
       }, true);
 
-      const editor = input.__lexicalEditor;
-      if (!editor?.parseEditorState || !editor?.setEditorState) {
-        throw new Error('packaged first Home run could not resolve the Lexical editor');
-      }
       input.focus();
       editor.setEditorState(editor.parseEditorState(JSON.stringify({
         root: {

--- a/e2e/lib/vitest/packaged-home-first-run.ts
+++ b/e2e/lib/vitest/packaged-home-first-run.ts
@@ -26,68 +26,157 @@ export type PackagedHomeFirstRunResult = {
   workspaceTabClicksBeforeOutput: number;
 };
 
-export type PackagedHomeFirstRunExpressionOptions = {
-  readinessPollIntervalMs?: number;
-  readinessTimeoutMs?: number;
+export type PackagedHomeFirstRunReadiness = {
+  composerContentEditable: boolean;
+  composerFound: boolean;
+  composerVisible: boolean;
+  loadingVisible: boolean;
+  onboardingVisible: boolean;
+  pathname: string;
 };
 
+export type PackagedHomeFirstRunSetupResult = {
+  hrefBefore: string;
+  inputTextBeforeSubmit: string;
+  instrumented: true;
+  navigationEntryCountBefore: number;
+  performanceTimeOriginBefore: number;
+  readiness: PackagedHomeFirstRunReadiness;
+  submitClicked: boolean;
+};
+
+export type PackagedHomeFirstRunWaitOptions = {
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+};
+
+export async function waitForPackagedHomeFirstRunSetup(
+  inspect: () => Promise<unknown>,
+  options: PackagedHomeFirstRunWaitOptions = {},
+): Promise<PackagedHomeFirstRunSetupResult> {
+  const pollIntervalMs = options.pollIntervalMs ?? 100;
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  const startedAt = Date.now();
+  let lastObservation: unknown = null;
+
+  do {
+    try {
+      lastObservation = await inspect();
+      const setup = asPackagedHomeFirstRunSetupResult(lastObservation);
+      if (setup != null) return setup;
+    } catch (error) {
+      lastObservation = {
+        error: error instanceof Error ? `${error.name}: ${error.message}` : String(error),
+      };
+    }
+
+    const remainingMs = timeoutMs - (Date.now() - startedAt);
+    if (remainingMs <= 0) break;
+    await new Promise((resolve) => setTimeout(resolve, Math.min(pollIntervalMs, remainingMs)));
+  } while (Date.now() - startedAt < timeoutMs);
+
+  throw new Error(
+    `packaged first Home run composer did not become ready: ${formatSetupObservation(lastObservation)}`,
+  );
+}
+
+function asPackagedHomeFirstRunSetupResult(
+  value: unknown,
+): PackagedHomeFirstRunSetupResult | null {
+  if (typeof value !== 'object' || value == null || Array.isArray(value)) return null;
+  const candidate = value as Partial<PackagedHomeFirstRunSetupResult>;
+  if (
+    candidate.instrumented !== true
+    || typeof candidate.hrefBefore !== 'string'
+    || typeof candidate.inputTextBeforeSubmit !== 'string'
+    || typeof candidate.navigationEntryCountBefore !== 'number'
+    || typeof candidate.performanceTimeOriginBefore !== 'number'
+    || !isPackagedHomeFirstRunReadiness(candidate.readiness)
+    || typeof candidate.submitClicked !== 'boolean'
+  ) {
+    return null;
+  }
+  return candidate as PackagedHomeFirstRunSetupResult;
+}
+
+function isPackagedHomeFirstRunReadiness(
+  value: unknown,
+): value is PackagedHomeFirstRunReadiness {
+  if (typeof value !== 'object' || value == null || Array.isArray(value)) return false;
+  const candidate = value as Partial<PackagedHomeFirstRunReadiness>;
+  return (
+    typeof candidate.composerContentEditable === 'boolean'
+    && typeof candidate.composerFound === 'boolean'
+    && typeof candidate.composerVisible === 'boolean'
+    && typeof candidate.loadingVisible === 'boolean'
+    && typeof candidate.onboardingVisible === 'boolean'
+    && typeof candidate.pathname === 'string'
+  );
+}
+
+function formatSetupObservation(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
 /**
- * Waits for the ready Home composer, then instruments the first packaged send
- * without recovering the renderer.
+ * Probes the Home composer and instruments the first packaged send atomically
+ * once it is ready, without recovering the renderer.
  * Output observation is polled through a separate expression, so this setup
  * never reloads the page or clicks a workspace tab after submission.
  */
-export function packagedHomeFirstRunExpression(
-  options: PackagedHomeFirstRunExpressionOptions = {},
-): string {
-  const readinessPollIntervalMs = options.readinessPollIntervalMs ?? 100;
-  const readinessTimeoutMs = options.readinessTimeoutMs ?? 30_000;
+export function packagedHomeFirstRunExpression(): string {
   return `
     (async () => {
       const prompt = ${JSON.stringify(PACKAGED_HOME_FIRST_RUN_PROMPT)};
-      const readinessStartedAt = Date.now();
-      let input = null;
-      let readiness = null;
-      while (input == null) {
-        const candidate = document.querySelector('[data-testid="home-hero-input"]');
-        const loadingSurface = document.querySelector('.od-loading-shell, .centered-loader');
-        const onboardingSurface = document.querySelector(
-          '.entry-shell--onboarding, .entry-onboarding-modal',
-        );
-        const composerVisible =
-          candidate instanceof HTMLElement && candidate.getClientRects().length > 0;
-        const composerContentEditable =
-          candidate instanceof HTMLElement && candidate.isContentEditable;
-        readiness = {
-          pathname: location.pathname,
-          loadingVisible:
-            loadingSurface instanceof HTMLElement && loadingSurface.getClientRects().length > 0,
-          onboardingVisible:
-            onboardingSurface instanceof HTMLElement && onboardingSurface.getClientRects().length > 0,
-          composerFound: candidate != null,
-          composerVisible,
-          composerContentEditable,
+      const stateKey = '__odPackagedHomeFirstRun';
+      const existingState = globalThis[stateKey];
+      if (existingState?.instrumented === true) {
+        return {
+          hrefBefore: existingState.hrefBefore,
+          inputTextBeforeSubmit: existingState.inputTextBeforeSubmit,
+          instrumented: true,
+          navigationEntryCountBefore: existingState.navigationEntryCountBefore,
+          performanceTimeOriginBefore: existingState.performanceTimeOriginBefore,
+          readiness: existingState.readiness,
+          submitClicked: existingState.submitClicked,
         };
-        if (composerVisible && composerContentEditable) {
-          input = candidate;
-          break;
-        }
-        if (Date.now() - readinessStartedAt >= ${JSON.stringify(readinessTimeoutMs)}) {
-          throw new Error(
-            'packaged first Home run composer did not become ready: '
-              + JSON.stringify(readiness),
-          );
-        }
-        await new Promise((resolve) => setTimeout(resolve, ${JSON.stringify(readinessPollIntervalMs)}));
       }
 
-      const stateKey = '__odPackagedHomeFirstRun';
+      const input = document.querySelector('[data-testid="home-hero-input"]');
+      const loadingSurface = document.querySelector('.od-loading-shell, .centered-loader');
+      const onboardingSurface = document.querySelector(
+        '.entry-shell--onboarding, .entry-onboarding-modal',
+      );
+      const composerVisible =
+        input instanceof HTMLElement && input.getClientRects().length > 0;
+      const composerContentEditable =
+        input instanceof HTMLElement && input.isContentEditable;
+      const readiness = {
+        pathname: location.pathname,
+        loadingVisible:
+          loadingSurface instanceof HTMLElement && loadingSurface.getClientRects().length > 0,
+        onboardingVisible:
+          onboardingSurface instanceof HTMLElement && onboardingSurface.getClientRects().length > 0,
+        composerFound: input != null,
+        composerVisible,
+        composerContentEditable,
+      };
+      if (!composerVisible || !composerContentEditable) {
+        return { instrumented: false, readiness };
+      }
+
       const state = {
         hrefBefore: location.href,
         inputTextBeforeSubmit: '',
+        instrumented: true,
         injectedAuthorityOutageCount: 0,
         navigationEntryCountBefore: performance.getEntriesByType('navigation').length,
         performanceTimeOriginBefore: performance.timeOrigin,
+        readiness,
         createRunRequestCount: 0,
         createRunResponseStatuses: [],
         runEventRequestCount: 0,
@@ -191,8 +280,10 @@ export function packagedHomeFirstRunExpression(
       return {
         hrefBefore: state.hrefBefore,
         inputTextBeforeSubmit: state.inputTextBeforeSubmit,
+        instrumented: true,
         navigationEntryCountBefore: state.navigationEntryCountBefore,
         performanceTimeOriginBefore: state.performanceTimeOriginBefore,
+        readiness,
         submitClicked: state.submitClicked,
       };
     })()

--- a/e2e/lib/vitest/packaged-home-first-run.ts
+++ b/e2e/lib/vitest/packaged-home-first-run.ts
@@ -26,15 +26,61 @@ export type PackagedHomeFirstRunResult = {
   workspaceTabClicksBeforeOutput: number;
 };
 
+export type PackagedHomeFirstRunExpressionOptions = {
+  readinessPollIntervalMs?: number;
+  readinessTimeoutMs?: number;
+};
+
 /**
- * Instruments the first packaged Home send without recovering the renderer.
+ * Waits for the ready Home composer, then instruments the first packaged send
+ * without recovering the renderer.
  * Output observation is polled through a separate expression, so this setup
  * never reloads the page or clicks a workspace tab after submission.
  */
-export function packagedHomeFirstRunExpression(): string {
+export function packagedHomeFirstRunExpression(
+  options: PackagedHomeFirstRunExpressionOptions = {},
+): string {
+  const readinessPollIntervalMs = options.readinessPollIntervalMs ?? 100;
+  const readinessTimeoutMs = options.readinessTimeoutMs ?? 30_000;
   return `
     (async () => {
       const prompt = ${JSON.stringify(PACKAGED_HOME_FIRST_RUN_PROMPT)};
+      const readinessStartedAt = Date.now();
+      let input = null;
+      let readiness = null;
+      while (input == null) {
+        const candidate = document.querySelector('[data-testid="home-hero-input"]');
+        const loadingSurface = document.querySelector('.od-loading-shell, .centered-loader');
+        const onboardingSurface = document.querySelector(
+          '.entry-shell--onboarding, .entry-onboarding-modal',
+        );
+        const composerVisible =
+          candidate instanceof HTMLElement && candidate.getClientRects().length > 0;
+        const composerContentEditable =
+          candidate instanceof HTMLElement && candidate.isContentEditable;
+        readiness = {
+          pathname: location.pathname,
+          loadingVisible:
+            loadingSurface instanceof HTMLElement && loadingSurface.getClientRects().length > 0,
+          onboardingVisible:
+            onboardingSurface instanceof HTMLElement && onboardingSurface.getClientRects().length > 0,
+          composerFound: candidate != null,
+          composerVisible,
+          composerContentEditable,
+        };
+        if (composerVisible && composerContentEditable) {
+          input = candidate;
+          break;
+        }
+        if (Date.now() - readinessStartedAt >= ${JSON.stringify(readinessTimeoutMs)}) {
+          throw new Error(
+            'packaged first Home run composer did not become ready: '
+              + JSON.stringify(readiness),
+          );
+        }
+        await new Promise((resolve) => setTimeout(resolve, ${JSON.stringify(readinessPollIntervalMs)}));
+      }
+
       const stateKey = '__odPackagedHomeFirstRun';
       const state = {
         hrefBefore: location.href,
@@ -107,11 +153,6 @@ export function packagedHomeFirstRunExpression(): string {
         }
       }, true);
 
-      const input = document.querySelector('[data-testid="home-hero-input"]');
-      const visible = input instanceof HTMLElement && input.getClientRects().length > 0;
-      if (!visible || !(input instanceof HTMLElement) || !input.isContentEditable) {
-        throw new Error('packaged first Home run found no visible Lexical composer');
-      }
       const editor = input.__lexicalEditor;
       if (!editor?.parseEditorState || !editor?.setEditorState) {
         throw new Error('packaged first Home run could not resolve the Lexical editor');

--- a/e2e/specs/mac.spec.ts
+++ b/e2e/specs/mac.spec.ts
@@ -18,6 +18,7 @@ import {
   packagedHomeFirstRunSnapshotExpression,
   packagedHomeFirstRunSubmitExpression,
   type PackagedHomeFirstRunResult,
+  waitForPackagedHomeFirstRunSetup,
 } from '@/vitest/packaged-home-first-run';
 import { createPackagedSmokeReport } from '@/vitest/packaged-report';
 import {
@@ -441,14 +442,17 @@ macDescribe('packaged mac runtime smoke', () => {
       expect(start.source).toBe('installed');
       await waitForHealthyDesktop();
 
-      const setup = await runToolsPackJson<MacInspectResult>('inspect', [
-        '--expr',
-        packagedHomeFirstRunExpression(),
-      ]);
-      if (setup.eval?.ok !== true) {
-        throw new Error(`packaged first Home run setup failed: ${formatUnknown(setup.eval)}`);
-      }
-      expect(setup.eval.value).toMatchObject({
+      const setup = await waitForPackagedHomeFirstRunSetup(async () => {
+        const inspect = await runToolsPackJson<MacInspectResult>('inspect', [
+          '--expr',
+          packagedHomeFirstRunExpression(),
+        ]);
+        if (inspect.eval?.ok !== true) {
+          throw new Error(`packaged first Home run setup failed: ${formatUnknown(inspect.eval)}`);
+        }
+        return inspect.eval.value;
+      });
+      expect(setup).toMatchObject({
         inputTextBeforeSubmit: PACKAGED_HOME_FIRST_RUN_PROMPT,
         submitClicked: false,
       });

--- a/e2e/tests/packaged/home-first-run.test.ts
+++ b/e2e/tests/packaged/home-first-run.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import {
   PACKAGED_HOME_FIRST_RUN_PROMPT,
   packagedHomeFirstRunExpression,
+  waitForPackagedHomeFirstRunSetup,
 } from '@/vitest/packaged-home-first-run';
 
 class FixtureElement {
@@ -92,33 +93,93 @@ async function evaluateExpression(
 }
 
 describe('packaged Home first-run readiness', () => {
-  it('waits for the visible editable composer before installing first-run instrumentation', async () => {
+  it('returns quickly until a later inspection can instrument the ready composer', async () => {
     const fixture = renderFixture({ composerAfterQueries: 2, loadingVisible: true });
 
-    const value = await evaluateExpression(packagedHomeFirstRunExpression(), fixture);
+    const first = await evaluateExpression(packagedHomeFirstRunExpression(), fixture);
+    const second = await evaluateExpression(packagedHomeFirstRunExpression(), fixture);
+    const ready = await evaluateExpression(packagedHomeFirstRunExpression(), fixture);
 
-    expect(fixture.composerQueries()).toBeGreaterThanOrEqual(3);
+    expect(first).toMatchObject({
+      instrumented: false,
+      readiness: { composerFound: false, composerVisible: false },
+    });
+    expect(second).toMatchObject({
+      instrumented: false,
+      readiness: { composerFound: false, composerVisible: false },
+    });
+    expect(fixture.composerQueries()).toBe(3);
     expect(fixture.input.textContent).toBe(PACKAGED_HOME_FIRST_RUN_PROMPT);
-    expect(value).toMatchObject({
+    expect(ready).toMatchObject({
+      instrumented: true,
       inputTextBeforeSubmit: PACKAGED_HOME_FIRST_RUN_PROMPT,
       submitClicked: false,
     });
   });
 
-  it('diagnoses a composer that never becomes ready', async () => {
+  it('polls through separate inspections until the composer can be instrumented', async () => {
+    const fixture = renderFixture({ composerAfterQueries: 2, loadingVisible: true });
+    let inspectionCount = 0;
+
+    const setup = await waitForPackagedHomeFirstRunSetup(async () => {
+      inspectionCount += 1;
+      return await evaluateExpression(packagedHomeFirstRunExpression(), fixture);
+    }, { pollIntervalMs: 0, timeoutMs: 100 });
+
+    expect(inspectionCount).toBe(3);
+    expect(setup).toMatchObject({
+      instrumented: true,
+      inputTextBeforeSubmit: PACKAGED_HOME_FIRST_RUN_PROMPT,
+    });
+  });
+
+  it('reports why the current composer is not ready without blocking the inspection', async () => {
     const fixture = renderFixture({
       composerContentEditable: false,
       composerVisible: false,
       loadingVisible: true,
       onboardingVisible: true,
     });
-    const expression = packagedHomeFirstRunExpression({
-      readinessPollIntervalMs: 1,
-      readinessTimeoutMs: 10,
-    });
-
-    await expect(evaluateExpression(expression, fixture, '/onboarding')).rejects.toThrow(
-      /pathname.*\/onboarding.*loadingVisible.*true.*onboardingVisible.*true.*composerFound.*true.*composerVisible.*false.*composerContentEditable.*false/,
+    const value = await evaluateExpression(
+      packagedHomeFirstRunExpression(),
+      fixture,
+      '/onboarding',
     );
+
+    expect(value).toMatchObject({
+      instrumented: false,
+      readiness: {
+        pathname: '/onboarding',
+        loadingVisible: true,
+        onboardingVisible: true,
+        composerFound: true,
+        composerVisible: false,
+        composerContentEditable: false,
+      },
+    });
+  });
+
+  it('times out with the final readiness snapshot when no inspection can instrument', async () => {
+    const fixture = renderFixture({
+      composerContentEditable: false,
+      composerVisible: false,
+      loadingVisible: true,
+      onboardingVisible: true,
+    });
+    let inspectionCount = 0;
+
+    const setup = waitForPackagedHomeFirstRunSetup(async () => {
+      inspectionCount += 1;
+      return await evaluateExpression(
+        packagedHomeFirstRunExpression(),
+        fixture,
+        '/onboarding',
+      );
+    }, { pollIntervalMs: 1, timeoutMs: 10 });
+
+    await expect(setup).rejects.toThrow(
+      /pathname.*\/onboarding.*loadingVisible.*true.*onboardingVisible.*true.*composerFound.*true.*composerVisible.*false.*composerContentEditable.*false/s,
+    );
+    expect(inspectionCount).toBeGreaterThan(1);
   });
 });

--- a/e2e/tests/packaged/home-first-run.test.ts
+++ b/e2e/tests/packaged/home-first-run.test.ts
@@ -33,14 +33,20 @@ type FixtureDocumentOptions = {
   editorAfterQueries?: number;
   loadingVisible?: boolean;
   onboardingVisible?: boolean;
+  promptInsertionFailures?: number;
 };
 
 function renderFixture(options: FixtureDocumentOptions = {}) {
   const input = new FixtureElement(options.composerVisible ?? true);
   input.isContentEditable = options.composerContentEditable ?? true;
+  let promptInsertionFailures = options.promptInsertionFailures ?? 0;
   const editor = {
     parseEditorState: (value: string) => JSON.parse(value),
     setEditorState: (value: unknown) => {
+      if (promptInsertionFailures > 0) {
+        promptInsertionFailures -= 1;
+        throw new Error('fixture prompt insertion failed');
+      }
       const root = value as {
         root?: { children?: Array<{ children?: Array<{ text?: string }> }> };
       };
@@ -122,7 +128,7 @@ describe('packaged Home first-run readiness', () => {
       instrumented: false,
       readiness: { composerFound: false, composerVisible: false },
     });
-    expect(fixture.composerQueries()).toBe(3);
+    expect(fixture.composerQueries()).toBe(4);
     expect(fixture.input.textContent).toBe(PACKAGED_HOME_FIRST_RUN_PROMPT);
     expect(ready).toMatchObject({
       instrumented: true,
@@ -168,6 +174,21 @@ describe('packaged Home first-run readiness', () => {
       inputTextBeforeSubmit: PACKAGED_HOME_FIRST_RUN_PROMPT,
       readiness: { lexicalEditorReady: true },
     });
+  });
+
+  it('retries prompt insertion without accepting provisional success state', async () => {
+    const fixture = renderFixture({ promptInsertionFailures: 1 });
+    const evaluate = createExpressionEvaluator(fixture);
+    let inspectionCount = 0;
+
+    const setup = await waitForPackagedHomeFirstRunSetup(async () => {
+      inspectionCount += 1;
+      return await evaluate(packagedHomeFirstRunExpression());
+    }, { pollIntervalMs: 0, timeoutMs: 100 });
+
+    expect(inspectionCount).toBe(2);
+    expect(fixture.input.textContent).toBe(PACKAGED_HOME_FIRST_RUN_PROMPT);
+    expect(setup.inputTextBeforeSubmit).toBe(PACKAGED_HOME_FIRST_RUN_PROMPT);
   });
 
   it('reports why the current composer is not ready without blocking the inspection', async () => {

--- a/e2e/tests/packaged/home-first-run.test.ts
+++ b/e2e/tests/packaged/home-first-run.test.ts
@@ -1,0 +1,124 @@
+import { runInNewContext } from 'node:vm';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  PACKAGED_HOME_FIRST_RUN_PROMPT,
+  packagedHomeFirstRunExpression,
+} from '@/vitest/packaged-home-first-run';
+
+class FixtureElement {
+  __lexicalEditor?: {
+    parseEditorState(value: string): unknown;
+    setEditorState(value: unknown): void;
+  };
+
+  isContentEditable = false;
+  textContent = '';
+
+  constructor(private readonly visible = true) {}
+
+  focus(): void {}
+
+  getClientRects(): ArrayLike<unknown> {
+    return this.visible ? [{}] : [];
+  }
+}
+
+type FixtureDocumentOptions = {
+  composerAfterQueries?: number;
+  composerContentEditable?: boolean;
+  composerVisible?: boolean;
+  loadingVisible?: boolean;
+  onboardingVisible?: boolean;
+};
+
+function renderFixture(options: FixtureDocumentOptions = {}) {
+  const input = new FixtureElement(options.composerVisible ?? true);
+  input.isContentEditable = options.composerContentEditable ?? true;
+  input.__lexicalEditor = {
+    parseEditorState: (value) => JSON.parse(value),
+    setEditorState: (value) => {
+      const root = value as {
+        root?: { children?: Array<{ children?: Array<{ text?: string }> }> };
+      };
+      input.textContent = root.root?.children?.[0]?.children?.[0]?.text ?? '';
+    },
+  };
+
+  const loading = options.loadingVisible ? new FixtureElement() : null;
+  const onboarding = options.onboardingVisible ? new FixtureElement() : null;
+  let composerQueries = 0;
+
+  return {
+    document: {
+      addEventListener: () => undefined,
+      querySelector: (selector: string) => {
+        if (selector === '[data-testid="home-hero-input"]') {
+          composerQueries += 1;
+          return composerQueries > (options.composerAfterQueries ?? 0) ? input : null;
+        }
+        if (selector === '.od-loading-shell, .centered-loader') return loading;
+        if (selector === '.entry-shell--onboarding, .entry-onboarding-modal') return onboarding;
+        return null;
+      },
+    },
+    input,
+    composerQueries: () => composerQueries,
+  };
+}
+
+async function evaluateExpression(
+  expression: string,
+  fixture: ReturnType<typeof renderFixture>,
+  pathname = '/',
+): Promise<unknown> {
+  const sandbox = {
+    document: fixture.document,
+    Element: FixtureElement,
+    HTMLElement: FixtureElement,
+    Headers,
+    location: { href: `od://app${pathname}`, pathname },
+    performance: {
+      getEntriesByType: () => [{}],
+      timeOrigin: 1234,
+    },
+    Request,
+    Response,
+    fetch: async () => new Response('{}', { status: 200 }),
+    setTimeout,
+  };
+  return await runInNewContext(expression, sandbox);
+}
+
+describe('packaged Home first-run readiness', () => {
+  it('waits for the visible editable composer before installing first-run instrumentation', async () => {
+    const fixture = renderFixture({ composerAfterQueries: 2, loadingVisible: true });
+
+    const value = await evaluateExpression(packagedHomeFirstRunExpression(), fixture);
+
+    expect(fixture.composerQueries()).toBeGreaterThanOrEqual(3);
+    expect(fixture.input.textContent).toBe(PACKAGED_HOME_FIRST_RUN_PROMPT);
+    expect(value).toMatchObject({
+      inputTextBeforeSubmit: PACKAGED_HOME_FIRST_RUN_PROMPT,
+      submitClicked: false,
+    });
+  });
+
+  it('diagnoses a composer that never becomes ready', async () => {
+    const fixture = renderFixture({
+      composerContentEditable: false,
+      composerVisible: false,
+      loadingVisible: true,
+      onboardingVisible: true,
+    });
+    const expression = packagedHomeFirstRunExpression({
+      readinessPollIntervalMs: 1,
+      readinessTimeoutMs: 10,
+    });
+
+    await expect(evaluateExpression(expression, fixture, '/onboarding')).rejects.toThrow(
+      /pathname.*\/onboarding.*loadingVisible.*true.*onboardingVisible.*true.*composerFound.*true.*composerVisible.*false.*composerContentEditable.*false/,
+    );
+  });
+});

--- a/e2e/tests/packaged/home-first-run.test.ts
+++ b/e2e/tests/packaged/home-first-run.test.ts
@@ -30,6 +30,7 @@ type FixtureDocumentOptions = {
   composerAfterQueries?: number;
   composerContentEditable?: boolean;
   composerVisible?: boolean;
+  editorAfterQueries?: number;
   loadingVisible?: boolean;
   onboardingVisible?: boolean;
 };
@@ -37,15 +38,16 @@ type FixtureDocumentOptions = {
 function renderFixture(options: FixtureDocumentOptions = {}) {
   const input = new FixtureElement(options.composerVisible ?? true);
   input.isContentEditable = options.composerContentEditable ?? true;
-  input.__lexicalEditor = {
-    parseEditorState: (value) => JSON.parse(value),
-    setEditorState: (value) => {
+  const editor = {
+    parseEditorState: (value: string) => JSON.parse(value),
+    setEditorState: (value: unknown) => {
       const root = value as {
         root?: { children?: Array<{ children?: Array<{ text?: string }> }> };
       };
       input.textContent = root.root?.children?.[0]?.children?.[0]?.text ?? '';
     },
   };
+  if (options.editorAfterQueries == null) input.__lexicalEditor = editor;
 
   const loading = options.loadingVisible ? new FixtureElement() : null;
   const onboarding = options.onboardingVisible ? new FixtureElement() : null;
@@ -57,6 +59,9 @@ function renderFixture(options: FixtureDocumentOptions = {}) {
       querySelector: (selector: string) => {
         if (selector === '[data-testid="home-hero-input"]') {
           composerQueries += 1;
+          if (composerQueries > (options.editorAfterQueries ?? Number.POSITIVE_INFINITY)) {
+            input.__lexicalEditor = editor;
+          }
           return composerQueries > (options.composerAfterQueries ?? 0) ? input : null;
         }
         if (selector === '.od-loading-shell, .centered-loader') return loading;
@@ -69,11 +74,10 @@ function renderFixture(options: FixtureDocumentOptions = {}) {
   };
 }
 
-async function evaluateExpression(
-  expression: string,
+function createExpressionEvaluator(
   fixture: ReturnType<typeof renderFixture>,
   pathname = '/',
-): Promise<unknown> {
+) {
   const sandbox = {
     document: fixture.document,
     Element: FixtureElement,
@@ -89,7 +93,17 @@ async function evaluateExpression(
     fetch: async () => new Response('{}', { status: 200 }),
     setTimeout,
   };
-  return await runInNewContext(expression, sandbox);
+  return async (expression: string): Promise<unknown> => {
+    return await runInNewContext(expression, sandbox);
+  };
+}
+
+async function evaluateExpression(
+  expression: string,
+  fixture: ReturnType<typeof renderFixture>,
+  pathname = '/',
+): Promise<unknown> {
+  return await createExpressionEvaluator(fixture, pathname)(expression);
 }
 
 describe('packaged Home first-run readiness', () => {
@@ -130,6 +144,29 @@ describe('packaged Home first-run readiness', () => {
     expect(setup).toMatchObject({
       instrumented: true,
       inputTextBeforeSubmit: PACKAGED_HOME_FIRST_RUN_PROMPT,
+    });
+  });
+
+  it('waits for Lexical attachment without persisting a poisoned setup', async () => {
+    const fixture = renderFixture({ editorAfterQueries: 2 });
+    const evaluate = createExpressionEvaluator(fixture);
+
+    const first = await evaluate(packagedHomeFirstRunExpression());
+    const second = await evaluate(packagedHomeFirstRunExpression());
+    const ready = await evaluate(packagedHomeFirstRunExpression());
+
+    expect(first).toMatchObject({
+      instrumented: false,
+      readiness: { lexicalEditorReady: false },
+    });
+    expect(second).toMatchObject({
+      instrumented: false,
+      readiness: { lexicalEditorReady: false },
+    });
+    expect(ready).toMatchObject({
+      instrumented: true,
+      inputTextBeforeSubmit: PACKAGED_HOME_FIRST_RUN_PROMPT,
+      readiness: { lexicalEditorReady: true },
     });
   });
 


### PR DESCRIPTION
## Why

The prerelease packaged mac smoke incident SMK-A7DCE1A6-FDRKD28 failed before prompt submission because the test treated daemon health as proof that the Home renderer was interactive. On a cold launch, the health endpoint can be ready while the visible editable Home composer has not mounted yet, so the smoke performed one DOM lookup and failed immediately.

This PR removes that UI-readiness race at the packaged test seam without changing Lexical, assistant rendering, or product behavior. It preserves the existing first-send, injected 503 retry, assistant output, no-refresh, and no-workspace-tab-click coverage.

## What users will see

No product UI changes. Packaged mac release validation now polls renderer readiness through separate short inspect calls and instruments the first Home send atomically once the composer is visible and editable.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this changes packaged smoke readiness only and does not alter a UI surface.

## Bug fix verification

- Test path that reproduces the bug: `e2e/tests/packaged/home-first-run.test.ts`
- Red on main: yes. The original delayed-composer test reproduced `packaged first Home run found no visible Lexical composer`. The follow-up red test proved that an in-expression readiness loop consumed multiple DOM probes inside one inspect instead of returning control for separate inspections.
- Green on this branch: yes, 6/6 focused cases pass.
- The regression suite executes the same generated renderer expression used by the packaged smoke. It covers immediate non-blocking readiness snapshots, a composer that becomes ready across three separate inspections, atomic instrumentation on the ready inspection, delayed Lexical attachment without poisoned state, retryable prompt insertion without provisional success, and permanent-unready timeout diagnostics with pathname, loading/onboarding surfaces, visibility, and editability.

## Validation

- `cd e2e && pnpm test tests/packaged/home-first-run.test.ts` — 6 passed
- `cd e2e && pnpm typecheck` — passed
- `pnpm guard` — passed
- `pnpm typecheck` — passed with pnpm 10.33.2; landing-page emitted existing hints and zero errors
- `git diff --check` — passed
- `cd e2e && pnpm test specs/mac.spec.ts` — spec loaded; 16 packaged mac cases skipped because `OD_PACKAGED_E2E_MAC=1` was not set

A real packaged mac cold-start run was not executed locally; the release artifact smoke and remote CI remain the acceptance evidence for that layer.


