### PR TITLE
fix daemon AMR media model chat guard

### DIFF
--- a/apps/daemon/src/runtimes/defs/amr.ts
+++ b/apps/daemon/src/runtimes/defs/amr.ts
@@ -98,11 +98,11 @@ function normalizeKnownVelaVersionId(rawId: string): string | null {
   return null;
 }
 
-function isVelaChatModelId(modelId: string): boolean {
+export function isVelaChatCapableModelId(modelId: string): boolean {
   // Temporary chat-surface guard: Vela already lists media-generation models,
   // but OpenDesign's AMR runtime currently drives only chat completions.
   // Remove this filter when AMR grows first-class image/video execution.
-  const id = modelId.toLowerCase();
+  const id = (normalizeVelaModelId(modelId) ?? modelId.trim()).toLowerCase();
   if (id.startsWith('gpt-image-')) return false;
   if (id.startsWith('nano-banana-')) return false;
   if (id.startsWith('seedream-')) return false;
@@ -122,7 +122,7 @@ export function parseVelaModels(stdout: string): RuntimeModelOption[] {
     const [rawId] = trimmed.split(/\s+/);
     if (!rawId) continue;
     const id = normalizeVelaModelId(rawId);
-    if (!id || seen.has(id) || !isVelaChatModelId(id)) continue;
+    if (!id || seen.has(id) || !isVelaChatCapableModelId(id)) continue;
     seen.add(id);
     models.push({ id, label: id });
   }
@@ -157,7 +157,7 @@ export function parseVelaModelJson(
       ? (item as { id?: unknown }).id
       : null;
     const id = typeof rawId === 'string' ? (normalizeVelaModelId(rawId) ?? '') : '';
-    if (!id || seen.has(id) || !isVelaChatModelId(id)) continue;
+    if (!id || seen.has(id) || !isVelaChatCapableModelId(id)) continue;
     seen.add(id);
     models.push(withVelaModelPriceFields({ id, label: id }, item));
   }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -283,6 +283,7 @@ import { amrModelLoadingCache } from './runtimes/amr-model-cache.js';
 import {
   fetchVelaPresetModels,
   fetchVelaRemoteModelsWithRetry,
+  isVelaChatCapableModelId,
 } from './runtimes/defs/amr.js';
 import { migrateLegacyDataDirSync } from './migration/index.js';
 import {
@@ -12623,6 +12624,17 @@ export async function startServer({
       // catalog can lag the live one, and a logged-in user picked a concrete
       // id; vela rejects a truly unsupported model at `session/set_model` with
       // a precise error, which beats a pre-emptive block on a flaky metadata read.
+    }
+
+    if (
+      def.id === 'amr' &&
+      safeModel &&
+      !isVelaChatCapableModelId(safeModel)
+    ) {
+      send('error', createAmrModelUnavailablePayload(safeModel, {
+        reason: 'model_not_chat_capable',
+      }));
+      return finishStrategyAwarePhysicalRun('failed', 1, null);
     }
 
     // Plain-streaming adapters that own a "continue most recent

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -133,6 +133,88 @@ describe('/api/chat', () => {
     };
   }
 
+  async function runAmrModelRequest(model: string): Promise<{
+    body: string;
+    invocations: string[];
+    responseOk: boolean;
+  }> {
+    if (!process.env.OD_DATA_DIR) {
+      throw new Error('OD_DATA_DIR is required for AMR model capability tests');
+    }
+    const previousRuntimeKey = process.env.VELA_RUNTIME_KEY;
+    const previousLinkUrl = process.env.VELA_LINK_URL;
+    const previousInvocationLog = process.env.FAKE_VELA_INVOCATION_LOG;
+    const previousLogSetModel = process.env.FAKE_VELA_LOG_SET_MODEL;
+    const previousLogPrompt = process.env.FAKE_VELA_LOG_PROMPT;
+    const invocationLog = join(tmpdir(), `od-amr-model-request-${randomUUID()}.jsonl`);
+    try {
+      process.env.VELA_RUNTIME_KEY = `fake-runtime-key-${randomUUID()}`;
+      process.env.VELA_LINK_URL = 'https://amr-link.open-design.ai/v1';
+      process.env.FAKE_VELA_INVOCATION_LOG = invocationLog;
+      process.env.FAKE_VELA_LOG_SET_MODEL = '1';
+      process.env.FAKE_VELA_LOG_PROMPT = '1';
+      const workspaceFixture = await createPersonalWorkspaceBoundProjectFixture(
+        `AMR model request ${randomUUID()}`,
+      );
+      let body = '';
+      let responseOk = false;
+
+      await withFakeAgent(
+        'vela',
+        `
+const { spawn } = require('node:child_process');
+const fixture = ${JSON.stringify(FAKE_VELA_FIXTURE)};
+const child = spawn(process.execPath, [fixture, ...process.argv.slice(2)], {
+  stdio: 'inherit',
+  env: process.env,
+});
+child.on('exit', (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  process.exit(code ?? 0);
+});
+`,
+        async () => {
+          const response = await fetch(`${baseUrl}/api/chat`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              ...workspaceFixture.headers,
+            },
+            body: JSON.stringify({
+              agentId: 'amr',
+              projectId: workspaceFixture.projectId,
+              message: 'Exercise the resolved AMR model.',
+              model,
+            }),
+          });
+          responseOk = response.ok;
+          body = await response.text();
+        },
+      );
+
+      const invocations = existsSync(invocationLog)
+        ? readFileSync(invocationLog, 'utf8')
+            .trim()
+            .split('\n')
+            .filter(Boolean)
+            .map((line) => (JSON.parse(line) as { method: string }).method)
+        : [];
+      return { body, invocations, responseOk };
+    } finally {
+      rmSync(invocationLog, { force: true });
+      if (previousRuntimeKey == null) delete process.env.VELA_RUNTIME_KEY;
+      else process.env.VELA_RUNTIME_KEY = previousRuntimeKey;
+      if (previousLinkUrl == null) delete process.env.VELA_LINK_URL;
+      else process.env.VELA_LINK_URL = previousLinkUrl;
+      if (previousInvocationLog == null) delete process.env.FAKE_VELA_INVOCATION_LOG;
+      else process.env.FAKE_VELA_INVOCATION_LOG = previousInvocationLog;
+      if (previousLogSetModel == null) delete process.env.FAKE_VELA_LOG_SET_MODEL;
+      else process.env.FAKE_VELA_LOG_SET_MODEL = previousLogSetModel;
+      if (previousLogPrompt == null) delete process.env.FAKE_VELA_LOG_PROMPT;
+      else process.env.FAKE_VELA_LOG_PROMPT = previousLogPrompt;
+    }
+  }
+
   async function createPluginFixture(args: {
     pluginId: string;
     dirName: string;
@@ -901,6 +983,34 @@ process.exit(1);
         expect(body).toContain('"status":"failed"');
       },
     );
+  });
+
+  it('rejects a requested media-only model before AMR ACP launch', async () => {
+    const { body, invocations, responseOk } = await runAmrModelRequest('nano-banana-2');
+
+    expect(responseOk).toBe(true);
+    expect(invocations).toEqual([]);
+    expect(body).toContain('AMR_MODEL_UNAVAILABLE');
+    expect(body).toContain('model_not_chat_capable');
+    expect(body).toContain('"status":"failed"');
+    expect(body).not.toContain('Hello from fake vela.');
+  });
+
+  it('forwards an unknown custom-provider chat slug when the AMR catalog is stale', async () => {
+    const { body, invocations, responseOk } = await runAmrModelRequest(
+      'custom-provider/future-chat-2027',
+    );
+
+    expect(responseOk).toBe(true);
+    expect(invocations).toEqual([
+      'new',
+      'set_model:custom-provider/future-chat-2027',
+      'prompt',
+    ]);
+    expect(body).not.toContain('AMR_MODEL_UNAVAILABLE');
+    expect(body).toContain('"type":"text_delta","delta":"Hello from fake "');
+    expect(body).toContain('"type":"text_delta","delta":"vela."');
+    expect(body).toContain('"status":"succeeded"');
   });
 
   it('survives transient AMR Link catalog failures without aborting the run', async () => {

--- a/apps/daemon/tests/fixtures/fake-vela.mjs
+++ b/apps/daemon/tests/fixtures/fake-vela.mjs
@@ -86,6 +86,8 @@
  *                                   session/set_model (legacy behaviour)
  *   FAKE_VELA_LOG_SET_MODEL      – when set to '1', include session/set_model
  *                                   entries in FAKE_VELA_INVOCATION_LOG
+ *   FAKE_VELA_LOG_PROMPT         – when set to '1', include session/prompt
+ *                                   entries in FAKE_VELA_INVOCATION_LOG
  */
 
 import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs';
@@ -338,6 +340,9 @@ function handleMessage(msg) {
       return;
     }
     case 'session/prompt': {
+      if (env.FAKE_VELA_LOG_PROMPT === '1') {
+        logInvocation('prompt');
+      }
       if (RESUME_FAILED && didLoad) {
         // Structured resume-miss: the resumed session is gone. Mirrors vela's
         // pre-prompt probe emitting resume_failed BEFORE any model call. Gated on


### PR DESCRIPTION
Fixes #7694

## Why

The AMR picker and Vela catalog parser already remove known image and video model families, but the chat run-launch path did not reuse that capability check. A concrete request such as `nano-banana-2` is absent from the filtered catalog; the intentional stale-catalog compatibility path therefore forwarded it to Vela, where it reached `session/set_model` and `session/prompt` on the chat-only ACP runtime.

This was identified while auditing an AMR 0.21.0 reliability miss. The user-facing pain is a media-only model entering the wrong execution surface and failing late with misleading runtime or provider behavior instead of a deterministic model-capability error.

## What users will see

When the final AMR model resolves to a known media-only family, the run now fails before the AMR agent process starts. It uses the existing `AMR_MODEL_UNAVAILABLE` error with `details.reason=model_not_chat_capable`, and no prompt is launched.

Unknown legal chat slugs, including custom provider slugs that are not present in a cached or preset catalog, still reach Vela. The picker/catalog filtering behavior and stale-catalog compatibility policy are unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this changes the daemon run-launch boundary and adds no UI surface.

## Bug fix verification

- Test path: `apps/daemon/tests/chat-route.test.ts`
- RED on upstream `main` (`743ae80d7`): the production-shaped `/api/chat` regression recorded `new`, `set_model:nano-banana-2`, and `prompt`.
- GREEN on this branch: the same request returns `AMR_MODEL_UNAVAILABLE` with `model_not_chat_capable` and records no ACP invocation.
- Compatibility coverage: `custom-provider/future-chat-2027`, absent from the catalog, still records `new`, `set_model`, and `prompt` and succeeds.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/chat-route.test.ts -t 'requested media-only model|unknown custom-provider chat slug'` — 2 passed
- `pnpm exec vitest run -c vitest.config.ts tests/amr-acp-integration.test.ts tests/chat-route.test.ts` — 117 passed
- `pnpm --filter @open-design/daemon test` — 9,767 passed, 7 skipped
- `pnpm typecheck` — passed
- `pnpm guard` — passed
- `git diff --check` — passed
