### PR TITLE
fix(web): scope artifact upgrade gate to active project

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -131,8 +131,9 @@ import {
   notifyWorkspaceContextRefresh,
   resolveBoundProjectWorkspaceContext,
   resolveCurrentWorkspaceContextReadWitness,
-  useWorkspaceBilling,
+  useWorkspaceBillingResponse,
   useWorkspaceContext,
+  workspaceBillingSummaryForContext,
   workspaceIdentityCacheKey,
   workspaceResourceReadContext,
 } from './collab/useWorkspaceContext';
@@ -874,7 +875,6 @@ function AppInner() {
       ? ['pending-account', workspaceAccountGeneration]
       : ['workspace-account', workspaceAccountGeneration, currentWorkspaceIdentity],
   );
-  const workspaceBilling = useWorkspaceBilling();
   const workspaceContextRef = useRef<WorkspaceCollabContext | null>(null);
   const workspaceContextStateRef = useRef(workspaceContextState);
   const projectRouteWorkspaceContextRef = useRef<WorkspaceCollabContext | null>(null);
@@ -1665,21 +1665,6 @@ function AppInner() {
     }, remainingMs);
     return () => window.clearTimeout(timeout);
   }, [amrAuthRetryContinuation, clearAmrAuthRetryContinuation]);
-  // The plan that gates free-tier surfaces (today: the post-generation artifact
-  // upsell). vela's login status is ACCOUNT-scoped, so a member whose plan is
-  // held by the team workspace reads `free` there and used to be shown the
-  // free-user banner; the workspace context's plan id is authoritative and
-  // wins. See resolvePlanTier for the full precedence rule.
-  const resolvedAmrPlan = resolvePlanTier({
-    billing: workspaceBilling,
-    context: workspaceContext,
-    accountPlan:
-      workspaceContextLoading || workspaceContext?.workspaceType === 'team'
-        ? null
-        : amrLoginStatus?.account?.plan?.trim()
-          || amrLoginStatus?.user?.plan?.trim()
-          || null,
-  });
   // Child surfaces report status snapshots, not login events. Deduplicate the
   // signed-in transition here: restarting the model poll for every Settings
   // snapshot updates `agents`, which makes Settings fetch status again and
