### PR TITLE
test(e2e): harden onboarding status mock against reload race

### DIFF
--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -58,9 +58,9 @@ async function safeEvaluate<T, A>(page: Page, pageFunction: (arg: A) => T, arg: 
 async function safeEvaluate<T, A>(page: Page, pageFunction: (arg: A) => T, arg?: A): Promise<T | undefined> {
   try {
     if (arg === undefined) {
-      return await page.evaluate(pageFunction as () => T);
+      return await (page.evaluate as unknown as (fn: () => T) => Promise<T>)(pageFunction as () => T);
     }
-    return await page.evaluate(pageFunction, arg as A);
+    return await (page.evaluate as unknown as (fn: (arg: A) => T, arg: A) => Promise<T>)(pageFunction, arg as A);
   } catch (error) {
     if (isOnboardingReloadRaceError(error)) return undefined;
     throw error;

--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -44,6 +44,29 @@ declare global {
   }
 }
 
+function isOnboardingReloadRaceError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes('Execution context was destroyed') ||
+    message.includes('Target page, context or browser has been closed') ||
+    message.includes('Target closed')
+  );
+}
+
+async function safeEvaluate<T>(page: Page, pageFunction: () => T): Promise<T | undefined>;
+async function safeEvaluate<T, A>(page: Page, pageFunction: (arg: A) => T, arg: A): Promise<T | undefined>;
+async function safeEvaluate<T, A>(page: Page, pageFunction: (arg: A) => T, arg?: A): Promise<T | undefined> {
+  try {
+    if (arg === undefined) {
+      return await page.evaluate(pageFunction as () => T);
+    }
+    return await page.evaluate(pageFunction, arg as A);
+  } catch (error) {
+    if (isOnboardingReloadRaceError(error)) return undefined;
+    throw error;
+  }
+}
+
 test.describe.configure({ timeout: T.xlong });
 
 test.beforeEach(async ({ page }) => {
@@ -1276,7 +1299,7 @@ async function wireOnboardingMocks(
 
   await page.route('**/api/integrations/vela/status', async (route) => {
     statusCalls += 1;
-    await page.evaluate((calls) => {
+    await safeEvaluate(page, (calls) => {
       window.__amrOnboardingStatusCalls = calls;
     }, statusCalls);
     if (options.statusGate) {
@@ -1289,14 +1312,14 @@ async function wireOnboardingMocks(
         body: JSON.stringify({ error: 'status unavailable' }),
       });
       statusResponses += 1;
-      await page.evaluate((responses) => {
+      await safeEvaluate(page, (responses) => {
         window.__amrOnboardingStatusResponses = responses;
       }, statusResponses);
       return;
     }
-    if (loginInFlight && await page.evaluate(() => (
-      window.__amrOnboardingCompleteLogin === true
-    ))) {
+    const shouldCompleteLogin = loginInFlight
+      && (await safeEvaluate(page, () => window.__amrOnboardingCompleteLogin === true)) === true;
+    if (shouldCompleteLogin) {
       loggedIn = true;
       loginInFlight = false;
     }
@@ -1307,11 +1330,11 @@ async function wireOnboardingMocks(
       (!loggedIn &&
         typeof options.delaySignedOutStatusMs === 'number' &&
         options.delaySignedOutStatusMs > 0 &&
-        (await page.evaluate(() => {
+        (await safeEvaluate(page, () => {
           if (!window.__amrOnboardingDelayNextSignedOutStatus) return false;
           window.__amrOnboardingDelayNextSignedOutStatus = false;
           return true;
-        })));
+        })) === true);
     if (shouldDelaySignedOutStatus) {
       const delayMs = shouldDelayAllStatuses
         ? delayAllStatusMs
@@ -1341,11 +1364,11 @@ async function wireOnboardingMocks(
           },
     });
     statusResponses += 1;
-    await page.evaluate((responses) => {
+    await safeEvaluate(page, (responses) => {
       window.__amrOnboardingStatusResponses = responses;
     }, statusResponses);
     if (shouldDelaySignedOutStatus) {
-      await page.evaluate(() => {
+      await safeEvaluate(page, () => {
         window.__amrOnboardingSlowStatusResolved = true;
       });
     }
@@ -1372,7 +1395,7 @@ async function wireOnboardingMocks(
       loggedIn = true;
       loginInFlight = false;
     }
-    await page.evaluate((calls) => {
+    await safeEvaluate(page, (calls) => {
       window.__amrOnboardingLoginCalls = calls;
     }, loginCalls);
     await route.fulfill({
@@ -1390,7 +1413,7 @@ async function wireOnboardingMocks(
     expect(route.request().postDataJSON()).toEqual({ authAttemptId });
     cancelCalls += 1;
     loginInFlight = false;
-    await page.evaluate((calls) => {
+    await safeEvaluate(page, (calls) => {
       window.__amrOnboardingCancelCalls = calls;
     }, cancelCalls);
     await route.fulfill({ json: { canceled: true, pids: [4242] } });


### PR DESCRIPTION
Fixes #7657

## Why

While validating #7655's loading-shell fix, the `entry-settings` group exposed a different failure in an unchanged test:

`[P0] onboarding reload restores and cancels an active Cloud login`

The error was `page.evaluate: Execution context was destroyed, most likely because of a navigation` inside `wireOnboardingMocks`' `/api/integrations/vela/status` route callback, where it writes `window.__amrOnboardingStatusCalls` via `page.evaluate`. The test intentionally reloads the page, so an in-flight status poll can race the navigation.

## What users will see

No product behavior changes. Onboarding mock instrumentation tolerates the intentional reload without evaluating against a destroyed document, while keeping restore/cancel assertions strict.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: test-only change.

## Bug fix verification

- Test path that reproduces the bug: `e2e/ui/amr-onboarding.test.ts` — `[P0] onboarding reload restores and cancels an active Cloud login` (and sibling reload-resume test)
- Did the test go red on `main` and green on this branch? No deterministic local repro without full Playwright runtime; verified by code inspection that the route handler's `page.evaluate` throws during reload and is now guarded. The existing reload assertions remain strict.
- Related: second attempt passed after retry (18.3s), confirming this is a retry-only flake, not a product bug.

## Validation

- `git diff --check` — passed
- `git diff --stat` — 1 file changed, 34 insertions(+), 11 deletions(-)
- Typecheck / guard / Playwright — NOT LOCALLY REPRODUCIBLE (isolated worktree without node_modules); upstream CI required