### PR TITLE
fix(daemon): keep unattributed local personal design systems readable

### DIFF
--- a/apps/daemon/src/collab/request-workspace-context.ts
+++ b/apps/daemon/src/collab/request-workspace-context.ts
@@ -97,3 +97,58 @@ export async function verifyWorkspaceRequestContext(input: {
     context: workspaceContextFromDirectoryItem(membership, input.configuredEnv),
   };
 }
+
+/**
+ * The local/dev counterpart of {@link verifyWorkspaceRequestContext}: there is
+ * no signed membership directory, so the request's explicit headers are the
+ * complete, static authority. It still never consults the daemon's mutable
+ * active-workspace context. Lives here rather than inline in `server.ts` so a
+ * test that builds a route in isolation can run the production local verifier
+ * instead of a hand-rolled double.
+ */
+export function verifyLocalWorkspaceRequestContext(
+  req: unknown,
+  options: { configuredEnv?: Record<string, string>; requireTeam?: boolean } = {},
+): VerifiedWorkspaceRequestContextResult {
+  const claimed = workspaceResourceContextFromRequest(req);
+  if (claimed === null) {
+    return {
+      ok: false,
+      status: 400,
+      code: 'WORKSPACE_CONTEXT_REQUIRED',
+      message: 'an explicit workspace context is required',
+    };
+  }
+  if (claimed === 'missing') {
+    return {
+      ok: false,
+      status: 400,
+      code: 'WORKSPACE_CONTEXT_INCOMPLETE',
+      message: 'both workspace and member identity are required',
+    };
+  }
+  if (
+    claimed.memberStatus !== 'active'
+    || claimed.lifecycleState === 'deleted'
+    || (options.requireTeam && claimed.workspaceType !== 'team')
+  ) {
+    return {
+      ok: false,
+      status: 403,
+      code: 'WORKSPACE_ACCESS_DENIED',
+      message: 'the requested workspace is not available to this member',
+    };
+  }
+  return {
+    ok: true,
+    context: workspaceContextFromDirectoryItem({
+      workspaceId: claimed.workspaceId,
+      workspaceName: claimed.workspaceId,
+      workspaceType: claimed.workspaceType,
+      workspaceMemberId: claimed.workspaceMemberId,
+      role: claimed.role,
+      memberStatus: claimed.memberStatus,
+      lifecycleState: claimed.lifecycleState,
+    }, options.configuredEnv),
+  };
+}

--- a/apps/daemon/src/collab/team-share-scope.ts
+++ b/apps/daemon/src/collab/team-share-scope.ts
@@ -49,12 +49,26 @@ export interface WorkspaceTypeFact {
  * fetches on every load, the workspace context the invalidation poller reads
  * every 15s). Nothing here fetches. An id it has never seen answers `null`, and
  * every consumer treats `null` as "no opinion".