@@ -4378,6 +4363,36 @@ function AppInner() {
     ? projectRouteWorkspaceContext.context
     : null;
   projectRouteWorkspaceContextRef.current = activeProjectWorkspaceContext;
+  // The post-generation upgrade gate belongs to the project that owns the
+  // conversation, not whichever Workspace the navigation shell currently
+  // selects. A bound project stays fail-closed until its exact membership and
+  // billing snapshot resolve; borrowing the ambient/account Free plan here is
+  // what interrupted paid Team members with the Free upsell.
+  const amrUpgradeWorkspaceContext = activeProject?.workspaceId
+    ? activeProjectWorkspaceContext
+    : workspaceContext;
+  const amrUpgradeWorkspaceContextLoading = activeProject?.workspaceId
+    ? activeProjectWorkspaceContext === null
+    : workspaceContextLoading;
+  const amrUpgradeBillingResponse = useWorkspaceBillingResponse({
+    context: amrUpgradeWorkspaceContext,
+    loading: amrUpgradeWorkspaceContextLoading,
+  });
+  const amrUpgradeBilling = workspaceBillingSummaryForContext(
+    amrUpgradeBillingResponse,
+    amrUpgradeWorkspaceContext,
+  );
+  const resolvedAmrPlan = resolvePlanTier({
+    billing: amrUpgradeBilling,
+    context: amrUpgradeWorkspaceContext,
+    accountPlan:
+      amrUpgradeWorkspaceContextLoading
+      || amrUpgradeWorkspaceContext?.workspaceType === 'team'
+        ? null
+        : amrLoginStatus?.account?.plan?.trim()
+          || amrLoginStatus?.user?.plan?.trim()
+          || null,
+  });
   useEffect(() => {
     const pending = amrAuthRetryContinuationRef.current;
     if (!pending) return;

--- a/apps/web/src/components/AmrArtifactUpgradeGate.tsx
+++ b/apps/web/src/components/AmrArtifactUpgradeGate.tsx
@@ -37,6 +37,14 @@ interface Props {
 interface RouteSurface {
   homeVisible: boolean;
   offer: AmrArtifactUpgradeHomeOffer | null;
+  plan: string | null;
+  planResolved: boolean;
+}
+
+interface PendingHomeOffer {
+  offer: AmrArtifactUpgradeHomeOffer;
+  plan: string | null;
+  planResolved: boolean;
 }
 
 interface PendingSendDecision {
@@ -87,7 +95,7 @@ export function AmrArtifactUpgradeGate({
   const [pendingRevision, setPendingRevision] = useState(0);
   const [dialogSessionKey, setDialogSessionKey] = useState<string | null>(null);
   const [pendingHomeOffer, setPendingHomeOffer] =
-    useState<AmrArtifactUpgradeHomeOffer | null>(null);
+    useState<PendingHomeOffer | null>(null);
   const openRef = useRef(false);
   const pendingSendRef = useRef<PendingSendDecision | null>(null);
   const eligibleSessionsRef = useRef<Set<string>>(new Set());
@@ -101,6 +109,8 @@ export function AmrArtifactUpgradeGate({
       activeConversationId,
       activeFileName,
     ),
+    plan,
+    planResolved,
   });
 
   useEffect(() => {
@@ -200,7 +210,11 @@ export function AmrArtifactUpgradeGate({
       && eligibleSessionsRef.current.has(previous.offer.sessionKey)
       && !homeOfferedSessionsRef.current.has(previous.offer.sessionKey)
     ) {
-      setPendingHomeOffer(previous.offer);
+      setPendingHomeOffer({
+        offer: previous.offer,
+        plan: previous.plan,
+        planResolved: previous.planResolved,
+      });
     }
     previousSurfaceRef.current = {
       homeVisible,
@@ -209,18 +223,34 @@ export function AmrArtifactUpgradeGate({
         activeConversationId,
         activeFileName,
       ),
+      plan,
+      planResolved,
     };
-  }, [activeConversationId, activeFileName, activeProjectId, homeVisible]);
+  }, [
+    activeConversationId,
+    activeFileName,
+    activeProjectId,
+    homeVisible,
+    plan,
+    planResolved,
+  ]);
 
   useEffect(() => {
-    if (!pendingHomeOffer || !planResolved) return;
-    if (cloudModelSelected && isFreePlanTier(plan) && !hasOpenModal()) {
-      homeOfferedSessionsRef.current.add(pendingHomeOffer.sessionKey);
-      promptedSessionsRef.current.add(pendingHomeOffer.sessionKey);
-      onHomeOfferChange?.(pendingHomeOffer);
+    if (!pendingHomeOffer) return;
+    if (
+      pendingHomeOffer.planResolved
+      && cloudModelSelected
+      && isFreePlanTier(pendingHomeOffer.plan)
+      && !hasOpenModal()
+    ) {
+      homeOfferedSessionsRef.current.add(pendingHomeOffer.offer.sessionKey);
+      promptedSessionsRef.current.add(pendingHomeOffer.offer.sessionKey);
+      onHomeOfferChange?.(pendingHomeOffer.offer);
+    } else {
+      onHomeOfferChange?.(null);
     }
     setPendingHomeOffer(null);
-  }, [cloudModelSelected, onHomeOfferChange, pendingHomeOffer, plan, planResolved]);
+  }, [cloudModelSelected, onHomeOfferChange, pendingHomeOffer]);
 
   useEffect(() => {
     if (cloudModelSelected && (!planResolved || isFreePlanTier(plan))) return;

--- a/apps/web/tests/components/AmrArtifactUpgradeGate.test.tsx
+++ b/apps/web/tests/components/AmrArtifactUpgradeGate.test.tsx
@@ -244,6 +244,37 @@ describe('AmrArtifactUpgradeGate', () => {
     expect(onHomeOfferChange).toHaveBeenCalledTimes(2);
   });
 
+  it('does not reinterpret a paid project session through the ambient Free plan on Home', async () => {
+    const onHomeOfferChange = vi.fn();
+    const view = render(
+      <AmrArtifactUpgradeGate
+        {...BASE_PROPS}
+        plan="team_pro"
+        planResolved
+        onHomeOfferChange={onHomeOfferChange}
+      />,
+    );
+
+    act(() => publishFinishedRun());
+    view.rerender(
+      <AmrArtifactUpgradeGate
+        {...BASE_PROPS}
+        activeProjectId={null}
+        activeConversationId={null}
+        activeFileName={null}
+        homeVisible
+        plan="free"
+        planResolved
+        onHomeOfferChange={onHomeOfferChange}
+      />,
+    );
+
+    await waitFor(() => expect(onHomeOfferChange).toHaveBeenCalledWith(null));
+    expect(onHomeOfferChange).not.toHaveBeenCalledWith(expect.objectContaining({
+      sessionKey: JSON.stringify(['project-1', 'conversation-1']),
+    }));
+  });
+
   it('fails open while the plan is unavailable, then prompts after Free resolves', async () => {
     const view = render(
       <AmrArtifactUpgradeGate {...BASE_PROPS} plan={null} planResolved={false} />,

--- a/apps/web/tests/components/App.amr-plan-tier.test.tsx
+++ b/apps/web/tests/components/App.amr-plan-tier.test.tsx
@@ -16,7 +16,8 @@ import { cleanup, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { App } from '../../src/App';
-import type { AppConfig } from '../../src/types';
+import type { Route } from '../../src/router';
+import type { AppConfig, Project } from '../../src/types';
 import { loadConfig, mergeDaemonConfig, fetchDaemonConfig } from '../../src/state/config';
 import {
   daemonIsLive,
@@ -36,10 +37,26 @@ import { resetCoalescedGet } from '../../src/lib/coalesced-get';
 import { workspaceDirectoryFixture } from '../helpers/workspace-context';
 
 const homeRouteMock = { kind: 'home' as const, view: 'home' as const };
-vi.mock('../../src/router', () => ({
-  navigate: vi.fn(),
-  useRoute: () => homeRouteMock,
-}));
+const useRouteMock = vi.fn<() => Route>(() => homeRouteMock);
+const useProjectRouteWorkspaceContextMock = vi.hoisted(() => vi.fn());
+vi.mock('../../src/router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/router')>();
+  return {
+    ...actual,
+    navigate: vi.fn(),
+    useRoute: () => useRouteMock(),
+  };
+});
+
+vi.mock('../../src/collab/useProjectRouteWorkspaceContext', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('../../src/collab/useProjectRouteWorkspaceContext')
+  >();
+  return {
+    ...actual,
+    useProjectRouteWorkspaceContext: useProjectRouteWorkspaceContextMock,
+  };
+});
 
 vi.mock('../../src/components/EntryView', () => ({
   EntryView: () => <div>Entry view</div>,
@@ -166,6 +183,37 @@ const baseConfig: AppConfig = {
   agentCliEnv: {},
 };
 
+const project: Project = {
+  id: 'project-team',
+  name: 'Team project',
+  skillId: null,
+  designSystemId: null,
+  customInstructions: '',
+  createdAt: 1,
+  updatedAt: 1,
+  workspaceId: 'ws-project-team',
+};
+
+const ambientFreeContext = {
+  workspaceId: 'ws-personal-free',
+  workspaceType: 'personal',
+  workspaceMemberId: 'member-personal',
+  role: 'owner',
+  memberStatus: 'active',
+  lifecycleState: 'active',
+  billingState: 'free',
+  planId: null,
+} as const;
+
+const projectTeamContext = {
+  workspaceId: 'ws-project-team',
+  workspaceType: 'team',
+  workspaceMemberId: 'member-team',
+  role: 'member',
+  memberStatus: 'active',
+  lifecycleState: 'active',
+} as const;
+
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status: 200,
@@ -179,6 +227,12 @@ describe('App AMR plan-tier gate', () => {
     resetWorkspaceContextCache();
     resetWorkspaceBillingCache();
     capturedPlanCalls.length = 0;
+    useRouteMock.mockReturnValue(homeRouteMock);
+    useProjectRouteWorkspaceContextMock.mockReturnValue({
+      context: null,
+      loading: false,
+      retry: vi.fn(),
+    });
     mockedDaemonIsLive.mockResolvedValue(true);
     mockedFetchAgentsStream.mockResolvedValue([]);
     mockedFetchSkills.mockResolvedValue([]);
@@ -274,6 +328,97 @@ describe('App AMR plan-tier gate', () => {
     await waitFor(() => {
       const last = capturedPlanCalls.at(-1);
       expect(last?.plan).toBe('team_plus');
+    });
+    expect(capturedPlanCalls.some((call) => call.plan === 'free')).toBe(false);
+  });
+
+  it('uses the active project Team plan instead of the ambient personal Free plan', async () => {
+    useRouteMock.mockReturnValue({
+      kind: 'project',
+      projectId: project.id,
+      conversationId: 'conversation-1',
+      fileName: null,
+    });
+    useProjectRouteWorkspaceContextMock.mockReturnValue({
+      context: projectTeamContext,
+      loading: false,
+      retry: vi.fn(),
+    });
+    mockedListProjects.mockResolvedValue([project]);
+    mockedFetchVelaLoginStatus.mockResolvedValue({
+      loggedIn: true,
+      loginInFlight: false,
+      profile: 'prod',
+      user: { id: 'member-1', email: 'member@example.com' },
+      configPath: '/tmp/amr-config.json',
+      account: { plan: 'free' },
+    });
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/api/workspace/directory')) {
+        return jsonResponse(workspaceDirectoryFixture([
+          ambientFreeContext,
+          projectTeamContext,
+        ]));
+      }
+      if (url.includes('/api/workspace/billing?')) {
+        const workspaceId = new URL(url, 'http://open-design.test')
+          .searchParams.get('workspaceId');
+        const context = workspaceId === projectTeamContext.workspaceId
+          ? projectTeamContext
+          : ambientFreeContext;
+        const teamScoped = context.workspaceId === projectTeamContext.workspaceId;
+        return jsonResponse({
+          summary: {
+            workspaceId: null,
+            membershipTier: 'free',
+            balanceUsd: '0',
+            workspaceBalance: null,
+          },
+          workspaceBalance: {
+            workspaceId: context.workspaceId,
+            workspaceMemberId: context.workspaceMemberId,
+            balanceUsd: teamScoped ? '12.34' : '0',
+            billingScopeVersion: 2,
+            expiresAt: null,
+            updatedAt: null,
+          },
+          workspaceSnapshot: {
+            schemaVersion: 1,
+            workspaceId: context.workspaceId,
+            workspaceMemberId: context.workspaceMemberId,
+            billingScopeVersion: 2,
+            billing: {
+              billingState: teamScoped ? 'active' : 'free',
+              planId: teamScoped ? 'team_pro' : null,
+            },
+            wallet: {
+              balanceUsd: teamScoped ? '12.34' : '0',
+              expiresAt: null,
+              updatedAt: null,
+            },
+            revisions: {
+              billing: `billing-${context.workspaceId}`,
+              wallet: `wallet-${context.workspaceId}`,
+            },
+          },
+        });
+      }
+      if (url.endsWith('/api/workspace/context')) {
+        return jsonResponse({ context: ambientFreeContext });
+      }
+      return jsonResponse({});
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(capturedPlanCalls.at(-1)).toEqual({
+        plan: 'team_pro',
+        planResolved: true,
+      });
     });
     expect(capturedPlanCalls.some((call) => call.plan === 'free')).toBe(false);
   });


### PR DESCRIPTION
## Why

While reproducing [OPEND-2386](https://plane.powerformer.net/open-design/browse/OPEND-2386/), I found that the post-generation artifact upgrade gate read billing from the ambient navigation workspace instead of the workspace bound to the active project. A Team Pro project opened while the user's personal Free workspace was ambient could therefore interrupt the next message with a Free-plan upgrade dialog.

The route-to-Home handoff also re-evaluated the completed project session against the newly ambient plan, so the same paid session could be reclassified as Free after leaving the project.

## What users will see

Members working in a Team Pro project can continue messaging after artifact generation without seeing the Free-plan upgrade dialog, even when their ambient personal workspace is Free. Returning Home also preserves the plan decision made for the completed project session.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this removes an incorrect conditional dialog and does not add or change a UI entry point. The conflicting workspace scopes are covered by the regression tests below.

## Bug fix verification

- Test paths that reproduce the bug:
  - `apps/web/tests/components/App.amr-plan-tier.test.tsx`
  - `apps/web/tests/components/AmrArtifactUpgradeGate.test.tsx`
- Yes. On `main`, the App regression received `{ plan: 'free', planResolved: true }` instead of Team Pro, and the Home-transition regression emitted an upgrade offer for the paid project session. Both are green on this branch.

## Validation

- `corepack pnpm --filter @open-design/web exec vitest run -c vitest.config.ts --maxWorkers=2 tests/components/App.amr-plan-tier.test.tsx tests/components/AmrArtifactUpgradeGate.test.tsx tests/useWorkspaceBilling.scope.test.tsx` — 55 passed
- `corepack pnpm --filter @open-design/web typecheck` — passed
- `git diff --check` — passed
- `corepack pnpm guard` — blocked by existing tracked JavaScript files `apps/landing-page/public/enhancers/cobe.js` and `matter.min.js`, outside this change
- `corepack pnpm typecheck` — Web passed; the repository run then failed in `tools/release/src/catalog/render-previews.ts` because the existing `sharp` module/types are unavailable, outside this change
- `corepack pnpm --filter @open-design/web test` — attempted, then stopped after sustained existing jsdom `HTMLCanvasElement.getContext()` warnings prevented the full suite from completing; the affected tests are covered by the focused 55-test run above