+ *
+ * Facts come in two tiers. `learn` records what a CALLER claimed about a
+ * workspace (an `x-od-workspace-type` header on a project route); those claims
+ * feed `typeOf`/`isKnownPersonal`, whose consumers only ever use them in the
+ * refusing direction (a claimed-personal workspace cannot host a team share).
+ * `learnVerified` records what the membership directory ESTABLISHED, and only
+ * those facts answer `verifiedTypeOf`. A gate that GRANTS something on
+ * "this workspace is personal" must read the verified tier: a caller's own
+ * claim can never stand in for the directory's word, or a Team member could
+ * teach the daemon that their Team workspace is personal.
  */
 export interface WorkspaceTypeRegistry {
   learn(facts: readonly WorkspaceTypeFact[] | WorkspaceTypeFact | null | undefined): void;
+  /** Record facts established by the membership directory (or its authoritative context). */
+  learnVerified(facts: readonly WorkspaceTypeFact[] | WorkspaceTypeFact | null | undefined): void;
   typeOf(workspaceId: string | null | undefined): WorkspaceType | null;
   /** True ONLY on positive evidence that this workspace is personal. */
   isKnownPersonal(workspaceId: string | null | undefined): boolean;
+  /** The type the membership directory established for the workspace — never a caller's claim. */
+  verifiedTypeOf(workspaceId: string | null | undefined): WorkspaceType | null;
 }
 
 function normalizeId(workspaceId: string | null | undefined): string {
@@ -67,23 +81,35 @@ function normalizeType(workspaceType: string | null | undefined): WorkspaceType 
 
 export function createWorkspaceTypeRegistry(): WorkspaceTypeRegistry {
   const types = new Map<string, WorkspaceType>();
-  const typeOf = (workspaceId: string | null | undefined): WorkspaceType | null => {
+  const verifiedTypes = new Map<string, WorkspaceType>();
+  const lookup = (
+    map: Map<string, WorkspaceType>,
+    workspaceId: string | null | undefined,
+  ): WorkspaceType | null => {
     const id = normalizeId(workspaceId);
-    return id ? types.get(id) ?? null : null;
+    return id ? map.get(id) ?? null : null;
   };
+  const record = (
+    facts: readonly WorkspaceTypeFact[] | WorkspaceTypeFact | null | undefined,
+    verified: boolean,
+  ) => {
+    if (!facts) return;
+    for (const fact of Array.isArray(facts) ? facts : [facts as WorkspaceTypeFact]) {
+      const id = normalizeId(fact?.workspaceId);
+      const type = normalizeType(fact?.workspaceType);
+      if (!id || !type) continue;
+      types.set(id, type);
+      if (verified) verifiedTypes.set(id, type);
+    }
+  };
+  const typeOf = (workspaceId: string | null | undefined) => lookup(types, workspaceId);
   return {
-    learn(facts) {
-      if (!facts) return;
-      for (const fact of Array.isArray(facts) ? facts : [facts as WorkspaceTypeFact]) {
-        const id = normalizeId(fact?.workspaceId);
-        const type = normalizeType(fact?.workspaceType);
-        if (!id || !type) continue;
-        types.set(id, type);
-      }
-    },
+    learn: (facts) => record(facts, false),
+    learnVerified: (facts) => record(facts, true),
     typeOf,
     // Bound, not a method: consumers routinely pass this around on its own.
     isKnownPersonal: (workspaceId) => typeOf(workspaceId) === 'personal',
+    verifiedTypeOf: (workspaceId) => lookup(verifiedTypes, workspaceId),
   };
 }
 

--- a/apps/daemon/src/collab/workspace-resource-mutation.ts
+++ b/apps/daemon/src/collab/workspace-resource-mutation.ts
@@ -179,6 +179,48 @@ export type OptionalWorkspaceRequestAuthorityResult =
   | Exclude<WorkspaceRequestAuthorityResult, { ok: true }>;
 
 /**
+ * Is `binding` a legacy local personal claim with NO recorded creator member?
+ *
+ * Legacy `workspace_projects` rows written by lazy orphan adoption carry no
+ * creator member on purpose (`ensureWorkspaceProjection`,
+ * routes/project/index.ts), and the design-system startup backfill
+ * (`backfillDesignSystemWorkspaceResources`) propagates that absence into the
+ * `workspace_resources` envelope it infers from them — the normal state of an
+ * install that has never signed into a Workspace. Such a binding cannot
+ * belong to "another member": it carries no member attribution at all. The
+ * projects layer already rules that this state means "the local user's own
+ * resource" outside team views (`workspaceProjectCreatedByCurrentMember`,
+ * routes/project/index.ts); this predicate is the design-system half of the
+ * same ruling. Team-visibility and tombstoned rows are never legacy-local.
+ *
+ * Invariant this predicate protects: no lane of the daemon may manufacture a
+ * binding that every read gate categorically rejects. The backfill writes
+ * unattributed personal rows when the member is unknown, so the read gates
+ * MUST accept exactly that shape for local (non-team) callers — otherwise a
+ * claimed system becomes invisible in the scoped lane (member mismatch) AND
+ * in the headerless lane (the row reads as foreign-ownership evidence), with
+ * no lane left that can ever show it.
+ */
+export function isUnattributedLocalPersonalDesignSystemBinding(
+  binding:
+    | {
+        visibility?: string | null;
+        resourceState?: string | null;
+        createdByWorkspaceMemberId?: string | null;
+      }
+    | null
+    | undefined,
+): boolean {
+  return Boolean(
+    binding
+    && binding.visibility === 'personal'
+    && binding.resourceState !== 'deleted'
+    && !(typeof binding.createdByWorkspaceMemberId === 'string'
+      && binding.createdByWorkspaceMemberId.trim()),
+  );
+}
+
+/**
  * Resolve Workspace identity for daemon-local data-plane work.
  *
  * The browser's Workspace headers are attribution and namespace selectors on
@@ -845,12 +887,18 @@ export async function enforceVerifiedWorkspaceResourceRead(
   }
   const context = workspaceResourceContextFromVerified(verified.context);
   const row = getWorkspaceResource(db, context.workspaceId, resourceId);
+  // Design system mirrors project's memberless-legacy allowance: an
+  // unattributed personal row read from a non-team scope is the local user's
+  // own resource (see `isUnattributedLocalPersonalDesignSystemBinding`), so
+  // only attributed rows keep the strict exact-creator requirement.
   const strictPersonalCreator =
     row?.visibility === 'personal'
     && (
       resourceType === 'plugin'
       || resourceType === 'skill'
-      || resourceType === 'design_system'
+      || (resourceType === 'design_system'
+        && !(context.workspaceType === 'personal'
+          && isUnattributedLocalPersonalDesignSystemBinding(row)))
       || (resourceType === 'project' && row.createdByWorkspaceMemberId != null)
     );
   if (

--- a/apps/daemon/src/collab/workspace-resource-mutation.ts
+++ b/apps/daemon/src/collab/workspace-resource-mutation.ts
@@ -150,9 +150,19 @@ export function requestWithWorkspaceNavigationScope(
     ? req.query.workspaceMemberId.trim()
     : '';
   if (!workspaceId && !workspaceMemberId) return req;
+  // The asserted workspace type travels with the identity pair so gates that
+  // key on the caller's EXPLICIT type assertion (`workspaceTypeAsserted`)
+  // treat a navigation read exactly like the header-carrying fetch that
+  // produced the URL. Values outside the enum are ignored, not normalized:
+  // an unasserted or garbled type must stay unasserted (fail-closed).
+  const queryWorkspaceType = typeof req.query?.workspaceType === 'string'
+    && (req.query.workspaceType === 'personal' || req.query.workspaceType === 'team')
+    ? req.query.workspaceType
+    : '';
   const headerWorkspaceId = req.get('x-od-workspace-id')?.trim() ?? '';
   const headerWorkspaceMemberId =
     req.get('x-od-workspace-member-id')?.trim() ?? '';
+  const headerWorkspaceType = req.get('x-od-workspace-type')?.trim() ?? '';
   if (
     (headerWorkspaceId || headerWorkspaceMemberId)
     && (
@@ -162,12 +172,18 @@ export function requestWithWorkspaceNavigationScope(
   ) {
     return 'conflict';
   }
+  if (queryWorkspaceType && headerWorkspaceType && headerWorkspaceType !== queryWorkspaceType) {
+    return 'conflict';
+  }
   return {
     get(name: string) {
       const normalized = name.toLowerCase();
       if (normalized === 'x-od-workspace-id') return workspaceId || undefined;
       if (normalized === 'x-od-workspace-member-id') {
         return workspaceMemberId || undefined;
+      }
+      if (normalized === 'x-od-workspace-type') {
+        return headerWorkspaceType || queryWorkspaceType || undefined;
       }
       return req.get(name);
     },
@@ -415,6 +431,20 @@ export type WorkspaceMutationAuthorityLease = {
     context: WorkspaceCollabContext,
   ) => boolean;
 };
+
+/**
+ * The caller's EXPLICIT `x-od-workspace-type` assertion, or null when the
+ * header is absent or out of enum. This is deliberately NOT the normalized
+ * `workspaceType` (`workspaceResourceContext` collapses a missing header to
+ * `'personal'`): gates that grant a personal-only allowance must key on the
+ * assertion so a Team caller cannot gain it by simply omitting the optional
+ * header. Mirrors `WorkspaceResourceContext.workspaceTypeAsserted` for call
+ * sites that hold only the request.
+ */
+export function assertedWorkspaceScopeType(req: any): 'personal' | 'team' | null {
+  const value = headerValue(req, 'x-od-workspace-type');
+  return value === 'personal' || value === 'team' ? value : null;
+}
 
 export function headerValue(req: any, name: string): string | null {
   const value = req.get(name);
@@ -888,16 +918,22 @@ export async function enforceVerifiedWorkspaceResourceRead(
   const context = workspaceResourceContextFromVerified(verified.context);
   const row = getWorkspaceResource(db, context.workspaceId, resourceId);
   // Design system mirrors project's memberless-legacy allowance: an
-  // unattributed personal row read from a non-team scope is the local user's
-  // own resource (see `isUnattributedLocalPersonalDesignSystemBinding`), so
-  // only attributed rows keep the strict exact-creator requirement.
+  // unattributed personal row is the local user's own resource (see
+  // `isUnattributedLocalPersonalDesignSystemBinding`), so only attributed
+  // rows keep the strict exact-creator requirement. The allowance keys on the
+  // caller's EXPLICIT personal assertion — never the normalized
+  // `workspaceType`, which collapses a missing header to `'personal'` and
+  // would hand the exception to a Team caller that omits the optional header.
+  const assertedPersonalScope =
+    claimed !== null && claimed !== 'missing'
+    && claimed.workspaceTypeAsserted === 'personal';
   const strictPersonalCreator =
     row?.visibility === 'personal'
     && (
       resourceType === 'plugin'
       || resourceType === 'skill'
       || (resourceType === 'design_system'
-        && !(context.workspaceType === 'personal'
+        && !(assertedPersonalScope
           && isUnattributedLocalPersonalDesignSystemBinding(row)))
       || (resourceType === 'project' && row.createdByWorkspaceMemberId != null)
     );

--- a/apps/daemon/src/collab/workspace-resource-mutation.ts
+++ b/apps/daemon/src/collab/workspace-resource-mutation.ts
@@ -151,10 +151,11 @@ export function requestWithWorkspaceNavigationScope(
     : '';
   if (!workspaceId && !workspaceMemberId) return req;
   // The asserted workspace type travels with the identity pair so gates that
-  // key on the caller's EXPLICIT type assertion (`workspaceTypeAsserted`)
-  // treat a navigation read exactly like the header-carrying fetch that
-  // produced the URL. Values outside the enum are ignored, not normalized:
-  // an unasserted or garbled type must stay unasserted (fail-closed).
+  // key on the caller's EXPLICIT type assertion (confirmed through
+  // `verifiedWorkspaceTypeAssertion`) treat a navigation read exactly like
+  // the header-carrying fetch that produced the URL. Values outside the enum
+  // are ignored, not normalized: an unasserted or garbled type must stay
+  // unasserted (fail-closed).
   const queryWorkspaceType = typeof req.query?.workspaceType === 'string'
     && (req.query.workspaceType === 'personal' || req.query.workspaceType === 'team')
     ? req.query.workspaceType
@@ -241,12 +242,22 @@ export function isUnattributedLocalPersonalDesignSystemBinding(
  * gate: does THIS caller reach THIS row through the ruling above?
  *
  * Two facts must both hold — the row is an unattributed personal design-system
- * binding, and the caller's scope EXPLICITLY asserts a personal workspace
- * (`assertedWorkspaceScopeType` / `WorkspaceResourceContext.workspaceTypeAsserted`,
- * never the normalized `workspaceType`, which collapses a missing header to
- * `'personal'`). A personal workspace has exactly one member — the local
- * user — so the assertion is the ownership witness the row itself cannot
- * carry. Read AND mutation gates share this predicate so the UI's capability
+ * binding, and the caller acts in a workspace that membership verification
+ * ESTABLISHED to be personal and that the caller also explicitly asserts to be
+ * personal (`workspaceTypeVerified`, produced only by
+ * {@link verifiedWorkspaceTypeAssertion}). A personal workspace has exactly
+ * one member — the local user — so the verified type is the ownership witness
+ * the row itself cannot carry.
+ *
+ * A raw `x-od-workspace-type` claim is never enough. The Vela verifier
+ * identifies a member by Workspace/member id and returns the directory's own
+ * type without rejecting a mismatched header, and lazy orphan adoption writes
+ * memberless rows into whatever workspace a request names — Team workspaces
+ * included — so a Team member claiming `personal` would otherwise reach every
+ * unattributed row in their Team workspace. The normalized `workspaceType`
+ * is equally unusable: it collapses a missing header to `'personal'`.
+ *
+ * Read AND mutation gates share this predicate so the UI's capability
  * projection (`canMutate`), the mutation routes, project validation, and
  * run-time prompt loading cannot drift apart again. No other resource type
  * has a memberless legacy lane; plugins and skills stay strictly
@@ -255,11 +266,11 @@ export function isUnattributedLocalPersonalDesignSystemBinding(
 export function unattributedLocalPersonalDesignSystemAllowance(
   resourceType: string,
   row: Parameters<typeof isUnattributedLocalPersonalDesignSystemBinding>[0],
-  workspaceTypeAsserted: 'personal' | 'team' | null | undefined,
+  workspaceTypeVerified: 'personal' | 'team' | null | undefined,
 ): boolean {
   return (
     resourceType === 'design_system'
-    && workspaceTypeAsserted === 'personal'
+    && workspaceTypeVerified === 'personal'
     && isUnattributedLocalPersonalDesignSystemBinding(row)
   );
 }
@@ -464,14 +475,117 @@ export type WorkspaceMutationAuthorityLease = {
  * The caller's EXPLICIT `x-od-workspace-type` assertion, or null when the
  * header is absent or out of enum. This is deliberately NOT the normalized
  * `workspaceType` (`workspaceResourceContext` collapses a missing header to
- * `'personal'`): gates that grant a personal-only allowance must key on the
- * assertion so a Team caller cannot gain it by simply omitting the optional
- * header. Mirrors `WorkspaceResourceContext.workspaceTypeAsserted` for call
- * sites that hold only the request.
+ * `'personal'`), so a Team caller cannot pass as personal by simply omitting
+ * the optional header. Mirrors `WorkspaceResourceContext.workspaceTypeAsserted`
+ * for call sites that hold only the request. It is a CLAIM: a gate that
+ * grants something on it must first confirm it through
+ * {@link verifiedWorkspaceTypeAssertion}.
  */
 export function assertedWorkspaceScopeType(req: any): 'personal' | 'team' | null {
   const value = headerValue(req, 'x-od-workspace-type');
   return value === 'personal' || value === 'team' ? value : null;
+}
+
+/**
+ * Where a gate learns what a workspace's type really is.
+ *
+ * `verifiedTypeOf` is the daemon's memo of directory-established types
+ * (`WorkspaceTypeRegistry.verifiedTypeOf`, fed only by successful membership
+ * directory reads — never by request claims). `verify` is the daemon's
+ * request verifier for the lane: the membership directory in the packaged
+ * runtime (`OD_WORKSPACE_CONTEXT_SOURCE=vela`), the explicit request headers
+ * in local/dev, where they are the complete static authority by design.
+ */
+export type WorkspaceTypeWitness = {
+  verifiedTypeOf?: ((workspaceId: string) => 'personal' | 'team' | null) | undefined;
+  verify?: VerifyWorkspaceRequestAuthority | undefined;
+};
+
+/**
+ * The caller's EXPLICIT `x-od-workspace-type` assertion, CONFIRMED by
+ * membership verification — or null.
+ *
+ * Null when the caller asserted nothing (a missing header is not an
+ * assertion), when the daemon knows the workspace to be of another type, or
+ * when nothing can establish the type at all (no witness, verification
+ * failed). Only a confirmed assertion may feed a gate that grants something on
+ * "this workspace is personal" (`unattributedLocalPersonalDesignSystemAllowance`).
+ *
+ * The memo is consulted first so a hot catalog read never re-fetches the
+ * directory for a workspace the daemon has already learned, and so a workspace
+ * the directory has established stays established across an authority outage
+ * (a workspace's type never changes); only a workspace the daemon has no
+ * verified opinion about goes to the verifier, whose result — in the packaged
+ * runtime, the directory item itself — says what the workspace really is.
+ */
+export async function verifiedWorkspaceTypeAssertion(
+  req: any,
+  witness: WorkspaceTypeWitness,
+): Promise<'personal' | 'team' | null> {
+  const asserted = assertedWorkspaceScopeType(req);
+  if (!asserted) return null;
+  const claimed = workspaceResourceContextFromRequest(req);
+  if (claimed === null || claimed === 'missing') return null;
+  const established = witness.verifiedTypeOf?.(claimed.workspaceId) ?? null;
+  if (established) return established === asserted ? asserted : null;
+  if (!witness.verify) return null;
+  const verified = await verifyWorkspaceRequestAuthorityForRequest(req, witness.verify);
+  return verified.ok
+    && verified.context.workspaceId === claimed.workspaceId
+    && verified.context.workspaceType === asserted
+    ? asserted
+    : null;
+}
+
+/**
+ * A witness resolver that settles once. Lanes that hand the decision to the
+ * catalog (`listAllDesignSystems`) pass `resolve`, which the catalog invokes
+ * only when an unattributed personal row is actually in play — a local
+ * catalog read stays off the authority plane otherwise — and read back what
+ * was established through `settled` afterwards (undefined when nothing ever
+ * needed it).
+ */
+export function settledWorkspaceTypeAssertion(
+  resolve: () => Promise<'personal' | 'team' | null>,
+): {
+  resolve: () => Promise<'personal' | 'team' | null>;
+  settled: () => 'personal' | 'team' | null | undefined;
+} {
+  let settled: { value: 'personal' | 'team' | null } | null = null;
+  let pending: Promise<'personal' | 'team' | null> | null = null;
+  return {
+    resolve: () => {
+      if (settled) return Promise.resolve(settled.value);
+      pending ??= resolve().then((value) => {
+        settled = { value };
+        return value;
+      });
+      return pending;
+    },
+    settled: () => settled?.value,
+  };
+}
+
+/**
+ * Present a selected/persisted workspace scope to the verifier as if it were
+ * the request that produced it, so a lane whose identity comes from a stored
+ * partition (project creation's catalog selection) confirms the partition's
+ * type through the same witness a header-carrying request does.
+ */
+export function workspaceScopeRequest(scope: {
+  workspaceId: string;
+  workspaceMemberId: string;
+  workspaceType?: 'personal' | 'team' | null | undefined;
+}): { get(name: string): string | undefined } {
+  return {
+    get(name: string) {
+      const normalized = name.toLowerCase();
+      if (normalized === 'x-od-workspace-id') return scope.workspaceId;
+      if (normalized === 'x-od-workspace-member-id') return scope.workspaceMemberId;
+      if (normalized === 'x-od-workspace-type') return scope.workspaceType ?? undefined;
+      return undefined;
+    },
+  };
 }
 
 export function headerValue(req: any, name: string): string | null {
@@ -604,23 +718,28 @@ function workspaceResourceMutationAllowed(
   capability: WorkspaceResourceMutationCapability,
   options: {
     /**
-     * The caller's EXPLICIT `x-od-workspace-type` claim, threaded by the
-     * verified gate from the REQUEST — not from `ctx`, whose
-     * `workspaceTypeAsserted` is the verifier's normalized type. Only the
-     * legacy local personal design-system allowance reads it.
+     * The caller's explicit type assertion CONFIRMED by membership
+     * verification (`verifiedWorkspaceTypeAssertion`), threaded by the route
+     * that holds the witness. Only the legacy local personal design-system
+     * allowance reads it; absent means no allowance (fail-closed).
      */
-    workspaceTypeAsserted?: 'personal' | 'team' | null;
+    workspaceTypeVerified?: 'personal' | 'team' | null;
   } = {},
 ): boolean {
   if (!row) return false;
   const access = workspaceResourceAccess(row, ctx);
-  // An unattributed personal design-system row reached from an explicitly
-  // personal scope is the local user's own resource
+  // An unattributed personal design-system row reached from a VERIFIED
+  // personal workspace is the local user's own resource
   // (`unattributedLocalPersonalDesignSystemAllowance`). `selfCreated` cannot
-  // witness that — the row records no creator — so the explicit assertion
-  // stands in for it, and every capability then follows the same
-  // frozen/lifecycle/permission checks a self-created row would.
-  if (unattributedLocalPersonalDesignSystemAllowance(resourceType, row, options.workspaceTypeAsserted)) {
+  // witness that — the row records no creator — so the verified type stands
+  // in for it, and every capability then follows the same
+  // frozen/lifecycle/permission checks a self-created row would. The gate's
+  // own verified context must agree too: whatever verifier produced `ctx`,
+  // a Team context never takes this branch.
+  if (
+    ctx.workspaceType === 'personal'
+    && unattributedLocalPersonalDesignSystemAllowance(resourceType, row, options.workspaceTypeVerified)
+  ) {
     return !access.frozen && ctx.canWriteSyncedFiles && ctx.memberStatus === 'active';
   }
   const strictPersonalCreator =
@@ -822,7 +941,17 @@ export async function enforceVerifiedWorkspaceResourceMutation(
   resourceId: string,
   capability: WorkspaceResourceMutationCapability,
   verifyWorkspaceRequestAuthority: VerifyWorkspaceRequestAuthority | undefined,
-  options: { authorityLease?: WorkspaceMutationAuthorityLease } = {},
+  options: {
+    authorityLease?: WorkspaceMutationAuthorityLease;
+    /**
+     * The caller's explicit type assertion confirmed by membership
+     * verification (`verifiedWorkspaceTypeAssertion`). The gate cannot derive
+     * it: for a local data-plane route the verifier it runs is the
+     * header-trusting local resolver, whose context would merely echo the
+     * claim. Only the legacy local personal design-system allowance reads it.
+     */
+    workspaceTypeVerified?: 'personal' | 'team' | null;
+  } = {},
 ): Promise<boolean> {
   // No persisted Workspace binding means this is a genuine legacy/local
   // resource. Preserve that path without inventing a Workspace from ambient
@@ -872,19 +1001,12 @@ export async function enforceVerifiedWorkspaceResourceMutation(
 
   const context = workspaceResourceContextFromVerified(verified.context);
   const row = getWorkspaceResource(db, context.workspaceId, resourceId);
-  // The legacy local personal design-system allowance keys on the caller's
-  // EXPLICIT type claim, read from the request exactly as the read gate below
-  // does — `context.workspaceTypeAsserted` here is the verifier's normalized
-  // type and would hand the exception to a caller that omitted the header.
-  const claimed = workspaceResourceContextFromRequest(req);
-  const workspaceTypeAsserted =
-    claimed !== null && claimed !== 'missing' ? claimed.workspaceTypeAsserted : null;
   if (!workspaceResourceMutationAllowed(
     resourceType,
     row,
     context,
     capability,
-    { workspaceTypeAsserted },
+    { workspaceTypeVerified: options.workspaceTypeVerified ?? null },
   )) {
     const code = row && isWorkspaceResourceLocked(context)
       ? 'WORKSPACE_LOCKED'
@@ -933,6 +1055,12 @@ export async function enforceVerifiedWorkspaceResourceRead(
   options: {
     allowNavigationQuery?: boolean;
     resolveAuthority?: ResolveWorkspaceResourceReadAuthority;
+    /**
+     * The caller's explicit type assertion confirmed by membership
+     * verification (`verifiedWorkspaceTypeAssertion`), threaded by the route
+     * that holds the witness — see `enforceVerifiedWorkspaceResourceMutation`.
+     */
+    workspaceTypeVerified?: 'personal' | 'team' | null;
   } = {},
 ): Promise<boolean> {
   if (!getWorkspaceResourceByResourceId(db, resourceId)) return true;
@@ -972,21 +1100,27 @@ export async function enforceVerifiedWorkspaceResourceRead(
   const context = workspaceResourceContextFromVerified(verified.context);
   const row = getWorkspaceResource(db, context.workspaceId, resourceId);
   // Design system mirrors project's memberless-legacy allowance: an
-  // unattributed personal row is the local user's own resource (see
-  // `unattributedLocalPersonalDesignSystemAllowance`), so only attributed
-  // rows keep the strict exact-creator requirement. The allowance keys on the
-  // caller's EXPLICIT personal assertion — never the normalized
-  // `workspaceType`, which collapses a missing header to `'personal'` and
-  // would hand the exception to a Team caller that omits the optional header.
-  const workspaceTypeAsserted =
-    claimed !== null && claimed !== 'missing' ? claimed.workspaceTypeAsserted : null;
+  // unattributed personal row in a VERIFIED personal workspace is the local
+  // user's own resource (see `unattributedLocalPersonalDesignSystemAllowance`),
+  // so only attributed rows keep the strict exact-creator requirement. The
+  // allowance keys on the route-confirmed assertion, and the gate's own
+  // verified context must agree — never on the raw claim, and never on the
+  // normalized `workspaceType`, which collapses a missing header to
+  // `'personal'`.
   const strictPersonalCreator =
     row?.visibility === 'personal'
     && (
       resourceType === 'plugin'
       || resourceType === 'skill'
       || (resourceType === 'design_system'
-        && !unattributedLocalPersonalDesignSystemAllowance(resourceType, row, workspaceTypeAsserted))
+        && !(
+          context.workspaceType === 'personal'
+          && unattributedLocalPersonalDesignSystemAllowance(
+            resourceType,
+            row,
+            options.workspaceTypeVerified ?? null,
+          )
+        ))
       || (resourceType === 'project' && row.createdByWorkspaceMemberId != null)
     );
   if (

--- a/apps/daemon/src/collab/workspace-resource-mutation.ts
+++ b/apps/daemon/src/collab/workspace-resource-mutation.ts
@@ -237,6 +237,34 @@ export function isUnattributedLocalPersonalDesignSystemBinding(
 }
 
 /**
+ * The legacy local personal design-system allowance, decided once for every
+ * gate: does THIS caller reach THIS row through the ruling above?
+ *
+ * Two facts must both hold — the row is an unattributed personal design-system
+ * binding, and the caller's scope EXPLICITLY asserts a personal workspace
+ * (`assertedWorkspaceScopeType` / `WorkspaceResourceContext.workspaceTypeAsserted`,
+ * never the normalized `workspaceType`, which collapses a missing header to
+ * `'personal'`). A personal workspace has exactly one member — the local
+ * user — so the assertion is the ownership witness the row itself cannot
+ * carry. Read AND mutation gates share this predicate so the UI's capability
+ * projection (`canMutate`), the mutation routes, project validation, and
+ * run-time prompt loading cannot drift apart again. No other resource type
+ * has a memberless legacy lane; plugins and skills stay strictly
+ * creator-bound.
+ */
+export function unattributedLocalPersonalDesignSystemAllowance(
+  resourceType: string,
+  row: Parameters<typeof isUnattributedLocalPersonalDesignSystemBinding>[0],
+  workspaceTypeAsserted: 'personal' | 'team' | null | undefined,
+): boolean {
+  return (
+    resourceType === 'design_system'
+    && workspaceTypeAsserted === 'personal'
+    && isUnattributedLocalPersonalDesignSystemBinding(row)
+  );
+}
+
+/**
  * Resolve Workspace identity for daemon-local data-plane work.
  *
  * The browser's Workspace headers are attribution and namespace selectors on
@@ -574,9 +602,27 @@ function workspaceResourceMutationAllowed(
   row: WorkspaceResourceAccessInput | null | undefined,
   ctx: WorkspaceResourceContext,
   capability: WorkspaceResourceMutationCapability,
+  options: {
+    /**
+     * The caller's EXPLICIT `x-od-workspace-type` claim, threaded by the
+     * verified gate from the REQUEST — not from `ctx`, whose
+     * `workspaceTypeAsserted` is the verifier's normalized type. Only the
+     * legacy local personal design-system allowance reads it.
+     */
+    workspaceTypeAsserted?: 'personal' | 'team' | null;
+  } = {},
 ): boolean {
   if (!row) return false;
   const access = workspaceResourceAccess(row, ctx);
+  // An unattributed personal design-system row reached from an explicitly
+  // personal scope is the local user's own resource
+  // (`unattributedLocalPersonalDesignSystemAllowance`). `selfCreated` cannot
+  // witness that — the row records no creator — so the explicit assertion
+  // stands in for it, and every capability then follows the same
+  // frozen/lifecycle/permission checks a self-created row would.
+  if (unattributedLocalPersonalDesignSystemAllowance(resourceType, row, options.workspaceTypeAsserted)) {
+    return !access.frozen && ctx.canWriteSyncedFiles && ctx.memberStatus === 'active';
+  }
   const strictPersonalCreator =
     row.visibility === 'personal'
     && (
@@ -826,11 +872,19 @@ export async function enforceVerifiedWorkspaceResourceMutation(
 
   const context = workspaceResourceContextFromVerified(verified.context);
   const row = getWorkspaceResource(db, context.workspaceId, resourceId);
+  // The legacy local personal design-system allowance keys on the caller's
+  // EXPLICIT type claim, read from the request exactly as the read gate below
+  // does — `context.workspaceTypeAsserted` here is the verifier's normalized
+  // type and would hand the exception to a caller that omitted the header.
+  const claimed = workspaceResourceContextFromRequest(req);
+  const workspaceTypeAsserted =
+    claimed !== null && claimed !== 'missing' ? claimed.workspaceTypeAsserted : null;
   if (!workspaceResourceMutationAllowed(
     resourceType,
     row,
     context,
     capability,
+    { workspaceTypeAsserted },
   )) {
     const code = row && isWorkspaceResourceLocked(context)
       ? 'WORKSPACE_LOCKED'
@@ -919,22 +973,20 @@ export async function enforceVerifiedWorkspaceResourceRead(
   const row = getWorkspaceResource(db, context.workspaceId, resourceId);
   // Design system mirrors project's memberless-legacy allowance: an
   // unattributed personal row is the local user's own resource (see
-  // `isUnattributedLocalPersonalDesignSystemBinding`), so only attributed
+  // `unattributedLocalPersonalDesignSystemAllowance`), so only attributed
   // rows keep the strict exact-creator requirement. The allowance keys on the
   // caller's EXPLICIT personal assertion — never the normalized
   // `workspaceType`, which collapses a missing header to `'personal'` and
   // would hand the exception to a Team caller that omits the optional header.
-  const assertedPersonalScope =
-    claimed !== null && claimed !== 'missing'
-    && claimed.workspaceTypeAsserted === 'personal';
+  const workspaceTypeAsserted =
+    claimed !== null && claimed !== 'missing' ? claimed.workspaceTypeAsserted : null;
   const strictPersonalCreator =
     row?.visibility === 'personal'
     && (
       resourceType === 'plugin'
       || resourceType === 'skill'
       || (resourceType === 'design_system'
-        && !(assertedPersonalScope
-          && isUnattributedLocalPersonalDesignSystemBinding(row)))
+        && !unattributedLocalPersonalDesignSystemAllowance(resourceType, row, workspaceTypeAsserted))
       || (resourceType === 'project' && row.createdByWorkspaceMemberId != null)
     );
   if (

--- a/apps/daemon/src/design-systems/server-services.ts
+++ b/apps/daemon/src/design-systems/server-services.ts
@@ -11,6 +11,7 @@ import {
   getWorkspaceResourceByResourceId,
 } from '../db.js';
 import { workspaceTeamSkillBindingAllowsRead } from '../skills/workspace-team-binding.js';
+import { isUnattributedLocalPersonalDesignSystemBinding } from '../collab/workspace-resource-mutation.js';
 import { workspaceTeamDesignSystemBindingAllowsRead } from './workspace-team-binding.js';
 
 type JsonRecord = Record<string, unknown>;
@@ -66,9 +67,21 @@ type DesignSystemListOptions = {
   workspaceId?: string | null;
 };
 
+/**
+ * How the caller's Workspace scope was asserted. Requests normalize the
+ * `x-od-workspace-type` header exactly like `workspaceResourceContext`
+ * (collab/workspace-resource-mutation.ts): `'team'` only on an explicit
+ * assertion, `'personal'` otherwise. Gates below treat only an explicit
+ * `'personal'` as eligible for the legacy unattributed-binding allowance, so
+ * a caller that does not thread the type stays on the strict pre-existing
+ * behavior (fail-closed).
+ */
+type DesignSystemWorkspaceScopeType = 'personal' | 'team';
+
 type DesignSystemWorkspaceOptions = {
   workspaceId?: string | null;
   workspaceMemberId?: string | null;
+  workspaceType?: DesignSystemWorkspaceScopeType | null;
   /** A verified Team binding forbids same-id Personal fallback. */
   exactTeam?: boolean;
 };
@@ -84,24 +97,38 @@ export type DesignSystemAssetSyncOutcome =
  * `workspaceId` claim while the envelope keeps the binding correct (issue
  * #6763), so the envelope alone must decide for `visibility: 'personal'`
  * systems. Mirrors `skillVisibleFromBinding` in `skills.ts`.
+ *
+ * A personal binding is readable by its exact recorded creator member — or,
+ * when the row is unattributed (see
+ * {@link isUnattributedLocalPersonalDesignSystemBinding}), by any member of
+ * the same workspace whose scope explicitly asserts a non-team (`'personal'`)
+ * workspace, mirroring the projects-layer ruling for memberless legacy rows.
  */
 function designSystemBindingAllowsRead(
   binding: ReturnType<typeof getWorkspaceResourceByResourceId>,
   workspaceId: string,
   workspaceMemberId: string,
+  workspaceType?: DesignSystemWorkspaceScopeType | null,
 ): boolean {
-  return Boolean(
-    binding
-    && binding.workspaceId === workspaceId
-    && binding.visibility === 'personal'
-    && binding.resourceState !== 'deleted'
-    && binding.createdByWorkspaceMemberId === workspaceMemberId,
+  if (
+    !binding
+    || binding.workspaceId !== workspaceId
+    || binding.visibility !== 'personal'
+    || binding.resourceState === 'deleted'
+  ) {
+    return false;
+  }
+  if (binding.createdByWorkspaceMemberId === workspaceMemberId) return true;
+  return (
+    workspaceType === 'personal'
+    && isUnattributedLocalPersonalDesignSystemBinding(binding)
   );
 }
 
 type DesignSystemUserReadScope = {
   workspaceId?: string | null;
   workspaceMemberId?: string | null;
+  workspaceType?: DesignSystemWorkspaceScopeType | null;
 };
 
 /**
@@ -112,7 +139,10 @@ type DesignSystemUserReadScope = {
  * stays readable after a re-finalize dropped its metadata claim; otherwise
  * keep the current metadata-gated read so claimed/hidden states behave as
  * before. An explicit signed-out/incomplete scope hides envelope-bound
- * systems, mirroring the catalog lane (spec 04 §10).
+ * systems, mirroring the catalog lane (spec 04 §10) — except an unattributed
+ * local personal envelope (see
+ * {@link isUnattributedLocalPersonalDesignSystemBinding}), which stays
+ * readable to local callers in every lane.
  */
 function designSystemUserReadOptions(
   db: Database.Database | undefined,
@@ -128,13 +158,28 @@ function designSystemUserReadOptions(
   if (scope.workspaceId !== undefined && (!workspaceId || !workspaceMemberId)) {
     // Explicit signed-out/incomplete scope (`null`, `''`, or a memberless
     // positive workspace): a persisted envelope is positive evidence the
-    // resource is not local-public and must stay hidden.
-    if (db && getWorkspaceResourceByResourceId(db, 'design_system', id)) return null;
+    // resource is not local-public and must stay hidden — UNLESS the envelope
+    // itself is an unattributed local personal claim (the backfill's output
+    // on a never-signed-in install), which is the local user's own resource
+    // and must stay readable to local callers. For the memberless positive
+    // workspace lane the claim must additionally name that exact workspace.
+    if (db) {
+      const binding = getWorkspaceResourceByResourceId(db, 'design_system', id);
+      if (binding) {
+        if (
+          isUnattributedLocalPersonalDesignSystemBinding(binding)
+          && (!workspaceId || binding.workspaceId === workspaceId)
+        ) {
+          return { idPrefix: 'user:' };
+        }
+        return null;
+      }
+    }
     return metadataGated;
   }
   if (!db || !workspaceId || !workspaceMemberId) return metadataGated;
   const binding = getWorkspaceResourceByResourceId(db, 'design_system', id);
-  if (designSystemBindingAllowsRead(binding, workspaceId, workspaceMemberId)) {
+  if (designSystemBindingAllowsRead(binding, workspaceId, workspaceMemberId, scope.workspaceType)) {
     // Issue #6763: the binding is authoritative even when a re-finalize
     // dropped `workspaceId` from metadata.json — read the FS copy unscoped.
     return { idPrefix: 'user:' };
@@ -230,6 +275,19 @@ export function createDesignSystemServerServices({
     designSystem: DesignSystemSummary,
   ) => void;
 }) {
+  // Hiding a resource from the catalog must never be silent: this class of
+  // bug otherwise gets diagnosed by reverse-engineering the filter. One line
+  // per (system, scope, reason) per daemon lifetime keeps a hot, frequently
+  // polled list endpoint from spamming the log while still answering "why is
+  // my system not in the list" from the daemon log alone.
+  const loggedCatalogHides = new Set<string>();
+  function logCatalogHide(systemId: string, scope: string, reason: string): void {
+    const key = `${systemId}\u0000${scope}\u0000${reason}`;
+    if (loggedCatalogHides.has(key)) return;
+    loggedCatalogHides.add(key);
+    console.warn(`[design-systems] catalog hid ${systemId} (${scope}): ${reason}`);
+  }
+
   /**
    * The functional-skills catalog. `workspaceId` narrows it to the
    * user-imported skills that workspace may see (mirrors
@@ -355,11 +413,21 @@ export function createDesignSystemServerServices({
    * the system correctly bound, so the metadata alone must never decide. The
    * signed-out lane hides BOTH envelope-bound systems and metadata-claimed
    * systems (spec 04 §10) — only genuinely unclaimed resources stay visible
-   * to a headerless caller.
+   * to a headerless caller, plus resources whose envelope is an unattributed
+   * local personal claim (see
+   * {@link isUnattributedLocalPersonalDesignSystemBinding}): that shape is
+   * the startup backfill's own output on an install that never signed into a
+   * Workspace, and hiding it would leave the resource with no readable lane
+   * at all.
+   *
+   * Every hide decision below logs its reason once per daemon lifetime, so
+   * "why is my system not in the list" is answerable from the daemon log
+   * instead of by reverse-engineering this filter.
    */
   async function listAllDesignSystems(options: {
     workspaceId?: string | null;
     workspaceMemberId?: string | null;
+    workspaceType?: DesignSystemWorkspaceScopeType | null;
     exactTeam?: boolean;
   } = {}) {
     const builtIn = (await designSystems.listDesignSystems(paths.DESIGN_SYSTEMS_DIR)).map((s) => ({
@@ -429,31 +497,74 @@ export function createDesignSystemServerServices({
     const exactWorkspaceId = options.workspaceId?.trim() ?? '';
     const exactMemberId = options.workspaceMemberId?.trim() ?? '';
     const db = getDb?.();
+    const scopeLabel = exactWorkspaceId || exactMemberId
+      ? `workspace=${exactWorkspaceId || '(none)'} member=${exactMemberId || '(none)'}`
+      : 'signed-out';
     return catalog.filter((system) => {
       if (system.source !== 'user') return true;
       // A fully headerless request is the signed-out/local compatibility
       // lane. It may see resources that have never been claimed by any
       // Workspace, but both a persisted binding and a metadata claim are
       // positive evidence that the resource is not local-public and must stay
-      // hidden without authority (spec 04 §10, issue #6763).
+      // hidden without authority (spec 04 §10, issue #6763) — except an
+      // unattributed local personal binding, which is the local user's own.
       if (!exactWorkspaceId && !exactMemberId) {
-        if (!db) return false;
-        return !system.workspaceId?.trim()
-          && !getWorkspaceResourceByResourceId(
-            db,
-            'design_system',
-            system.id,
-          );
+        if (!db) {
+          logCatalogHide(system.id, scopeLabel, 'no database open for the signed-out catalog');
+          return false;
+        }
+        const binding = getWorkspaceResourceByResourceId(db, 'design_system', system.id);
+        if (binding) {
+          if (isUnattributedLocalPersonalDesignSystemBinding(binding)) return true;
+          logCatalogHide(system.id, scopeLabel, 'bound to a Workspace; a signed-out caller cannot read it');
+          return false;
+        }
+        if (system.workspaceId?.trim()) {
+          logCatalogHide(system.id, scopeLabel, 'metadata claims a Workspace; a signed-out caller cannot read it');
+          return false;
+        }
+        return true;
       }
       if (system.teamSynced === true) {
-        return Boolean(exactWorkspaceId) && system.workspaceId === exactWorkspaceId;
+        if (Boolean(exactWorkspaceId) && system.workspaceId === exactWorkspaceId) return true;
+        logCatalogHide(system.id, scopeLabel, 'team mirror belongs to another Workspace');
+        return false;
       }
-      if (!db || !exactWorkspaceId || !exactMemberId) return false;
-      return designSystemBindingAllowsRead(
-        getWorkspaceResourceByResourceId(db, 'design_system', system.id),
-        exactWorkspaceId,
-        exactMemberId,
+      if (!db || !exactWorkspaceId) {
+        logCatalogHide(system.id, scopeLabel, 'incomplete Workspace scope');
+        return false;
+      }
+      const binding = getWorkspaceResourceByResourceId(db, 'design_system', system.id);
+      if (!exactMemberId) {
+        // A workspace-bound caller with NO member identity of its own — a
+        // legacy memberless project driving a run — may read exactly the
+        // resources that are equally unattributed in its own workspace.
+        if (
+          binding?.workspaceId === exactWorkspaceId
+          && isUnattributedLocalPersonalDesignSystemBinding(binding)
+        ) {
+          return true;
+        }
+        logCatalogHide(system.id, scopeLabel, 'memberless scope may only read unattributed bindings of its own workspace');
+        return false;
+      }
+      if (designSystemBindingAllowsRead(binding, exactWorkspaceId, exactMemberId, options.workspaceType)) {
+        return true;
+      }
+      logCatalogHide(
+        system.id,
+        scopeLabel,
+        !binding
+          ? 'unclaimed systems are quarantined from explicit Workspace scopes'
+          : binding.workspaceId !== exactWorkspaceId
+            ? 'bound to another Workspace'
+            : binding.resourceState === 'deleted'
+              ? 'binding is tombstoned'
+              : binding.visibility !== 'personal'
+                ? 'team-visibility binding requires the Team catalog lane'
+                : 'personal binding belongs to another member',
       );
+      return false;
     });
   }
 

--- a/apps/daemon/src/design-systems/server-services.ts
+++ b/apps/daemon/src/design-systems/server-services.ts
@@ -68,12 +68,13 @@ type DesignSystemListOptions = {
 };
 
 /**
- * How the caller's Workspace scope was asserted. Requests normalize the
- * `x-od-workspace-type` header exactly like `workspaceResourceContext`
- * (collab/workspace-resource-mutation.ts): `'team'` only on an explicit
- * assertion, `'personal'` otherwise. Gates below treat only an explicit
- * `'personal'` as eligible for the legacy unattributed-binding allowance, so
- * a caller that does not thread the type stays on the strict pre-existing
+ * The caller's EXPLICIT Workspace-type assertion (the raw
+ * `x-od-workspace-type` claim, `assertedWorkspaceScopeType` in
+ * collab/workspace-resource-mutation.ts) — never the normalized
+ * `workspaceType`, which collapses a missing header to `'personal'`. Gates
+ * below grant the legacy unattributed-binding allowance only on an explicit
+ * `'personal'` assertion, so a caller that omits the optional header — or a
+ * lane that never threads the assertion — stays on the strict pre-existing
  * behavior (fail-closed).
  */
 type DesignSystemWorkspaceScopeType = 'personal' | 'team';
@@ -81,7 +82,7 @@ type DesignSystemWorkspaceScopeType = 'personal' | 'team';
 type DesignSystemWorkspaceOptions = {
   workspaceId?: string | null;
   workspaceMemberId?: string | null;
-  workspaceType?: DesignSystemWorkspaceScopeType | null;
+  workspaceTypeAsserted?: DesignSystemWorkspaceScopeType | null;
   /** A verified Team binding forbids same-id Personal fallback. */
   exactTeam?: boolean;
 };
@@ -101,14 +102,15 @@ export type DesignSystemAssetSyncOutcome =
  * A personal binding is readable by its exact recorded creator member — or,
  * when the row is unattributed (see
  * {@link isUnattributedLocalPersonalDesignSystemBinding}), by any member of
- * the same workspace whose scope explicitly asserts a non-team (`'personal'`)
- * workspace, mirroring the projects-layer ruling for memberless legacy rows.
+ * the same workspace whose scope EXPLICITLY asserts a personal workspace.
+ * An unasserted type is not an assertion — the allowance stays off. This
+ * mirrors the projects-layer ruling for memberless legacy rows.
  */
 function designSystemBindingAllowsRead(
   binding: ReturnType<typeof getWorkspaceResourceByResourceId>,
   workspaceId: string,
   workspaceMemberId: string,
-  workspaceType?: DesignSystemWorkspaceScopeType | null,
+  workspaceTypeAsserted?: DesignSystemWorkspaceScopeType | null,
 ): boolean {
   if (
     !binding
@@ -120,7 +122,7 @@ function designSystemBindingAllowsRead(
   }
   if (binding.createdByWorkspaceMemberId === workspaceMemberId) return true;
   return (
-    workspaceType === 'personal'
+    workspaceTypeAsserted === 'personal'
     && isUnattributedLocalPersonalDesignSystemBinding(binding)
   );
 }
@@ -128,7 +130,7 @@ function designSystemBindingAllowsRead(
 type DesignSystemUserReadScope = {
   workspaceId?: string | null;
   workspaceMemberId?: string | null;
-  workspaceType?: DesignSystemWorkspaceScopeType | null;
+  workspaceTypeAsserted?: DesignSystemWorkspaceScopeType | null;
 };
 
 /**
@@ -179,7 +181,7 @@ function designSystemUserReadOptions(
   }
   if (!db || !workspaceId || !workspaceMemberId) return metadataGated;
   const binding = getWorkspaceResourceByResourceId(db, 'design_system', id);
-  if (designSystemBindingAllowsRead(binding, workspaceId, workspaceMemberId, scope.workspaceType)) {
+  if (designSystemBindingAllowsRead(binding, workspaceId, workspaceMemberId, scope.workspaceTypeAsserted)) {
     // Issue #6763: the binding is authoritative even when a re-finalize
     // dropped `workspaceId` from metadata.json — read the FS copy unscoped.
     return { idPrefix: 'user:' };
@@ -427,7 +429,7 @@ export function createDesignSystemServerServices({
   async function listAllDesignSystems(options: {
     workspaceId?: string | null;
     workspaceMemberId?: string | null;
-    workspaceType?: DesignSystemWorkspaceScopeType | null;
+    workspaceTypeAsserted?: DesignSystemWorkspaceScopeType | null;
     exactTeam?: boolean;
   } = {}) {
     const builtIn = (await designSystems.listDesignSystems(paths.DESIGN_SYSTEMS_DIR)).map((s) => ({
@@ -548,7 +550,7 @@ export function createDesignSystemServerServices({
         logCatalogHide(system.id, scopeLabel, 'memberless scope may only read unattributed bindings of its own workspace');
         return false;
       }
-      if (designSystemBindingAllowsRead(binding, exactWorkspaceId, exactMemberId, options.workspaceType)) {
+      if (designSystemBindingAllowsRead(binding, exactWorkspaceId, exactMemberId, options.workspaceTypeAsserted)) {
         return true;
       }
       logCatalogHide(
@@ -562,7 +564,9 @@ export function createDesignSystemServerServices({
               ? 'binding is tombstoned'
               : binding.visibility !== 'personal'
                 ? 'team-visibility binding requires the Team catalog lane'
-                : 'personal binding belongs to another member',
+                : isUnattributedLocalPersonalDesignSystemBinding(binding)
+                  ? 'unattributed binding requires an explicitly asserted personal scope'
+                  : 'personal binding belongs to another member',
       );
       return false;
     });

--- a/apps/daemon/src/design-systems/server-services.ts
+++ b/apps/daemon/src/design-systems/server-services.ts
@@ -71,21 +71,43 @@ type DesignSystemListOptions = {
 };
 
 /**
- * The caller's EXPLICIT Workspace-type assertion (the raw
- * `x-od-workspace-type` claim, `assertedWorkspaceScopeType` in
- * collab/workspace-resource-mutation.ts) — never the normalized
- * `workspaceType`, which collapses a missing header to `'personal'`. Gates
- * below grant the legacy unattributed-binding allowance only on an explicit
- * `'personal'` assertion, so a caller that omits the optional header — or a
- * lane that never threads the assertion — stays on the strict pre-existing
- * behavior (fail-closed).
+ * The caller's EXPLICIT Workspace-type assertion CONFIRMED by membership
+ * verification (`verifiedWorkspaceTypeAssertion` in
+ * collab/workspace-resource-mutation.ts) — never the raw
+ * `x-od-workspace-type` claim, and never the normalized `workspaceType`,
+ * which collapses a missing header to `'personal'`. Gates below grant the
+ * legacy unattributed-binding allowance only on a verified `'personal'`
+ * workspace, so a caller that omits the optional header, a caller whose claim
+ * the membership directory contradicts, or a lane that never threads the
+ * witness stays on the strict pre-existing behavior (fail-closed).
  */
 type DesignSystemWorkspaceScopeType = 'personal' | 'team';
+
+/**
+ * How a lane hands the verified type to the catalog: as a settled value, or
+ * as a resolver the catalog invokes only when the decision actually needs it
+ * — an unattributed personal binding is in the caller's workspace. The
+ * witness behind a resolver may consult the daemon's request verifier (the
+ * membership directory in the packaged runtime), and a local catalog read
+ * must stay off that plane unless a legacy row demands it.
+ */
+export type DesignSystemWorkspaceTypeVerifiedInput =
+  | DesignSystemWorkspaceScopeType
+  | null
+  | (() => Promise<DesignSystemWorkspaceScopeType | null>);
+
+async function resolveWorkspaceTypeVerified(
+  input: DesignSystemWorkspaceTypeVerifiedInput | undefined,
+  needed: () => boolean,
+): Promise<DesignSystemWorkspaceScopeType | null> {
+  if (typeof input !== 'function') return input ?? null;
+  return needed() ? await input() : null;
+}
 
 type DesignSystemWorkspaceOptions = {
   workspaceId?: string | null;
   workspaceMemberId?: string | null;
-  workspaceTypeAsserted?: DesignSystemWorkspaceScopeType | null;
+  workspaceTypeVerified?: DesignSystemWorkspaceScopeType | null;
   /** A verified Team binding forbids same-id Personal fallback. */
   exactTeam?: boolean;
 };
@@ -110,15 +132,15 @@ export type DesignSystemAssetSyncOutcome =
  * readable by:
  *
  * - its exact recorded creator member;
- * - any member of that workspace whose scope EXPLICITLY asserts a personal
- *   workspace, when the row is unattributed
+ * - any member of that workspace whose explicit personal assertion membership
+ *   verification confirmed, when the row is unattributed
  *   ({@link unattributedLocalPersonalDesignSystemAllowance});
  * - a workspace-bound caller with NO member identity of its own, when the
  *   row is equally unattributed — a legacy memberless project's persisted
  *   scope may read exactly the unattributed bindings of its own workspace.
  *
- * An unasserted type is not an assertion — the allowance stays off. This
- * mirrors the projects-layer ruling for memberless legacy rows.
+ * An unasserted or unconfirmed type is not a witness — the allowance stays
+ * off. This mirrors the projects-layer ruling for memberless legacy rows.
  */
 export function designSystemPersonalBindingReadable(
   binding: ReturnType<typeof getWorkspaceResourceByResourceId>,
@@ -140,7 +162,7 @@ export function designSystemPersonalBindingReadable(
   return unattributedLocalPersonalDesignSystemAllowance(
     'design_system',
     binding,
-    scope.workspaceTypeAsserted,
+    scope.workspaceTypeVerified,
   );
 }
 
@@ -152,13 +174,13 @@ export function designSystemPersonalBindingReadable(
 export type DesignSystemPersonalBindingScope = {
   workspaceId: string;
   workspaceMemberId: string;
-  workspaceTypeAsserted?: DesignSystemWorkspaceScopeType | null;
+  workspaceTypeVerified?: DesignSystemWorkspaceScopeType | null;
 };
 
 type DesignSystemUserReadScope = {
   workspaceId?: string | null;
   workspaceMemberId?: string | null;
-  workspaceTypeAsserted?: DesignSystemWorkspaceScopeType | null;
+  workspaceTypeVerified?: DesignSystemWorkspaceScopeType | null;
 };
 
 /**
@@ -213,7 +235,7 @@ function designSystemUserReadOptions(
   if (designSystemPersonalBindingReadable(binding, {
     workspaceId,
     workspaceMemberId,
-    workspaceTypeAsserted: scope.workspaceTypeAsserted ?? null,
+    workspaceTypeVerified: scope.workspaceTypeVerified ?? null,
   })) {
     // Issue #6763: the binding is authoritative even when a re-finalize
     // dropped `workspaceId` from metadata.json — read the FS copy unscoped.
@@ -462,7 +484,7 @@ export function createDesignSystemServerServices({
   async function listAllDesignSystems(options: {
     workspaceId?: string | null;
     workspaceMemberId?: string | null;
-    workspaceTypeAsserted?: DesignSystemWorkspaceScopeType | null;
+    workspaceTypeVerified?: DesignSystemWorkspaceTypeVerifiedInput;
     exactTeam?: boolean;
   } = {}) {
     const builtIn = (await designSystems.listDesignSystems(paths.DESIGN_SYSTEMS_DIR)).map((s) => ({
@@ -535,6 +557,19 @@ export function createDesignSystemServerServices({
     const scopeLabel = exactWorkspaceId || exactMemberId
       ? `workspace=${exactWorkspaceId || '(none)'} member=${exactMemberId || '(none)'}`
       : 'signed-out';
+    // Settle the witness only if an unattributed personal binding of this
+    // exact workspace is in the catalog — the one shape the allowance can
+    // grant — so a scoped read of attributed systems never consults it.
+    const workspaceTypeVerified = await resolveWorkspaceTypeVerified(
+      options.workspaceTypeVerified,
+      () => catalog.some((system) => {
+        if (!db || !exactWorkspaceId || !exactMemberId) return false;
+        if (system.source !== 'user' || system.teamSynced === true) return false;
+        const binding = getWorkspaceResourceByResourceId(db, 'design_system', system.id);
+        return binding?.workspaceId === exactWorkspaceId
+          && isUnattributedLocalPersonalDesignSystemBinding(binding);
+      }),
+    );
     return catalog.filter((system) => {
       if (system.source !== 'user') return true;
       // A fully headerless request is the signed-out/local compatibility
@@ -573,7 +608,7 @@ export function createDesignSystemServerServices({
       if (designSystemPersonalBindingReadable(binding, {
         workspaceId: exactWorkspaceId,
         workspaceMemberId: exactMemberId,
-        workspaceTypeAsserted: options.workspaceTypeAsserted ?? null,
+        workspaceTypeVerified,
       })) {
         return true;
       }
@@ -591,7 +626,7 @@ export function createDesignSystemServerServices({
                 : !exactMemberId
                   ? 'memberless scope may only read unattributed bindings of its own workspace'
                   : isUnattributedLocalPersonalDesignSystemBinding(binding)
-                    ? 'unattributed binding requires an explicitly asserted personal scope'
+                    ? 'unattributed binding requires a verified personal workspace scope'
                     : 'personal binding belongs to another member',
       );
       return false;
@@ -692,7 +727,7 @@ export function createDesignSystemServerServices({
     options: {
       workspaceId?: string | null;
       workspaceMemberId?: string | null;
-      workspaceTypeAsserted?: DesignSystemWorkspaceScopeType | null;
+      workspaceTypeVerified?: DesignSystemWorkspaceTypeVerifiedInput;
     } = {},
   ) {
     // Product boundary: this validator identifies the item in the daemon's
@@ -794,7 +829,7 @@ export function createDesignSystemServerServices({
    * own, so reopening the editor reuses it instead of forking a
    * workspace-scoped copy? The design system's editing project inherits the
    * same ruling as its resource binding: a legacy memberless personal row in
-   * the caller's EXPLICITLY personal workspace is the local user's own
+   * the caller's VERIFIED personal workspace is the local user's own
    * editing project, not another member's — forking it would open an editor
    * whose edits run-time prompt loading (which reads `summary.projectId`)
    * never sees.
@@ -804,7 +839,7 @@ export function createDesignSystemServerServices({
     summary: DesignSystemSummary,
     workspaceId: string,
     workspaceMemberId: string,
-    workspaceTypeAsserted: DesignSystemWorkspaceScopeType | null,
+    workspaceTypeVerified: DesignSystemWorkspaceScopeType | null,
   ) {
     if (!binding || binding.workspaceId !== workspaceId || binding.resourceState === 'deleted') {
       return false;
@@ -813,7 +848,7 @@ export function createDesignSystemServerServices({
     return binding.visibility === 'personal'
       && (
         binding.createdByWorkspaceMemberId === workspaceMemberId
-        || unattributedLocalPersonalDesignSystemAllowance('design_system', binding, workspaceTypeAsserted)
+        || unattributedLocalPersonalDesignSystemAllowance('design_system', binding, workspaceTypeVerified)
       );
   }
 
@@ -831,13 +866,13 @@ export function createDesignSystemServerServices({
     // what allowed a Team operation to mutate a same-id Personal project.
     if (isScoped && (!workspaceId || !workspaceMemberId)) return null;
 
-    const workspaceTypeAsserted = options.workspaceTypeAsserted ?? null;
+    const workspaceTypeVerified = options.workspaceTypeVerified ?? null;
     const systems = await listAllDesignSystems(
       isScoped
         ? {
             workspaceId,
             workspaceMemberId,
-            workspaceTypeAsserted,
+            workspaceTypeVerified,
             ...(options.exactTeam !== undefined ? { exactTeam: options.exactTeam } : {}),
           }
         : {},
@@ -863,7 +898,7 @@ export function createDesignSystemServerServices({
         summary,
         workspaceId,
         workspaceMemberId,
-        workspaceTypeAsserted,
+        workspaceTypeVerified,
       );
       if (existing && !exactBinding) {
         projectId = workspaceScopedDesignSystemProjectId(id, workspaceId);
@@ -877,7 +912,7 @@ export function createDesignSystemServerServices({
           summary,
           workspaceId,
           workspaceMemberId,
-          workspaceTypeAsserted,
+          workspaceTypeVerified,
         )) {
           return null;
         }

--- a/apps/daemon/src/design-systems/server-services.ts
+++ b/apps/daemon/src/design-systems/server-services.ts
@@ -11,7 +11,10 @@ import {
   getWorkspaceResourceByResourceId,
 } from '../db.js';
 import { workspaceTeamSkillBindingAllowsRead } from '../skills/workspace-team-binding.js';
-import { isUnattributedLocalPersonalDesignSystemBinding } from '../collab/workspace-resource-mutation.js';
+import {
+  isUnattributedLocalPersonalDesignSystemBinding,
+  unattributedLocalPersonalDesignSystemAllowance,
+} from '../collab/workspace-resource-mutation.js';
 import { workspaceTeamDesignSystemBindingAllowsRead } from './workspace-team-binding.js';
 
 type JsonRecord = Record<string, unknown>;
@@ -99,33 +102,58 @@ export type DesignSystemAssetSyncOutcome =
  * #6763), so the envelope alone must decide for `visibility: 'personal'`
  * systems. Mirrors `skillVisibleFromBinding` in `skills.ts`.
  *
- * A personal binding is readable by its exact recorded creator member — or,
- * when the row is unattributed (see
- * {@link isUnattributedLocalPersonalDesignSystemBinding}), by any member of
- * the same workspace whose scope EXPLICITLY asserts a personal workspace.
+ * This is THE read decision for a `visibility: 'personal'` binding, shared by
+ * the catalog filter, the detail/static read options, project validation
+ * (`validateProjectDesignSystemId`), and run-time prompt loading
+ * (`designSystemVisibleToRun` in server.ts), so no two of them can disagree
+ * about the same row. A personal binding in the scope's workspace is
+ * readable by:
+ *
+ * - its exact recorded creator member;
+ * - any member of that workspace whose scope EXPLICITLY asserts a personal
+ *   workspace, when the row is unattributed
+ *   ({@link unattributedLocalPersonalDesignSystemAllowance});
+ * - a workspace-bound caller with NO member identity of its own, when the
+ *   row is equally unattributed — a legacy memberless project's persisted
+ *   scope may read exactly the unattributed bindings of its own workspace.
+ *
  * An unasserted type is not an assertion — the allowance stays off. This
  * mirrors the projects-layer ruling for memberless legacy rows.
  */
-function designSystemBindingAllowsRead(
+export function designSystemPersonalBindingReadable(
   binding: ReturnType<typeof getWorkspaceResourceByResourceId>,
-  workspaceId: string,
-  workspaceMemberId: string,
-  workspaceTypeAsserted?: DesignSystemWorkspaceScopeType | null,
+  scope: DesignSystemPersonalBindingScope,
 ): boolean {
   if (
     !binding
-    || binding.workspaceId !== workspaceId
+    || !scope.workspaceId
+    || binding.workspaceId !== scope.workspaceId
     || binding.visibility !== 'personal'
     || binding.resourceState === 'deleted'
   ) {
     return false;
   }
-  if (binding.createdByWorkspaceMemberId === workspaceMemberId) return true;
-  return (
-    workspaceTypeAsserted === 'personal'
-    && isUnattributedLocalPersonalDesignSystemBinding(binding)
+  if (!scope.workspaceMemberId) {
+    return isUnattributedLocalPersonalDesignSystemBinding(binding);
+  }
+  if (binding.createdByWorkspaceMemberId === scope.workspaceMemberId) return true;
+  return unattributedLocalPersonalDesignSystemAllowance(
+    'design_system',
+    binding,
+    scope.workspaceTypeAsserted,
   );
 }
+
+/**
+ * The scope a personal-binding read runs under. `workspaceMemberId` is empty
+ * for a workspace-bound caller with no member identity of its own (the
+ * persisted scope of a legacy memberless project driving a run).
+ */
+export type DesignSystemPersonalBindingScope = {
+  workspaceId: string;
+  workspaceMemberId: string;
+  workspaceTypeAsserted?: DesignSystemWorkspaceScopeType | null;
+};
 
 type DesignSystemUserReadScope = {
   workspaceId?: string | null;
@@ -169,8 +197,9 @@ function designSystemUserReadOptions(
       const binding = getWorkspaceResourceByResourceId(db, 'design_system', id);
       if (binding) {
         if (
-          isUnattributedLocalPersonalDesignSystemBinding(binding)
-          && (!workspaceId || binding.workspaceId === workspaceId)
+          workspaceId
+            ? designSystemPersonalBindingReadable(binding, { workspaceId, workspaceMemberId: '' })
+            : isUnattributedLocalPersonalDesignSystemBinding(binding)
         ) {
           return { idPrefix: 'user:' };
         }
@@ -181,7 +210,11 @@ function designSystemUserReadOptions(
   }
   if (!db || !workspaceId || !workspaceMemberId) return metadataGated;
   const binding = getWorkspaceResourceByResourceId(db, 'design_system', id);
-  if (designSystemBindingAllowsRead(binding, workspaceId, workspaceMemberId, scope.workspaceTypeAsserted)) {
+  if (designSystemPersonalBindingReadable(binding, {
+    workspaceId,
+    workspaceMemberId,
+    workspaceTypeAsserted: scope.workspaceTypeAsserted ?? null,
+  })) {
     // Issue #6763: the binding is authoritative even when a re-finalize
     // dropped `workspaceId` from metadata.json — read the FS copy unscoped.
     return { idPrefix: 'user:' };
@@ -537,20 +570,11 @@ export function createDesignSystemServerServices({
         return false;
       }
       const binding = getWorkspaceResourceByResourceId(db, 'design_system', system.id);
-      if (!exactMemberId) {
-        // A workspace-bound caller with NO member identity of its own — a
-        // legacy memberless project driving a run — may read exactly the
-        // resources that are equally unattributed in its own workspace.
-        if (
-          binding?.workspaceId === exactWorkspaceId
-          && isUnattributedLocalPersonalDesignSystemBinding(binding)
-        ) {
-          return true;
-        }
-        logCatalogHide(system.id, scopeLabel, 'memberless scope may only read unattributed bindings of its own workspace');
-        return false;
-      }
-      if (designSystemBindingAllowsRead(binding, exactWorkspaceId, exactMemberId, options.workspaceTypeAsserted)) {
+      if (designSystemPersonalBindingReadable(binding, {
+        workspaceId: exactWorkspaceId,
+        workspaceMemberId: exactMemberId,
+        workspaceTypeAsserted: options.workspaceTypeAsserted ?? null,
+      })) {
         return true;
       }
       logCatalogHide(
@@ -564,9 +588,11 @@ export function createDesignSystemServerServices({
               ? 'binding is tombstoned'
               : binding.visibility !== 'personal'
                 ? 'team-visibility binding requires the Team catalog lane'
-                : isUnattributedLocalPersonalDesignSystemBinding(binding)
-                  ? 'unattributed binding requires an explicitly asserted personal scope'
-                  : 'personal binding belongs to another member',
+                : !exactMemberId
+                  ? 'memberless scope may only read unattributed bindings of its own workspace'
+                  : isUnattributedLocalPersonalDesignSystemBinding(binding)
+                    ? 'unattributed binding requires an explicitly asserted personal scope'
+                    : 'personal binding belongs to another member',
       );
       return false;
     });
@@ -666,6 +692,7 @@ export function createDesignSystemServerServices({
     options: {
       workspaceId?: string | null;
       workspaceMemberId?: string | null;
+      workspaceTypeAsserted?: DesignSystemWorkspaceScopeType | null;
     } = {},
   ) {
     // Product boundary: this validator identifies the item in the daemon's
@@ -762,18 +789,32 @@ export function createDesignSystemServerServices({
     return `${prefix}${suffix}`;
   }
 
+  /**
+   * Is `binding` (the editing project's `workspace_projects` row) the caller's
+   * own, so reopening the editor reuses it instead of forking a
+   * workspace-scoped copy? The design system's editing project inherits the
+   * same ruling as its resource binding: a legacy memberless personal row in
+   * the caller's EXPLICITLY personal workspace is the local user's own
+   * editing project, not another member's — forking it would open an editor
+   * whose edits run-time prompt loading (which reads `summary.projectId`)
+   * never sees.
+   */
   function isExactDesignSystemProjectBinding(
     binding: ReturnType<typeof getWorkspaceProjectByProjectId>,
     summary: DesignSystemSummary,
     workspaceId: string,
     workspaceMemberId: string,
+    workspaceTypeAsserted: DesignSystemWorkspaceScopeType | null,
   ) {
     if (!binding || binding.workspaceId !== workspaceId || binding.resourceState === 'deleted') {
       return false;
     }
     if (summary.teamSynced === true) return binding.visibility === 'team';
     return binding.visibility === 'personal'
-      && binding.createdByWorkspaceMemberId === workspaceMemberId;
+      && (
+        binding.createdByWorkspaceMemberId === workspaceMemberId
+        || unattributedLocalPersonalDesignSystemAllowance('design_system', binding, workspaceTypeAsserted)
+      );
   }
 
   async function resolveDesignSystemWorkspaceProject(
@@ -790,11 +831,13 @@ export function createDesignSystemServerServices({
     // what allowed a Team operation to mutate a same-id Personal project.
     if (isScoped && (!workspaceId || !workspaceMemberId)) return null;
 
+    const workspaceTypeAsserted = options.workspaceTypeAsserted ?? null;
     const systems = await listAllDesignSystems(
       isScoped
         ? {
             workspaceId,
             workspaceMemberId,
+            workspaceTypeAsserted,
             ...(options.exactTeam !== undefined ? { exactTeam: options.exactTeam } : {}),
           }
         : {},
@@ -820,6 +863,7 @@ export function createDesignSystemServerServices({
         summary,
         workspaceId,
         workspaceMemberId,
+        workspaceTypeAsserted,
       );
       if (existing && !exactBinding) {
         projectId = workspaceScopedDesignSystemProjectId(id, workspaceId);
@@ -833,6 +877,7 @@ export function createDesignSystemServerServices({
           summary,
           workspaceId,
           workspaceMemberId,
+          workspaceTypeAsserted,
         )) {
           return null;
         }

--- a/apps/daemon/src/routes/design-systems.ts
+++ b/apps/daemon/src/routes/design-systems.ts
@@ -24,9 +24,9 @@ import {
   enforceVerifiedWorkspaceResourceMutation,
   enforceVerifiedWorkspaceResourceRead,
   headerValue,
-  isUnattributedLocalPersonalDesignSystemBinding,
   requestWithWorkspaceNavigationScope,
   resolveOptionalLocalWorkspaceRequestAuthority,
+  unattributedLocalPersonalDesignSystemAllowance,
   type VerifyWorkspaceRequestAuthority,
   type WorkspaceResourceAccessInput,
 } from '../collab/workspace-resource-mutation.js';
@@ -94,6 +94,7 @@ export interface RegisterDesignSystemRoutesDeps extends RouteDeps<'db' | 'paths'
       options?: {
         workspaceId?: string | null;
         workspaceMemberId?: string | null;
+        workspaceTypeAsserted?: 'personal' | 'team' | null;
         exactTeam?: boolean;
       },
     ) => Promise<DesignSystemWorkspaceProject | null>;
@@ -141,6 +142,7 @@ export interface RegisterDesignSystemRoutesDeps extends RouteDeps<'db' | 'paths'
       options?: {
         workspaceId?: string | null;
         workspaceMemberId?: string | null;
+        workspaceTypeAsserted?: 'personal' | 'team' | null;
         exactTeam?: boolean;
       },
     ) => Promise<{ ok: true; synced: string[] } | { ok: false; reason: 'not-found' | 'no-workspace-project' }>;
@@ -371,8 +373,11 @@ export function registerDesignSystemRoutes(
         binding
         && binding.visibility !== 'team'
         && binding.createdByWorkspaceMemberId !== resolution.context.workspaceMemberId
-        && !(assertedWorkspaceScopeType(scopedRequest) === 'personal'
-          && isUnattributedLocalPersonalDesignSystemBinding(binding))
+        && !unattributedLocalPersonalDesignSystemAllowance(
+          'design_system',
+          binding,
+          assertedWorkspaceScopeType(scopedRequest),
+        )
       )
     )) {
       res.status(403).json({
@@ -443,11 +448,22 @@ export function registerDesignSystemRoutes(
         binding = personalBinding;
       }
     }
+    // Mirror `authorizeDesignSystemRead`: an unattributed local personal
+    // binding reached from an explicitly personal scope is the local user's
+    // own (`unattributedLocalPersonalDesignSystemAllowance`), so the UI's
+    // Publish/Edit/Delete controls — enabled by that read's `canMutate` — are
+    // backed by a mutation gate that accepts the same scope. The verified
+    // gate below applies the same allowance.
     if (resolution.context && (
       !binding
       || (
         binding.visibility !== 'team'
         && binding.createdByWorkspaceMemberId !== resolution.context.workspaceMemberId
+        && !unattributedLocalPersonalDesignSystemAllowance(
+          'design_system',
+          binding,
+          assertedWorkspaceScopeType(req),
+        )
       )
     )) {
       res.status(403).json({
@@ -846,7 +862,12 @@ export function registerDesignSystemRoutes(
         db,
         req.params.id,
         workspaceId || workspaceMemberId
-          ? { workspaceId, workspaceMemberId, exactTeam: storage.exactTeam }
+          ? {
+              workspaceId,
+              workspaceMemberId,
+              workspaceTypeAsserted: requestAssertedWorkspaceScopeType(req),
+              exactTeam: storage.exactTeam,
+            }
           : undefined,
       );
       if (!workspace) {
@@ -962,7 +983,12 @@ export function registerDesignSystemRoutes(
         db,
         req.params.id,
         workspaceId || workspaceMemberId
-          ? { workspaceId, workspaceMemberId, exactTeam: storage.exactTeam }
+          ? {
+              workspaceId,
+              workspaceMemberId,
+              workspaceTypeAsserted: requestAssertedWorkspaceScopeType(req),
+              exactTeam: storage.exactTeam,
+            }
           : undefined,
       );
       if (!outcome.ok) {

--- a/apps/daemon/src/routes/design-systems.ts
+++ b/apps/daemon/src/routes/design-systems.ts
@@ -20,6 +20,7 @@ import type {
 } from '../design-systems/generation-jobs.js';
 import { deleteWorkspaceResourceByResourceId, type openDatabase } from '../db.js';
 import {
+  assertedWorkspaceScopeType,
   enforceVerifiedWorkspaceResourceMutation,
   enforceVerifiedWorkspaceResourceRead,
   headerValue,
@@ -99,7 +100,7 @@ export interface RegisterDesignSystemRoutesDeps extends RouteDeps<'db' | 'paths'
     listAllDesignSystems: (options?: {
       workspaceId?: string | null;
       workspaceMemberId?: string | null;
-      workspaceType?: 'personal' | 'team' | null;
+      workspaceTypeAsserted?: 'personal' | 'team' | null;
       exactTeam?: boolean;
     }) => Promise<AvailableDesignSystemSummary[]>;
     listUserDesignSystemFiles: (root: string, id: string) => Promise<DesignSystemFileSummary[] | null>;
@@ -107,16 +108,16 @@ export interface RegisterDesignSystemRoutesDeps extends RouteDeps<'db' | 'paths'
     prepareDesignTokenContractRebuild: (root: string, id: string, options?: { force?: boolean }) => Promise<DesignTokenContractRebuildPreparation>;
     readAvailableDesignSystem: (
       id: string,
-      options?: { workspaceId?: string | null; workspaceMemberId?: string | null; workspaceType?: 'personal' | 'team' | null; exactTeam?: boolean },
+      options?: { workspaceId?: string | null; workspaceMemberId?: string | null; workspaceTypeAsserted?: 'personal' | 'team' | null; exactTeam?: boolean },
     ) => Promise<string | null>;
     readAvailableDesignSystemPackageInfo: (
       id: string,
-      options?: { workspaceId?: string | null; workspaceMemberId?: string | null; workspaceType?: 'personal' | 'team' | null; exactTeam?: boolean },
+      options?: { workspaceId?: string | null; workspaceMemberId?: string | null; workspaceTypeAsserted?: 'personal' | 'team' | null; exactTeam?: boolean },
     ) => Promise<DesignSystemPackageInfo | null>;
     readAvailableDesignSystemStaticFile: (
       id: string,
       filePath: string,
-      options?: { workspaceId?: string | null; workspaceMemberId?: string | null; workspaceType?: 'personal' | 'team' | null; exactTeam?: boolean },
+      options?: { workspaceId?: string | null; workspaceMemberId?: string | null; workspaceTypeAsserted?: 'personal' | 'team' | null; exactTeam?: boolean },
     ) => Promise<{
       bytes: Buffer;
       contentType: string;
@@ -253,14 +254,24 @@ export function registerDesignSystemRoutes(
   );
 
   /**
-   * The caller's asserted Workspace scope type, normalized exactly like
-   * `workspaceResourceContext` (collab/workspace-resource-mutation.ts):
-   * `'team'` only on an explicit assertion, `'personal'` otherwise. Read
-   * services use it to decide whether the unattributed-legacy-binding
-   * allowance applies (`isUnattributedLocalPersonalDesignSystemBinding`).
+   * The caller's EXPLICIT Workspace-type assertion, or null when nothing was
+   * asserted — never the normalized `workspaceType`, which collapses a
+   * missing header to `'personal'` and would hand the personal-only legacy
+   * allowance (`isUnattributedLocalPersonalDesignSystemBinding`) to a Team
+   * caller that omits the optional header. Navigation transports (iframe/img
+   * URLs) cannot attach headers, so routes that accept the query identity
+   * pair accept the same explicit assertion from the query.
    */
-  function requestWorkspaceScopeType(req: any): 'personal' | 'team' {
-    return headerValue(req, 'x-od-workspace-type') === 'team' ? 'team' : 'personal';
+  function requestAssertedWorkspaceScopeType(
+    req: any,
+    allowNavigationQuery = false,
+  ): 'personal' | 'team' | null {
+    const asserted = assertedWorkspaceScopeType(req);
+    if (asserted || !allowNavigationQuery) return asserted;
+    const queryType = typeof req.query?.workspaceType === 'string'
+      ? req.query.workspaceType
+      : '';
+    return queryType === 'personal' || queryType === 'team' ? queryType : null;
   }
 
   function resolveDesignSystemStorage(
@@ -360,7 +371,7 @@ export function registerDesignSystemRoutes(
         binding
         && binding.visibility !== 'team'
         && binding.createdByWorkspaceMemberId !== resolution.context.workspaceMemberId
-        && !(resolution.context.workspaceType === 'personal'
+        && !(assertedWorkspaceScopeType(scopedRequest) === 'personal'
           && isUnattributedLocalPersonalDesignSystemBinding(binding))
       )
     )) {
@@ -682,12 +693,12 @@ export function registerDesignSystemRoutes(
       if (!(await authorizeDesignSystemRead(req, res, req.params.id))) return;
       const workspaceId = headerValue(req, 'x-od-workspace-id');
       const workspaceMemberId = headerValue(req, 'x-od-workspace-member-id');
-      const workspaceType = requestWorkspaceScopeType(req);
+      const workspaceTypeAsserted = requestAssertedWorkspaceScopeType(req);
       const storage = resolveDesignSystemStorage(req, req.params.id);
       const systems = await listAllDesignSystems({
         workspaceId,
         workspaceMemberId,
-        workspaceType,
+        workspaceTypeAsserted,
         exactTeam: storage.exactTeam,
       });
       const summary = systems.find((s) => s.id === req.params.id);
@@ -695,7 +706,7 @@ export function registerDesignSystemRoutes(
       const body = projectBody ?? await readAvailableDesignSystem(req.params.id, {
         workspaceId,
         workspaceMemberId,
-        workspaceType,
+        workspaceTypeAsserted,
         exactTeam: storage.exactTeam,
       });
       if (body === null || !summary) {
@@ -704,7 +715,7 @@ export function registerDesignSystemRoutes(
       const packageInfo = await readAvailableDesignSystemPackageInfo(req.params.id, {
         workspaceId,
         workspaceMemberId,
-        workspaceType,
+        workspaceTypeAsserted,
         exactTeam: storage.exactTeam,
       });
       // recvqb6mfyqXLD: mirror the exact PATCH/DELETE verdict onto the read
@@ -743,7 +754,7 @@ export function registerDesignSystemRoutes(
       const body = await readAvailableDesignSystem(req.params.id, {
         workspaceId,
         workspaceMemberId,
-        workspaceType: requestWorkspaceScopeType(req),
+        workspaceTypeAsserted: requestAssertedWorkspaceScopeType(req, true),
         exactTeam: storage.exactTeam,
       });
       if (body === null) return res.status(404).type('text/plain').send('not found');
@@ -769,7 +780,7 @@ export function registerDesignSystemRoutes(
       const packaged = await readAvailableDesignSystemStaticFile(
         req.params.id,
         PACKAGED_SHOWCASE_PATH,
-        { workspaceId, workspaceMemberId, workspaceType: requestWorkspaceScopeType(req), exactTeam: storage.exactTeam },
+        { workspaceId, workspaceMemberId, workspaceTypeAsserted: requestAssertedWorkspaceScopeType(req, true), exactTeam: storage.exactTeam },
       );
       if (packaged?.contentType.startsWith('text/html')) {
         const workspaceQuery = designSystemNavigationWorkspaceQuery(req);
@@ -787,7 +798,7 @@ export function registerDesignSystemRoutes(
       const body = await readAvailableDesignSystem(req.params.id, {
         workspaceId,
         workspaceMemberId,
-        workspaceType: requestWorkspaceScopeType(req),
+        workspaceTypeAsserted: requestAssertedWorkspaceScopeType(req, true),
         exactTeam: storage.exactTeam,
       });
       if (body === null) return res.status(404).type('text/plain').send('not found');
@@ -814,7 +825,7 @@ export function registerDesignSystemRoutes(
       const file = await readAvailableDesignSystemStaticFile(
         req.params.id,
         requestedPath,
-        { workspaceId, workspaceMemberId, workspaceType: requestWorkspaceScopeType(req), exactTeam: storage.exactTeam },
+        { workspaceId, workspaceMemberId, workspaceTypeAsserted: requestAssertedWorkspaceScopeType(req, true), exactTeam: storage.exactTeam },
       );
       if (!file) return res.status(404).type('text/plain').send('not found');
       res.setHeader('Cache-Control', 'no-store');
@@ -1078,7 +1089,7 @@ export function rewriteDesignSystemShowcaseAssetUrls(
   html: string,
   designSystemId: string,
   baseDir: string,
-  workspaceQuery?: { workspaceId: string; workspaceMemberId: string } | null,
+  workspaceQuery?: { workspaceId: string; workspaceMemberId: string; workspaceType?: 'personal' | 'team' } | null,
 ): string {
   if (!html) return html;
   return html
@@ -1106,7 +1117,7 @@ function rewriteDesignSystemShowcaseAssetUrl(
   rawUrl: string,
   designSystemId: string,
   baseDir: string,
-  workspaceQuery?: { workspaceId: string; workspaceMemberId: string } | null,
+  workspaceQuery?: { workspaceId: string; workspaceMemberId: string; workspaceType?: 'personal' | 'team' } | null,
 ): string {
   const value = rawUrl.trim();
   if (
@@ -1137,6 +1148,9 @@ function rewriteDesignSystemShowcaseAssetUrl(
     + (workspaceQuery
       ? `&workspaceId=${encodeURIComponent(workspaceQuery.workspaceId)}`
         + `&workspaceMemberId=${encodeURIComponent(workspaceQuery.workspaceMemberId)}`
+        + (workspaceQuery.workspaceType
+          ? `&workspaceType=${encodeURIComponent(workspaceQuery.workspaceType)}`
+          : '')
       : '');
   if (suffix.startsWith('?')) return `${staticUrl}&${suffix.slice(1)}`;
   return `${staticUrl}${suffix}`;
@@ -1144,14 +1158,16 @@ function rewriteDesignSystemShowcaseAssetUrl(
 
 function designSystemNavigationWorkspaceQuery(
   req: any,
-): { workspaceId: string; workspaceMemberId: string } | null {
+): { workspaceId: string; workspaceMemberId: string; workspaceType?: 'personal' | 'team' } | null {
   const workspaceId =
     typeof req.query?.workspaceId === 'string' ? req.query.workspaceId.trim() : '';
   const workspaceMemberId =
     typeof req.query?.workspaceMemberId === 'string'
       ? req.query.workspaceMemberId.trim()
       : '';
-  return workspaceId && workspaceMemberId
-    ? { workspaceId, workspaceMemberId }
-    : null;
+  if (!workspaceId || !workspaceMemberId) return null;
+  const workspaceType = req.query?.workspaceType;
+  return workspaceType === 'personal' || workspaceType === 'team'
+    ? { workspaceId, workspaceMemberId, workspaceType }
+    : { workspaceId, workspaceMemberId };
 }

--- a/apps/daemon/src/routes/design-systems.ts
+++ b/apps/daemon/src/routes/design-systems.ts
@@ -20,16 +20,19 @@ import type {
 } from '../design-systems/generation-jobs.js';
 import { deleteWorkspaceResourceByResourceId, type openDatabase } from '../db.js';
 import {
-  assertedWorkspaceScopeType,
   enforceVerifiedWorkspaceResourceMutation,
   enforceVerifiedWorkspaceResourceRead,
   headerValue,
+  isUnattributedLocalPersonalDesignSystemBinding,
   requestWithWorkspaceNavigationScope,
   resolveOptionalLocalWorkspaceRequestAuthority,
   unattributedLocalPersonalDesignSystemAllowance,
+  verifiedWorkspaceTypeAssertion,
   type VerifyWorkspaceRequestAuthority,
   type WorkspaceResourceAccessInput,
+  type WorkspaceTypeWitness,
 } from '../collab/workspace-resource-mutation.js';
+import type { WorkspaceTypeRegistry } from '../collab/team-share-scope.js';
 import type { Project, ProjectFile } from '@open-design/contracts';
 
 type DbHandle = ReturnType<typeof openDatabase>;
@@ -47,6 +50,14 @@ const PACKAGED_SHOWCASE_PATH = 'system/kit.html';
 
 export interface RegisterDesignSystemRoutesDeps extends RouteDeps<'db' | 'paths' | 'projectFiles' | 'projectStore'> {
   verifyWorkspaceRequestAuthority: VerifyWorkspaceRequestAuthority;
+  /**
+   * Settled, TTL-bounded authority. Only the witness behind the legacy local
+   * personal design-system allowance consults it, and only for a workspace
+   * the daemon has not already learned from the directory.
+   */
+  verifyWorkspaceReadAuthority?: VerifyWorkspaceRequestAuthority;
+  /** The daemon's memo of directory-established workspace types (verified tier only). */
+  workspaceTypes?: Pick<WorkspaceTypeRegistry, 'verifiedTypeOf'>;
   workspaceResources: {
     getWorkspaceResource: (
       db: DbHandle,
@@ -94,14 +105,14 @@ export interface RegisterDesignSystemRoutesDeps extends RouteDeps<'db' | 'paths'
       options?: {
         workspaceId?: string | null;
         workspaceMemberId?: string | null;
-        workspaceTypeAsserted?: 'personal' | 'team' | null;
+        workspaceTypeVerified?: 'personal' | 'team' | null;
         exactTeam?: boolean;
       },
     ) => Promise<DesignSystemWorkspaceProject | null>;
     listAllDesignSystems: (options?: {
       workspaceId?: string | null;
       workspaceMemberId?: string | null;
-      workspaceTypeAsserted?: 'personal' | 'team' | null;
+      workspaceTypeVerified?: 'personal' | 'team' | null;
       exactTeam?: boolean;
     }) => Promise<AvailableDesignSystemSummary[]>;
     listUserDesignSystemFiles: (root: string, id: string) => Promise<DesignSystemFileSummary[] | null>;
@@ -109,16 +120,16 @@ export interface RegisterDesignSystemRoutesDeps extends RouteDeps<'db' | 'paths'
     prepareDesignTokenContractRebuild: (root: string, id: string, options?: { force?: boolean }) => Promise<DesignTokenContractRebuildPreparation>;
     readAvailableDesignSystem: (
       id: string,
-      options?: { workspaceId?: string | null; workspaceMemberId?: string | null; workspaceTypeAsserted?: 'personal' | 'team' | null; exactTeam?: boolean },
+      options?: { workspaceId?: string | null; workspaceMemberId?: string | null; workspaceTypeVerified?: 'personal' | 'team' | null; exactTeam?: boolean },
     ) => Promise<string | null>;
     readAvailableDesignSystemPackageInfo: (
       id: string,
-      options?: { workspaceId?: string | null; workspaceMemberId?: string | null; workspaceTypeAsserted?: 'personal' | 'team' | null; exactTeam?: boolean },
+      options?: { workspaceId?: string | null; workspaceMemberId?: string | null; workspaceTypeVerified?: 'personal' | 'team' | null; exactTeam?: boolean },
     ) => Promise<DesignSystemPackageInfo | null>;
     readAvailableDesignSystemStaticFile: (
       id: string,
       filePath: string,
-      options?: { workspaceId?: string | null; workspaceMemberId?: string | null; workspaceTypeAsserted?: 'personal' | 'team' | null; exactTeam?: boolean },
+      options?: { workspaceId?: string | null; workspaceMemberId?: string | null; workspaceTypeVerified?: 'personal' | 'team' | null; exactTeam?: boolean },
     ) => Promise<{
       bytes: Buffer;
       contentType: string;
@@ -142,7 +153,7 @@ export interface RegisterDesignSystemRoutesDeps extends RouteDeps<'db' | 'paths'
       options?: {
         workspaceId?: string | null;
         workspaceMemberId?: string | null;
-        workspaceTypeAsserted?: 'personal' | 'team' | null;
+        workspaceTypeVerified?: 'personal' | 'team' | null;
         exactTeam?: boolean;
       },
     ) => Promise<{ ok: true; synced: string[] } | { ok: false; reason: 'not-found' | 'no-workspace-project' }>;
@@ -255,25 +266,47 @@ export function registerDesignSystemRoutes(
     resourceId,
   );
 
+  // The witness behind the legacy local personal design-system allowance:
+  // the directory-established type memo, else the settled read authority (the
+  // membership directory in the packaged runtime, the explicit headers in
+  // local/dev). Never the fresh mutation verifier: a workspace's type does not
+  // change, and this lane must not add a directory round trip to every
+  // mutation of an attributed system.
+  const workspaceTypeWitness: WorkspaceTypeWitness = {
+    verifiedTypeOf: ctx.workspaceTypes?.verifiedTypeOf,
+    verify: ctx.verifyWorkspaceReadAuthority ?? ctx.verifyWorkspaceRequestAuthority,
+  };
+
   /**
-   * The caller's EXPLICIT Workspace-type assertion, or null when nothing was
-   * asserted — never the normalized `workspaceType`, which collapses a
-   * missing header to `'personal'` and would hand the personal-only legacy
-   * allowance (`isUnattributedLocalPersonalDesignSystemBinding`) to a Team
-   * caller that omits the optional header. Navigation transports (iframe/img
-   * URLs) cannot attach headers, so routes that accept the query identity
-   * pair accept the same explicit assertion from the query.
+   * The caller's EXPLICIT Workspace-type assertion CONFIRMED by membership
+   * verification (`verifiedWorkspaceTypeAssertion`), or null when nothing
+   * was asserted or the assertion could not be confirmed — never the
+   * normalized `workspaceType`, which collapses a missing header to
+   * `'personal'` and would hand the personal-only legacy allowance
+   * (`unattributedLocalPersonalDesignSystemAllowance`) to a Team caller that
+   * omits the optional header; and never the raw claim, which would hand it
+   * to a Team member asserting `personal` inside their Team workspace.
+   * Navigation transports (iframe/img URLs) cannot attach headers, so routes
+   * that accept the query identity pair confirm the same assertion from the
+   * query.
+   *
+   * Consulted only when `id`'s own binding is an unattributed personal row —
+   * the one shape the allowance can grant — so an attributed or unbound
+   * system never triggers verification on this local data-plane lane.
    */
-  function requestAssertedWorkspaceScopeType(
+  async function requestVerifiedWorkspaceType(
     req: any,
+    id: string,
     allowNavigationQuery = false,
-  ): 'personal' | 'team' | null {
-    const asserted = assertedWorkspaceScopeType(req);
-    if (asserted || !allowNavigationQuery) return asserted;
-    const queryType = typeof req.query?.workspaceType === 'string'
-      ? req.query.workspaceType
-      : '';
-    return queryType === 'personal' || queryType === 'team' ? queryType : null;
+  ): Promise<'personal' | 'team' | null> {
+    if (!isUnattributedLocalPersonalDesignSystemBinding(getDesignSystemBinding(db, id))) {
+      return null;
+    }
+    const scopedRequest = allowNavigationQuery
+      ? requestWithWorkspaceNavigationScope(req)
+      : req;
+    if (scopedRequest === 'conflict') return null;
+    return verifiedWorkspaceTypeAssertion(scopedRequest, workspaceTypeWitness);
   }
 
   function resolveDesignSystemStorage(
@@ -359,14 +392,19 @@ export function registerDesignSystemRoutes(
           workspaceId: resolution.context.workspaceId,
         })).some((system) => system.id === id && system.source === 'built-in')
       : false;
+    // Only an unattributed personal row can take the legacy allowance, so
+    // only that shape consults the witness (see `requestVerifiedWorkspaceType`).
+    const workspaceTypeVerified = isUnattributedLocalPersonalDesignSystemBinding(binding)
+      ? await verifiedWorkspaceTypeAssertion(scopedRequest, workspaceTypeWitness)
+      : null;
     // Explicit Workspace requests never inherit ownerless legacy resources.
     // A Personal design system is private to its exact persisted creator even
     // when the caller is an owner/admin in the same Workspace. Team resources
     // remain readable by every verified active member through the shared
     // gate. The one exception is an unattributed local personal binding read
-    // from a non-team scope: it records no creator at all (the startup
-    // backfill's output on a never-signed-in install) and belongs to the
-    // local user — see `isUnattributedLocalPersonalDesignSystemBinding`.
+    // from a VERIFIED personal scope: it records no creator at all (the
+    // startup backfill's output on a never-signed-in install) and belongs to
+    // the local user — see `unattributedLocalPersonalDesignSystemAllowance`.
     if (resolution.context && (
       (!binding && !isPublicBuiltIn)
       || (
@@ -376,7 +414,7 @@ export function registerDesignSystemRoutes(
         && !unattributedLocalPersonalDesignSystemAllowance(
           'design_system',
           binding,
-          assertedWorkspaceScopeType(scopedRequest),
+          workspaceTypeVerified,
         )
       )
     )) {
@@ -406,7 +444,7 @@ export function registerDesignSystemRoutes(
       resolution.context
         ? async () => ({ ok: true as const, context: resolution.context! })
         : ctx.verifyWorkspaceRequestAuthority,
-      { allowNavigationQuery },
+      { allowNavigationQuery, workspaceTypeVerified },
     );
   }
 
@@ -449,11 +487,14 @@ export function registerDesignSystemRoutes(
       }
     }
     // Mirror `authorizeDesignSystemRead`: an unattributed local personal
-    // binding reached from an explicitly personal scope is the local user's
-    // own (`unattributedLocalPersonalDesignSystemAllowance`), so the UI's
+    // binding reached from a VERIFIED personal scope is the local user's own
+    // (`unattributedLocalPersonalDesignSystemAllowance`), so the UI's
     // Publish/Edit/Delete controls — enabled by that read's `canMutate` — are
     // backed by a mutation gate that accepts the same scope. The verified
-    // gate below applies the same allowance.
+    // gate below applies the same allowance on the same witness.
+    const workspaceTypeVerified = isUnattributedLocalPersonalDesignSystemBinding(binding)
+      ? await verifiedWorkspaceTypeAssertion(req, workspaceTypeWitness)
+      : null;
     if (resolution.context && (
       !binding
       || (
@@ -462,7 +503,7 @@ export function registerDesignSystemRoutes(
         && !unattributedLocalPersonalDesignSystemAllowance(
           'design_system',
           binding,
-          assertedWorkspaceScopeType(req),
+          workspaceTypeVerified,
         )
       )
     )) {
@@ -493,6 +534,7 @@ export function registerDesignSystemRoutes(
       resolution.context
         ? async () => ({ ok: true as const, context: resolution.context! })
         : ctx.verifyWorkspaceRequestAuthority,
+      { workspaceTypeVerified },
     );
   }
 
@@ -709,12 +751,12 @@ export function registerDesignSystemRoutes(
       if (!(await authorizeDesignSystemRead(req, res, req.params.id))) return;
       const workspaceId = headerValue(req, 'x-od-workspace-id');
       const workspaceMemberId = headerValue(req, 'x-od-workspace-member-id');
-      const workspaceTypeAsserted = requestAssertedWorkspaceScopeType(req);
+      const workspaceTypeVerified = await requestVerifiedWorkspaceType(req, req.params.id);
       const storage = resolveDesignSystemStorage(req, req.params.id);
       const systems = await listAllDesignSystems({
         workspaceId,
         workspaceMemberId,
-        workspaceTypeAsserted,
+        workspaceTypeVerified,
         exactTeam: storage.exactTeam,
       });
       const summary = systems.find((s) => s.id === req.params.id);
@@ -722,7 +764,7 @@ export function registerDesignSystemRoutes(
       const body = projectBody ?? await readAvailableDesignSystem(req.params.id, {
         workspaceId,
         workspaceMemberId,
-        workspaceTypeAsserted,
+        workspaceTypeVerified,
         exactTeam: storage.exactTeam,
       });
       if (body === null || !summary) {
@@ -731,7 +773,7 @@ export function registerDesignSystemRoutes(
       const packageInfo = await readAvailableDesignSystemPackageInfo(req.params.id, {
         workspaceId,
         workspaceMemberId,
-        workspaceTypeAsserted,
+        workspaceTypeVerified,
         exactTeam: storage.exactTeam,
       });
       // recvqb6mfyqXLD: mirror the exact PATCH/DELETE verdict onto the read
@@ -770,7 +812,7 @@ export function registerDesignSystemRoutes(
       const body = await readAvailableDesignSystem(req.params.id, {
         workspaceId,
         workspaceMemberId,
-        workspaceTypeAsserted: requestAssertedWorkspaceScopeType(req, true),
+        workspaceTypeVerified: await requestVerifiedWorkspaceType(req, req.params.id, true),
         exactTeam: storage.exactTeam,
       });
       if (body === null) return res.status(404).type('text/plain').send('not found');
@@ -796,7 +838,7 @@ export function registerDesignSystemRoutes(
       const packaged = await readAvailableDesignSystemStaticFile(
         req.params.id,
         PACKAGED_SHOWCASE_PATH,
-        { workspaceId, workspaceMemberId, workspaceTypeAsserted: requestAssertedWorkspaceScopeType(req, true), exactTeam: storage.exactTeam },
+        { workspaceId, workspaceMemberId, workspaceTypeVerified: await requestVerifiedWorkspaceType(req, req.params.id, true), exactTeam: storage.exactTeam },
       );
       if (packaged?.contentType.startsWith('text/html')) {
         const workspaceQuery = designSystemNavigationWorkspaceQuery(req);
@@ -814,7 +856,7 @@ export function registerDesignSystemRoutes(
       const body = await readAvailableDesignSystem(req.params.id, {
         workspaceId,
         workspaceMemberId,
-        workspaceTypeAsserted: requestAssertedWorkspaceScopeType(req, true),
+        workspaceTypeVerified: await requestVerifiedWorkspaceType(req, req.params.id, true),
         exactTeam: storage.exactTeam,
       });
       if (body === null) return res.status(404).type('text/plain').send('not found');
@@ -841,7 +883,7 @@ export function registerDesignSystemRoutes(
       const file = await readAvailableDesignSystemStaticFile(
         req.params.id,
         requestedPath,
-        { workspaceId, workspaceMemberId, workspaceTypeAsserted: requestAssertedWorkspaceScopeType(req, true), exactTeam: storage.exactTeam },
+        { workspaceId, workspaceMemberId, workspaceTypeVerified: await requestVerifiedWorkspaceType(req, req.params.id, true), exactTeam: storage.exactTeam },
       );
       if (!file) return res.status(404).type('text/plain').send('not found');
       res.setHeader('Cache-Control', 'no-store');
@@ -865,7 +907,7 @@ export function registerDesignSystemRoutes(
           ? {
               workspaceId,
               workspaceMemberId,
-              workspaceTypeAsserted: requestAssertedWorkspaceScopeType(req),
+              workspaceTypeVerified: await requestVerifiedWorkspaceType(req, req.params.id),
               exactTeam: storage.exactTeam,
             }
           : undefined,
@@ -986,7 +1028,7 @@ export function registerDesignSystemRoutes(
           ? {
               workspaceId,
               workspaceMemberId,
-              workspaceTypeAsserted: requestAssertedWorkspaceScopeType(req),
+              workspaceTypeVerified: await requestVerifiedWorkspaceType(req, req.params.id),
               exactTeam: storage.exactTeam,
             }
           : undefined,

--- a/apps/daemon/src/routes/design-systems.ts
+++ b/apps/daemon/src/routes/design-systems.ts
@@ -23,6 +23,7 @@ import {
   enforceVerifiedWorkspaceResourceMutation,
   enforceVerifiedWorkspaceResourceRead,
   headerValue,
+  isUnattributedLocalPersonalDesignSystemBinding,
   requestWithWorkspaceNavigationScope,
   resolveOptionalLocalWorkspaceRequestAuthority,
   type VerifyWorkspaceRequestAuthority,
@@ -98,6 +99,7 @@ export interface RegisterDesignSystemRoutesDeps extends RouteDeps<'db' | 'paths'
     listAllDesignSystems: (options?: {
       workspaceId?: string | null;
       workspaceMemberId?: string | null;
+      workspaceType?: 'personal' | 'team' | null;
       exactTeam?: boolean;
     }) => Promise<AvailableDesignSystemSummary[]>;
     listUserDesignSystemFiles: (root: string, id: string) => Promise<DesignSystemFileSummary[] | null>;
@@ -105,16 +107,16 @@ export interface RegisterDesignSystemRoutesDeps extends RouteDeps<'db' | 'paths'
     prepareDesignTokenContractRebuild: (root: string, id: string, options?: { force?: boolean }) => Promise<DesignTokenContractRebuildPreparation>;
     readAvailableDesignSystem: (
       id: string,
-      options?: { workspaceId?: string | null; workspaceMemberId?: string | null; exactTeam?: boolean },
+      options?: { workspaceId?: string | null; workspaceMemberId?: string | null; workspaceType?: 'personal' | 'team' | null; exactTeam?: boolean },
     ) => Promise<string | null>;
     readAvailableDesignSystemPackageInfo: (
       id: string,
-      options?: { workspaceId?: string | null; workspaceMemberId?: string | null; exactTeam?: boolean },
+      options?: { workspaceId?: string | null; workspaceMemberId?: string | null; workspaceType?: 'personal' | 'team' | null; exactTeam?: boolean },
     ) => Promise<DesignSystemPackageInfo | null>;
     readAvailableDesignSystemStaticFile: (
       id: string,
       filePath: string,
-      options?: { workspaceId?: string | null; workspaceMemberId?: string | null; exactTeam?: boolean },
+      options?: { workspaceId?: string | null; workspaceMemberId?: string | null; workspaceType?: 'personal' | 'team' | null; exactTeam?: boolean },
     ) => Promise<{
       bytes: Buffer;
       contentType: string;
@@ -250,6 +252,17 @@ export function registerDesignSystemRoutes(
     resourceId,
   );
 
+  /**
+   * The caller's asserted Workspace scope type, normalized exactly like
+   * `workspaceResourceContext` (collab/workspace-resource-mutation.ts):
+   * `'team'` only on an explicit assertion, `'personal'` otherwise. Read
+   * services use it to decide whether the unattributed-legacy-binding
+   * allowance applies (`isUnattributedLocalPersonalDesignSystemBinding`).
+   */
+  function requestWorkspaceScopeType(req: any): 'personal' | 'team' {
+    return headerValue(req, 'x-od-workspace-type') === 'team' ? 'team' : 'personal';
+  }
+
   function resolveDesignSystemStorage(
     req: any,
     id: string,
@@ -336,13 +349,19 @@ export function registerDesignSystemRoutes(
     // Explicit Workspace requests never inherit ownerless legacy resources.
     // A Personal design system is private to its exact persisted creator even
     // when the caller is an owner/admin in the same Workspace. Team resources
-    // remain readable by every verified active member through the shared gate.
+    // remain readable by every verified active member through the shared
+    // gate. The one exception is an unattributed local personal binding read
+    // from a non-team scope: it records no creator at all (the startup
+    // backfill's output on a never-signed-in install) and belongs to the
+    // local user — see `isUnattributedLocalPersonalDesignSystemBinding`.
     if (resolution.context && (
       (!binding && !isPublicBuiltIn)
       || (
         binding
         && binding.visibility !== 'team'
         && binding.createdByWorkspaceMemberId !== resolution.context.workspaceMemberId
+        && !(resolution.context.workspaceType === 'personal'
+          && isUnattributedLocalPersonalDesignSystemBinding(binding))
       )
     )) {
       res.status(403).json({
@@ -663,10 +682,12 @@ export function registerDesignSystemRoutes(
       if (!(await authorizeDesignSystemRead(req, res, req.params.id))) return;
       const workspaceId = headerValue(req, 'x-od-workspace-id');
       const workspaceMemberId = headerValue(req, 'x-od-workspace-member-id');
+      const workspaceType = requestWorkspaceScopeType(req);
       const storage = resolveDesignSystemStorage(req, req.params.id);
       const systems = await listAllDesignSystems({
         workspaceId,
         workspaceMemberId,
+        workspaceType,
         exactTeam: storage.exactTeam,
       });
       const summary = systems.find((s) => s.id === req.params.id);
@@ -674,6 +695,7 @@ export function registerDesignSystemRoutes(
       const body = projectBody ?? await readAvailableDesignSystem(req.params.id, {
         workspaceId,
         workspaceMemberId,
+        workspaceType,
         exactTeam: storage.exactTeam,
       });
       if (body === null || !summary) {
@@ -682,6 +704,7 @@ export function registerDesignSystemRoutes(
       const packageInfo = await readAvailableDesignSystemPackageInfo(req.params.id, {
         workspaceId,
         workspaceMemberId,
+        workspaceType,
         exactTeam: storage.exactTeam,
       });
       // recvqb6mfyqXLD: mirror the exact PATCH/DELETE verdict onto the read
@@ -720,6 +743,7 @@ export function registerDesignSystemRoutes(
       const body = await readAvailableDesignSystem(req.params.id, {
         workspaceId,
         workspaceMemberId,
+        workspaceType: requestWorkspaceScopeType(req),
         exactTeam: storage.exactTeam,
       });
       if (body === null) return res.status(404).type('text/plain').send('not found');
@@ -745,7 +769,7 @@ export function registerDesignSystemRoutes(
       const packaged = await readAvailableDesignSystemStaticFile(
         req.params.id,
         PACKAGED_SHOWCASE_PATH,
-        { workspaceId, workspaceMemberId, exactTeam: storage.exactTeam },
+        { workspaceId, workspaceMemberId, workspaceType: requestWorkspaceScopeType(req), exactTeam: storage.exactTeam },
       );
       if (packaged?.contentType.startsWith('text/html')) {
         const workspaceQuery = designSystemNavigationWorkspaceQuery(req);
@@ -763,6 +787,7 @@ export function registerDesignSystemRoutes(
       const body = await readAvailableDesignSystem(req.params.id, {
         workspaceId,
         workspaceMemberId,
+        workspaceType: requestWorkspaceScopeType(req),
         exactTeam: storage.exactTeam,
       });
       if (body === null) return res.status(404).type('text/plain').send('not found');
@@ -789,7 +814,7 @@ export function registerDesignSystemRoutes(
       const file = await readAvailableDesignSystemStaticFile(
         req.params.id,
         requestedPath,
-        { workspaceId, workspaceMemberId, exactTeam: storage.exactTeam },
+        { workspaceId, workspaceMemberId, workspaceType: requestWorkspaceScopeType(req), exactTeam: storage.exactTeam },
       );
       if (!file) return res.status(404).type('text/plain').send('not found');
       res.setHeader('Cache-Control', 'no-store');

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -131,10 +131,14 @@ import {
   workspaceResourceContext as workspaceProjectContext,
   workspaceResourceContextFromRequest as workspaceProjectContextFromRequest,
   workspaceResourceContextFromVerified,
+  settledWorkspaceTypeAssertion,
+  verifiedWorkspaceTypeAssertion,
+  workspaceScopeRequest,
   type VerifyWorkspaceRequestAuthority,
   type WorkspaceResourceAccessInput,
   type WorkspaceResourceContext,
   type WorkspaceResourceMutationCapability,
+  type WorkspaceTypeWitness,
 } from '../../collab/workspace-resource-mutation.js';
 import {
   resolveLocalProjectWorkspaceScope,
@@ -270,63 +274,85 @@ function parseLocalCatalogScope(value: unknown, field: string): LocalCatalogScop
 }
 
 /**
- * A selection partition that carries no type assertion of its own (an older
- * composer draft) inherits the request's, when the request names that same
- * workspace: both are the same client's claim about the same partition, and
- * the persisted provenance must carry what run-time prompt loading keys on.
- */
-function withRequestAssertedWorkspaceType(
-  scope: LocalCatalogScope | null,
-  request: WorkspaceResourceContext | null,
-): LocalCatalogScope | null {
-  if (!scope || scope.workspaceType) return scope;
-  if (!request?.workspaceTypeAsserted || request.workspaceId !== scope.workspaceId) return scope;
-  return { ...scope, workspaceType: request.workspaceTypeAsserted };
-}
-
-/**
  * The scope a project-create design-system validation reads the catalog
  * under: the selection's persisted partition when the client supplied one,
- * else the request's local attribution. The EXPLICIT type assertion travels
- * with it — the legacy unattributed personal binding allowance
- * (`designSystemPersonalBindingReadable`) keys on it — and an unasserted
- * type stays unasserted.
+ * else the request's local attribution. The partition's type travels with it
+ * only once membership verification has CONFIRMED it
+ * (`verifiedWorkspaceTypeAssertion`): the legacy unattributed personal
+ * binding allowance (`designSystemPersonalBindingReadable`) keys on a
+ * verified personal workspace, never on the client's claim. A partition that
+ * carries no type of its own (an older composer draft) inherits the request's
+ * assertion when the request names that same workspace, and the inherited
+ * assertion goes through the same confirmation. An unasserted or unconfirmed
+ * type stays unasserted (fail-closed).
+ *
+ * The confirmation is handed to the validator as a resolver it settles only
+ * when the selected system's binding is an unattributed personal row, so a
+ * Send that selects an attributed or built-in system never touches the
+ * authority plane; `settledWorkspaceType` reads back what was established.
  */
 function designSystemCatalogReadScope(
   catalogScope: LocalCatalogScope | null,
   request: WorkspaceResourceContext | null,
+  req: unknown,
+  witness: WorkspaceTypeWitness,
 ): {
-  workspaceId: string | null;
-  workspaceMemberId: string | null;
-  workspaceTypeAsserted: 'personal' | 'team' | null;
+  scope: {
+    workspaceId: string | null;
+    workspaceMemberId: string | null;
+    workspaceTypeVerified: (() => Promise<'personal' | 'team' | null>) | null;
+  };
+  settledWorkspaceType: () => 'personal' | 'team' | null | undefined;
 } {
   if (catalogScope) {
+    const claimed = catalogScope.workspaceType
+      ?? (request?.workspaceId === catalogScope.workspaceId
+        ? request.workspaceTypeAsserted
+        : null);
+    const confirmation = claimed
+      ? settledWorkspaceTypeAssertion(() => verifiedWorkspaceTypeAssertion(
+          workspaceScopeRequest({ ...catalogScope, workspaceType: claimed }),
+          witness,
+        ))
+      : null;
     return {
-      workspaceId: catalogScope.workspaceId,
-      workspaceMemberId: catalogScope.workspaceMemberId,
-      workspaceTypeAsserted: catalogScope.workspaceType ?? null,
+      scope: {
+        workspaceId: catalogScope.workspaceId,
+        workspaceMemberId: catalogScope.workspaceMemberId,
+        workspaceTypeVerified: confirmation?.resolve ?? null,
+      },
+      settledWorkspaceType: () => confirmation?.settled(),
     };
   }
+  const confirmation = request?.workspaceTypeAsserted
+    ? settledWorkspaceTypeAssertion(() => verifiedWorkspaceTypeAssertion(req, witness))
+    : null;
   return {
-    workspaceId: request?.workspaceId ?? null,
-    workspaceMemberId: request?.workspaceMemberId ?? null,
-    workspaceTypeAsserted: request?.workspaceTypeAsserted ?? null,
+    scope: {
+      workspaceId: request?.workspaceId ?? null,
+      workspaceMemberId: request?.workspaceMemberId ?? null,
+      workspaceTypeVerified: confirmation?.resolve ?? null,
+    },
+    settledWorkspaceType: () => confirmation?.settled(),
   };
 }
 
 /**
- * The explicit workspace-type assertion to present on behalf of a project's
- * PERSISTED binding — a lane whose identity comes from the row, not from the
- * request. Two witnesses, either sufficient: the caller's own assertion when
- * the request names that same workspace, else what the daemon has learned
- * about the workspace from exact directory/context reads
- * (`WorkspaceTypeRegistry`). Silence stays silence (fail-closed).
+ * The verified workspace type to present on behalf of a project's PERSISTED
+ * binding — a lane whose identity comes from the row, not from the request.
+ * Two witnesses, either sufficient, neither a bare claim: the caller's own
+ * assertion when the request names that same workspace, confirmed through
+ * membership verification; else what the membership directory has
+ * established about the workspace (`WorkspaceTypeRegistry.verifiedTypeOf` —
+ * never the claim tier a project route learns from raw headers). Silence
+ * stays silence (fail-closed). Settled lazily, like
+ * `designSystemCatalogReadScope`.
  */
-function persistedBindingWorkspaceTypeAssertion(
+function persistedBindingWorkspaceTypeWitness(
   req: unknown,
   workspaceId: string | null | undefined,
-  workspaceTypes: Pick<WorkspaceTypeRegistry, 'typeOf'> | null | undefined,
-): 'personal' | 'team' | null {
+  witness: WorkspaceTypeWitness,
+): ReturnType<typeof settledWorkspaceTypeAssertion> | null {
   if (!workspaceId) return null;
   const claimed = workspaceProjectContextFromRequest(req);
   if (
@@ -335,9 +361,10 @@ function persistedBindingWorkspaceTypeAssertion(
     && claimed.workspaceId === workspaceId
     && claimed.workspaceTypeAsserted
   ) {
-    return claimed.workspaceTypeAsserted;
+    return settledWorkspaceTypeAssertion(() => verifiedWorkspaceTypeAssertion(req, witness));
   }
-  return workspaceTypes?.typeOf(workspaceId) ?? null;
+  const established = witness.verifiedTypeOf?.(workspaceId) ?? null;
+  return established ? settledWorkspaceTypeAssertion(async () => established) : null;
 }
 
 function sameLocalCatalogScopes(left: unknown, right: unknown): boolean {
@@ -441,7 +468,7 @@ export interface RegisterProjectRoutesDeps extends RouteDeps<'db' | 'design' | '
    * team share aimed at a personal workspace even when the caller's headers say
    * otherwise. See `collab/team-share-scope.ts`.
    */
-  workspaceTypes?: Pick<WorkspaceTypeRegistry, 'isKnownPersonal' | 'learn' | 'typeOf'>;
+  workspaceTypes?: Pick<WorkspaceTypeRegistry, 'isKnownPersonal' | 'learn' | 'typeOf' | 'verifiedTypeOf'>;
 }
 
 // `WorkspaceProjectContext`/`WorkspaceProjectMutationCapability`/
@@ -2157,6 +2184,16 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
   };
   const verifyWorkspaceProjectReadAuthority =
     ctx.verifyWorkspaceReadAuthority ?? ctx.verifyWorkspaceRequestAuthority;
+  // The witness behind the legacy local personal design-system allowance in
+  // project validation: the directory-established type memo, else the settled
+  // read authority (the membership directory in the packaged runtime, the
+  // explicit headers in local/dev). Consulted only for a design-system
+  // selection that claims a workspace type the daemon has not yet learned —
+  // ordinary Send keeps its no-network shape.
+  const designSystemWorkspaceTypeWitness: WorkspaceTypeWitness = {
+    verifiedTypeOf: workspaceTypes?.verifiedTypeOf,
+    verify: verifyWorkspaceProjectReadAuthority,
+  };
   const authorizeProjectRequest =
     ctx.authorizeProjectRequest ??
     createAuthorizeProjectRequest({
@@ -3873,12 +3910,9 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
           req.body?.skillCatalogScope,
           'skillCatalogScope',
         );
-        designSystemCatalogScope = withRequestAssertedWorkspaceType(
-          parseLocalCatalogScope(
-            req.body?.designSystemCatalogScope,
-            'designSystemCatalogScope',
-          ),
-          createWorkspace.context,
+        designSystemCatalogScope = parseLocalCatalogScope(
+          req.body?.designSystemCatalogScope,
+          'designSystemCatalogScope',
         );
       } catch (error) {
         return sendApiError(res, 400, 'BAD_REQUEST', String(error));
@@ -3887,9 +3921,15 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       // snapshot while a Workspace switch is loading. Use the partition that
       // produced that exact selection for local lookup only. It does not bind
       // this local project to that Workspace or prove current membership.
+      const designSystemReadScope = designSystemCatalogReadScope(
+        designSystemCatalogScope,
+        createWorkspace.context,
+        req,
+        designSystemWorkspaceTypeWitness,
+      );
       const designSystemValidation = await validateProjectDesignSystemId(
         designSystemId,
-        designSystemCatalogReadScope(designSystemCatalogScope, createWorkspace.context),
+        designSystemReadScope.scope,
       );
       if (!designSystemValidation.ok) {
         return sendApiError(
@@ -3900,6 +3940,18 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
         );
       }
       const normalizedDesignSystemId = designSystemValidation.id;
+      // Persist the partition with the type membership verification
+      // confirmed, when the selection needed that witness at all — never the
+      // client's raw claim, which run-time prompt loading would otherwise
+      // take as a verified witness.
+      if (designSystemCatalogScope) {
+        const { workspaceType: _claimedWorkspaceType, ...partition } = designSystemCatalogScope;
+        const workspaceTypeVerified = designSystemReadScope.settledWorkspaceType();
+        designSystemCatalogScope = {
+          ...partition,
+          ...(workspaceTypeVerified ? { workspaceType: workspaceTypeVerified } : {}),
+        };
+      }
       const skillValidation = await validateProjectSkillId(
         skillId,
         skillCatalogScope ?? creationWorkspaceScope,
@@ -5218,18 +5270,24 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       if (typeof patch.customInstructions === 'string' && patch.customInstructions.length > 5000) {
         return sendApiError(res, 400, 'BAD_REQUEST', 'customInstructions exceeds 5 000 character limit');
       }
+      // The partition a PATCH-selected design system was validated under,
+      // when the project's own binding can name it. Run-time prompt loading
+      // reads the verified type back from the persisted partition
+      // (`LocalCatalogScope.workspaceType`), where no request headers exist.
+      let designSystemSelectionScope: LocalCatalogScope | null = null;
       if (Object.prototype.hasOwnProperty.call(patch, 'designSystemId')) {
         const projectBinding = getWorkspaceProjectByProjectId(db, req.params.id);
+        const bindingWorkspaceTypeWitness = persistedBindingWorkspaceTypeWitness(
+          req,
+          projectBinding?.workspaceId,
+          designSystemWorkspaceTypeWitness,
+        );
         const designSystemValidation = await validateProjectDesignSystemId(
           patch.designSystemId,
           {
             workspaceId: projectBinding?.workspaceId ?? null,
             workspaceMemberId: projectBinding?.createdByWorkspaceMemberId ?? null,
-            workspaceTypeAsserted: persistedBindingWorkspaceTypeAssertion(
-              req,
-              projectBinding?.workspaceId,
-              workspaceTypes,
-            ),
+            workspaceTypeVerified: bindingWorkspaceTypeWitness?.resolve ?? null,
           },
         );
         if (!designSystemValidation.ok) {
@@ -5241,6 +5299,18 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
           );
         }
         patch.designSystemId = designSystemValidation.id;
+        const bindingWorkspaceTypeVerified = bindingWorkspaceTypeWitness?.settled() ?? null;
+        designSystemSelectionScope =
+          designSystemValidation.id
+          && projectBinding?.workspaceId
+          && projectBinding.createdByWorkspaceMemberId
+          && bindingWorkspaceTypeVerified
+            ? {
+                workspaceId: projectBinding.workspaceId,
+                workspaceMemberId: projectBinding.createdByWorkspaceMemberId,
+                workspaceType: bindingWorkspaceTypeVerified,
+              }
+            : null;
       }
       if (Object.prototype.hasOwnProperty.call(patch, 'skillId')) {
         const projectBinding = getWorkspaceProjectByProjectId(db, req.params.id);
@@ -5266,18 +5336,23 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
           ? patch.metadata
           : patchProject.metadata;
         const currentScopes = currentMetadata?.localCatalogScopes;
-        if (currentScopes) {
-          const nextScopes = { ...currentScopes };
+        const designSystemChanged =
+          Object.prototype.hasOwnProperty.call(patch, 'designSystemId')
+          && patch.designSystemId !== patchProject.designSystemId;
+        if (currentScopes || (designSystemChanged && designSystemSelectionScope)) {
+          const nextScopes = { ...(currentScopes ?? {}) };
           if (
             Object.prototype.hasOwnProperty.call(patch, 'skillId')
             && patch.skillId !== patchProject.skillId
           ) delete nextScopes.skill;
-          if (
-            Object.prototype.hasOwnProperty.call(patch, 'designSystemId')
-            && patch.designSystemId !== patchProject.designSystemId
-          ) delete nextScopes.designSystem;
+          if (designSystemChanged) {
+            delete nextScopes.designSystem;
+            if (designSystemSelectionScope) {
+              nextScopes.designSystem = designSystemSelectionScope;
+            }
+          }
           const { localCatalogScopes: _localCatalogScopes, ...metadataWithoutScopes } =
-            currentMetadata;
+            currentMetadata ?? {};
           patch.metadata = Object.keys(nextScopes).length > 0
             ? { ...metadataWithoutScopes, localCatalogScopes: nextScopes }
             : metadataWithoutScopes;

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -259,7 +259,85 @@ function parseLocalCatalogScope(value: unknown, field: string): LocalCatalogScop
   if (!workspaceId || !workspaceMemberId) {
     throw new Error(`${field} must contain workspaceId and workspaceMemberId`);
   }
-  return { workspaceId, workspaceMemberId };
+  // The type the client asserted for that partition travels with it. Values
+  // outside the enum are dropped, not normalized: an unasserted type must
+  // stay unasserted (fail-closed).
+  const workspaceType =
+    record.workspaceType === 'personal' || record.workspaceType === 'team'
+      ? record.workspaceType
+      : null;
+  return { workspaceId, workspaceMemberId, ...(workspaceType ? { workspaceType } : {}) };
+}
+
+/**
+ * A selection partition that carries no type assertion of its own (an older
+ * composer draft) inherits the request's, when the request names that same
+ * workspace: both are the same client's claim about the same partition, and
+ * the persisted provenance must carry what run-time prompt loading keys on.
+ */
+function withRequestAssertedWorkspaceType(
+  scope: LocalCatalogScope | null,
+  request: WorkspaceResourceContext | null,
+): LocalCatalogScope | null {
+  if (!scope || scope.workspaceType) return scope;
+  if (!request?.workspaceTypeAsserted || request.workspaceId !== scope.workspaceId) return scope;
+  return { ...scope, workspaceType: request.workspaceTypeAsserted };
+}
+
+/**
+ * The scope a project-create design-system validation reads the catalog
+ * under: the selection's persisted partition when the client supplied one,
+ * else the request's local attribution. The EXPLICIT type assertion travels
+ * with it — the legacy unattributed personal binding allowance
+ * (`designSystemPersonalBindingReadable`) keys on it — and an unasserted
+ * type stays unasserted.
+ */
+function designSystemCatalogReadScope(
+  catalogScope: LocalCatalogScope | null,
+  request: WorkspaceResourceContext | null,
+): {
+  workspaceId: string | null;
+  workspaceMemberId: string | null;
+  workspaceTypeAsserted: 'personal' | 'team' | null;
+} {
+  if (catalogScope) {
+    return {
+      workspaceId: catalogScope.workspaceId,
+      workspaceMemberId: catalogScope.workspaceMemberId,
+      workspaceTypeAsserted: catalogScope.workspaceType ?? null,
+    };
+  }
+  return {
+    workspaceId: request?.workspaceId ?? null,
+    workspaceMemberId: request?.workspaceMemberId ?? null,
+    workspaceTypeAsserted: request?.workspaceTypeAsserted ?? null,
+  };
+}
+
+/**
+ * The explicit workspace-type assertion to present on behalf of a project's
+ * PERSISTED binding — a lane whose identity comes from the row, not from the
+ * request. Two witnesses, either sufficient: the caller's own assertion when
+ * the request names that same workspace, else what the daemon has learned
+ * about the workspace from exact directory/context reads
+ * (`WorkspaceTypeRegistry`). Silence stays silence (fail-closed).
+ */
+function persistedBindingWorkspaceTypeAssertion(
+  req: unknown,
+  workspaceId: string | null | undefined,
+  workspaceTypes: Pick<WorkspaceTypeRegistry, 'typeOf'> | null | undefined,
+): 'personal' | 'team' | null {
+  if (!workspaceId) return null;
+  const claimed = workspaceProjectContextFromRequest(req);
+  if (
+    claimed
+    && claimed !== 'missing'
+    && claimed.workspaceId === workspaceId
+    && claimed.workspaceTypeAsserted
+  ) {
+    return claimed.workspaceTypeAsserted;
+  }
+  return workspaceTypes?.typeOf(workspaceId) ?? null;
 }
 
 function sameLocalCatalogScopes(left: unknown, right: unknown): boolean {
@@ -3795,9 +3873,12 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
           req.body?.skillCatalogScope,
           'skillCatalogScope',
         );
-        designSystemCatalogScope = parseLocalCatalogScope(
-          req.body?.designSystemCatalogScope,
-          'designSystemCatalogScope',
+        designSystemCatalogScope = withRequestAssertedWorkspaceType(
+          parseLocalCatalogScope(
+            req.body?.designSystemCatalogScope,
+            'designSystemCatalogScope',
+          ),
+          createWorkspace.context,
         );
       } catch (error) {
         return sendApiError(res, 400, 'BAD_REQUEST', String(error));
@@ -3808,7 +3889,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       // this local project to that Workspace or prove current membership.
       const designSystemValidation = await validateProjectDesignSystemId(
         designSystemId,
-        designSystemCatalogScope ?? creationWorkspaceScope,
+        designSystemCatalogReadScope(designSystemCatalogScope, createWorkspace.context),
       );
       if (!designSystemValidation.ok) {
         return sendApiError(
@@ -5144,6 +5225,11 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
           {
             workspaceId: projectBinding?.workspaceId ?? null,
             workspaceMemberId: projectBinding?.createdByWorkspaceMemberId ?? null,
+            workspaceTypeAsserted: persistedBindingWorkspaceTypeAssertion(
+              req,
+              projectBinding?.workspaceId,
+              workspaceTypes,
+            ),
           },
         );
         if (!designSystemValidation.ok) {

--- a/apps/daemon/src/routes/static-resource.ts
+++ b/apps/daemon/src/routes/static-resource.ts
@@ -31,12 +31,14 @@ import {
   getWorkspaceResourceByResourceId,
 } from '../db.js';
 import {
-  assertedWorkspaceScopeType,
   enforceVerifiedWorkspaceResourceMutation,
   resolveOptionalLocalWorkspaceRequestAuthority,
+  settledWorkspaceTypeAssertion,
   unattributedLocalPersonalDesignSystemAllowance,
+  verifiedWorkspaceTypeAssertion,
   type VerifyWorkspaceRequestAuthority,
 } from '../collab/workspace-resource-mutation.js';
+import type { WorkspaceTypeRegistry } from '../collab/team-share-scope.js';
 import { listCodexPets, readCodexPetSpritesheet } from '../codex-pets.js';
 import { syncCommunityPets } from '../community-pets-sync.js';
 import {
@@ -79,6 +81,12 @@ export interface RegisterStaticResourceRoutesDeps extends RouteDeps<'db' | 'http
   verifyWorkspaceReadAuthority?: VerifyWorkspaceRequestAuthority;
   /** Fresh authority for mutations, materialization, and detail reads. */
   verifyWorkspaceRequestAuthority?: VerifyWorkspaceRequestAuthority;
+  /**
+   * The daemon's memo of directory-established workspace types (verified
+   * tier only) — the first witness behind the legacy local personal
+   * design-system allowance in the catalog.
+   */
+  workspaceTypes?: Pick<WorkspaceTypeRegistry, 'verifiedTypeOf'>;
   tokenContractRebuild?: {
     maybeStartForImportedDesignSystem?: (
       designSystemId: string,
@@ -813,14 +821,27 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
         ?? (catalogAuthority ? null : (await resolveWorkspaceScope?.(req)) ?? null);
       const workspaceMemberId = workspaceContext?.workspaceMemberId ?? null;
       // The legacy unattributed-binding allowance keys on the caller's
-      // EXPLICIT type assertion, never the verified context's normalized
-      // `workspaceType` (a missing header normalizes to 'personal').
-      const workspaceTypeAsserted = assertedWorkspaceScopeType(req);
+      // explicit type assertion CONFIRMED by membership verification — the
+      // daemon's directory memo first, else the same settled authority this
+      // catalog resolves identity through. Never the raw claim (a Team
+      // member can send `personal`), and never the verified context's
+      // normalized `workspaceType` (a missing header normalizes to 'personal').
+      // Handed to the catalog as a resolver: a local catalog read stays off
+      // the authority plane unless an unattributed personal binding of this
+      // workspace is actually in the list.
+      const workspaceTypeWitness = settledWorkspaceTypeAssertion(() =>
+        verifiedWorkspaceTypeAssertion(req, {
+          verifiedTypeOf: ctx.workspaceTypes?.verifiedTypeOf,
+          verify: catalogAuthority,
+        }));
       const catalog = await listAllDesignSystems({
         workspaceId,
         workspaceMemberId,
-        workspaceTypeAsserted,
+        workspaceTypeVerified: workspaceTypeWitness.resolve,
       });
+      // What the catalog established, if it needed to; the duplicate filter
+      // below can only ever see the systems the catalog already admitted.
+      const workspaceTypeVerified = workspaceTypeWitness.settled() ?? null;
       const visibleSystems = workspaceId && workspaceMemberId
         ? catalog.filter((system) => {
             if (system.source !== 'user') return true;
@@ -848,7 +869,7 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
                 || unattributedLocalPersonalDesignSystemAllowance(
                   'design_system',
                   personalBinding,
-                  workspaceTypeAsserted,
+                  workspaceTypeVerified,
                 ));
           })
         : catalog;

--- a/apps/daemon/src/routes/static-resource.ts
+++ b/apps/daemon/src/routes/static-resource.ts
@@ -31,6 +31,7 @@ import {
   getWorkspaceResourceByResourceId,
 } from '../db.js';
 import {
+  assertedWorkspaceScopeType,
   enforceVerifiedWorkspaceResourceMutation,
   isUnattributedLocalPersonalDesignSystemBinding,
   resolveOptionalLocalWorkspaceRequestAuthority,
@@ -811,11 +812,14 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
       const workspaceId = workspaceContext?.workspaceId
         ?? (catalogAuthority ? null : (await resolveWorkspaceScope?.(req)) ?? null);
       const workspaceMemberId = workspaceContext?.workspaceMemberId ?? null;
-      const workspaceType = workspaceContext?.workspaceType ?? null;
+      // The legacy unattributed-binding allowance keys on the caller's
+      // EXPLICIT type assertion, never the verified context's normalized
+      // `workspaceType` (a missing header normalizes to 'personal').
+      const workspaceTypeAsserted = assertedWorkspaceScopeType(req);
       const catalog = await listAllDesignSystems({
         workspaceId,
         workspaceMemberId,
-        workspaceType,
+        workspaceTypeAsserted,
       });
       const visibleSystems = workspaceId && workspaceMemberId
         ? catalog.filter((system) => {
@@ -841,7 +845,7 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
               && personalBinding.visibility !== 'team'
               && personalBinding.resourceState !== 'deleted'
               && (personalBinding.createdByWorkspaceMemberId === workspaceMemberId
-                || (workspaceType === 'personal'
+                || (workspaceTypeAsserted === 'personal'
                   && isUnattributedLocalPersonalDesignSystemBinding(personalBinding)));
           })
         : catalog;

--- a/apps/daemon/src/routes/static-resource.ts
+++ b/apps/daemon/src/routes/static-resource.ts
@@ -32,6 +32,7 @@ import {
 } from '../db.js';
 import {
   enforceVerifiedWorkspaceResourceMutation,
+  isUnattributedLocalPersonalDesignSystemBinding,
   resolveOptionalLocalWorkspaceRequestAuthority,
   type VerifyWorkspaceRequestAuthority,
 } from '../collab/workspace-resource-mutation.js';
@@ -810,9 +811,11 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
       const workspaceId = workspaceContext?.workspaceId
         ?? (catalogAuthority ? null : (await resolveWorkspaceScope?.(req)) ?? null);
       const workspaceMemberId = workspaceContext?.workspaceMemberId ?? null;
+      const workspaceType = workspaceContext?.workspaceType ?? null;
       const catalog = await listAllDesignSystems({
         workspaceId,
         workspaceMemberId,
+        workspaceType,
       });
       const visibleSystems = workspaceId && workspaceMemberId
         ? catalog.filter((system) => {
@@ -837,7 +840,9 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
             return personalBinding?.workspaceId === workspaceId
               && personalBinding.visibility !== 'team'
               && personalBinding.resourceState !== 'deleted'
-              && personalBinding.createdByWorkspaceMemberId === workspaceMemberId;
+              && (personalBinding.createdByWorkspaceMemberId === workspaceMemberId
+                || (workspaceType === 'personal'
+                  && isUnattributedLocalPersonalDesignSystemBinding(personalBinding)));
           })
         : catalog;
       // recvqb6mfyqXLD: decorate every teamSynced entry with the same

--- a/apps/daemon/src/routes/static-resource.ts
+++ b/apps/daemon/src/routes/static-resource.ts
@@ -33,8 +33,8 @@ import {
 import {
   assertedWorkspaceScopeType,
   enforceVerifiedWorkspaceResourceMutation,
-  isUnattributedLocalPersonalDesignSystemBinding,
   resolveOptionalLocalWorkspaceRequestAuthority,
+  unattributedLocalPersonalDesignSystemAllowance,
   type VerifyWorkspaceRequestAuthority,
 } from '../collab/workspace-resource-mutation.js';
 import { listCodexPets, readCodexPetSpritesheet } from '../codex-pets.js';
@@ -845,8 +845,11 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
               && personalBinding.visibility !== 'team'
               && personalBinding.resourceState !== 'deleted'
               && (personalBinding.createdByWorkspaceMemberId === workspaceMemberId
-                || (workspaceTypeAsserted === 'personal'
-                  && isUnattributedLocalPersonalDesignSystemBinding(personalBinding)));
+                || unattributedLocalPersonalDesignSystemAllowance(
+                  'design_system',
+                  personalBinding,
+                  workspaceTypeAsserted,
+                ));
           })
         : catalog;
       // recvqb6mfyqXLD: decorate every teamSynced entry with the same

--- a/apps/daemon/src/server-context.ts
+++ b/apps/daemon/src/server-context.ts
@@ -54,10 +54,16 @@ export interface ResourceDeps {
   listAllDesignSystems: (options?: {
     workspaceId?: string | null;
     workspaceMemberId?: string | null;
-    // The caller's EXPLICIT `x-od-workspace-type` assertion (null when not
-    // asserted) — see `assertedWorkspaceScopeType`. Never pass the
-    // normalized `workspaceType`.
-    workspaceTypeAsserted?: 'personal' | 'team' | null;
+    // The caller's explicit `x-od-workspace-type` assertion CONFIRMED by
+    // membership verification (null when not asserted or not confirmed) —
+    // see `verifiedWorkspaceTypeAssertion` — or a resolver the catalog
+    // invokes only when an unattributed personal binding needs it. Never
+    // pass the raw claim or the normalized `workspaceType`.
+    workspaceTypeVerified?:
+      | 'personal'
+      | 'team'
+      | null
+      | (() => Promise<'personal' | 'team' | null>);
   }) => Promise<Array<DesignSystemSummary & { source?: string }>>;
   // The workspace a catalog read should be scoped to (#145). Data-plane reads
   // resolve it from this exact request's explicit Workspace/member identity,

--- a/apps/daemon/src/server-context.ts
+++ b/apps/daemon/src/server-context.ts
@@ -54,7 +54,10 @@ export interface ResourceDeps {
   listAllDesignSystems: (options?: {
     workspaceId?: string | null;
     workspaceMemberId?: string | null;
-    workspaceType?: 'personal' | 'team' | null;
+    // The caller's EXPLICIT `x-od-workspace-type` assertion (null when not
+    // asserted) — see `assertedWorkspaceScopeType`. Never pass the
+    // normalized `workspaceType`.
+    workspaceTypeAsserted?: 'personal' | 'team' | null;
   }) => Promise<Array<DesignSystemSummary & { source?: string }>>;
   // The workspace a catalog read should be scoped to (#145). Data-plane reads
   // resolve it from this exact request's explicit Workspace/member identity,

--- a/apps/daemon/src/server-context.ts
+++ b/apps/daemon/src/server-context.ts
@@ -54,6 +54,7 @@ export interface ResourceDeps {
   listAllDesignSystems: (options?: {
     workspaceId?: string | null;
     workspaceMemberId?: string | null;
+    workspaceType?: 'personal' | 'team' | null;
   }) => Promise<Array<DesignSystemSummary & { source?: string }>>;
   // The workspace a catalog read should be scoped to (#145). Data-plane reads
   // resolve it from this exact request's explicit Workspace/member identity,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -916,7 +916,10 @@ import {
   velaWorkspaceDirectoryIdentity,
   workspaceContextFromDirectoryItem,
 } from './collab/vela-workspace-context.js';
-import { verifyWorkspaceRequestContext } from './collab/request-workspace-context.js';
+import {
+  verifyLocalWorkspaceRequestContext,
+  verifyWorkspaceRequestContext,
+} from './collab/request-workspace-context.js';
 import {
   createWorkspaceBillingRuntimeCoordinator,
   shouldEmitWorkspaceBillingRuntimeNudge,
@@ -3481,7 +3484,9 @@ export async function startServer({
       const result = await fetchVelaWorkspaceDirectory({
         configuredEnv: configuredAmrEnv(),
       });
-      if (result.ok) workspaceTypes.learn(result.items);
+      // The directory is the one source that ESTABLISHES a workspace's type;
+      // request claims learned elsewhere never reach the verified tier.
+      if (result.ok) workspaceTypes.learnVerified(result.items);
       return result;
     },
     identityKey: () => velaWorkspaceDirectoryIdentity(
@@ -3529,47 +3534,10 @@ export async function startServer({
     // Local/dev has no signed membership directory. Its explicit request
     // headers are the complete, static authority; still never consult the
     // daemon's mutable active-workspace context.
-    const claimed = workspaceResourceContextFromRequest(input.req);
-    if (claimed === null) {
-      return {
-        ok: false as const,
-        status: 400 as const,
-        code: 'WORKSPACE_CONTEXT_REQUIRED' as const,
-        message: 'an explicit workspace context is required',
-      };
-    }
-    if (claimed === 'missing') {
-      return {
-        ok: false as const,
-        status: 400 as const,
-        code: 'WORKSPACE_CONTEXT_INCOMPLETE' as const,
-        message: 'both workspace and member identity are required',
-      };
-    }
-    if (
-      claimed.memberStatus !== 'active'
-      || claimed.lifecycleState === 'deleted'
-      || (input.requireTeam && claimed.workspaceType !== 'team')
-    ) {
-      return {
-        ok: false as const,
-        status: 403 as const,
-        code: 'WORKSPACE_ACCESS_DENIED' as const,
-        message: 'the requested workspace is not available to this member',
-      };
-    }
-    return {
-      ok: true as const,
-      context: workspaceContextFromDirectoryItem({
-        workspaceId: claimed.workspaceId,
-        workspaceName: claimed.workspaceId,
-        workspaceType: claimed.workspaceType,
-        workspaceMemberId: claimed.workspaceMemberId,
-        role: claimed.role,
-        memberStatus: claimed.memberStatus,
-        lifecycleState: claimed.lifecycleState,
-      }, configuredAmrEnv()),
-    };
+    return verifyLocalWorkspaceRequestContext(input.req, {
+      configuredEnv: configuredAmrEnv(),
+      ...(input.requireTeam !== undefined ? { requireTeam: input.requireTeam } : {}),
+    });
   };
   const verifyWorkspaceReadAuthority = (req: unknown) =>
     verifyExplicitWorkspaceRequestContext({ req }, { fresh: false });
@@ -5532,7 +5500,7 @@ export async function startServer({
         getWorkspaceContext: async () => {
           const context =
             await resolveAuthoritativeTeamWorkspaceContext(workspaceId);
-          workspaceTypes.learn(context);
+          workspaceTypes.learnVerified(context);
           return context;
         },
         listTeamProjects: (context) => teamProjectsForDisplay(context),
@@ -8515,6 +8483,7 @@ export async function startServer({
     paths: pathDeps,
     verifyWorkspaceReadAuthority,
     verifyWorkspaceRequestAuthority,
+    workspaceTypes,
     teamResources: collab.teamResources,
     resources: {
       listAllSkills,
@@ -8547,6 +8516,8 @@ export async function startServer({
     projectStore: projectStoreDeps,
     projectFiles: projectFileDeps,
     verifyWorkspaceRequestAuthority,
+    verifyWorkspaceReadAuthority,
+    workspaceTypes,
     workspaceResources: { getWorkspaceResource, getWorkspaceResourceByResourceId },
     designSystems: {
       buildUserDesignSystemArchive,
@@ -9349,9 +9320,10 @@ export async function startServer({
       const workspaceMemberId = typeof value?.workspaceMemberId === 'string'
         ? value.workspaceMemberId.trim()
         : '';
-      // The type the selecting client asserted for that partition, persisted
-      // with it (`LocalCatalogScope.workspaceType`). Anything else stays
-      // unasserted rather than normalized.
+      // The type membership verification confirmed for that partition at
+      // selection time, persisted with it (`LocalCatalogScope.workspaceType`;
+      // the daemon drops a claim it could not confirm before persisting).
+      // Anything else stays unasserted rather than normalized.
       const workspaceType =
         value?.workspaceType === 'personal' || value?.workspaceType === 'team'
           ? value.workspaceType
@@ -9372,17 +9344,20 @@ export async function startServer({
       designSystemCatalogScope?.workspaceId ?? projectWorkspaceId;
     const designSystemMemberId =
       designSystemCatalogScope?.workspaceMemberId ?? projectCreatorMemberId;
-    // The explicit personal assertion behind the legacy unattributed-binding
+    // The verified personal workspace behind the legacy unattributed-binding
     // allowance (`designSystemPersonalBindingReadable`), for a lane that has
     // no request headers of its own. Two witnesses, either sufficient, both
-    // silent by default (fail-closed): the type the selecting client asserted
-    // for the persisted catalog partition, else what this daemon has learned
-    // about the project's workspace from exact directory/context reads
-    // (`WorkspaceTypeRegistry`). Shell/current Workspace state still never
-    // participates — the workspace itself comes only from the persisted scope.
-    const designSystemWorkspaceTypeAsserted =
+    // silent by default (fail-closed), and neither a caller's claim: the type
+    // membership verification confirmed for the persisted catalog partition
+    // when the selection was validated, else what the membership directory
+    // has established about the project's workspace
+    // (`WorkspaceTypeRegistry.verifiedTypeOf` — never the claim tier, which a
+    // project route learns from raw headers). Shell/current Workspace state
+    // still never participates — the workspace itself comes only from the
+    // persisted scope.
+    const designSystemWorkspaceTypeVerified =
       designSystemCatalogScope?.workspaceType
-      ?? workspaceTypes.typeOf(designSystemWorkspaceId)
+      ?? workspaceTypes.verifiedTypeOf(designSystemWorkspaceId)
       ?? null;
     const projectDesignSystemBinding = (summary) => {
       if (!designSystemWorkspaceId || summary?.source === 'built-in') return null;
@@ -9430,7 +9405,7 @@ export async function startServer({
       return designSystemPersonalBindingReadable(binding, {
         workspaceId: designSystemWorkspaceId,
         workspaceMemberId: designSystemMemberId,
-        workspaceTypeAsserted: designSystemWorkspaceTypeAsserted,
+        workspaceTypeVerified: designSystemWorkspaceTypeVerified,
       });
     };
     let appConfigForPrompt = null;
@@ -9756,7 +9731,7 @@ export async function startServer({
         ? {
             workspaceId: designSystemWorkspaceId,
             workspaceMemberId: designSystemMemberId || null,
-            workspaceTypeAsserted: designSystemWorkspaceTypeAsserted,
+            workspaceTypeVerified: designSystemWorkspaceTypeVerified,
           }
         : {};
       let systems = await listAllDesignSystems(designSystemListOptions);

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -373,7 +373,10 @@ import {
   deleteWorkspaceOwnedDesignSystem as removeWorkspaceOwnedDesignSystem,
 } from './design-systems/workspace-owned-create.js';
 import { createDesignSystemGenerationJobStore } from './design-systems/generation-jobs.js';
-import { createDesignSystemServerServices } from './design-systems/server-services.js';
+import {
+  createDesignSystemServerServices,
+  designSystemPersonalBindingReadable,
+} from './design-systems/server-services.js';
 import {
   designSystemIdFromWorkspaceTeamBinding,
   designSystemLogicalResourceId,
@@ -9346,8 +9349,15 @@ export async function startServer({
       const workspaceMemberId = typeof value?.workspaceMemberId === 'string'
         ? value.workspaceMemberId.trim()
         : '';
+      // The type the selecting client asserted for that partition, persisted
+      // with it (`LocalCatalogScope.workspaceType`). Anything else stays
+      // unasserted rather than normalized.
+      const workspaceType =
+        value?.workspaceType === 'personal' || value?.workspaceType === 'team'
+          ? value.workspaceType
+          : null;
       return workspaceId && workspaceMemberId
-        ? { workspaceId, workspaceMemberId }
+        ? { workspaceId, workspaceMemberId, workspaceType }
         : null;
     };
     // Resource provenance is intentionally independent from project
@@ -9362,6 +9372,18 @@ export async function startServer({
       designSystemCatalogScope?.workspaceId ?? projectWorkspaceId;
     const designSystemMemberId =
       designSystemCatalogScope?.workspaceMemberId ?? projectCreatorMemberId;
+    // The explicit personal assertion behind the legacy unattributed-binding
+    // allowance (`designSystemPersonalBindingReadable`), for a lane that has
+    // no request headers of its own. Two witnesses, either sufficient, both
+    // silent by default (fail-closed): the type the selecting client asserted
+    // for the persisted catalog partition, else what this daemon has learned
+    // about the project's workspace from exact directory/context reads
+    // (`WorkspaceTypeRegistry`). Shell/current Workspace state still never
+    // participates — the workspace itself comes only from the persisted scope.
+    const designSystemWorkspaceTypeAsserted =
+      designSystemCatalogScope?.workspaceType
+      ?? workspaceTypes.typeOf(designSystemWorkspaceId)
+      ?? null;
     const projectDesignSystemBinding = (summary) => {
       if (!designSystemWorkspaceId || summary?.source === 'built-in') return null;
       const logicalResourceId =
@@ -9402,9 +9424,14 @@ export async function startServer({
         return false;
       }
       if (binding.visibility === 'team') return true;
-      return binding.visibility === 'personal'
-        && Boolean(designSystemMemberId)
-        && binding.createdByWorkspaceMemberId?.trim() === designSystemMemberId;
+      // The same personal-binding decision the catalog, the detail read, and
+      // project validation make, so a system a project could select is a
+      // system its run can load.
+      return designSystemPersonalBindingReadable(binding, {
+        workspaceId: designSystemWorkspaceId,
+        workspaceMemberId: designSystemMemberId,
+        workspaceTypeAsserted: designSystemWorkspaceTypeAsserted,
+      });
     };
     let appConfigForPrompt = null;
     try {
@@ -9729,6 +9756,7 @@ export async function startServer({
         ? {
             workspaceId: designSystemWorkspaceId,
             workspaceMemberId: designSystemMemberId || null,
+            workspaceTypeAsserted: designSystemWorkspaceTypeAsserted,
           }
         : {};
       let systems = await listAllDesignSystems(designSystemListOptions);

--- a/apps/daemon/tests/design-systems/design-system-family-workspace-authority.test.ts
+++ b/apps/daemon/tests/design-systems/design-system-family-workspace-authority.test.ts
@@ -375,12 +375,13 @@ describe('Design System route family exact Workspace authority', () => {
     expect(calls.static).toHaveBeenCalledWith(
       DESIGN_SYSTEM_ID,
       'system/kit.html',
-      { workspaceId: WORKSPACE_ID, workspaceMemberId: MEMBER_ID, workspaceType: 'personal', exactTeam: false },
+      // A query scope that names no workspace type has asserted none.
+      { workspaceId: WORKSPACE_ID, workspaceMemberId: MEMBER_ID, workspaceTypeAsserted: null, exactTeam: false },
     );
     expect(calls.static).toHaveBeenCalledWith(
       DESIGN_SYSTEM_ID,
       'tokens.css',
-      { workspaceId: WORKSPACE_ID, workspaceMemberId: MEMBER_ID, workspaceType: 'personal', exactTeam: false },
+      { workspaceId: WORKSPACE_ID, workspaceMemberId: MEMBER_ID, workspaceTypeAsserted: null, exactTeam: false },
     );
     expect(verifyWorkspaceRequestAuthority).not.toHaveBeenCalled();
   });

--- a/apps/daemon/tests/design-systems/design-system-family-workspace-authority.test.ts
+++ b/apps/daemon/tests/design-systems/design-system-family-workspace-authority.test.ts
@@ -375,12 +375,12 @@ describe('Design System route family exact Workspace authority', () => {
     expect(calls.static).toHaveBeenCalledWith(
       DESIGN_SYSTEM_ID,
       'system/kit.html',
-      { workspaceId: WORKSPACE_ID, workspaceMemberId: MEMBER_ID, exactTeam: false },
+      { workspaceId: WORKSPACE_ID, workspaceMemberId: MEMBER_ID, workspaceType: 'personal', exactTeam: false },
     );
     expect(calls.static).toHaveBeenCalledWith(
       DESIGN_SYSTEM_ID,
       'tokens.css',
-      { workspaceId: WORKSPACE_ID, workspaceMemberId: MEMBER_ID, exactTeam: false },
+      { workspaceId: WORKSPACE_ID, workspaceMemberId: MEMBER_ID, workspaceType: 'personal', exactTeam: false },
     );
     expect(verifyWorkspaceRequestAuthority).not.toHaveBeenCalled();
   });

--- a/apps/daemon/tests/design-systems/design-system-family-workspace-authority.test.ts
+++ b/apps/daemon/tests/design-systems/design-system-family-workspace-authority.test.ts
@@ -376,12 +376,12 @@ describe('Design System route family exact Workspace authority', () => {
       DESIGN_SYSTEM_ID,
       'system/kit.html',
       // A query scope that names no workspace type has asserted none.
-      { workspaceId: WORKSPACE_ID, workspaceMemberId: MEMBER_ID, workspaceTypeAsserted: null, exactTeam: false },
+      { workspaceId: WORKSPACE_ID, workspaceMemberId: MEMBER_ID, workspaceTypeVerified: null, exactTeam: false },
     );
     expect(calls.static).toHaveBeenCalledWith(
       DESIGN_SYSTEM_ID,
       'tokens.css',
-      { workspaceId: WORKSPACE_ID, workspaceMemberId: MEMBER_ID, workspaceTypeAsserted: null, exactTeam: false },
+      { workspaceId: WORKSPACE_ID, workspaceMemberId: MEMBER_ID, workspaceTypeVerified: null, exactTeam: false },
     );
     expect(verifyWorkspaceRequestAuthority).not.toHaveBeenCalled();
   });

--- a/apps/daemon/tests/design-systems/explicit-workspace-scope-routes.test.ts
+++ b/apps/daemon/tests/design-systems/explicit-workspace-scope-routes.test.ts
@@ -524,7 +524,9 @@ describe('design-system explicit Workspace request scope', () => {
     expect(listAllDesignSystems).toHaveBeenCalledWith({
       workspaceId: 'workspace-a',
       workspaceMemberId: null,
-      workspaceType: null,
+      // The route threads the caller's EXPLICIT type assertion (the fixture
+      // headers assert `team`), never a normalized fallback.
+      workspaceTypeAsserted: 'team',
     });
   });
 

--- a/apps/daemon/tests/design-systems/explicit-workspace-scope-routes.test.ts
+++ b/apps/daemon/tests/design-systems/explicit-workspace-scope-routes.test.ts
@@ -524,6 +524,7 @@ describe('design-system explicit Workspace request scope', () => {
     expect(listAllDesignSystems).toHaveBeenCalledWith({
       workspaceId: 'workspace-a',
       workspaceMemberId: null,
+      workspaceType: null,
     });
   });
 

--- a/apps/daemon/tests/design-systems/explicit-workspace-scope-routes.test.ts
+++ b/apps/daemon/tests/design-systems/explicit-workspace-scope-routes.test.ts
@@ -524,9 +524,11 @@ describe('design-system explicit Workspace request scope', () => {
     expect(listAllDesignSystems).toHaveBeenCalledWith({
       workspaceId: 'workspace-a',
       workspaceMemberId: null,
-      // The route threads the caller's EXPLICIT type assertion (the fixture
-      // headers assert `team`), never a normalized fallback.
-      workspaceTypeAsserted: 'team',
+      // The route hands the catalog a resolver for the caller's EXPLICIT
+      // type assertion, which the catalog settles only when an unattributed
+      // personal binding is in the list — never a normalized fallback, and
+      // never a value read off the raw header.
+      workspaceTypeVerified: expect.any(Function),
     });
   });
 

--- a/apps/daemon/tests/design-systems/local-install-personal-journey.test.ts
+++ b/apps/daemon/tests/design-systems/local-install-personal-journey.test.ts
@@ -20,9 +20,13 @@
 // selection -> project creation -> mutation -> run, for both a project created
 // from that selection and a legacy memberless project.
 //
-// Every allowance keys on the caller's EXPLICIT personal assertion. A
-// same-workspace caller that omits or contradicts the type stays refused at
-// every one of these gates — pinned alongside each happy path.
+// Every allowance keys on the caller's EXPLICIT personal assertion CONFIRMED
+// by the daemon's membership verification — on this local/dev install the
+// explicit headers are that authority; local-install-personal-verified-
+// workspace.test.ts covers the packaged runtime, where the membership
+// directory is. A same-workspace caller that omits or contradicts the type
+// stays refused at every one of these gates — pinned alongside each happy
+// path.
 
 import Database from 'better-sqlite3';
 import { execFileSync } from 'node:child_process';

--- a/apps/daemon/tests/design-systems/local-install-personal-journey.test.ts
+++ b/apps/daemon/tests/design-systems/local-install-personal-journey.test.ts
@@ -1,0 +1,414 @@
+// Regression for the QA-verified end-to-end journey on a local install that
+// never signed into a Workspace (PR #7693 review): the legacy unattributed
+// personal design system must be USABLE, not merely visible.
+//
+// The install's normal state (see local-install-personal-visibility.test.ts):
+// the web shell sends the local personal Workspace scope on every request
+// (`x-od-workspace-id` + `x-od-workspace-member-id` + `x-od-workspace-type:
+// personal`), while lazy orphan adoption left the design system's editing
+// project bound to that workspace with NO creator member, so the startup
+// backfill wrote an equally unattributed `visibility: 'personal'` binding.
+//
+// Making that binding readable fixed the catalog and detail reads but left
+// three sibling gates on the strict exact-creator rule, so the primary user
+// journey still broke end to end: Home listed the system but project creation
+// answered 400 DESIGN_SYSTEM_NOT_FOUND; the UI offered Publish/Edit/Delete but
+// every mutation answered 403; existing projects could select it but the run
+// path filtered it out of the prompt. These specs drive the whole chain
+// through the real daemon (real startup backfill, real routes, real run
+// composition with a stub agent that reports what reached its stdin):
+// selection -> project creation -> mutation -> run, for both a project created
+// from that selection and a legacy memberless project.
+//
+// Every allowance keys on the caller's EXPLICIT personal assertion. A
+// same-workspace caller that omits or contradicts the type stays refused at
+// every one of these gates — pinned alongside each happy path.
+
+import Database from 'better-sqlite3';
+import { execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { promises as fsp } from 'node:fs';
+import type http from 'node:http';
+import { tmpdir } from 'node:os';
+import { delimiter, join, resolve } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  ensureWorkspaceProject,
+  getWorkspaceResourceByResourceId,
+  insertProject,
+} from '../../src/db.js';
+import { backfillDesignSystemWorkspaceResources } from '../../src/design-systems/index.js';
+import { startServer } from '../../src/server.js';
+
+const WORKSPACE = `local-personal-ws-${randomUUID()}`;
+const LOCAL_MEMBER = `local-member-${randomUUID()}`;
+const DIR_ID = `legacy-local-${randomUUID()}`;
+const DESIGN_SYSTEM_ID = `user:${DIR_ID}`;
+const EDITING_PROJECT_ID = `ds-editing-${randomUUID()}`;
+const MARKER = `LEGACY_LOCAL_DS_${randomUUID().replace(/-/g, '')}`;
+
+let server: http.Server;
+let baseUrl: string;
+let designSystemDir: string;
+let createdProjectId: string | null = null;
+let legacyProjectId: string | null = null;
+
+function personalScopeHeaders(): Record<string, string> {
+  return {
+    'content-type': 'application/json',
+    'x-od-workspace-id': WORKSPACE,
+    'x-od-workspace-member-id': LOCAL_MEMBER,
+    'x-od-workspace-type': 'personal',
+  };
+}
+
+function unassertedScopeHeaders(): Record<string, string> {
+  const { 'x-od-workspace-type': _type, ...rest } = personalScopeHeaders();
+  return rest;
+}
+
+function teamAssertedScopeHeaders(): Record<string, string> {
+  return { ...personalScopeHeaders(), 'x-od-workspace-type': 'team' };
+}
+
+function openSqlite(): Database.Database {
+  return new Database(resolve(process.env.OD_DATA_DIR!, 'app.sqlite'));
+}
+
+/** The stub agent reports whether the design system's DESIGN.md reached the prompt. */
+const PROMPT_PROBE = `
+let prompt = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => { prompt += chunk; });
+process.stdin.on('end', () => {
+  const result = prompt.includes(${JSON.stringify(MARKER)})
+    ? 'legacy-design-system-visible'
+    : 'legacy-design-system-missing';
+  console.log(JSON.stringify({ type: 'step_start' }));
+  console.log(JSON.stringify({ type: 'text', part: { text: result } }));
+  console.log(JSON.stringify({ type: 'step_finish', part: { tokens: { input: 1, output: 1 } } }));
+  process.exit(0);
+});
+`;
+
+function killProcessesUsingPath(pathFragment: string): void {
+  if (process.platform === 'win32') return;
+  let output = '';
+  try {
+    output = execFileSync('pgrep', ['-f', pathFragment], { encoding: 'utf8' });
+  } catch {
+    return;
+  }
+  for (const line of output.split('\n')) {
+    const pid = Number(line.trim());
+    if (!Number.isInteger(pid) || pid <= 0 || pid === process.pid) continue;
+    try {
+      process.kill(-pid, 'SIGKILL');
+    } catch {
+      try { process.kill(pid, 'SIGKILL'); } catch { /* already gone */ }
+    }
+  }
+}
+
+async function withPromptProbeAgent<T>(run: () => Promise<T>): Promise<T> {
+  const dir = await fsp.mkdtemp(join(tmpdir(), 'od-legacy-ds-bin-'));
+  const oldPath = process.env.PATH;
+  try {
+    if (process.platform === 'win32') {
+      const runner = join(dir, 'opencode-test-runner.cjs');
+      await fsp.writeFile(runner, PROMPT_PROBE);
+      await fsp.writeFile(join(dir, 'opencode.cmd'), `@echo off\r\nnode "${runner}" %*\r\n`);
+    } else {
+      const bin = join(dir, 'opencode');
+      await fsp.writeFile(bin, `#!/usr/bin/env node\n${PROMPT_PROBE}`);
+      await fsp.chmod(bin, 0o755);
+    }
+    process.env.PATH = `${dir}${delimiter}${oldPath ?? ''}`;
+    return await run();
+  } finally {
+    process.env.PATH = oldPath;
+    killProcessesUsingPath(dir);
+    await fsp.rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function runProjectAndProbePrompt(
+  projectId: string,
+  headers: Record<string, string>,
+): Promise<string> {
+  return withPromptProbeAgent(async () => {
+    const response = await fetch(`${baseUrl}/api/chat`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        agentId: 'opencode',
+        projectId,
+        message: 'draft with my local brand',
+      }),
+    });
+    const body = await response.text();
+    expect(response.ok).toBe(true);
+    return body;
+  });
+}
+
+async function listCatalogIds(headers: Record<string, string>): Promise<string[]> {
+  const response = await fetch(`${baseUrl}/api/design-systems`, { headers });
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as { designSystems: Array<{ id: string }> };
+  return body.designSystems.map((system) => system.id);
+}
+
+async function createProject(
+  headers: Record<string, string>,
+  designSystemCatalogScope: Record<string, string>,
+): Promise<{ id: string; response: Response }> {
+  const id = `proj-legacy-ds-${randomUUID()}`;
+  const response = await fetch(`${baseUrl}/api/projects`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      id,
+      name: 'Legacy local design system project',
+      designSystemId: DESIGN_SYSTEM_ID,
+      designSystemCatalogScope,
+      skipDiscoveryBrief: true,
+    }),
+  });
+  return { id, response };
+}
+
+beforeAll(async () => {
+  if (!process.env.OD_DATA_DIR) {
+    throw new Error('OD_DATA_DIR is required for the local-install design-system journey');
+  }
+  const started = (await startServer({ port: 0, returnServer: true })) as {
+    url: string;
+    server: http.Server;
+  };
+  baseUrl = started.url;
+  server = started.server;
+
+  // The exact on-disk + DB state of the reported install, reproduced through
+  // the same startup backfill `server.ts` runs.
+  designSystemDir = resolve(process.env.OD_DATA_DIR, 'design-systems', DIR_ID);
+  await fsp.mkdir(designSystemDir, { recursive: true });
+  await fsp.writeFile(
+    resolve(designSystemDir, 'DESIGN.md'),
+    `# Legacy local design system\n\n## Colors\n\n${MARKER}\n`,
+    'utf8',
+  );
+  await fsp.writeFile(
+    resolve(designSystemDir, 'metadata.json'),
+    `${JSON.stringify({
+      title: 'Legacy local design system',
+      status: 'published',
+      projectId: EDITING_PROJECT_ID,
+    }, null, 2)}\n`,
+    'utf8',
+  );
+  // The design system's editing project exists on disk too, as it does on a
+  // real install (the run path re-reads DESIGN.md through that project).
+  const editingProjectDir = resolve(process.env.OD_DATA_DIR, 'projects', EDITING_PROJECT_ID);
+  await fsp.mkdir(editingProjectDir, { recursive: true });
+  await fsp.copyFile(resolve(designSystemDir, 'DESIGN.md'), resolve(editingProjectDir, 'DESIGN.md'));
+  const sqlite = openSqlite();
+  try {
+    insertProject(sqlite as never, {
+      id: EDITING_PROJECT_ID,
+      name: 'Legacy local design system',
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    // Legacy orphan adoption shape: bound to the personal workspace with NO
+    // creator member (`ensureWorkspaceProjection` writes exactly this).
+    ensureWorkspaceProject(sqlite as never, {
+      workspaceId: WORKSPACE,
+      projectId: EDITING_PROJECT_ID,
+      visibility: 'personal',
+      resourceState: 'active',
+      createdByWorkspaceMemberId: null,
+    });
+    await backfillDesignSystemWorkspaceResources(
+      sqlite as never,
+      resolve(process.env.OD_DATA_DIR, 'design-systems'),
+    );
+    const binding = getWorkspaceResourceByResourceId(
+      sqlite as never,
+      'design_system',
+      DESIGN_SYSTEM_ID,
+    );
+    expect(binding).toMatchObject({
+      workspaceId: WORKSPACE,
+      visibility: 'personal',
+      createdByWorkspaceMemberId: null,
+    });
+  } finally {
+    sqlite.close();
+  }
+});
+
+afterAll(async () => {
+  for (const id of [createdProjectId, legacyProjectId, EDITING_PROJECT_ID]) {
+    if (!id) continue;
+    await fetch(`${baseUrl}/api/projects/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+      headers: personalScopeHeaders(),
+    }).catch(() => {});
+  }
+  await fsp.rm(designSystemDir, { recursive: true, force: true }).catch(() => {});
+  await new Promise<void>((done) => server.close(() => done()));
+});
+
+describe('legacy local personal design system: selection -> create -> mutate -> run', () => {
+  const designSystemUrl = () =>
+    `${baseUrl}/api/design-systems/${encodeURIComponent(DESIGN_SYSTEM_ID)}`;
+
+  it('accepts the Home selection on project creation under the asserted personal scope', async () => {
+    expect(await listCatalogIds(personalScopeHeaders())).toContain(DESIGN_SYSTEM_ID);
+
+    const created = await createProject(personalScopeHeaders(), {
+      workspaceId: WORKSPACE,
+      workspaceMemberId: LOCAL_MEMBER,
+      workspaceType: 'personal',
+    });
+
+    expect(created.response.status, await created.response.clone().text()).toBe(200);
+    createdProjectId = created.id;
+  });
+
+  it('keeps refusing project creation for a same-workspace selection that does not assert its type', async () => {
+    // A missing `x-od-workspace-type` is not an assertion of a personal
+    // workspace; the project-create validator stays on the strict gate like
+    // every other read lane (fail-closed).
+    const created = await createProject(unassertedScopeHeaders(), {
+      workspaceId: WORKSPACE,
+      workspaceMemberId: LOCAL_MEMBER,
+    });
+
+    expect(created.response.status).toBe(400);
+    expect(await created.response.text()).toContain('DESIGN_SYSTEM_NOT_FOUND');
+  });
+
+  it('injects the selected DESIGN.md into a run of the project created from that selection', async () => {
+    expect(createdProjectId).not.toBeNull();
+
+    const body = await runProjectAndProbePrompt(createdProjectId!, personalScopeHeaders());
+
+    expect(body).toContain('legacy-design-system-visible');
+    expect(body).not.toContain('legacy-design-system-missing');
+  });
+
+  it('injects the selected DESIGN.md into a run of a legacy memberless project', async () => {
+    // An existing project adopted without a creator member — the same legacy
+    // shape as the design system's own binding — selects the system through
+    // the UI's PATCH, then runs from its persisted scope, which carries no
+    // member and no type assertion of its own.
+    legacyProjectId = `proj-legacy-memberless-${randomUUID()}`;
+    const createResponse = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        id: legacyProjectId,
+        name: 'Legacy memberless project',
+        skipDiscoveryBrief: true,
+      }),
+    });
+    expect(createResponse.ok).toBe(true);
+    const sqlite = openSqlite();
+    try {
+      ensureWorkspaceProject(sqlite as never, {
+        workspaceId: WORKSPACE,
+        projectId: legacyProjectId,
+        visibility: 'personal',
+        resourceState: 'active',
+        createdByWorkspaceMemberId: null,
+      });
+    } finally {
+      sqlite.close();
+    }
+    const selected = await fetch(`${baseUrl}/api/projects/${encodeURIComponent(legacyProjectId)}`, {
+      method: 'PATCH',
+      headers: personalScopeHeaders(),
+      body: JSON.stringify({ designSystemId: DESIGN_SYSTEM_ID }),
+    });
+    expect(selected.status, await selected.clone().text()).toBe(200);
+
+    const body = await runProjectAndProbePrompt(legacyProjectId, personalScopeHeaders());
+
+    expect(body).toContain('legacy-design-system-visible');
+    expect(body).not.toContain('legacy-design-system-missing');
+  });
+
+  it('accepts a PATCH from the asserted personal scope and refuses team or unasserted scopes', async () => {
+    const teamAsserted = await fetch(designSystemUrl(), {
+      method: 'PATCH',
+      headers: teamAssertedScopeHeaders(),
+      body: JSON.stringify({ title: 'Must not rename' }),
+    });
+    expect(teamAsserted.status).toBe(403);
+    const unasserted = await fetch(designSystemUrl(), {
+      method: 'PATCH',
+      headers: unassertedScopeHeaders(),
+      body: JSON.stringify({ title: 'Must not rename' }),
+    });
+    expect(unasserted.status).toBe(403);
+
+    const renamed = await fetch(designSystemUrl(), {
+      method: 'PATCH',
+      headers: personalScopeHeaders(),
+      body: JSON.stringify({ title: 'Renamed legacy local design system' }),
+    });
+    expect(renamed.status, await renamed.clone().text()).toBe(200);
+
+    // The detail read's `canMutate` is what enables the UI's Publish/Edit/
+    // Delete controls; it must agree with the verdict the mutation routes
+    // just gave.
+    const detail = await fetch(designSystemUrl(), { headers: personalScopeHeaders() });
+    expect(detail.status).toBe(200);
+    const detailBody = (await detail.json()) as { title?: string; canMutate?: boolean };
+    expect(detailBody.title).toBe('Renamed legacy local design system');
+    expect(detailBody.canMutate).toBe(true);
+  });
+
+  it('opens the editor on the legacy editing project itself and syncs assets under the asserted personal scope', async () => {
+    const denied = await fetch(`${designSystemUrl()}/workspace`, {
+      method: 'POST',
+      headers: teamAssertedScopeHeaders(),
+    });
+    expect(denied.status).toBe(403);
+
+    const opened = await fetch(`${designSystemUrl()}/workspace`, {
+      method: 'POST',
+      headers: personalScopeHeaders(),
+    });
+    expect(opened.status, await opened.clone().text()).toBe(201);
+    const openedBody = (await opened.json()) as { project?: { id?: string } };
+    // The system's own editing project — the one run-time prompt loading
+    // reads DESIGN.md through — not a forked workspace-scoped copy whose
+    // edits the run would never see.
+    expect(openedBody.project?.id).toBe(EDITING_PROJECT_ID);
+
+    const synced = await fetch(`${designSystemUrl()}/sync-assets`, {
+      method: 'POST',
+      headers: personalScopeHeaders(),
+    });
+    expect(synced.status, await synced.clone().text()).toBe(200);
+  });
+
+  it('accepts a DELETE from the asserted personal scope and refuses a team-asserted one', async () => {
+    const denied = await fetch(designSystemUrl(), {
+      method: 'DELETE',
+      headers: teamAssertedScopeHeaders(),
+    });
+    expect(denied.status).toBe(403);
+
+    const deleted = await fetch(designSystemUrl(), {
+      method: 'DELETE',
+      headers: personalScopeHeaders(),
+    });
+    expect(deleted.status, await deleted.clone().text()).toBe(204);
+    expect(await listCatalogIds(personalScopeHeaders())).not.toContain(DESIGN_SYSTEM_ID);
+  });
+});

--- a/apps/daemon/tests/design-systems/local-install-personal-verified-workspace.test.ts
+++ b/apps/daemon/tests/design-systems/local-install-personal-verified-workspace.test.ts
@@ -1,0 +1,413 @@
+// Regression (PR #7693 review): the legacy unattributed personal design-system
+// allowance must key on the workspace type the membership directory
+// ESTABLISHED, never on the caller's `x-od-workspace-type` claim.
+//
+// In the packaged runtime (`OD_WORKSPACE_CONTEXT_SOURCE=vela`) the verifier
+// identifies a member by Workspace/member id and returns the directory item's
+// own type; it does not reject a mismatched type header. Lazy orphan adoption
+// writes memberless `workspace_projects` rows into whatever workspace a request
+// names — Team workspaces included — and the startup backfill turns them into
+// unattributed `visibility: 'personal'` bindings. Keyed on the raw claim, the
+// allowance would let a Team member send `x-od-workspace-type: personal` and
+// read, select, edit, publish, and delete every such legacy system inside
+// their Team workspace. The daemon's claim-tier workspace-type memo is no
+// witness either: a project route learns it from the same raw header.
+//
+// These specs drive the real daemon against a stub membership directory that
+// holds one Team and one Personal membership, each workspace carrying a legacy
+// unattributed personal design system. The Team workspace's system must stay
+// refused at every gate for a member claiming `personal` — catalog, detail,
+// mutation, project creation, PATCH selection — even after that member has
+// taught the claim tier that the workspace is personal. The Personal
+// workspace is the positive control: the same gates grant, proving the
+// verified path is what grants, not a blanket refusal.
+
+import Database from 'better-sqlite3';
+import { randomUUID } from 'node:crypto';
+import { promises as fsp } from 'node:fs';
+import http from 'node:http';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import {
+  ensureWorkspaceProject,
+  getProject,
+  getWorkspaceResourceByResourceId,
+  insertProject,
+} from '../../src/db.js';
+import { backfillDesignSystemWorkspaceResources } from '../../src/design-systems/index.js';
+import { startServer } from '../../src/server.js';
+
+const TEAM_WORKSPACE = `team-ws-${randomUUID()}`;
+const TEAM_MEMBER = `team-member-${randomUUID()}`;
+const PERSONAL_WORKSPACE = `personal-ws-${randomUUID()}`;
+const PERSONAL_MEMBER = `personal-member-${randomUUID()}`;
+
+const TEAM_DIR_ID = `legacy-in-team-${randomUUID()}`;
+const TEAM_DESIGN_SYSTEM_ID = `user:${TEAM_DIR_ID}`;
+const TEAM_EDITING_PROJECT_ID = `ds-editing-team-${randomUUID()}`;
+const PERSONAL_DIR_ID = `legacy-in-personal-${randomUUID()}`;
+const PERSONAL_DESIGN_SYSTEM_ID = `user:${PERSONAL_DIR_ID}`;
+const PERSONAL_EDITING_PROJECT_ID = `ds-editing-personal-${randomUUID()}`;
+
+let daemon: { url: string; server: http.Server; shutdown?: () => Promise<void> | void };
+let authority: http.Server;
+let scratch: string;
+let directoryReads = 0;
+const createdProjectIds: string[] = [];
+
+function scopeHeaders(
+  workspaceId: string,
+  workspaceMemberId: string,
+  workspaceType: 'personal' | 'team',
+): Record<string, string> {
+  return {
+    'content-type': 'application/json',
+    'x-od-workspace-id': workspaceId,
+    'x-od-workspace-member-id': workspaceMemberId,
+    'x-od-workspace-type': workspaceType,
+  };
+}
+
+/** A Team member of the Team workspace claiming it is personal. */
+const teamMemberClaimingPersonal = () => scopeHeaders(TEAM_WORKSPACE, TEAM_MEMBER, 'personal');
+/** The same member with an honest claim. */
+const teamMemberHonest = () => scopeHeaders(TEAM_WORKSPACE, TEAM_MEMBER, 'team');
+/** The Personal workspace's only member, asserting what the directory confirms. */
+const personalMember = () => scopeHeaders(PERSONAL_WORKSPACE, PERSONAL_MEMBER, 'personal');
+
+function openSqlite(): Database.Database {
+  return new Database(resolve(process.env.OD_DATA_DIR!, 'app.sqlite'));
+}
+
+function designSystemUrl(id: string): string {
+  return `${daemon.url}/api/design-systems/${encodeURIComponent(id)}`;
+}
+
+async function listCatalogIds(headers: Record<string, string>): Promise<string[]> {
+  const response = await fetch(`${daemon.url}/api/design-systems`, { headers });
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as { designSystems: Array<{ id: string }> };
+  return body.designSystems.map((system) => system.id);
+}
+
+async function createProject(
+  headers: Record<string, string>,
+  body: Record<string, unknown>,
+): Promise<{ id: string; response: Response }> {
+  const id = `proj-verified-ws-${randomUUID()}`;
+  createdProjectIds.push(id);
+  const response = await fetch(`${daemon.url}/api/projects`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ id, name: 'Verified workspace spec project', skipDiscoveryBrief: true, ...body }),
+  });
+  return { id, response };
+}
+
+async function startAuthority(): Promise<string> {
+  authority = http.createServer((req, res) => {
+    if (req.url === '/api/v1/workspaces' && req.method === 'GET') {
+      directoryReads += 1;
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        items: [
+          {
+            workspaceId: TEAM_WORKSPACE,
+            workspaceName: 'Verified team',
+            workspaceType: 'team',
+            workspaceMemberId: TEAM_MEMBER,
+            role: 'member',
+            memberStatus: 'active',
+            lifecycleState: 'active',
+          },
+          {
+            workspaceId: PERSONAL_WORKSPACE,
+            workspaceName: 'Verified personal',
+            workspaceType: 'personal',
+            workspaceMemberId: PERSONAL_MEMBER,
+            role: 'owner',
+            memberStatus: 'active',
+            lifecycleState: 'active',
+          },
+        ],
+      }));
+      return;
+    }
+    res.writeHead(404, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not_found' }));
+  });
+  await new Promise<void>((done) => authority.listen(0, '127.0.0.1', done));
+  const address = authority.address();
+  if (!address || typeof address === 'string') throw new Error('authority did not bind');
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function writeVelaStub(root: string): Promise<string> {
+  const script = join(root, 'vela-stub.mjs');
+  await fsp.writeFile(script, "process.stdout.write(JSON.stringify([]) + '\\n');\n", 'utf8');
+  const bin = join(root, 'vela');
+  await fsp.writeFile(
+    bin,
+    `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(script)} "$@"\n`,
+    'utf8',
+  );
+  await fsp.chmod(bin, 0o755);
+  return bin;
+}
+
+/** The exact on-disk + DB state of a legacy install, per workspace. */
+async function seedLegacyDesignSystem(
+  sqlite: Database.Database,
+  input: { dirId: string; editingProjectId: string; workspaceId: string; title: string },
+): Promise<void> {
+  const dataDir = process.env.OD_DATA_DIR!;
+  const designSystemDir = resolve(dataDir, 'design-systems', input.dirId);
+  await fsp.mkdir(designSystemDir, { recursive: true });
+  await fsp.writeFile(
+    resolve(designSystemDir, 'DESIGN.md'),
+    `# ${input.title}\n\nA legacy local design system.\n`,
+    'utf8',
+  );
+  await fsp.writeFile(
+    resolve(designSystemDir, 'metadata.json'),
+    `${JSON.stringify({ title: input.title, status: 'published', projectId: input.editingProjectId }, null, 2)}\n`,
+    'utf8',
+  );
+  const editingProjectDir = resolve(dataDir, 'projects', input.editingProjectId);
+  await fsp.mkdir(editingProjectDir, { recursive: true });
+  await fsp.copyFile(resolve(designSystemDir, 'DESIGN.md'), resolve(editingProjectDir, 'DESIGN.md'));
+  insertProject(sqlite as never, {
+    id: input.editingProjectId,
+    name: input.title,
+    createdAt: 1,
+    updatedAt: 1,
+  });
+  // Legacy orphan adoption shape: bound to the workspace the request named,
+  // with NO creator member (`ensureWorkspaceProjection` writes exactly this,
+  // for Team workspaces too).
+  ensureWorkspaceProject(sqlite as never, {
+    workspaceId: input.workspaceId,
+    projectId: input.editingProjectId,
+    visibility: 'personal',
+    resourceState: 'active',
+    createdByWorkspaceMemberId: null,
+  });
+}
+
+beforeAll(async () => {
+  if (!process.env.OD_DATA_DIR) {
+    throw new Error('OD_DATA_DIR is required for the verified-workspace design-system spec');
+  }
+  scratch = await fsp.mkdtemp(join(tmpdir(), 'od-ds-verified-workspace-'));
+  const authorityUrl = await startAuthority();
+  vi.stubEnv('OD_WORKSPACE_CONTEXT_SOURCE', 'vela');
+  vi.stubEnv('VELA_API_URL', authorityUrl);
+  vi.stubEnv('VELA_CONTROL_KEY', 'verified-workspace-control-key');
+  vi.stubEnv('VELA_BIN', await writeVelaStub(scratch));
+  vi.stubEnv('AMR_HOME', join(scratch, 'empty-amr-home'));
+  vi.stubEnv('OD_COLLAB_TRANSPORT', 'off');
+  vi.stubEnv('OD_RESOURCE_TRANSPORT', 'off');
+  vi.stubEnv('OD_TEAM_PROJECTS_TRANSPORT', 'off');
+
+  daemon = (await startServer({ port: 0, returnServer: true })) as typeof daemon;
+
+  const sqlite = openSqlite();
+  try {
+    await seedLegacyDesignSystem(sqlite, {
+      dirId: TEAM_DIR_ID,
+      editingProjectId: TEAM_EDITING_PROJECT_ID,
+      workspaceId: TEAM_WORKSPACE,
+      title: 'Legacy system adopted into a Team workspace',
+    });
+    await seedLegacyDesignSystem(sqlite, {
+      dirId: PERSONAL_DIR_ID,
+      editingProjectId: PERSONAL_EDITING_PROJECT_ID,
+      workspaceId: PERSONAL_WORKSPACE,
+      title: 'Legacy system adopted into a Personal workspace',
+    });
+    await backfillDesignSystemWorkspaceResources(
+      sqlite as never,
+      resolve(process.env.OD_DATA_DIR, 'design-systems'),
+    );
+    for (const [id, workspaceId] of [
+      [TEAM_DESIGN_SYSTEM_ID, TEAM_WORKSPACE],
+      [PERSONAL_DESIGN_SYSTEM_ID, PERSONAL_WORKSPACE],
+    ] as const) {
+      expect(getWorkspaceResourceByResourceId(sqlite as never, 'design_system', id)).toMatchObject({
+        workspaceId,
+        visibility: 'personal',
+        createdByWorkspaceMemberId: null,
+      });
+    }
+  } finally {
+    sqlite.close();
+  }
+}, 60_000);
+
+afterAll(async () => {
+  for (const id of [...createdProjectIds, TEAM_EDITING_PROJECT_ID, PERSONAL_EDITING_PROJECT_ID]) {
+    await fetch(`${daemon.url}/api/projects/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+      headers: teamMemberHonest(),
+    }).catch(() => {});
+    await fetch(`${daemon.url}/api/projects/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+      headers: personalMember(),
+    }).catch(() => {});
+  }
+  for (const dirId of [TEAM_DIR_ID, PERSONAL_DIR_ID]) {
+    await fsp.rm(resolve(process.env.OD_DATA_DIR!, 'design-systems', dirId), { recursive: true, force: true })
+      .catch(() => {});
+  }
+  await Promise.resolve(daemon?.shutdown?.());
+  daemon?.server.closeAllConnections?.();
+  if (daemon?.server.listening) {
+    await new Promise<void>((done) => daemon.server.close(() => done()));
+  }
+  authority?.closeAllConnections?.();
+  if (authority?.listening) {
+    await new Promise<void>((done) => authority.close(() => done()));
+  }
+  await fsp.rm(scratch, { recursive: true, force: true }).catch(() => {});
+  vi.unstubAllEnvs();
+}, 60_000);
+
+describe('legacy personal design-system allowance keys on the directory-verified workspace type', () => {
+  it('hides the Team workspace system from a member claiming personal, even after the claim tier learned it', async () => {
+    // Teach the daemon's claim-tier memo that the Team workspace is personal
+    // — a project route learns `x-od-workspace-type` from the raw header —
+    // then read the catalog under the same claim. Only the directory's word
+    // may grant, and the directory says Team.
+    const poison = await createProject(teamMemberClaimingPersonal(), {});
+    expect(poison.response.status, await poison.response.clone().text()).toBe(200);
+
+    expect(await listCatalogIds(teamMemberClaimingPersonal())).not.toContain(TEAM_DESIGN_SYSTEM_ID);
+    expect(await listCatalogIds(teamMemberHonest())).not.toContain(TEAM_DESIGN_SYSTEM_ID);
+    expect(directoryReads).toBeGreaterThan(0);
+  });
+
+  it('refuses the detail read and every navigation read for the claimed-personal Team scope', async () => {
+    const detail = await fetch(designSystemUrl(TEAM_DESIGN_SYSTEM_ID), {
+      headers: teamMemberClaimingPersonal(),
+    });
+    expect(detail.status).toBe(403);
+
+    const query = `workspaceId=${TEAM_WORKSPACE}&workspaceMemberId=${TEAM_MEMBER}&workspaceType=personal`;
+    const preview = await fetch(`${designSystemUrl(TEAM_DESIGN_SYSTEM_ID)}/preview?${query}`);
+    expect(preview.status).toBe(403);
+  });
+
+  it('refuses every mutation for the claimed-personal Team scope', async () => {
+    const renamed = await fetch(designSystemUrl(TEAM_DESIGN_SYSTEM_ID), {
+      method: 'PATCH',
+      headers: teamMemberClaimingPersonal(),
+      body: JSON.stringify({ title: 'Must not rename' }),
+    });
+    expect(renamed.status).toBe(403);
+
+    const opened = await fetch(`${designSystemUrl(TEAM_DESIGN_SYSTEM_ID)}/workspace`, {
+      method: 'POST',
+      headers: teamMemberClaimingPersonal(),
+    });
+    expect(opened.status).toBe(403);
+
+    const deleted = await fetch(designSystemUrl(TEAM_DESIGN_SYSTEM_ID), {
+      method: 'DELETE',
+      headers: teamMemberClaimingPersonal(),
+    });
+    expect(deleted.status).toBe(403);
+
+    const sqlite = openSqlite();
+    try {
+      expect(getWorkspaceResourceByResourceId(sqlite as never, 'design_system', TEAM_DESIGN_SYSTEM_ID))
+        .toMatchObject({ workspaceId: TEAM_WORKSPACE, resourceState: 'active' });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it('refuses project creation whose selection partition claims the Team workspace is personal', async () => {
+    const created = await createProject(teamMemberClaimingPersonal(), {
+      designSystemId: TEAM_DESIGN_SYSTEM_ID,
+      designSystemCatalogScope: {
+        workspaceId: TEAM_WORKSPACE,
+        workspaceMemberId: TEAM_MEMBER,
+        workspaceType: 'personal',
+      },
+    });
+
+    expect(created.response.status).toBe(400);
+    expect(await created.response.text()).toContain('DESIGN_SYSTEM_NOT_FOUND');
+  });
+
+  it('refuses a PATCH selection on a Team-workspace project whose request claims personal', async () => {
+    const created = await createProject(teamMemberHonest(), {});
+    expect(created.response.status, await created.response.clone().text()).toBe(200);
+
+    const selected = await fetch(`${daemon.url}/api/projects/${encodeURIComponent(created.id)}`, {
+      method: 'PATCH',
+      headers: teamMemberClaimingPersonal(),
+      body: JSON.stringify({ designSystemId: TEAM_DESIGN_SYSTEM_ID }),
+    });
+
+    expect(selected.status, await selected.clone().text()).toBe(400);
+    expect(await selected.text()).toContain('DESIGN_SYSTEM_NOT_FOUND');
+  });
+
+  it('grants the Personal workspace system to its verified member at every gate (positive control)', async () => {
+    expect(await listCatalogIds(personalMember())).toContain(PERSONAL_DESIGN_SYSTEM_ID);
+
+    const detail = await fetch(designSystemUrl(PERSONAL_DESIGN_SYSTEM_ID), { headers: personalMember() });
+    expect(detail.status, await detail.clone().text()).toBe(200);
+    expect(((await detail.json()) as { canMutate?: boolean }).canMutate).toBe(true);
+
+    const renamed = await fetch(designSystemUrl(PERSONAL_DESIGN_SYSTEM_ID), {
+      method: 'PATCH',
+      headers: personalMember(),
+      body: JSON.stringify({ title: 'Renamed under a verified personal workspace' }),
+    });
+    expect(renamed.status, await renamed.clone().text()).toBe(200);
+
+    const created = await createProject(personalMember(), {
+      designSystemId: PERSONAL_DESIGN_SYSTEM_ID,
+      designSystemCatalogScope: {
+        workspaceId: PERSONAL_WORKSPACE,
+        workspaceMemberId: PERSONAL_MEMBER,
+        workspaceType: 'personal',
+      },
+    });
+    expect(created.response.status, await created.response.clone().text()).toBe(200);
+
+    // The persisted partition carries the type the directory CONFIRMED —
+    // what run-time prompt loading reads back as its witness.
+    const sqlite = openSqlite();
+    try {
+      const project = getProject(sqlite as never, created.id) as {
+        metadata?: { localCatalogScopes?: { designSystem?: { workspaceType?: string } } };
+      } | undefined;
+      expect(project?.metadata?.localCatalogScopes?.designSystem?.workspaceType).toBe('personal');
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it('does not persist a selection partition type the directory contradicts', async () => {
+    // The Personal member selects an ATTRIBUTED-free system of their own but
+    // the composer draft (mis)labels the partition as team: validation still
+    // needs a verified personal workspace, so the legacy system is refused —
+    // and nothing is persisted that a later run could mistake for a witness.
+    const created = await createProject(personalMember(), {
+      designSystemId: PERSONAL_DESIGN_SYSTEM_ID,
+      designSystemCatalogScope: {
+        workspaceId: PERSONAL_WORKSPACE,
+        workspaceMemberId: PERSONAL_MEMBER,
+        workspaceType: 'team',
+      },
+    });
+
+    expect(created.response.status).toBe(400);
+    expect(await created.response.text()).toContain('DESIGN_SYSTEM_NOT_FOUND');
+  });
+});

--- a/apps/daemon/tests/design-systems/local-install-personal-visibility.test.ts
+++ b/apps/daemon/tests/design-systems/local-install-personal-visibility.test.ts
@@ -325,6 +325,65 @@ describe('local install without a Workspace sign-in keeps its personal design sy
     expect(foreignScope).not.toContain('user:skyfarm');
   });
 
+  it('keeps the strict gate for a same-workspace scope that does not assert its type', async () => {
+    // The `x-od-workspace-type` header is optional on the wire, and a missing
+    // header is NOT an assertion of a personal workspace: a Team client that
+    // simply omits the optional header must not inherit the personal-only
+    // legacy allowance. The allowance keys on the caller's EXPLICIT
+    // `personal` assertion (`workspaceTypeAsserted`), so an unasserted scope
+    // stays on the strict pre-existing behavior (fail-closed).
+    const seeded = await seedLocalInstall();
+    const catalogUrl = await startCatalogRoute(seeded);
+
+    const unasserted = await listCatalogIds(catalogUrl, {
+      'x-od-workspace-id': WORKSPACE,
+      'x-od-workspace-member-id': LOCAL_MEMBER,
+    });
+
+    expect(unasserted).not.toContain('user:skyfarm');
+  });
+
+  it('rejects the detail read for a same-workspace scope that does not assert its type', async () => {
+    const seeded = await seedLocalInstall();
+    const baseUrl = await startDetailRoute(seeded);
+
+    const resp = await fetch(`${baseUrl}/api/design-systems/user%3Askyfarm`, {
+      headers: {
+        'x-od-workspace-id': WORKSPACE,
+        'x-od-workspace-member-id': LOCAL_MEMBER,
+      },
+    });
+
+    expect(resp.status).toBe(403);
+  });
+
+  it('serves navigation reads whose URL carries the asserted personal scope', async () => {
+    // iframe/img navigations cannot attach headers; the web shell preserves
+    // the exact scope in query parameters (`workspaceResourceUrl`), including
+    // the asserted workspace type.
+    const seeded = await seedLocalInstall();
+    const baseUrl = await startDetailRoute(seeded);
+
+    const query = `workspaceId=${WORKSPACE}&workspaceMemberId=${LOCAL_MEMBER}&workspaceType=personal`;
+    const resp = await fetch(
+      `${baseUrl}/api/design-systems/user%3Askyfarm/preview?${query}`,
+    );
+
+    expect(resp.status).toBe(200);
+  });
+
+  it('rejects navigation reads whose URL does not assert the personal scope', async () => {
+    const seeded = await seedLocalInstall();
+    const baseUrl = await startDetailRoute(seeded);
+
+    const query = `workspaceId=${WORKSPACE}&workspaceMemberId=${LOCAL_MEMBER}`;
+    const resp = await fetch(
+      `${baseUrl}/api/design-systems/user%3Askyfarm/preview?${query}`,
+    );
+
+    expect(resp.status).toBe(403);
+  });
+
   it('serves the detail read for the local personal-workspace scope', async () => {
     const seeded = await seedLocalInstall();
     const baseUrl = await startDetailRoute(seeded);
@@ -351,7 +410,7 @@ describe('local install without a Workspace sign-in keeps its personal design sy
     const scoped = await seeded.services.listAllDesignSystems({
       workspaceId: WORKSPACE,
       workspaceMemberId: LOCAL_MEMBER,
-      workspaceType: 'personal',
+      workspaceTypeAsserted: 'personal',
     } as never);
     const headerless = await seeded.services.listAllDesignSystems({
       workspaceId: null,
@@ -385,7 +444,7 @@ describe('local install without a Workspace sign-in keeps its personal design sy
     const scoped = await seeded.services.listAllDesignSystems({
       workspaceId: WORKSPACE,
       workspaceMemberId: LOCAL_MEMBER,
-      workspaceType: 'personal',
+      workspaceTypeAsserted: 'personal',
     } as never);
 
     expect(scoped.map((system) => system.id)).not.toContain('user:foreign');

--- a/apps/daemon/tests/design-systems/local-install-personal-visibility.test.ts
+++ b/apps/daemon/tests/design-systems/local-install-personal-visibility.test.ts
@@ -53,6 +53,7 @@ import {
   syncUserDesignSystemAssetsFromFiles,
 } from '../../src/design-systems/index.js';
 import { createDesignSystemServerServices } from '../../src/design-systems/server-services.js';
+import { verifyLocalWorkspaceRequestContext } from '../../src/collab/request-workspace-context.js';
 import { registerDesignSystemRoutes } from '../../src/routes/design-systems.js';
 import { registerStaticResourceRoutes } from '../../src/routes/static-resource.js';
 import {
@@ -191,11 +192,12 @@ async function startCatalogRoute(
   app.use(express.json());
   registerStaticResourceRoutes(app, {
     db: seeded.db,
-    // Presence alone selects the scoped catalog lane; the list route resolves
-    // the actual identity through the local header authority, like production.
-    verifyWorkspaceRequestAuthority: async () => {
-      throw new Error('catalog read must not verify remote Workspace authority');
-    },
+    // The list route resolves identity through the local header authority,
+    // like production. The legacy allowance's witness is the daemon's own
+    // request verifier, which on a local/dev install (no signed membership
+    // directory) is the production local verifier: the explicit headers are
+    // the complete, static authority there.
+    verifyWorkspaceRequestAuthority: async (req: unknown) => verifyLocalWorkspaceRequestContext(req),
     http: {
       createSseResponse: () => undefined,
       getPublicBaseUrl: () => '',
@@ -229,9 +231,8 @@ async function startDetailRoute(
     paths: seeded.paths,
     projectFiles: {} as never,
     projectStore: {} as never,
-    verifyWorkspaceRequestAuthority: async () => {
-      throw new Error('detail read must not verify remote Workspace authority');
-    },
+    // Same witness as the catalog fixture above: the production local verifier.
+    verifyWorkspaceRequestAuthority: async (req: unknown) => verifyLocalWorkspaceRequestContext(req),
     workspaceResources: {
       getWorkspaceResource: getWorkspaceResource as never,
       getWorkspaceResourceByResourceId: getWorkspaceResourceByResourceId as never,
@@ -330,8 +331,11 @@ describe('local install without a Workspace sign-in keeps its personal design sy
     // header is NOT an assertion of a personal workspace: a Team client that
     // simply omits the optional header must not inherit the personal-only
     // legacy allowance. The allowance keys on the caller's EXPLICIT
-    // `personal` assertion (`workspaceTypeAsserted`), so an unasserted scope
-    // stays on the strict pre-existing behavior (fail-closed).
+    // `personal` assertion confirmed by membership verification
+    // (`workspaceTypeVerified`), so an unasserted scope stays on the strict
+    // pre-existing behavior (fail-closed). The Vela-mode counterpart — a
+    // directory that says Team while the request claims personal — lives in
+    // local-install-personal-verified-workspace.test.ts.
     const seeded = await seedLocalInstall();
     const catalogUrl = await startCatalogRoute(seeded);
 
@@ -410,7 +414,7 @@ describe('local install without a Workspace sign-in keeps its personal design sy
     const scoped = await seeded.services.listAllDesignSystems({
       workspaceId: WORKSPACE,
       workspaceMemberId: LOCAL_MEMBER,
-      workspaceTypeAsserted: 'personal',
+      workspaceTypeVerified: 'personal',
     } as never);
     const headerless = await seeded.services.listAllDesignSystems({
       workspaceId: null,
@@ -444,7 +448,7 @@ describe('local install without a Workspace sign-in keeps its personal design sy
     const scoped = await seeded.services.listAllDesignSystems({
       workspaceId: WORKSPACE,
       workspaceMemberId: LOCAL_MEMBER,
-      workspaceTypeAsserted: 'personal',
+      workspaceTypeVerified: 'personal',
     } as never);
 
     expect(scoped.map((system) => system.id)).not.toContain('user:foreign');

--- a/apps/daemon/tests/design-systems/local-install-personal-visibility.test.ts
+++ b/apps/daemon/tests/design-systems/local-install-personal-visibility.test.ts
@@ -1,0 +1,398 @@
+// Regression: a local install that never signed into a Workspace lost its
+// personal design system from EVERY catalog lane after the 0.21.x
+// `workspace_resources` envelope regime shipped.
+//
+// The install's normal state: the web/desktop shell always sends the local
+// personal Workspace scope (`x-od-workspace-id` + `x-od-workspace-member-id`,
+// type `personal`), while its legacy `workspace_projects` rows carry NO
+// `created_by_workspace_member_id` — lazy orphan adoption deliberately writes
+// them unattributed (`ensureWorkspaceProjection`, routes/project/index.ts).
+// On startup, `backfillDesignSystemWorkspaceResources` infers a design
+// system's claim from such a row and writes an equally unattributed
+// `visibility: 'personal'` binding. The read gate then rejected that binding
+// in the scoped lane (creator-member mismatch) AND hid the system from the
+// headerless lane (any binding is "positive evidence" of Workspace
+// ownership) — a catch-22 with no lane left that could ever show the system.
+//
+// The projects layer already rules on this exact state: an unattributed
+// personal row in a non-team workspace belongs to the local user
+// (`workspaceProjectCreatedByCurrentMember`, routes/project/index.ts). These
+// specs pin the same ruling for the design-system catalog and read gates,
+// plus the backfill invariant that it must never manufacture a binding the
+// read gate categorically rejects.
+
+import express from 'express';
+import type http from 'node:http';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  closeDatabase,
+  ensureWorkspaceProject,
+  ensureWorkspaceResource,
+  getProject,
+  getWorkspaceResource,
+  getWorkspaceResourceByResourceId,
+  insertProject,
+  openDatabase,
+  updateProject,
+} from '../../src/db.js';
+import {
+  backfillDesignSystemWorkspaceResources,
+  LEGACY_DESIGN_SYSTEM_ARTIFACTS,
+  linkUserDesignSystemProject,
+  listDesignSystems,
+  listUserDesignSystemFiles,
+  readDesignSystem,
+  readDesignSystemPackageInfo,
+  readDesignSystemStaticFile,
+  readUserDesignSystemFile,
+  readUserDesignSystemFileBytes,
+  syncUserDesignSystemAssetsFromFiles,
+} from '../../src/design-systems/index.js';
+import { createDesignSystemServerServices } from '../../src/design-systems/server-services.js';
+import { registerDesignSystemRoutes } from '../../src/routes/design-systems.js';
+import { registerStaticResourceRoutes } from '../../src/routes/static-resource.js';
+import {
+  isSafeId,
+  listFiles,
+  readProjectFile,
+  resolveProjectDir,
+  writeProjectFile,
+} from '../../src/projects.js';
+
+const WORKSPACE = 'ytzcr6qaq2ko4z8q8q8p14zf';
+const OTHER_WORKSPACE = 'jg63to8cbic0kzbczbu95a4g';
+const LOCAL_MEMBER = 'local-member-1';
+
+let server: http.Server | null = null;
+let root: string | null = null;
+
+afterEach(async () => {
+  if (server) {
+    await new Promise<void>((resolve) => server?.close(() => resolve()));
+    server = null;
+  }
+  closeDatabase();
+  vi.restoreAllMocks();
+  if (root) {
+    rmSync(root, { recursive: true, force: true });
+    root = null;
+  }
+});
+
+function commonPaths(base: string) {
+  return {
+    ARTIFACTS_DIR: path.join(base, 'artifacts'),
+    BRANDS_DIR: path.join(base, 'brands'),
+    BUNDLED_PETS_DIR: path.join(base, 'pets'),
+    CRAFT_DIR: path.join(base, 'craft'),
+    DESIGN_SYSTEMS_DIR: path.join(base, 'design-systems'),
+    DESIGN_TEMPLATES_DIR: path.join(base, 'design-templates'),
+    LIBRARY_DIR: path.join(base, 'library'),
+    OD_BIN: path.join(base, 'od'),
+    PROJECT_ROOT: base,
+    PROJECTS_DIR: path.join(base, 'projects'),
+    PROMPT_TEMPLATES_DIR: path.join(base, 'prompt-templates'),
+    RUNTIME_DATA_DIR: path.join(base, 'data'),
+    RUNTIME_DATA_DIR_CANONICAL: path.join(base, 'data'),
+    SKILLS_DIR: path.join(base, 'skills'),
+    USER_DESIGN_SYSTEMS_DIR: path.join(base, 'user-design-systems'),
+    USER_DESIGN_TEMPLATES_DIR: path.join(base, 'user-design-templates'),
+    USER_SKILLS_DIR: path.join(base, 'user-skills'),
+  };
+}
+
+function seedUserSystem(base: string, dirId: string, metadata: Record<string, unknown>): void {
+  const dir = path.join(base, 'user-design-systems', dirId);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, 'DESIGN.md'), `# ${dirId}\n\nA local personal system.\n`, 'utf8');
+  writeFileSync(
+    path.join(dir, 'metadata.json'),
+    `${JSON.stringify(metadata, null, 2)}\n`,
+    'utf8',
+  );
+}
+
+/**
+ * Reproduce the exact on-disk + DB state of the reported install, then run
+ * the same startup backfill `server.ts` runs, and build the REAL server
+ * services over that state (no stubbed catalog).
+ */
+async function seedLocalInstall() {
+  root = mkdtempSync(path.join(os.tmpdir(), 'od-ds-local-install-'));
+  const paths = commonPaths(root);
+  seedUserSystem(root, 'skyfarm', { title: 'Skyfarm', projectId: 'ds-skyfarm' });
+  const db = openDatabase(paths.RUNTIME_DATA_DIR, { dataDir: paths.RUNTIME_DATA_DIR });
+  insertProject(db, { id: 'ds-skyfarm', name: 'Skyfarm', createdAt: 1, updatedAt: 1 });
+  // Legacy orphan adoption shape: bound to the personal workspace with NO
+  // creator member (`ensureWorkspaceProjection` writes exactly this).
+  ensureWorkspaceProject(db, {
+    workspaceId: WORKSPACE,
+    projectId: 'ds-skyfarm',
+    visibility: 'personal',
+    resourceState: 'active',
+    createdByWorkspaceMemberId: null,
+  });
+  await backfillDesignSystemWorkspaceResources(db, paths.USER_DESIGN_SYSTEMS_DIR);
+  const services = createDesignSystemServerServices({
+    getDb: () => db,
+    roots: { SKILL_ROOTS: [], DESIGN_TEMPLATE_ROOTS: [], ALL_SKILL_LIKE_ROOTS: [] },
+    paths: {
+      PROJECTS_DIR: paths.PROJECTS_DIR,
+      DESIGN_SYSTEMS_DIR: paths.DESIGN_SYSTEMS_DIR,
+      USER_DESIGN_SYSTEMS_DIR: paths.USER_DESIGN_SYSTEMS_DIR,
+    },
+    skills: {
+      listSkills: async () => [],
+      findSkillById: () => undefined,
+    },
+    designSystems: {
+      listDesignSystems,
+      readDesignSystem,
+      readDesignSystemPackageInfo,
+      readDesignSystemStaticFile,
+      listUserDesignSystemFiles,
+      readUserDesignSystemFile,
+      readUserDesignSystemFileBytes,
+      linkUserDesignSystemProject,
+      syncUserDesignSystemAssetsFromFiles,
+      LEGACY_DESIGN_SYSTEM_ARTIFACTS,
+    } as never,
+    projects: {
+      getProject,
+      insertProject,
+      updateProject,
+      readProjectFile,
+      writeProjectFile,
+      listFiles,
+      resolveProjectDir,
+      isSafeId,
+    },
+  });
+  return { db, paths, services };
+}
+
+function listen(app: express.Express): Promise<string> {
+  return new Promise((resolve) => {
+    server = app.listen(0, '127.0.0.1', () => {
+      const address = server?.address() as { port: number };
+      resolve(`http://127.0.0.1:${address.port}`);
+    });
+  });
+}
+
+async function startCatalogRoute(
+  seeded: Awaited<ReturnType<typeof seedLocalInstall>>,
+): Promise<string> {
+  const app = express();
+  app.use(express.json());
+  registerStaticResourceRoutes(app, {
+    db: seeded.db,
+    // Presence alone selects the scoped catalog lane; the list route resolves
+    // the actual identity through the local header authority, like production.
+    verifyWorkspaceRequestAuthority: async () => {
+      throw new Error('catalog read must not verify remote Workspace authority');
+    },
+    http: {
+      createSseResponse: () => undefined,
+      getPublicBaseUrl: () => '',
+      isLocalSameOrigin: () => true,
+      requireLocalDaemonRequest: (_req: unknown, _res: unknown, next: () => void) => next(),
+      resolvedPortRef: { current: 0 },
+      sendApiError: () => undefined,
+      sendLiveArtifactRouteError: () => undefined,
+      sendMulterError: () => undefined,
+    },
+    paths: seeded.paths,
+    resources: {
+      listAllDesignSystems: seeded.services.listAllDesignSystems,
+      resolveWorkspaceScope: async () => null,
+      listAllSkills: async () => [],
+      listAllDesignTemplates: async () => [],
+      listAllSkillLikeEntries: async () => [],
+      mimeFor: () => 'application/octet-stream',
+    },
+  } as never);
+  return listen(app);
+}
+
+async function startDetailRoute(
+  seeded: Awaited<ReturnType<typeof seedLocalInstall>>,
+): Promise<string> {
+  const app = express();
+  app.use(express.json());
+  registerDesignSystemRoutes(app, {
+    db: seeded.db,
+    paths: seeded.paths,
+    projectFiles: {} as never,
+    projectStore: {} as never,
+    verifyWorkspaceRequestAuthority: async () => {
+      throw new Error('detail read must not verify remote Workspace authority');
+    },
+    workspaceResources: {
+      getWorkspaceResource: getWorkspaceResource as never,
+      getWorkspaceResourceByResourceId: getWorkspaceResourceByResourceId as never,
+    },
+    designSystems: {
+      buildUserDesignSystemArchive: async () => null,
+      canMutateUserDesignSystem: async () => true,
+      createUserDesignSystem: async () => {
+        throw new Error('not exercised');
+      },
+      deleteUserDesignSystem: async () => false,
+      ensureUserDesignSystemWorkspaceProject: async () => null,
+      listAllDesignSystems: seeded.services.listAllDesignSystems,
+      listUserDesignSystemFiles: async () => null,
+      listUserDesignSystemRevisions: async () => null,
+      prepareDesignTokenContractRebuild: async () => ({ decision: { available: false } }) as never,
+      readAvailableDesignSystem: seeded.services.readAvailableDesignSystem,
+      readAvailableDesignSystemPackageInfo: seeded.services.readAvailableDesignSystemPackageInfo,
+      readAvailableDesignSystemStaticFile: seeded.services.readAvailableDesignSystemStaticFile,
+      readDesignSystemWorkspaceTextFile: seeded.services.readDesignSystemWorkspaceTextFile,
+      readUserDesignSystemFile: async () => null,
+      renderDesignSystemPreview: () => '',
+      renderDesignSystemShowcase: () => '',
+      syncUserDesignSystemAssetsFromWorkspace: async () => ({ ok: false, reason: 'not-found' }),
+      unshareTeamDesignSystemIfShared: async () => false,
+      updateUserDesignSystem: async () => null,
+      updateUserDesignSystemRevisionStatus: async () => null,
+    },
+    generationJobs: {
+      get: () => null,
+      rebuildTokenContract: () => ({}) as never,
+      revise: () => ({}) as never,
+      start: () => ({}) as never,
+    },
+  } as never);
+  return listen(app);
+}
+
+function personalScopeHeaders(): Record<string, string> {
+  return {
+    'x-od-workspace-id': WORKSPACE,
+    'x-od-workspace-member-id': LOCAL_MEMBER,
+    'x-od-workspace-type': 'personal',
+  };
+}
+
+async function listCatalogIds(
+  baseUrl: string,
+  headers?: Record<string, string>,
+): Promise<string[]> {
+  const resp = await fetch(`${baseUrl}/api/design-systems`, headers ? { headers } : {});
+  expect(resp.status).toBe(200);
+  const body = (await resp.json()) as { designSystems: Array<{ id: string }> };
+  return body.designSystems.map((system) => system.id);
+}
+
+describe('local install without a Workspace sign-in keeps its personal design system', () => {
+  it('lists the backfilled system for the local personal-workspace scope (the lane the UI uses)', async () => {
+    const seeded = await seedLocalInstall();
+    const baseUrl = await startCatalogRoute(seeded);
+
+    const ids = await listCatalogIds(baseUrl, personalScopeHeaders());
+
+    expect(ids).toContain('user:skyfarm');
+  });
+
+  it('lists the backfilled system for the headerless local lane (the lane the CLI uses)', async () => {
+    const seeded = await seedLocalInstall();
+    const baseUrl = await startCatalogRoute(seeded);
+
+    const ids = await listCatalogIds(baseUrl);
+
+    expect(ids).toContain('user:skyfarm');
+  });
+
+  it('still hides the unattributed personal binding from team and foreign-workspace scopes', async () => {
+    const seeded = await seedLocalInstall();
+    const baseUrl = await startCatalogRoute(seeded);
+
+    const teamScope = await listCatalogIds(baseUrl, {
+      ...personalScopeHeaders(),
+      'x-od-workspace-type': 'team',
+    });
+    const foreignScope = await listCatalogIds(baseUrl, {
+      'x-od-workspace-id': OTHER_WORKSPACE,
+      'x-od-workspace-member-id': 'member-elsewhere',
+      'x-od-workspace-type': 'personal',
+    });
+
+    expect(teamScope).not.toContain('user:skyfarm');
+    expect(foreignScope).not.toContain('user:skyfarm');
+  });
+
+  it('serves the detail read for the local personal-workspace scope', async () => {
+    const seeded = await seedLocalInstall();
+    const baseUrl = await startDetailRoute(seeded);
+
+    const resp = await fetch(`${baseUrl}/api/design-systems/user%3Askyfarm`, {
+      headers: personalScopeHeaders(),
+    });
+
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { body?: string };
+    expect(body.body).toContain('A local personal system.');
+  });
+
+  it('backfill never manufactures a binding the catalog gate categorically rejects', async () => {
+    // The invariant, pinned at the service layer independent of route
+    // plumbing: whatever the backfill writes for a local legacy system must
+    // be readable through at least the lanes a local caller actually has —
+    // the personal-workspace scope and the headerless lane.
+    const seeded = await seedLocalInstall();
+
+    const binding = getWorkspaceResourceByResourceId(seeded.db, 'design_system', 'user:skyfarm');
+    expect(binding?.workspaceId).toBe(WORKSPACE);
+
+    const scoped = await seeded.services.listAllDesignSystems({
+      workspaceId: WORKSPACE,
+      workspaceMemberId: LOCAL_MEMBER,
+      workspaceType: 'personal',
+    } as never);
+    const headerless = await seeded.services.listAllDesignSystems({
+      workspaceId: null,
+      workspaceMemberId: null,
+    });
+    // The lane run-prompt composition uses: scope derived from the legacy
+    // project's persisted binding, whose creator member is equally empty.
+    const memberlessProjectScope = await seeded.services.listAllDesignSystems({
+      workspaceId: WORKSPACE,
+      workspaceMemberId: null,
+    });
+
+    expect(scoped.map((system) => system.id)).toContain('user:skyfarm');
+    expect(headerless.map((system) => system.id)).toContain('user:skyfarm');
+    expect(memberlessProjectScope.map((system) => system.id)).toContain('user:skyfarm');
+  });
+
+  it('logs a reason instead of silently hiding a system from the scoped catalog', async () => {
+    const seeded = await seedLocalInstall();
+    // A system genuinely owned by ANOTHER member must stay hidden — but not
+    // silently: diagnosing this class of bug must not require
+    // reverse-engineering the filter.
+    seedUserSystem(root!, 'foreign', { title: 'Foreign', workspaceId: WORKSPACE });
+    ensureWorkspaceResource(seeded.db, 'design_system', WORKSPACE, 'user:foreign', {
+      visibility: 'personal',
+      resourceState: 'active',
+      createdByWorkspaceMemberId: 'member-someone-else',
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const scoped = await seeded.services.listAllDesignSystems({
+      workspaceId: WORKSPACE,
+      workspaceMemberId: LOCAL_MEMBER,
+      workspaceType: 'personal',
+    } as never);
+
+    expect(scoped.map((system) => system.id)).not.toContain('user:foreign');
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('[design-systems]'),
+    );
+    const messages = warn.mock.calls.map((call) => String(call[0]));
+    expect(messages.some((message) => message.includes('user:foreign'))).toBe(true);
+  });
+});

--- a/apps/daemon/tests/routes/project-resource-scope-validation.test.ts
+++ b/apps/daemon/tests/routes/project-resource-scope-validation.test.ts
@@ -276,7 +276,7 @@ describe('project resource selection uses the persisted exact member', () => {
     expect(validateDesignSystem).toHaveBeenCalledWith('user:workspace-brand', {
       workspaceId: WORKSPACE_ID,
       workspaceMemberId: MEMBER_ID,
-      workspaceTypeAsserted: null,
+      workspaceTypeVerified: null,
     });
     expect(validateSkill).toHaveBeenCalledWith('workspace-skill', {
       workspaceId: WORKSPACE_ID,
@@ -323,7 +323,7 @@ describe('project resource selection uses the persisted exact member', () => {
     expect(validateDesignSystem).toHaveBeenCalledWith('user:private-brand', {
       workspaceId: WORKSPACE_ID,
       workspaceMemberId: MEMBER_ID,
-      workspaceTypeAsserted: null,
+      workspaceTypeVerified: null,
     });
     expect(validateSkill).toHaveBeenCalledWith('private-skill', {
       workspaceId: WORKSPACE_ID,
@@ -353,7 +353,7 @@ describe('project resource selection uses the persisted exact member', () => {
     expect(validateDesignSystem).toHaveBeenCalledWith('user:private-brand', {
       workspaceId: WORKSPACE_ID,
       workspaceMemberId: MEMBER_ID,
-      workspaceTypeAsserted: null,
+      workspaceTypeVerified: null,
     });
     expect(validateSkill).toHaveBeenCalledWith('private-skill', {
       workspaceId: WORKSPACE_ID,

--- a/apps/daemon/tests/routes/project-resource-scope-validation.test.ts
+++ b/apps/daemon/tests/routes/project-resource-scope-validation.test.ts
@@ -271,9 +271,12 @@ describe('project resource selection uses the persisted exact member', () => {
     });
 
     expect(response.status).toBe(200);
+    // The selection partition carried no type and the request asserted none:
+    // the validator sees an explicitly unasserted type (fail-closed).
     expect(validateDesignSystem).toHaveBeenCalledWith('user:workspace-brand', {
       workspaceId: WORKSPACE_ID,
       workspaceMemberId: MEMBER_ID,
+      workspaceTypeAsserted: null,
     });
     expect(validateSkill).toHaveBeenCalledWith('workspace-skill', {
       workspaceId: WORKSPACE_ID,
@@ -320,6 +323,7 @@ describe('project resource selection uses the persisted exact member', () => {
     expect(validateDesignSystem).toHaveBeenCalledWith('user:private-brand', {
       workspaceId: WORKSPACE_ID,
       workspaceMemberId: MEMBER_ID,
+      workspaceTypeAsserted: null,
     });
     expect(validateSkill).toHaveBeenCalledWith('private-skill', {
       workspaceId: WORKSPACE_ID,
@@ -349,6 +353,7 @@ describe('project resource selection uses the persisted exact member', () => {
     expect(validateDesignSystem).toHaveBeenCalledWith('user:private-brand', {
       workspaceId: WORKSPACE_ID,
       workspaceMemberId: MEMBER_ID,
+      workspaceTypeAsserted: null,
     });
     expect(validateSkill).toHaveBeenCalledWith('private-skill', {
       workspaceId: WORKSPACE_ID,

--- a/apps/web/src/collab/workspace-identity.ts
+++ b/apps/web/src/collab/workspace-identity.ts
@@ -22,7 +22,10 @@ export function workspaceProjectHeaders(context: WorkspaceCollabContext): Header
 /**
  * Browser-owned navigations (iframe/img/a) cannot attach request headers.
  * Preserve the exact authority in the URL for those surfaces; the daemon
- * freshly verifies both values before serving Workspace-owned bytes.
+ * freshly verifies both values before serving Workspace-owned bytes. The
+ * workspace type travels too: daemon gates that key on the caller's EXPLICIT
+ * type assertion (e.g. the unattributed local personal design-system
+ * allowance) must see the same assertion the header-carrying fetches make.
  */
 export function workspaceResourceUrl(
   path: string,
@@ -31,7 +34,8 @@ export function workspaceResourceUrl(
   if (!context) return path;
   const separator = path.includes('?') ? '&' : '?';
   return `${path}${separator}workspaceId=${encodeURIComponent(context.workspaceId)}`
-    + `&workspaceMemberId=${encodeURIComponent(context.workspaceMemberId)}`;
+    + `&workspaceMemberId=${encodeURIComponent(context.workspaceMemberId)}`
+    + `&workspaceType=${encodeURIComponent(context.workspaceType)}`;
 }
 
 /** Append a query fragment without corrupting an already workspace-scoped URL. */

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -411,10 +411,20 @@ function localCatalogScopeFromWorkspaceContext(
   context: WorkspaceCollabContext | null,
 ): LocalCatalogScope | null {
   if (!context?.workspaceId?.trim() || !context.workspaceMemberId?.trim()) return null;
+  // The type this client asserts for the partition — the same
+  // `x-od-workspace-type` its catalog reads carry. Daemon gates keyed on the
+  // explicit assertion must see it again on project creation and at run
+  // time, where no request headers exist.
+  const workspaceType = localCatalogScopeWorkspaceType(context.workspaceType);
   return {
     workspaceId: context.workspaceId.trim(),
     workspaceMemberId: context.workspaceMemberId.trim(),
+    ...(workspaceType ? { workspaceType } : {}),
   };
+}
+
+function localCatalogScopeWorkspaceType(value: unknown): LocalCatalogScope['workspaceType'] | null {
+  return value === 'personal' || value === 'team' ? value : null;
 }
 
 function readLocalCatalogScopeDraft(key: string): LocalCatalogScope | null {
@@ -423,9 +433,11 @@ function readLocalCatalogScopeDraft(key: string): LocalCatalogScope | null {
   try {
     const parsed = JSON.parse(raw) as Partial<LocalCatalogScope> | null;
     if (!parsed?.workspaceId?.trim() || !parsed.workspaceMemberId?.trim()) return null;
+    const workspaceType = localCatalogScopeWorkspaceType(parsed.workspaceType);
     return {
       workspaceId: parsed.workspaceId.trim(),
       workspaceMemberId: parsed.workspaceMemberId.trim(),
+      ...(workspaceType ? { workspaceType } : {}),
     };
   } catch {
     return null;

--- a/apps/web/tests/components/BrandLogo.workspace-scope.test.tsx
+++ b/apps/web/tests/components/BrandLogo.workspace-scope.test.tsx
@@ -44,7 +44,7 @@ describe('BrandLogo Workspace scope', () => {
     const { container } = render(createElement(BrandLogo, props));
 
     expect(container.querySelector('img')?.getAttribute('src')).toBe(
-      '/api/brands/brand-nike/logo?workspaceId=workspace-brand&workspaceMemberId=member-brand',
+      '/api/brands/brand-nike/logo?workspaceId=workspace-brand&workspaceMemberId=member-brand&workspaceType=team',
     );
   });
 
@@ -75,7 +75,7 @@ describe('BrandLogo Workspace scope', () => {
       />,
     );
     expect(view.container.querySelector('img')?.getAttribute('src')).toBe(
-      '/api/brands/brand-nike/logo?workspaceId=workspace-brand&workspaceMemberId=member-brand',
+      '/api/brands/brand-nike/logo?workspaceId=workspace-brand&workspaceMemberId=member-brand&workspaceType=team',
     );
   });
 });

--- a/apps/web/tests/components/HomeView.context-picker.test.tsx
+++ b/apps/web/tests/components/HomeView.context-picker.test.tsx
@@ -228,11 +228,13 @@ describe('HomeView context picker', () => {
       skillCatalogScope: {
         workspaceId: workspaceA.workspaceId,
         workspaceMemberId: workspaceA.workspaceMemberId,
+        workspaceType: workspaceA.workspaceType,
       },
       designSystemId: WORKSPACE_DESIGN_SYSTEM.id,
       designSystemCatalogScope: {
         workspaceId: workspaceA.workspaceId,
         workspaceMemberId: workspaceA.workspaceMemberId,
+        workspaceType: workspaceA.workspaceType,
       },
     }));
   });

--- a/apps/web/tests/components/PluginPreviewHero.workspace-scope.test.tsx
+++ b/apps/web/tests/components/PluginPreviewHero.workspace-scope.test.tsx
@@ -29,7 +29,7 @@ it('pins iframe and popout navigation to the project Workspace after the shell s
 
   const expected =
     '/api/plugins/deck-plugin/example/overview'
-    + '?workspaceId=workspace-a&workspaceMemberId=member-a';
+    + '?workspaceId=workspace-a&workspaceMemberId=member-a&workspaceType=team';
   const iframe = screen.getByTestId('plugin-details-hero-iframe');
   const popout = screen.getByTestId('plugin-details-hero-popout');
   expect(iframe.getAttribute('src')).toBe(expected);

--- a/apps/web/tests/components/SettingsDialog.test.ts
+++ b/apps/web/tests/components/SettingsDialog.test.ts
@@ -94,7 +94,7 @@ describe('SettingsDialog Orbit artifact scope', () => {
 
   it('adds navigation scope for a bound Workspace artifact', () => {
     expect(orbitLiveArtifactHref('project-1', 'artifact-1', context)).toBe(
-      '/api/live-artifacts/artifact-1/preview?projectId=project-1&workspaceId=workspace-team&workspaceMemberId=member-1',
+      '/api/live-artifacts/artifact-1/preview?projectId=project-1&workspaceId=workspace-team&workspaceMemberId=member-1&workspaceType=team',
     );
   });
 

--- a/packages/contracts/src/api/projects.ts
+++ b/packages/contracts/src/api/projects.ts
@@ -165,12 +165,14 @@ export interface LocalCatalogScope {
   workspaceId: string;
   workspaceMemberId: string;
   /**
-   * The workspace type the selecting client asserted for that partition (the
-   * same `x-od-workspace-type` its catalog reads carry). Daemon gates that
-   * key on the caller's explicit assertion — the legacy unattributed local
-   * personal design-system allowance — must see it again on project creation
-   * and at run time, where no request headers exist. Optional: an older
-   * draft without it stays unasserted.
+   * The workspace type of that partition. A client sends the type it asserts
+   * (the same `x-od-workspace-type` its catalog reads carry); the daemon
+   * persists it only once its membership verification has confirmed it at
+   * selection time, and drops a claim it cannot confirm. Daemon gates that
+   * key on a verified personal workspace — the legacy unattributed local
+   * personal design-system allowance — read the persisted value again at run
+   * time, where no request headers exist. Optional: an older draft without it
+   * stays unasserted.
    */
   workspaceType?: WorkspaceType;
 }

--- a/packages/contracts/src/api/projects.ts
+++ b/packages/contracts/src/api/projects.ts
@@ -7,7 +7,7 @@ import type {
 } from './context.js';
 import type { ProjectSyncIntent, ProjectSyncIntentEvent, ProjectSyncState } from './project-sync.js';
 import type { TeamResourceState } from './team-resources.js';
-import type { WorkspaceCollabContext } from './collab.js';
+import type { WorkspaceCollabContext, WorkspaceType } from './collab.js';
 
 export type ProjectKind =
   | 'prototype'
@@ -164,6 +164,15 @@ export interface PromptTemplateMetadata {
 export interface LocalCatalogScope {
   workspaceId: string;
   workspaceMemberId: string;
+  /**
+   * The workspace type the selecting client asserted for that partition (the
+   * same `x-od-workspace-type` its catalog reads carry). Daemon gates that
+   * key on the caller's explicit assertion — the legacy unattributed local
+   * personal design-system allowance — must see it again on project creation
+   * and at run time, where no request headers exist. Optional: an older
+   * draft without it stays unasserted.
+   */
+  workspaceType?: WorkspaceType;
 }
 
 export interface ProjectResourceCatalogScopes {


### PR DESCRIPTION
## Why

Dogfooding my own local install (packaged 0.21.1 via tools-pack, never signed into a Workspace): after upgrading, my personal design system vanished from «Your systems» — while its files on disk were intact and the headerless `/api/design-systems` still returned it. Diagnosing took reverse-engineering the catalog filter, because hiding is silent.

The root cause is a catch-22 between two shipped changes:

- `backfillDesignSystemWorkspaceResources` runs on every daemon start and claims a design system into the workspace inferred from its `metadata.projectId` → `workspace_projects` row. On an install that never signed into a Workspace, those rows are the **legacy memberless** shape (`created_by_workspace_member_id` is NULL — lazy orphan adoption via `ensureWorkspaceProjection` writes exactly that on purpose). The backfill propagates the absence, creating an equally unattributed `visibility: 'personal'` binding in `workspace_resources`.
- Every design-system read gate required exact creator-member equality for personal bindings (`designSystemBindingAllowsRead`, the list route's duplicate filter, `authorizeDesignSystemRead`, and `enforceVerifiedWorkspaceResourceRead`'s `strictPersonalCreator`). An unattributed binding can never satisfy that — and its mere existence also hides the system from the headerless lane ("positive evidence of Workspace ownership").

Net effect: no lane can ever show the system. Removing the claim by hand doesn't stick — the backfill recreates it on the next start.

The projects layer already ruled on this exact state: an unattributed personal row outside team views belongs to the local user (`workspaceProjectCreatedByCurrentMember`, `workspaceProjectRowBelongsToCurrentWorkspace` in `routes/project/index.ts`). That's why projects with the same memberless rows stayed visible while design systems disappeared. This PR mirrors that ruling for design systems.

## What users will see

- On a local install that never signed into a Workspace, personal design systems appear again in Settings → Design systems and in the Home composer's design-system picker (the web shell always sends the local personal Workspace scope, so this is the lane the UI lives in).
- `od` CLI / headerless catalog reads show the system again too.
- Design-system detail/preview/showcase/static reads stop returning 403 for these systems.
- Picking such a system in the Home composer and sending now creates the project (was `400 DESIGN_SYSTEM_NOT_FOUND`); selecting it on an existing project works the same way.
- Its Publish toggle, Edit (editor open + asset sync), and Delete controls work (were `403 WORKSPACE_DESIGN_SYSTEM_PERMISSION_DENIED`); opening the editor reuses the system's own editing project instead of forking a scoped copy.
- Runs of a project that selected it get the full `DESIGN.md` in the prompt again — both for a project created from that selection and for a legacy memberless project.
- When the catalog does hide a system, the daemon log now says why: `[design-systems] catalog hid <id> (<scope>): <reason>` (deduped per daemon lifetime), so this class of bug no longer requires reverse-engineering the filter.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — `LocalCatalogScope` (`packages/contracts/src/api/projects.ts`) gains an optional `workspaceType`, the type the selecting client asserted for that partition; sent by the Home composer on `POST /api/projects` and persisted in `metadata.localCatalogScopes`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [x] **Default behavior change** — previously-hidden (broken-hidden) personal design systems on local no-Workspace installs reappear without opting in; catalog hides now emit a `console.warn` line. No schema or setting changes.
- [ ] **None** — internal refactor, docs, tests, or translation update only

## How it works

One named predicate carries the invariant — `isUnattributedLocalPersonalDesignSystemBinding` in `collab/workspace-resource-mutation.ts` (docblock explains the ruling and why the backfill's output must stay readable). It is applied at every read gate:

- `designSystemBindingAllowsRead` accepts an unattributed personal binding only when the caller's scope **explicitly asserts** a personal workspace. The threaded option is `workspaceTypeAsserted` — the raw `x-od-workspace-type` claim (`assertedWorkspaceScopeType`), mirroring the existing `WorkspaceResourceContext.workspaceTypeAsserted` — never the normalized `workspaceType`, which collapses a missing header to `'personal'`. A caller that omits the optional header (or a lane that never threads the assertion) keeps the strict pre-existing behavior, fail-closed.
- The catalog's headerless lane treats an unattributed personal binding as local-public instead of foreign-ownership evidence; the memberless positive-workspace lane (what run-prompt composition passes for legacy projects) may read exactly the unattributed bindings of its own workspace.
- `GET /api/design-systems`'s duplicate filter, `authorizeDesignSystemRead`'s 403, and `enforceVerifiedWorkspaceResourceRead`'s `strictPersonalCreator` all reuse the same predicate keyed on the same explicit assertion, so the gates cannot drift apart again.
- Navigation transports (preview/showcase/static via iframe/img URLs) cannot attach headers, so the web's `workspaceResourceUrl` now carries the same explicit `workspaceType` assertion in the query, `requestWithWorkspaceNavigationScope` presents it as the type header (with the existing exact-agreement conflict rule), and the showcase asset-URL rewrite propagates it to nested static loads. An URL that asserts nothing stays on the strict gate.

Team isolation is untouched: a scope asserting `workspaceType: 'team'`, a foreign workspace, an attributed binding with a different creator, team-visibility bindings, and tombstones all stay hidden — pinned by tests.

**QA follow-up (selection → create → mutate → run):** the allowance is now one predicate for every gate, `unattributedLocalPersonalDesignSystemAllowance` (`collab/workspace-resource-mutation.ts`), and the personal-binding read decision is one exported function, `designSystemPersonalBindingReadable` (`design-systems/server-services.ts`), shared by the catalog filter, the detail/static read options, `validateProjectDesignSystemId`, and `designSystemVisibleToRun` in `server.ts`:

- **Project validation** takes `workspaceTypeAsserted`. Create derives it from the selection partition (`LocalCatalogScope.workspaceType`, which the web composer now sends and `parseLocalCatalogScope` persists; an older draft inherits the request's assertion for the same workspace) or from the request's local attribution. PATCH derives it from the request when it names the binding's workspace, else from the daemon's `WorkspaceTypeRegistry`.
- **Mutation** — `authorizeDesignSystemMutation`'s inline 403 and `workspaceResourceMutationAllowed` behind `enforceVerifiedWorkspaceResourceMutation` (which now reads the caller's explicit claim from the request exactly as the read gate does) apply the same allowance, so PATCH/publish, `sync-assets`, `/workspace` (editor open), and DELETE accept the scope whose detail read advertises `canMutate: true`. `isExactDesignSystemProjectBinding` applies it too, so the editor reuses the legacy editing project rather than forking a scoped copy whose edits the run would never read.
- **Run path** has no request headers, so the assertion comes from two fail-closed witnesses: the persisted `localCatalogScopes.designSystem.workspaceType`, else `WorkspaceTypeRegistry.typeOf(workspaceId)` (what the daemon learned from exact directory/context reads). A memberless persisted scope keeps reading exactly the unattributed bindings of its own workspace. The workspace itself still comes only from the persisted scope.

No data migration: the read-side allowance makes existing broken rows readable in place, matching how projects handled the same legacy shape (rows stay memberless; the allowance lives in the gates).

**Review follow-up (verified workspace type):** the allowance no longer keys on the raw `x-od-workspace-type` claim. The Vela verifier matches membership by Workspace/member id and returns the directory item's type without rejecting a mismatched header, and lazy orphan adoption writes memberless rows into Team workspaces too, so a Team member claiming `personal` could reach every unattributed row in their Team workspace. Every producer now goes through one witness, `verifiedWorkspaceTypeAssertion` (`collab/workspace-resource-mutation.ts`): the explicit assertion **confirmed by membership verification** — a new verified tier of `WorkspaceTypeRegistry` (`learnVerified` / `verifiedTypeOf`, fed only by successful membership directory reads, never by the request claims project routes learn), else the lane's request verifier (the membership directory in the packaged runtime, the explicit headers in local/dev where they are the complete static authority). The threaded option is renamed `workspaceTypeAsserted` → `workspaceTypeVerified`, and the shared gates additionally require their own verified context to be personal. Project creation persists only the confirmed type into `localCatalogScopes.designSystem.workspaceType`, PATCH selection persists the verified partition, and the run path falls back to the verified memo only — no lane takes a claim as a witness anymore. Local data-plane reads stay off the authority plane: the witness is a lazily settled resolver the catalog and validator invoke only when an unattributed personal binding is actually in the list, and a binding-aware check in the design-system routes, so attributed and unbound systems never trigger verification.

## Bug fix verification

- Test path: `apps/daemon/tests/design-systems/local-install-personal-visibility.test.ts` — reproduces the full install state through the real startup backfill, real server services, and real HTTP routes (catalog with scope headers, headerless catalog, detail read, backfill invariant, hide-reason logging, and team/foreign-scope isolation guards).
- Red on `main`, green on this branch: **yes** — 5 of 6 original specs fail on `main` with exactly the reported symptoms (empty catalog in both lanes, 403 on detail, silent hiding); all pass with the fix. The team/foreign-scope guard passes on both, pinning that the allowance does not widen team access.
- Review follow-up (fail-closed assertion) added four more specs, red-first on the pre-review branch state: a same-workspace scope with ID/member headers but **no** type header stays hidden in the catalog and 403s on detail; a navigation URL carrying `workspaceType=personal` reads; a navigation URL asserting nothing is rejected.
- Live verification on a real packaged install in the broken state: after this fix, the same daemon shows the system in the scoped lane (with the UI's real member id), the headerless lane, and the detail read — and the new log line explains any remaining hide.
- QA follow-up: `apps/daemon/tests/design-systems/local-install-personal-journey.test.ts` drives the whole chain through the real daemon (`startServer`, real startup backfill, real routes, real run composition with a stub `opencode` that reports whether the `DESIGN.md` marker reached its stdin): catalog → `POST /api/projects` with the selection → run of that project → PATCH-select on a legacy memberless project → run of that project → PATCH / `/workspace` (asserting the legacy editing project id, no fork) / `sync-assets` / DELETE. Red on the previous head with exactly QA's symptoms (create 400, mutations 403, prompt missing), green now; the fail-closed counterparts (unasserted create → 400, team-asserted/unasserted mutations → 403) are pinned alongside.
- Review follow-up (verified workspace type): `apps/daemon/tests/design-systems/local-install-personal-verified-workspace.test.ts` drives the real daemon in vela mode against a stub membership directory holding one Team and one Personal membership, each with a legacy unattributed system. The Team member claiming `personal` is refused at catalog, detail, navigation read, PATCH, editor open, DELETE, project creation, and PATCH selection — after first teaching the claim-tier memo via `POST /api/projects`; the Personal member is granted at every gate and the persisted partition carries the directory-confirmed type. Red on the previous head (5 of 7 specs, with exactly the reviewer's symptoms), green now.

## Validation

- `pnpm guard` — green
- `pnpm typecheck` (whole workspace) — green
- `apps/daemon` vitest: full suite on the fix tree — 9718 passed; the only failing files also fail identically on the clean base (hook-timeout flakes under load: `od-next-automatic-simple-server`, `export-tool-token-nonloopback-authority`; verified via stash + baseline rerun, and they reference none of the changed modules)
- Targeted rerun of `tests/design-systems`, `tests/collab`, `tests/skills`, `tests/workspace-resource-read-authority.test.ts` — green (103 files / 1302 tests after the review follow-up)
- Navigation-scope consumer suites (`plugin-asset-workspace-authority`, `brand-routes`, `chat-project-authority`, `collab-workspace-events-route`, `skill-navigation-workspace-authority`, `routes/projects`) — green after `requestWithWorkspaceNavigationScope` learned the type assertion
- Two pre-existing tests that pinned the exact options shape passed to `listAllDesignSystems` / `readAvailableDesignSystemStaticFile` were updated for the new `workspaceTypeAsserted` field (`explicit-workspace-scope-routes.test.ts`, `design-system-family-workspace-authority.test.ts`); four web tests pinning navigation URL shapes were updated for the new `workspaceType` query parameter
- QA follow-up: `pnpm guard` and workspace `pnpm typecheck` green; `tests/design-systems`, `tests/collab`, `tests/routes`, `tests/skills`, `tests/workspace-resource-read-authority`, `tests/static-resource-routes`, `tests/project-design-system-routes`, and the design-system prompt cases of `tests/chat-route` green; three pins on the exact validator options in `project-resource-scope-validation.test.ts` and one on the composer's catalog-scope shape in `HomeView.context-picker.test.tsx` updated for the new fields. One 20s hook timeout in `routes/projects.test.ts` (`project-locations`) appeared only while two full-server suites ran concurrently and passes in isolation on both the fix tree and the previous head.
- Review follow-up (verified workspace type): `pnpm guard` and workspace `pnpm typecheck` green; `tests/design-systems`, `tests/collab`, `tests/routes/project-resource-scope-validation`, `tests/workspace-resource-read-authority`, `tests/static-resource-routes`, `tests/project-design-system-routes` green (104 files / 1296 tests), plus `tests/routes/projects` and `tests/chat-route` in isolation. Two option-shape pins were renamed for `workspaceTypeVerified`; the catalog pin in `explicit-workspace-scope-routes` now expects the lazily settled resolver; the visibility spec's route fixtures run the production local verifier (`verifyLocalWorkspaceRequestContext`, extracted from `server.ts`) instead of a throwing double.

## Adjacent issues (deliberately out of scope, per AGENTS.md "Hold the spec's scope")

- ~~Mutation gate / run path / `isExactDesignSystemProjectBinding` fork~~ — addressed in the QA follow-up above.
- In the packaged runtime (`OD_WORKSPACE_CONTEXT_SOURCE=vela`), DELETE additionally runs `unshareTeamDesignSystemIfShared`, which verifies the header identity against the membership directory before the local delete; that is pre-existing for any header-carrying delete of a bound system and independent of the legacy shape (the local/dev verifier treats the explicit headers as authoritative, which is what the journey spec exercises).
- `resolveSafeReal` (`projects.ts`) falls back to the unresolved directory when the project dir does not exist yet, so under a symlinked root (macOS `tmpdir`) a read of a not-yet-materialized project trips the symlink guard; only reachable in tests that seed a project row without its directory.
- The skills and plugin read gates have the same strict shape; latent today because nothing backfills memberless bindings for them.
- Unclaimed user design systems (no binding, no metadata claim, no `projectId` to infer from) remain quarantined from workspace scopes with no adoption-on-read equivalent of `bindUnboundProjectsToPersonalWorkspace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


