### PR TITLE
feat(daemon): persist tool execution lifecycle diagnostics

### DIFF
--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -482,12 +482,14 @@ export function attachAcpSession({
   const emitAcpExecutionObservability = (update: JsonObject): boolean => {
     const name = typeof update.sessionUpdate === 'string' ? update.sessionUpdate : '';
     if (name === 'tool_execution_lifecycle') {
-      const diagnostic = sanitizeToolExecutionLifecycleUpdate(update);
-      if (diagnostic && toolExecutionLifecycleDeduper.accept(diagnostic)) {
-        send('agent', {
-          ...diagnostic,
-          elapsedMs: Date.now() - runStartedAt,
-        });
+      if (modelUnavailableErrorCode) {
+        const diagnostic = sanitizeToolExecutionLifecycleUpdate(update);
+        if (diagnostic && toolExecutionLifecycleDeduper.accept(diagnostic)) {
+          send('agent', {
+            ...diagnostic,
+            elapsedMs: Date.now() - runStartedAt,
+          });
+        }
       }
       // Private adapter diagnostics never fall through to generic status or
       // tool-result projection, including unknown schema versions.

--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -64,6 +64,10 @@ import { buildAcpSessionNewParams, buildPromptBlocks, type AcpMcpServerInput } f
 import { withholdStdioMcpServersForBuild } from './stdio-mcp.js';
 import { createVelaChildEvidenceConsumer } from '../../runtimes/vela-child-evidence.js';
 import { withAcpEmissionProvenance, type AcpEmissionMeta } from './emission-provenance.js';
+import {
+  createToolExecutionLifecycleDeduper,
+  sanitizeToolExecutionLifecycleUpdate,
+} from './tool-execution-lifecycle.js';
 
 const NON_DISPLAYABLE_ACP_SESSION_UPDATES = new Set([
   'usage_update',
@@ -190,6 +194,7 @@ export function attachAcpSession({
   onTerminal,
 }: AttachAcpSessionOptions) {
   const runStartedAt = Date.now();
+  const toolExecutionLifecycleDeduper = createToolExecutionLifecycleDeduper();
   const effectiveCwd = path.resolve(cwd || process.cwd());
   if (!child.stdin || !child.stdout) {
     throw new Error('ACP child process must expose stdin and stdout streams');
@@ -476,6 +481,18 @@ export function attachAcpSession({
 
   const emitAcpExecutionObservability = (update: JsonObject): boolean => {
     const name = typeof update.sessionUpdate === 'string' ? update.sessionUpdate : '';
+    if (name === 'tool_execution_lifecycle') {
+      const diagnostic = sanitizeToolExecutionLifecycleUpdate(update);
+      if (diagnostic && toolExecutionLifecycleDeduper.accept(diagnostic)) {
+        send('agent', {
+          ...diagnostic,
+          elapsedMs: Date.now() - runStartedAt,
+        });
+      }
+      // Private adapter diagnostics never fall through to generic status or
+      // tool-result projection, including unknown schema versions.
+      return true;
+    }
     if (
       name !== 'assistant_message_lifecycle' &&
       name !== 'model_step_lifecycle' &&

--- a/apps/daemon/src/agent-protocol/acp/tool-execution-lifecycle.ts
+++ b/apps/daemon/src/agent-protocol/acp/tool-execution-lifecycle.ts
@@ -1,0 +1,343 @@
+/**
+ * Frozen Open Design consumer for Vela's private
+ * `sessionUpdate: tool_execution_lifecycle`, `vela.tool_execution_lifecycle`
+ * version 1 contract.
+ * Rebuilds every persisted/telemetry field from fixed allowlists; arbitrary
+ * adapter metadata is never copied into a diagnostic.
+ */
+import { constants as osConstants } from 'node:os';
+import type { JsonObject } from './types.js';
+import { acpTelemetryToolCallId } from './updates.js';
+
+const MAX_EVENTS = 64;
+const MAX_ERROR_CHAIN = 4;
+const MAX_TOOL_DEDUPE_ENTRIES = 256;
+const MAX_LIFECYCLE_INTEGER = Number.MAX_SAFE_INTEGER;
+
+const PHASES = new Set([
+  'spawn_requested', 'spawn', 'spawn_error', 'exit', 'close',
+  'stdout_close', 'stderr_close', 'kill_requested', 'kill_sent', 'kill_failed',
+  'release_started', 'release_finished', 'deadline', 'abort_observed',
+  'kill_settled', 'output_consumer_finished', 'output_sink_close_requested',
+  'output_sink_settled', 'executor_settled',
+]);
+const OUTCOMES = new Set(['success', 'failure', 'interrupted']);
+const TRIGGERS = new Set(['exit', 'abort', 'deadline']);
+const STATUSES = new Set(['pending', 'in_progress', 'completed', 'failed']);
+const EXECUTION_TERMINALS = new Set(['running', 'returned', 'failed', 'interrupted']);
+const TERMINAL_SOURCES = new Set(['tool_result', 'tool_error', 'processor_cleanup']);
+const TARGETS = new Set(['group', 'process']);
+const MECHANISMS = new Set(['taskkill', 'process_group', 'process_signal']);
+const SIGNALS = new Set([
+  'SIGHUP', 'SIGINT', 'SIGQUIT', 'SIGILL', 'SIGTRAP', 'SIGABRT',
+  'SIGBUS', 'SIGFPE', 'SIGKILL', 'SIGUSR1', 'SIGSEGV', 'SIGUSR2',
+  'SIGPIPE', 'SIGALRM', 'SIGTERM', 'SIGCHLD', 'SIGCONT', 'SIGSTOP',
+  'SIGTSTP', 'SIGTTIN', 'SIGTTOU', 'SIGURG', 'SIGXCPU', 'SIGXFSZ',
+  'SIGVTALRM', 'SIGPROF', 'SIGWINCH', 'SIGIO', 'SIGSYS', 'SIGBREAK',
+  'SIGINFO', 'SIGLOST', 'SIGPOLL', 'SIGPWR', 'SIGSTKFLT',
+]);
+const ERROR_TYPES = new Set([
+  'Error', 'TypeError', 'RangeError', 'AbortError', 'SystemError',
+  'PlatformError', 'BadArgument', 'SqlError', 'SqliteError', 'SQLiteError',
+  'UnknownError', 'ConstraintError', 'ConnectionError', 'ToolFailure',
+  'ToolInvalidArgumentsError',
+]);
+const ERROR_CODES = new Set([
+  ...Object.keys(osConstants.errno),
+  'ABORT_ERR',
+  'ERR_STREAM_PREMATURE_CLOSE',
+  ...[
+    'ERROR', 'INTERNAL', 'PERM', 'ABORT', 'BUSY', 'LOCKED', 'NOMEM',
+    'READONLY', 'INTERRUPT', 'IOERR', 'CORRUPT', 'NOTFOUND', 'FULL',
+    'CANTOPEN', 'PROTOCOL', 'EMPTY', 'SCHEMA', 'TOOBIG', 'CONSTRAINT',
+    'MISMATCH', 'MISUSE', 'NOLFS', 'AUTH', 'FORMAT', 'RANGE', 'NOTADB',
+    'NOTICE', 'WARNING', 'BUSY_RECOVERY', 'BUSY_SNAPSHOT', 'BUSY_TIMEOUT',
+    'LOCKED_SHAREDCACHE', 'LOCKED_VTAB', 'CONSTRAINT_CHECK',
+    'CONSTRAINT_FOREIGNKEY', 'CONSTRAINT_NOTNULL', 'CONSTRAINT_PRIMARYKEY',
+    'CONSTRAINT_TRIGGER', 'CONSTRAINT_UNIQUE', 'CONSTRAINT_ROWID',
+    'CONSTRAINT_DATATYPE', 'IOERR_READ', 'IOERR_SHORT_READ', 'IOERR_WRITE',
+    'IOERR_FSYNC', 'IOERR_LOCK', 'IOERR_NOMEM',
+  ].map((code) => `SQLITE_${code}`),
+]);
+
+type RecordValue = Record<string, unknown>;
+
+export interface ToolExecutionLifecycleDiagnostic {
+  type: 'diagnostic';
+  name: 'tool_execution_lifecycle';
+  source: 'amr-opencode';
+  schema: 'vela.tool_execution_lifecycle';
+  version: 1;
+  toolCallIdHash: string;
+  status?: string;
+  phase?: string;
+  executionVersion?: 1;
+  elapsedMs?: number;
+  requestedTimeoutMs?: number | null;
+  effectiveTimeoutMs?: number;
+  forceKillAfterMs?: number;
+  trigger?: string;
+  terminal?: string;
+  droppedEvents?: number;
+  events?: RecordValue[];
+  toolTerminal?: RecordValue;
+}
+
+function record(value: unknown): RecordValue | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as RecordValue
+    : null;
+}
+
+function enumValue(value: unknown, allowed: Set<string>): string | undefined {
+  return typeof value === 'string' && allowed.has(value) ? value : undefined;
+}
+
+function integer(value: unknown, min: number, max: number): number | undefined {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= min && value <= max
+    ? value
+    : undefined;
+}
+
+function nullableInteger(value: unknown, min: number, max: number): number | null | undefined {
+  if (value === null) return null;
+  return integer(value, min, max);
+}
+
+function boolean(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function errorChain(value: unknown): RecordValue[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const errors: RecordValue[] = [];
+  for (const raw of value.slice(0, MAX_ERROR_CHAIN)) {
+    const item = record(raw);
+    if (!item) continue;
+    const type = enumValue(item.type, ERROR_TYPES);
+    if (!type) continue;
+    const code = enumValue(item.code, ERROR_CODES);
+    const errno = integer(item.errno, -2_147_483_648, 2_147_483_647);
+    errors.push({
+      type,
+      ...(code ? { code } : {}),
+      ...(errno !== undefined ? { errno } : {}),
+    });
+  }
+  return errors.length > 0 ? errors : undefined;
+}
+
+function lifecycleEvent(value: unknown): RecordValue | null {
+  const item = record(value);
+  if (!item) return null;
+  const phase = enumValue(item.phase, PHASES);
+  if (!phase) return null;
+  const atMs = integer(item.at_ms, 0, MAX_LIFECYCLE_INTEGER);
+  const elapsedMs = integer(item.elapsed_ms, 0, MAX_LIFECYCLE_INTEGER);
+  const outcome = enumValue(item.outcome, OUTCOMES);
+  const pid = integer(item.pid, 1, 2_147_483_647);
+  const code = nullableInteger(item.code, -2_147_483_648, 2_147_483_647);
+  const signal = item.signal === null ? null : enumValue(item.signal, SIGNALS);
+  const target = enumValue(item.target, TARGETS);
+  const mechanism = enumValue(item.mechanism, MECHANISMS);
+  const stdoutClosed = boolean(item.stdout_closed);
+  const stderrClosed = boolean(item.stderr_closed);
+  const errors = errorChain(item.error);
+  return {
+    phase,
+    ...(atMs !== undefined ? { atMs } : {}),
+    ...(elapsedMs !== undefined ? { elapsedMs } : {}),
+    ...(outcome ? { outcome } : {}),
+    ...(pid !== undefined ? { pid } : {}),
+    ...(code !== undefined ? { code } : {}),
+    ...(signal !== undefined ? { signal } : {}),
+    ...(target ? { target } : {}),
+    ...(mechanism ? { mechanism } : {}),
+    ...(stdoutClosed !== undefined ? { stdoutClosed } : {}),
+    ...(stderrClosed !== undefined ? { stderrClosed } : {}),
+    ...(errors ? { error: errors } : {}),
+  };
+}
+
+function terminalProvenance(value: unknown): RecordValue | undefined {
+  const item = record(value);
+  if (!item) return undefined;
+  const source = enumValue(item.source, TERMINAL_SOURCES);
+  const confirmed = boolean(item.confirmed);
+  if (!source || confirmed === undefined) return undefined;
+  const atMs = integer(item.at_ms, 0, MAX_LIFECYCLE_INTEGER);
+  const errors = errorChain(item.error);
+  return {
+    source,
+    confirmed,
+    ...(atMs !== undefined ? { atMs } : {}),
+    ...(errors ? { error: errors } : {}),
+  };
+}
+
+export function sanitizeToolExecutionLifecycleUpdate(
+  update: JsonObject,
+): ToolExecutionLifecycleDiagnostic | null {
+  if (
+    update.sessionUpdate !== 'tool_execution_lifecycle' ||
+    update.schema !== 'vela.tool_execution_lifecycle' ||
+    update.version !== 1
+  ) {
+    return null;
+  }
+  const rawToolCallId = typeof update.toolCallId === 'string' ? update.toolCallId.trim() : '';
+  if (!rawToolCallId || Buffer.byteLength(rawToolCallId, 'utf8') > 512) return null;
+  const rawExecution = record(update.execution);
+  const execution = rawExecution?.version === 1 ? rawExecution : null;
+  const toolTerminal = terminalProvenance(update.toolTerminal);
+  const status = enumValue(update.status, STATUSES);
+  const phase = enumValue(update.phase, PHASES);
+  const requestedTimeoutMs = nullableInteger(execution?.requested_timeout_ms, 0, MAX_LIFECYCLE_INTEGER);
+  const effectiveTimeoutMs = integer(execution?.effective_timeout_ms, 0, MAX_LIFECYCLE_INTEGER);
+  const forceKillAfterMs = integer(execution?.force_kill_after_ms, 0, MAX_LIFECYCLE_INTEGER);
+  const trigger = enumValue(execution?.trigger, TRIGGERS);
+  const terminal = enumValue(execution?.terminal, EXECUTION_TERMINALS);
+  const droppedEvents = integer(execution?.dropped_events, 0, MAX_LIFECYCLE_INTEGER);
+  const events = Array.isArray(execution?.events)
+    ? execution.events.slice(-MAX_EVENTS).map(lifecycleEvent).filter((event): event is RecordValue => event !== null)
+    : [];
+  if (
+    !status && !phase && requestedTimeoutMs === undefined && effectiveTimeoutMs === undefined &&
+    forceKillAfterMs === undefined && !trigger && !terminal &&
+    droppedEvents === undefined && events.length === 0 && !toolTerminal
+  ) {
+    return null;
+  }
+  return {
+    type: 'diagnostic',
+    name: 'tool_execution_lifecycle',
+    source: 'amr-opencode',
+    schema: 'vela.tool_execution_lifecycle',
+    version: 1,
+    toolCallIdHash: acpTelemetryToolCallId(rawToolCallId),
+    ...(status ? { status } : {}),
+    ...(phase ? { phase } : {}),
+    ...(execution ? { executionVersion: 1 as const } : {}),
+    ...(requestedTimeoutMs !== undefined ? { requestedTimeoutMs } : {}),
+    ...(effectiveTimeoutMs !== undefined ? { effectiveTimeoutMs } : {}),
+    ...(forceKillAfterMs !== undefined ? { forceKillAfterMs } : {}),
+    ...(trigger ? { trigger } : {}),
+    ...(terminal ? { terminal } : {}),
+    ...(droppedEvents !== undefined ? { droppedEvents } : {}),
+    ...(events.length > 0 ? { events } : {}),
+    ...(toolTerminal ? { toolTerminal } : {}),
+  };
+}
+
+export function createToolExecutionLifecycleDeduper(): {
+  accept(diagnostic: ToolExecutionLifecycleDiagnostic): boolean;
+} {
+  const fingerprints = new Map<string, string>();
+  return {
+    accept(diagnostic) {
+      const key = diagnostic.toolCallIdHash;
+      const fingerprint = JSON.stringify(diagnostic);
+      if (fingerprints.get(key) === fingerprint) return false;
+      fingerprints.delete(key);
+      fingerprints.set(key, fingerprint);
+      if (fingerprints.size > MAX_TOOL_DEDUPE_ENTRIES) {
+        const oldest = fingerprints.keys().next().value;
+        if (typeof oldest === 'string') fingerprints.delete(oldest);
+      }
+      return true;
+    },
+  };
+}
+
+function projectedLifecycleEvent(value: unknown): RecordValue | null {
+  const item = record(value);
+  if (!item) return null;
+  const phase = enumValue(item.phase, PHASES);
+  if (!phase) return null;
+  const atMs = integer(item.atMs, 0, MAX_LIFECYCLE_INTEGER);
+  const elapsedMs = integer(item.elapsedMs, 0, MAX_LIFECYCLE_INTEGER);
+  const outcome = enumValue(item.outcome, OUTCOMES);
+  const pid = integer(item.pid, 1, 2_147_483_647);
+  const code = nullableInteger(item.code, -2_147_483_648, 2_147_483_647);
+  const signal = item.signal === null ? null : enumValue(item.signal, SIGNALS);
+  const target = enumValue(item.target, TARGETS);
+  const mechanism = enumValue(item.mechanism, MECHANISMS);
+  const stdoutClosed = boolean(item.stdoutClosed);
+  const stderrClosed = boolean(item.stderrClosed);
+  const errors = errorChain(item.error);
+  return {
+    phase,
+    ...(atMs !== undefined ? { at_ms: atMs } : {}),
+    ...(elapsedMs !== undefined ? { elapsed_ms: elapsedMs } : {}),
+    ...(outcome ? { outcome } : {}),
+    ...(pid !== undefined ? { pid } : {}),
+    ...(code !== undefined ? { code } : {}),
+    ...(signal !== undefined ? { signal } : {}),
+    ...(target ? { target } : {}),
+    ...(mechanism ? { mechanism } : {}),
+    ...(stdoutClosed !== undefined ? { stdout_closed: stdoutClosed } : {}),
+    ...(stderrClosed !== undefined ? { stderr_closed: stderrClosed } : {}),
+    ...(errors ? { error: errors } : {}),
+  };
+}
+
+/** Re-validates persisted diagnostics before they leave the daemon for Langfuse. */
+export function projectToolExecutionLifecycleDiagnostic(value: unknown): RecordValue | null {
+  const diagnostic = record(value);
+  if (
+    diagnostic?.type !== 'diagnostic' ||
+    diagnostic.name !== 'tool_execution_lifecycle' ||
+    diagnostic.source !== 'amr-opencode' ||
+    diagnostic.schema !== 'vela.tool_execution_lifecycle' ||
+    diagnostic.version !== 1 ||
+    typeof diagnostic.toolCallIdHash !== 'string' ||
+    !/^acp_[a-f0-9]{24}$/.test(diagnostic.toolCallIdHash)
+  ) {
+    return null;
+  }
+  const elapsedMs = integer(diagnostic.elapsedMs, 0, MAX_LIFECYCLE_INTEGER);
+  const status = enumValue(diagnostic.status, STATUSES);
+  const phase = enumValue(diagnostic.phase, PHASES);
+  const executionVersion = diagnostic.executionVersion === 1 ? 1 : undefined;
+  const requestedTimeoutMs = nullableInteger(diagnostic.requestedTimeoutMs, 0, MAX_LIFECYCLE_INTEGER);
+  const effectiveTimeoutMs = integer(diagnostic.effectiveTimeoutMs, 0, MAX_LIFECYCLE_INTEGER);
+  const forceKillAfterMs = integer(diagnostic.forceKillAfterMs, 0, MAX_LIFECYCLE_INTEGER);
+  const trigger = enumValue(diagnostic.trigger, TRIGGERS);
+  const terminal = enumValue(diagnostic.terminal, EXECUTION_TERMINALS);
+  const droppedEvents = integer(diagnostic.droppedEvents, 0, MAX_LIFECYCLE_INTEGER);
+  const events = Array.isArray(diagnostic.events)
+    ? diagnostic.events.slice(-MAX_EVENTS).map(projectedLifecycleEvent).filter((event): event is RecordValue => event !== null)
+    : [];
+  const rawToolTerminal = record(diagnostic.toolTerminal);
+  const terminalSource = enumValue(rawToolTerminal?.source, TERMINAL_SOURCES);
+  const terminalConfirmed = boolean(rawToolTerminal?.confirmed);
+  const terminalAtMs = integer(rawToolTerminal?.atMs, 0, MAX_LIFECYCLE_INTEGER);
+  const terminalErrors = errorChain(rawToolTerminal?.error);
+  const toolTerminal = terminalSource !== undefined && terminalConfirmed !== undefined
+    ? {
+        source: terminalSource,
+        confirmed: terminalConfirmed,
+        ...(terminalAtMs !== undefined ? { at_ms: terminalAtMs } : {}),
+        ...(terminalErrors ? { error: terminalErrors } : {}),
+      }
+    : undefined;
+  return {
+    name: 'tool_execution_lifecycle',
+    source: 'amr-opencode',
+    ...(elapsedMs !== undefined ? { elapsed_ms: elapsedMs } : {}),
+    schema: 'vela.tool_execution_lifecycle',
+    version: 1,
+    tool_call_id_hash: diagnostic.toolCallIdHash,
+    ...(status ? { status } : {}),
+    ...(phase ? { phase } : {}),
+    ...(executionVersion ? { execution_version: executionVersion } : {}),
+    ...(requestedTimeoutMs !== undefined ? { requested_timeout_ms: requestedTimeoutMs } : {}),
+    ...(effectiveTimeoutMs !== undefined ? { effective_timeout_ms: effectiveTimeoutMs } : {}),
+    ...(forceKillAfterMs !== undefined ? { force_kill_after_ms: forceKillAfterMs } : {}),
+    ...(trigger ? { trigger } : {}),
+    ...(terminal ? { terminal } : {}),
+    ...(droppedEvents !== undefined ? { dropped_events: droppedEvents } : {}),
+    ...(events.length > 0 ? { events } : {}),
+    ...(toolTerminal ? { tool_terminal: toolTerminal } : {}),
+  };
+}

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -603,11 +603,12 @@ function collectAgentEvents(
         typeof data.name === 'string' && data.name.length > 0
           ? data.name
           : 'runtime_diagnostic';
-      const index = diagnosticCounts.get(diagnosticName) ?? 0;
-      diagnosticCounts.set(diagnosticName, index + 1);
       const toolExecutionLifecycle = diagnosticName === 'tool_execution_lifecycle'
         ? projectToolExecutionLifecycleDiagnostic(data)
         : null;
+      if (diagnosticName === 'tool_execution_lifecycle' && !toolExecutionLifecycle) continue;
+      const index = diagnosticCounts.get(diagnosticName) ?? 0;
+      diagnosticCounts.set(diagnosticName, index + 1);
       out.push({
         id: `diagnostic-${diagnosticName}-${index}`,
         name: `agent-diagnostic:${diagnosticName}`,

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -62,6 +62,7 @@ import {
   collectStdoutTailSummary,
   summarizeRunDiagnosticsForAnalytics,
 } from './run-diagnostics.js';
+import { projectToolExecutionLifecycleDiagnostic } from './agent-protocol/acp/tool-execution-lifecycle.js';
 import {
   classifyRunFailure,
   type RunFailureClassification,
@@ -604,12 +605,15 @@ function collectAgentEvents(
           : 'runtime_diagnostic';
       const index = diagnosticCounts.get(diagnosticName) ?? 0;
       diagnosticCounts.set(diagnosticName, index + 1);
+      const toolExecutionLifecycle = diagnosticName === 'tool_execution_lifecycle'
+        ? projectToolExecutionLifecycleDiagnostic(data)
+        : null;
       out.push({
         id: `diagnostic-${diagnosticName}-${index}`,
         name: `agent-diagnostic:${diagnosticName}`,
         timestamp,
         input: eventInput('diagnostic'),
-        output: {
+        output: toolExecutionLifecycle ?? {
           name: diagnosticName,
           ...(typeof data.source === 'string' ? { source: data.source } : {}),
           ...(typeof data.reason === 'string' ? { reason: data.reason } : {}),

--- a/apps/daemon/src/run-diagnostics.ts
+++ b/apps/daemon/src/run-diagnostics.ts
@@ -197,7 +197,7 @@ function collapseLifecycleEnum<T extends string>(values: Set<T>): T | 'mixed' | 
 function toolExecutionLifecycleAnalytics(
   events: RunEventForDiagnostics[],
 ): Partial<RunDiagnosticsAnalytics> {
-  const fingerprints = new Set<string>();
+  const toolCallIds = new Set<string>();
   const triggers = new Set<'exit' | 'abort' | 'deadline'>();
   const terminals = new Set<'running' | 'returned' | 'failed' | 'interrupted'>();
   const terminalSources = new Set<'tool_result' | 'tool_error' | 'processor_cleanup'>();
@@ -257,29 +257,12 @@ function toolExecutionLifecycleAnalytics(
               : {}),
           }
         : null;
-    const fingerprint = JSON.stringify({
-      toolCallIdHash:
-        typeof data.toolCallIdHash === 'string' && /^acp_[a-f0-9]{24}$/.test(data.toolCallIdHash)
-          ? data.toolCallIdHash
-          : 'unknown',
-      trigger:
-        data.trigger === 'exit' || data.trigger === 'abort' || data.trigger === 'deadline'
-          ? data.trigger
-          : 'unknown',
-      terminal:
-        data.terminal === 'running' || data.terminal === 'returned' ||
-        data.terminal === 'failed' || data.terminal === 'interrupted'
-          ? data.terminal
-          : 'unknown',
-      droppedEvents:
-        typeof data.droppedEvents === 'number' && data.droppedEvents > 0
-          ? 'present'
-          : 'none',
-      events: safeLifecycleEvents,
-      toolTerminal: safeToolTerminal,
-    });
-    if (fingerprints.has(fingerprint)) continue;
-    fingerprints.add(fingerprint);
+    const toolCallIdHash = data.toolCallIdHash;
+    if (typeof toolCallIdHash !== 'string' || !/^acp_[a-f0-9]{24}$/.test(toolCallIdHash)) {
+      continue;
+    }
+    if (toolCallIds.has(toolCallIdHash)) continue;
+    toolCallIds.add(toolCallIdHash);
     lifecycleCount += 1;
 
     if (data.trigger === 'exit' || data.trigger === 'abort' || data.trigger === 'deadline') {

--- a/apps/daemon/src/run-diagnostics.ts
+++ b/apps/daemon/src/run-diagnostics.ts
@@ -65,6 +65,16 @@ export interface RunDiagnosticsAnalytics {
   // with a fresh session + full transcript, with no user-facing error. Lets us
   // monitor how often the resume optimization falls back (should be rare).
   resume_auto_reseeded: boolean;
+  tool_execution_lifecycle_seen?: boolean;
+  tool_execution_lifecycle_count_bucket?: '1' | '2_5' | '6_20' | 'gt_20';
+  tool_execution_trigger?: 'exit' | 'abort' | 'deadline' | 'mixed' | 'unknown';
+  tool_execution_terminal?: 'running' | 'returned' | 'failed' | 'interrupted' | 'mixed' | 'unknown';
+  tool_terminal_source?: 'tool_result' | 'tool_error' | 'processor_cleanup' | 'mixed' | 'unknown';
+  tool_kill_outcome?: 'none' | 'requested' | 'sent' | 'failed';
+  tool_child_close_seen?: boolean;
+  tool_stdout_close_seen?: boolean;
+  tool_stderr_close_seen?: boolean;
+  tool_execution_evidence_incomplete?: boolean;
 }
 
 export interface RunToolProgress {
@@ -168,6 +178,179 @@ function amrOpenCodeDiagnosticsFromError(data: unknown): Partial<RunDiagnosticsA
     ...(lastEventType ? { amr_opencode_last_event_type: lastEventType } : {}),
     ...(lastToolStatus ? { amr_opencode_last_tool_status: lastToolStatus } : {}),
     ...(lastToolKind ? { amr_opencode_last_tool_kind: lastToolKind } : {}),
+  };
+}
+
+function lifecycleCountBucket(count: number): NonNullable<RunDiagnosticsAnalytics['tool_execution_lifecycle_count_bucket']> {
+  if (count <= 1) return '1';
+  if (count <= 5) return '2_5';
+  if (count <= 20) return '6_20';
+  return 'gt_20';
+}
+
+function collapseLifecycleEnum<T extends string>(values: Set<T>): T | 'mixed' | 'unknown' {
+  if (values.size === 0) return 'unknown';
+  if (values.size > 1) return 'mixed';
+  return values.values().next().value ?? 'unknown';
+}
+
+function toolExecutionLifecycleAnalytics(
+  events: RunEventForDiagnostics[],
+): Partial<RunDiagnosticsAnalytics> {
+  const fingerprints = new Set<string>();
+  const triggers = new Set<'exit' | 'abort' | 'deadline'>();
+  const terminals = new Set<'running' | 'returned' | 'failed' | 'interrupted'>();
+  const terminalSources = new Set<'tool_result' | 'tool_error' | 'processor_cleanup'>();
+  let lifecycleCount = 0;
+  let killRequested = false;
+  let killSent = false;
+  let killFailed = false;
+  let childCloseSeen = false;
+  let stdoutCloseSeen = false;
+  let stderrCloseSeen = false;
+  let evidenceIncomplete = false;
+
+  // Terminal snapshots carry the most complete evidence. Bound work and
+  // memory to the latest 64 distinct diagnostics while preserving that tail.
+  for (const event of events.slice().reverse()) {
+    if (event.event !== 'agent') continue;
+    const data = recordValue(event.data);
+    if (
+      data?.type !== 'diagnostic' ||
+      data.name !== 'tool_execution_lifecycle' ||
+      data.schema !== 'vela.tool_execution_lifecycle' ||
+      data.version !== 1
+    ) {
+      continue;
+    }
+    const safeLifecycleEvents = Array.isArray(data.events)
+      ? data.events.slice(-64).flatMap((rawLifecycleEvent) => {
+          const lifecycleEvent = recordValue(rawLifecycleEvent);
+          const phase = lifecycleEvent?.phase;
+          if (
+            phase !== 'kill_requested' && phase !== 'kill_sent' &&
+            phase !== 'kill_failed' && phase !== 'stdout_close' &&
+            phase !== 'stderr_close' && phase !== 'close'
+          ) {
+            return [];
+          }
+          return [{
+            phase,
+            ...(typeof lifecycleEvent?.stdoutClosed === 'boolean'
+              ? { stdoutClosed: lifecycleEvent.stdoutClosed }
+              : {}),
+            ...(typeof lifecycleEvent?.stderrClosed === 'boolean'
+              ? { stderrClosed: lifecycleEvent.stderrClosed }
+              : {}),
+          }];
+        })
+      : [];
+    const rawToolTerminal = recordValue(data.toolTerminal);
+    const safeToolTerminal =
+      rawToolTerminal?.source === 'tool_result' ||
+      rawToolTerminal?.source === 'tool_error' ||
+      rawToolTerminal?.source === 'processor_cleanup'
+        ? {
+            source: rawToolTerminal.source,
+            ...(typeof rawToolTerminal.confirmed === 'boolean'
+              ? { confirmed: rawToolTerminal.confirmed }
+              : {}),
+          }
+        : null;
+    const fingerprint = JSON.stringify({
+      toolCallIdHash:
+        typeof data.toolCallIdHash === 'string' && /^acp_[a-f0-9]{24}$/.test(data.toolCallIdHash)
+          ? data.toolCallIdHash
+          : 'unknown',
+      trigger:
+        data.trigger === 'exit' || data.trigger === 'abort' || data.trigger === 'deadline'
+          ? data.trigger
+          : 'unknown',
+      terminal:
+        data.terminal === 'running' || data.terminal === 'returned' ||
+        data.terminal === 'failed' || data.terminal === 'interrupted'
+          ? data.terminal
+          : 'unknown',
+      droppedEvents:
+        typeof data.droppedEvents === 'number' && data.droppedEvents > 0
+          ? 'present'
+          : 'none',
+      events: safeLifecycleEvents,
+      toolTerminal: safeToolTerminal,
+    });
+    if (fingerprints.has(fingerprint)) continue;
+    fingerprints.add(fingerprint);
+    lifecycleCount += 1;
+
+    if (data.trigger === 'exit' || data.trigger === 'abort' || data.trigger === 'deadline') {
+      triggers.add(data.trigger);
+    }
+    if (
+      data.terminal === 'running' || data.terminal === 'returned' ||
+      data.terminal === 'failed' || data.terminal === 'interrupted'
+    ) {
+      terminals.add(data.terminal);
+    }
+    if (data.terminal === 'running') evidenceIncomplete = true;
+    if (typeof data.droppedEvents === 'number' && data.droppedEvents > 0) {
+      evidenceIncomplete = true;
+    }
+
+    const toolTerminal = safeToolTerminal;
+    if (
+      toolTerminal?.source === 'tool_result' ||
+      toolTerminal?.source === 'tool_error' ||
+      toolTerminal?.source === 'processor_cleanup'
+    ) {
+      terminalSources.add(toolTerminal.source);
+      if (toolTerminal.source === 'processor_cleanup' || toolTerminal.confirmed !== true) {
+        evidenceIncomplete = true;
+      }
+    } else {
+      evidenceIncomplete = true;
+    }
+
+    if (safeLifecycleEvents.length > 0) {
+      for (const lifecycleEvent of safeLifecycleEvents) {
+        const phase = lifecycleEvent?.phase;
+        if (phase === 'kill_requested') killRequested = true;
+        if (phase === 'kill_sent') killSent = true;
+        if (phase === 'kill_failed') killFailed = true;
+        if (phase === 'stdout_close') stdoutCloseSeen = true;
+        if (phase === 'stderr_close') stderrCloseSeen = true;
+        if (phase === 'close') {
+          childCloseSeen = true;
+          if (lifecycleEvent?.stdoutClosed === true) stdoutCloseSeen = true;
+          if (lifecycleEvent?.stderrClosed === true) stderrCloseSeen = true;
+          if (lifecycleEvent?.stdoutClosed !== true || lifecycleEvent?.stderrClosed !== true) {
+            evidenceIncomplete = true;
+          }
+        }
+      }
+    }
+    if (lifecycleCount >= 64) break;
+  }
+
+  if (lifecycleCount === 0) return {};
+  if (triggers.size > 0 && !childCloseSeen) evidenceIncomplete = true;
+  if (killRequested && !killSent && !killFailed) evidenceIncomplete = true;
+  return {
+    tool_execution_lifecycle_seen: true,
+    tool_execution_lifecycle_count_bucket: lifecycleCountBucket(lifecycleCount),
+    tool_execution_trigger: collapseLifecycleEnum(triggers),
+    tool_execution_terminal: collapseLifecycleEnum(terminals),
+    tool_terminal_source: collapseLifecycleEnum(terminalSources),
+    tool_kill_outcome: killFailed
+      ? 'failed'
+      : killSent
+        ? 'sent'
+        : killRequested
+          ? 'requested'
+          : 'none',
+    tool_child_close_seen: childCloseSeen,
+    tool_stdout_close_seen: stdoutCloseSeen,
+    tool_stderr_close_seen: stderrCloseSeen,
+    tool_execution_evidence_incomplete: evidenceIncomplete,
   };
 }
 
@@ -315,6 +498,7 @@ export function summarizeRunDiagnosticsForAnalytics(args: {
 }): RunDiagnosticsAnalytics {
   const events = args.events ?? [];
   const toolProgress = summarizeRunToolProgress(events);
+  const toolExecutionLifecycle = toolExecutionLifecycleAnalytics(events);
   let stderr = '';
   let stdout = '';
   let userVisibleOutputSeen = false;
@@ -426,5 +610,6 @@ export function summarizeRunDiagnosticsForAnalytics(args: {
     live_artifact_seen: liveArtifactSeen,
     resume_auto_reseeded: resumeAutoReseeded,
     ...amrOpenCodeDiagnostics,
+    ...toolExecutionLifecycle,
   };
 }

--- a/apps/daemon/src/runtimes/run-terminal-reconciliation.ts
+++ b/apps/daemon/src/runtimes/run-terminal-reconciliation.ts
@@ -13,6 +13,7 @@ import {
 import { appendMessageStatusEvent } from '../db.js';
 import { reconcileStrategyTaskRunTerminal } from '../strategies/task-store.js';
 import { classifyRunFailure } from '../run-failure-classification.js';
+import { summarizeRunDiagnosticsForAnalytics } from '../run-diagnostics.js';
 import { deriveRunErrorCode, runResultFromStatus } from '../run-result.js';
 import { runAskedUserQuestion } from './run-artifacts.js';
 import {
@@ -469,6 +470,12 @@ export async function reconcileDurableRunTerminals(
         terminal_recovery_reason: recoveryReason,
         ...(errorCode ? { error_code: errorCode } : {}),
         ...(failure ?? {}),
+        ...summarizeRunDiagnosticsForAnalytics({
+          events,
+          exitCode: state.exitCode ?? null,
+          signal: state.signal ?? null,
+          cancelRequested: state.status === 'canceled',
+        }),
       };
       const taskLineage: RunTaskLineageProps = {
         task_execution_id:

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -922,6 +922,7 @@ test('attachAcpSession consumes bounded tool execution lifecycle diagnostics out
     cwd: '/tmp/od-project',
     model: null,
     mcpServers: [],
+    modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE',
     send: (event, payload) => events.push({ event, payload }),
   });
 
@@ -993,6 +994,61 @@ test('attachAcpSession consumes bounded tool execution lifecycle diagnostics out
   }
 });
 
+test('attachAcpSession swallows non-AMR tool execution lifecycle updates without persisting them', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'describe the project',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_execution_lifecycle',
+    schema: 'vela.tool_execution_lifecycle',
+    version: 1,
+    toolCallId: 'tool-1',
+    status: 'completed',
+    phase: 'close',
+    execution: {
+      version: 1,
+      terminal: 'returned',
+      trigger: 'exit',
+      events: [{ phase: 'close', stdout_closed: true, stderr_closed: true }],
+    },
+    toolTerminal: { source: 'tool_result', confirmed: true },
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: 'Run continued' },
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const agentPayloads = events
+    .filter((entry) => entry.event === 'agent')
+    .map((entry) => entry.payload as Record<string, unknown>);
+  assert.equal(
+    agentPayloads.some((payload) => payload.name === 'tool_execution_lifecycle'),
+    false,
+  );
+  assert.equal(
+    agentPayloads.some(
+      (payload) => payload.type === 'status' && payload.label === 'tool_execution_lifecycle',
+    ),
+    false,
+  );
+  assert.equal(agentPayloads.some((payload) => payload.type === 'tool_result'), false);
+  assert.ok(agentPayloads.some(
+    (payload) => payload.type === 'text_delta' && payload.delta === 'Run continued',
+  ));
+});
+
 test('attachAcpSession keeps lifecycle observability failures from blocking the run', () => {
   const child = new FakeAcpChild();
   const events: Array<{ event: string; payload: unknown }> = [];
@@ -1003,6 +1059,7 @@ test('attachAcpSession keeps lifecycle observability failures from blocking the 
     cwd: '/tmp/od-project',
     model: null,
     mcpServers: [],
+    modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE',
     send: (event, payload) => {
       if (
         event === 'agent' &&

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -866,6 +866,185 @@ test('attachAcpSession preserves AMR assistant and model-step lifecycle diagnost
   });
 });
 
+test('attachAcpSession consumes bounded tool execution lifecycle diagnostics out of band', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+  const toolCallId = 'bash:/Users/alice/private/.env?token=secret';
+  const update = {
+    sessionUpdate: 'tool_execution_lifecycle',
+    schema: 'vela.tool_execution_lifecycle',
+    version: 1,
+    toolCallId,
+    status: 'failed',
+    phase: 'close',
+    execution: {
+      version: 1,
+      requested_timeout_ms: 120_000,
+      effective_timeout_ms: 120_100,
+      force_kill_after_ms: 3_000,
+      trigger: 'deadline',
+      terminal: 'interrupted',
+      dropped_events: 2,
+      events: [
+        { phase: 'deadline', at_ms: 1_700_000_000_000, elapsed_ms: 120_000 },
+        {
+          phase: 'kill_sent',
+          at_ms: 1_700_000_000_010,
+          elapsed_ms: 120_010,
+          target: 'group',
+          mechanism: 'process_group',
+        },
+        {
+          phase: 'close',
+          at_ms: 1_700_000_000_020,
+          elapsed_ms: 120_020,
+          code: null,
+          signal: 'SIGKILL',
+          stdout_closed: true,
+          stderr_closed: false,
+        },
+      ],
+    },
+    toolTerminal: {
+      source: 'processor_cleanup',
+      confirmed: false,
+      at_ms: 1_700_000_000_030,
+    },
+    command: 'cat /Users/alice/private/.env',
+    path: '/Users/alice/private/.env',
+    rawOutput: 'OPENAI_API_KEY=secret',
+    metadata: { headers: { authorization: 'Bearer secret' } },
+  };
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'describe the project',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, update);
+  writeAcpUpdate(child, update);
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const agentPayloads = events
+    .filter((entry) => entry.event === 'agent')
+    .map((entry) => entry.payload as Record<string, unknown>);
+  const diagnostics = agentPayloads.filter(
+    (payload) => payload.type === 'diagnostic' && payload.name === 'tool_execution_lifecycle',
+  );
+  assert.equal(diagnostics.length, 1, 'duplicate lifecycle snapshots must be deduplicated');
+  assert.deepEqual(diagnostics[0], {
+    type: 'diagnostic',
+    name: 'tool_execution_lifecycle',
+    source: 'amr-opencode',
+    elapsedMs: diagnostics[0]?.elapsedMs,
+    schema: 'vela.tool_execution_lifecycle',
+    version: 1,
+    toolCallIdHash: acpTelemetryToolCallId(toolCallId),
+    status: 'failed',
+    phase: 'close',
+    executionVersion: 1,
+    requestedTimeoutMs: 120_000,
+    effectiveTimeoutMs: 120_100,
+    forceKillAfterMs: 3_000,
+    trigger: 'deadline',
+    terminal: 'interrupted',
+    droppedEvents: 2,
+    events: [
+      { phase: 'deadline', atMs: 1_700_000_000_000, elapsedMs: 120_000 },
+      {
+        phase: 'kill_sent',
+        atMs: 1_700_000_000_010,
+        elapsedMs: 120_010,
+        target: 'group',
+        mechanism: 'process_group',
+      },
+      {
+        phase: 'close',
+        atMs: 1_700_000_000_020,
+        elapsedMs: 120_020,
+        code: null,
+        signal: 'SIGKILL',
+        stdoutClosed: true,
+        stderrClosed: false,
+      },
+    ],
+    toolTerminal: {
+      source: 'processor_cleanup',
+      confirmed: false,
+      atMs: 1_700_000_000_030,
+    },
+  });
+  assert.equal(
+    agentPayloads.some(
+      (payload) => payload.type === 'status' && payload.label === 'tool_execution_lifecycle',
+    ),
+    false,
+  );
+  assert.equal(agentPayloads.some((payload) => payload.type === 'tool_result'), false);
+  const serialized = JSON.stringify(diagnostics);
+  for (const forbidden of ['cat ', '/Users/alice', 'OPENAI_API_KEY', 'authorization', 'Bearer']) {
+    assert.equal(serialized.includes(forbidden), false, `diagnostic leaked ${forbidden}`);
+  }
+});
+
+test('attachAcpSession keeps lifecycle observability failures from blocking the run', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'describe the project',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => {
+      if (
+        event === 'agent' &&
+        (payload as { name?: unknown })?.name === 'tool_execution_lifecycle'
+      ) {
+        throw new Error('diagnostic persistence unavailable');
+      }
+      events.push({ event, payload });
+    },
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  assert.doesNotThrow(() => writeAcpUpdate(child, {
+    sessionUpdate: 'tool_execution_lifecycle',
+    schema: 'vela.tool_execution_lifecycle',
+    version: 1,
+    toolCallId: 'tool-1',
+    status: 'completed',
+    phase: 'close',
+    execution: {
+      version: 1,
+      terminal: 'returned',
+      trigger: 'exit',
+      events: [{ phase: 'close', stdout_closed: true, stderr_closed: true }],
+    },
+    toolTerminal: { source: 'tool_result', confirmed: true },
+  }));
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: 'Run continued' },
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  assert.ok(events.some(
+    ({ event, payload }) =>
+      event === 'agent' &&
+      (payload as { type?: unknown; delta?: unknown }).type === 'text_delta' &&
+      (payload as { delta?: unknown }).delta === 'Run continued',
+  ));
+});
+
 test('attachAcpSession consumes negotiated Vela child evidence only on the AMR path', () => {
   const child = new FakeAcpChild();
   const events: Array<{ event: string; payload: unknown }> = [];

--- a/apps/daemon/tests/agent-protocol/tool-execution-lifecycle.test.ts
+++ b/apps/daemon/tests/agent-protocol/tool-execution-lifecycle.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  projectToolExecutionLifecycleDiagnostic,
+  sanitizeToolExecutionLifecycleUpdate,
+} from '../../src/agent-protocol/acp/tool-execution-lifecycle.js';
+
+describe('tool execution lifecycle ACP diagnostics', () => {
+  it('rebuilds the v1 allowlist with bounded events and error chains', () => {
+    const events = Array.from({ length: 70 }, (_, index) => ({
+      phase: 'kill_failed',
+      at_ms: 1_700_000_000_000 + index,
+      elapsed_ms: index,
+      target: 'group',
+      mechanism: 'process_group',
+      error: Array.from({ length: 8 }, () => ({
+        type: 'SystemError',
+        code: 'EPERM',
+        errno: 1,
+        message: 'secret message',
+        path: '/private/secret',
+      })),
+      command: 'cat /private/secret',
+      output: 'OPENAI_API_KEY=secret',
+    }));
+    const diagnostic = sanitizeToolExecutionLifecycleUpdate({
+      sessionUpdate: 'tool_execution_lifecycle',
+      schema: 'vela.tool_execution_lifecycle',
+      version: 1,
+      toolCallId: 'secret-shaped-tool-id',
+      status: 'failed',
+      phase: 'kill_failed',
+      execution: {
+        version: 1,
+        requested_timeout_ms: 1_000,
+        effective_timeout_ms: Number.POSITIVE_INFINITY,
+        trigger: 'untrusted-trigger',
+        terminal: 'failed',
+        events,
+        dropped_events: 6,
+        command: 'cat /private/secret',
+      },
+      toolTerminal: {
+        source: 'tool_error',
+        confirmed: true,
+        error: [{ type: 'SqliteError', code: 'SQLITE_BUSY', message: 'database secret' }],
+      },
+      headers: { authorization: 'Bearer secret' },
+      metadata: { rawOutput: 'secret output' },
+    });
+
+    expect(diagnostic).toMatchObject({
+      schema: 'vela.tool_execution_lifecycle',
+      version: 1,
+      status: 'failed',
+      phase: 'kill_failed',
+      executionVersion: 1,
+      terminal: 'failed',
+      requestedTimeoutMs: 1_000,
+      droppedEvents: 6,
+      toolTerminal: {
+        source: 'tool_error',
+        confirmed: true,
+        error: [{ type: 'SqliteError', code: 'SQLITE_BUSY' }],
+      },
+    });
+    expect(diagnostic?.events).toHaveLength(64);
+    expect((diagnostic?.events as Array<{ error?: unknown[] }>)[0]?.error).toHaveLength(4);
+    expect(diagnostic).not.toHaveProperty('trigger');
+    expect(diagnostic).not.toHaveProperty('effectiveTimeoutMs');
+    const serialized = JSON.stringify(diagnostic);
+    for (const forbidden of ['secret', '/private', 'command', 'output', 'headers', 'message']) {
+      expect(serialized).not.toContain(forbidden);
+    }
+  });
+
+  it('rejects unknown schemas and revalidates persisted Langfuse projections', () => {
+    expect(sanitizeToolExecutionLifecycleUpdate({
+      sessionUpdate: 'tool_execution_lifecycle',
+      schema: 'vela.tool_execution_lifecycle',
+      version: 2,
+      toolCallId: 'tool-1',
+      execution: { version: 1, terminal: 'returned' },
+    })).toBeNull();
+
+    expect(sanitizeToolExecutionLifecycleUpdate({
+      sessionUpdate: 'tool_execution_lifecycle',
+      schema: 'vela.tool_execution_lifecycle',
+      version: 1,
+      toolCallId: '😀'.repeat(2_000),
+      execution: { version: 1, terminal: 'returned' },
+    })).toBeNull();
+
+    expect(projectToolExecutionLifecycleDiagnostic({
+      type: 'diagnostic',
+      name: 'tool_execution_lifecycle',
+      source: 'amr-opencode',
+      schema: 'vela.tool_execution_lifecycle',
+      version: 1,
+      toolCallIdHash: 'raw-private-tool-id',
+      trigger: 'deadline',
+      command: 'cat /private/secret',
+    })).toBeNull();
+  });
+});

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -510,6 +510,33 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
                 files: ['index.html'],
               },
             },
+            {
+              id: 2,
+              event: 'agent',
+              timestamp: Date.now() - 50,
+              data: {
+                type: 'diagnostic',
+                name: 'tool_execution_lifecycle',
+                source: 'amr-opencode',
+                elapsedMs: 50,
+                schema: 'vela.tool_execution_lifecycle',
+                version: 1,
+                status: 'failed',
+                phase: 'close',
+                executionVersion: 1,
+                toolCallIdHash: 'acp_0123456789abcdef01234567',
+                trigger: 'deadline',
+                terminal: 'interrupted',
+                droppedEvents: 1,
+                events: [
+                  { phase: 'kill_sent', elapsedMs: 10, target: 'group', mechanism: 'process_group' },
+                  { phase: 'close', stdoutClosed: true, stderrClosed: false },
+                ],
+                toolTerminal: { source: 'processor_cleanup', confirmed: false },
+                command: 'cat /private/secret',
+                headers: { authorization: 'Bearer secret' },
+              },
+            },
           ] as any,
         }) as any,
         fetchImpl: fetchSpy as any,
@@ -542,6 +569,33 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
         diagnostic_name: 'acp_artifact_text_suppression',
       },
     });
+    expect(
+      bodyOf(batch, 'event-create', 'agent-diagnostic:tool_execution_lifecycle'),
+    ).toMatchObject({
+      output: {
+        name: 'tool_execution_lifecycle',
+        source: 'amr-opencode',
+        elapsed_ms: 50,
+        schema: 'vela.tool_execution_lifecycle',
+        version: 1,
+        tool_call_id_hash: 'acp_0123456789abcdef01234567',
+        status: 'failed',
+        phase: 'close',
+        execution_version: 1,
+        trigger: 'deadline',
+        terminal: 'interrupted',
+        dropped_events: 1,
+        events: [
+          { phase: 'kill_sent', elapsed_ms: 10, target: 'group', mechanism: 'process_group' },
+          { phase: 'close', stdout_closed: true, stderr_closed: false },
+        ],
+        tool_terminal: { source: 'processor_cleanup', confirmed: false },
+      },
+      metadata: { diagnostic_name: 'tool_execution_lifecycle' },
+    });
+    const serializedBatch = JSON.stringify(batch);
+    expect(serializedBatch).not.toContain('cat /private/secret');
+    expect(serializedBatch).not.toContain('Bearer secret');
   });
 
   it('keeps canonical tool spans without projecting ACP tool snapshot statuses', async () => {

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -537,6 +537,20 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
                 headers: { authorization: 'Bearer secret' },
               },
             },
+            {
+              id: 3,
+              event: 'agent',
+              timestamp: Date.now() - 25,
+              data: {
+                type: 'diagnostic',
+                name: 'tool_execution_lifecycle',
+                source: 'amr-opencode',
+                schema: 'vela.tool_execution_lifecycle',
+                version: 1,
+                toolCallIdHash: 'invalid-hash',
+                reason: 'private-command --token super-secret-lifecycle-value',
+              },
+            },
           ] as any,
         }) as any,
         fetchImpl: fetchSpy as any,
@@ -596,6 +610,7 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     const serializedBatch = JSON.stringify(batch);
     expect(serializedBatch).not.toContain('cat /private/secret');
     expect(serializedBatch).not.toContain('Bearer secret');
+    expect(serializedBatch).not.toContain('super-secret-lifecycle-value');
   });
 
   it('keeps canonical tool spans without projecting ACP tool snapshot statuses', async () => {

--- a/apps/daemon/tests/run-diagnostics.test.ts
+++ b/apps/daemon/tests/run-diagnostics.test.ts
@@ -17,7 +17,7 @@ describe('run diagnostics', () => {
             name: 'tool_execution_lifecycle',
             schema: 'vela.tool_execution_lifecycle',
             version: 1,
-            toolCallIdHash: 'acp_deadbeef',
+            toolCallIdHash: 'acp_deadbeefdeadbeefdeadbeef',
             trigger: 'deadline',
             terminal: 'interrupted',
             droppedEvents: 2,
@@ -44,7 +44,46 @@ describe('run diagnostics', () => {
       tool_stderr_close_seen: false,
       tool_execution_evidence_incomplete: true,
     });
-    expect(JSON.stringify(result)).not.toContain('acp_deadbeef');
+    expect(JSON.stringify(result)).not.toContain('acp_deadbeefdeadbeefdeadbeef');
+  });
+
+  it('aggregates only the latest lifecycle snapshot for each tool execution', () => {
+    const toolCallIdHash = 'acp_0123456789abcdef01234567';
+    const result = summarizeRunDiagnosticsForAnalytics({
+      events: [
+        {
+          event: 'agent',
+          data: {
+            type: 'diagnostic',
+            name: 'tool_execution_lifecycle',
+            schema: 'vela.tool_execution_lifecycle',
+            version: 1,
+            toolCallIdHash,
+            terminal: 'running',
+          },
+        },
+        {
+          event: 'agent',
+          data: {
+            type: 'diagnostic',
+            name: 'tool_execution_lifecycle',
+            schema: 'vela.tool_execution_lifecycle',
+            version: 1,
+            toolCallIdHash,
+            trigger: 'exit',
+            terminal: 'returned',
+            events: [{ phase: 'close', stdoutClosed: true, stderrClosed: true }],
+            toolTerminal: { source: 'tool_result', confirmed: true },
+          },
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      tool_execution_lifecycle_count_bucket: '1',
+      tool_execution_terminal: 'returned',
+      tool_execution_evidence_incomplete: false,
+    });
   });
 
   it('bounds lifecycle aggregation to the latest 64 distinct diagnostics', () => {

--- a/apps/daemon/tests/run-diagnostics.test.ts
+++ b/apps/daemon/tests/run-diagnostics.test.ts
@@ -7,6 +7,96 @@ import {
 } from '../src/run-diagnostics.js';
 
 describe('run diagnostics', () => {
+  it('summarizes tool execution lifecycle evidence with bounded low-cardinality fields', () => {
+    const result = summarizeRunDiagnosticsForAnalytics({
+      events: [
+        {
+          event: 'agent',
+          data: {
+            type: 'diagnostic',
+            name: 'tool_execution_lifecycle',
+            schema: 'vela.tool_execution_lifecycle',
+            version: 1,
+            toolCallIdHash: 'acp_deadbeef',
+            trigger: 'deadline',
+            terminal: 'interrupted',
+            droppedEvents: 2,
+            events: [
+              { phase: 'kill_requested' },
+              { phase: 'kill_sent' },
+              { phase: 'close', stdoutClosed: true, stderrClosed: false },
+            ],
+            toolTerminal: { source: 'processor_cleanup', confirmed: false },
+          },
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      tool_execution_lifecycle_seen: true,
+      tool_execution_lifecycle_count_bucket: '1',
+      tool_execution_trigger: 'deadline',
+      tool_execution_terminal: 'interrupted',
+      tool_terminal_source: 'processor_cleanup',
+      tool_kill_outcome: 'sent',
+      tool_child_close_seen: true,
+      tool_stdout_close_seen: true,
+      tool_stderr_close_seen: false,
+      tool_execution_evidence_incomplete: true,
+    });
+    expect(JSON.stringify(result)).not.toContain('acp_deadbeef');
+  });
+
+  it('bounds lifecycle aggregation to the latest 64 distinct diagnostics', () => {
+    const events = Array.from({ length: 100 }, (_, index) => ({
+      event: 'agent',
+      data: {
+        type: 'diagnostic',
+        name: 'tool_execution_lifecycle',
+        schema: 'vela.tool_execution_lifecycle',
+        version: 1,
+        toolCallIdHash: `acp_${index.toString(16).padStart(24, '0')}`,
+        trigger: index < 36 ? 'deadline' : 'exit',
+        terminal: 'returned',
+        events: [{ phase: 'close', stdoutClosed: true, stderrClosed: true }],
+        toolTerminal: { source: 'tool_result', confirmed: true },
+      },
+    }));
+
+    expect(summarizeRunDiagnosticsForAnalytics({ events })).toMatchObject({
+      tool_execution_lifecycle_count_bucket: 'gt_20',
+      tool_execution_trigger: 'exit',
+      tool_execution_terminal: 'returned',
+      tool_terminal_source: 'tool_result',
+      tool_execution_evidence_incomplete: false,
+    });
+  });
+
+  it('ignores arbitrary persisted diagnostic objects without blocking run_finished', () => {
+    const circular: Record<string, unknown> = { command: 'cat /private/secret' };
+    circular.self = circular;
+    const events = [{
+      event: 'agent',
+      data: {
+        type: 'diagnostic',
+        name: 'tool_execution_lifecycle',
+        schema: 'vela.tool_execution_lifecycle',
+        version: 1,
+        toolCallIdHash: 'acp_0123456789abcdef01234567',
+        trigger: 'exit',
+        terminal: 'returned',
+        events: [{ phase: 'close', stdoutClosed: true, stderrClosed: true }],
+        toolTerminal: { source: 'tool_result', confirmed: true },
+        metadata: circular,
+      },
+    }];
+
+    expect(() => summarizeRunDiagnosticsForAnalytics({ events })).not.toThrow();
+    const serialized = JSON.stringify(summarizeRunDiagnosticsForAnalytics({ events }));
+    expect(serialized).not.toContain('/private/secret');
+    expect(serialized).not.toContain('command');
+  });
+
   it('summarizes stderr into redacted bounded tails for Langfuse', () => {
     const events = Array.from({ length: 25 }, (_, i) => ({
       event: 'stderr',

--- a/apps/daemon/tests/runtimes/run-terminal-reconciliation.test.ts
+++ b/apps/daemon/tests/runtimes/run-terminal-reconciliation.test.ts
@@ -244,6 +244,22 @@ describe('durable run terminal reconciliation', () => {
         insertId: 'run-created-1',
       },
     }));
+    fs.writeFileSync(path.join(runDir, 'events.jsonl'), `${JSON.stringify({
+      id: 1,
+      event: 'agent',
+      timestamp: 1_500,
+      data: {
+        type: 'diagnostic',
+        name: 'tool_execution_lifecycle',
+        schema: 'vela.tool_execution_lifecycle',
+        version: 1,
+        toolCallIdHash: 'acp_0123456789abcdef01234567',
+        trigger: 'abort',
+        terminal: 'interrupted',
+        events: [{ phase: 'kill_requested' }],
+        toolTerminal: { source: 'processor_cleanup', confirmed: false },
+      },
+    })}\n`);
     db.prepare(
       `INSERT INTO messages (id, run_id, run_status, events_json)
        VALUES (?, ?, 'running', '[]')`,
@@ -290,6 +306,11 @@ describe('durable run terminal reconciliation', () => {
         terminal_reconciled: true,
         terminal_integrity: 'reconciled',
         terminal_recovery_reason: 'daemon_restart',
+        tool_execution_lifecycle_seen: true,
+        tool_execution_trigger: 'abort',
+        tool_terminal_source: 'processor_cleanup',
+        tool_kill_outcome: 'requested',
+        tool_execution_evidence_incomplete: true,
       }),
     }));
     expect(reportLangfuse).toHaveBeenCalledWith(expect.objectContaining({

--- a/packages/contracts/src/analytics/events/result-events.ts
+++ b/packages/contracts/src/analytics/events/result-events.ts
@@ -514,6 +514,17 @@ export interface RunFinishedProps extends Omit<RunCreatedProps, 'area'> {
   tool_call_seen?: boolean;
   artifact_write_seen?: boolean;
   live_artifact_seen?: boolean;
+  /** Bounded summary of Vela/OpenCode v1 tool-execution lifecycle diagnostics. */
+  tool_execution_lifecycle_seen?: boolean;
+  tool_execution_lifecycle_count_bucket?: '1' | '2_5' | '6_20' | 'gt_20';
+  tool_execution_trigger?: 'exit' | 'abort' | 'deadline' | 'mixed' | 'unknown';
+  tool_execution_terminal?: 'running' | 'returned' | 'failed' | 'interrupted' | 'mixed' | 'unknown';
+  tool_terminal_source?: 'tool_result' | 'tool_error' | 'processor_cleanup' | 'mixed' | 'unknown';
+  tool_kill_outcome?: 'none' | 'requested' | 'sent' | 'failed';
+  tool_child_close_seen?: boolean;
+  tool_stdout_close_seen?: boolean;
+  tool_stderr_close_seen?: boolean;
+  tool_execution_evidence_incomplete?: boolean;
   deliverable_valid?: boolean;
   deliverable_validation?: 'valid' | 'invalid';
   artifact_origin_status?: ArtifactOriginStatus;

--- a/packages/contracts/tests/analytics-run-finished-contract.test.ts
+++ b/packages/contracts/tests/analytics-run-finished-contract.test.ts
@@ -162,6 +162,16 @@ describe('analytics run_finished contract', () => {
         tool_call_seen: true,
         tool_result_sent: false,
         approval_requested: true,
+        tool_execution_lifecycle_seen: true,
+        tool_execution_lifecycle_count_bucket: '2_5',
+        tool_execution_trigger: 'deadline',
+        tool_execution_terminal: 'interrupted',
+        tool_terminal_source: 'processor_cleanup',
+        tool_kill_outcome: 'sent',
+        tool_child_close_seen: true,
+        tool_stdout_close_seen: true,
+        tool_stderr_close_seen: false,
+        tool_execution_evidence_incomplete: true,
         stdin_backpressure: false,
         last_progress_age_ms: 610_000,
         amr_opencode_error_phase: 'timeout',
@@ -272,6 +282,9 @@ describe('analytics run_finished contract', () => {
     expect(payload.props.first_token_seen).toBe(true);
     expect(payload.props.tool_result_sent).toBe(false);
     expect(payload.props.approval_requested).toBe(true);
+    expect(payload.props.tool_execution_trigger).toBe('deadline');
+    expect(payload.props.tool_terminal_source).toBe('processor_cleanup');
+    expect(payload.props.tool_execution_evidence_incomplete).toBe(true);
     expect(payload.props.stdin_backpressure).toBe(false);
     expect(payload.props.last_progress_age_ms).toBe(610_000);
     expect(payload.props.amr_opencode_error_phase).toBe('timeout');


### PR DESCRIPTION
Relates to #3408 and #5528.\n\n## Why\n\nThis PR implements the Open Design consumer side of the AMR tool-execution lifecycle observability chain. The daemon previously ignored the private Vela lifecycle update, while a generic tool update could stringify structured raw output into a normal tool result. That left timeout, abort, kill, child-close, stream-close, and terminal-provenance evidence unavailable as a queryable diagnostic.\n\nThe scope is observability only. It depends on powerformer/opencode#15 and powerformer/vela#1857 for the producer path and intentionally does not change timeout, kill, retry, remediation, prompt-budget, or user/model-visible behavior.\n\n## What users will see\n\nNo new UI, CLI output, model-facing tool result, or user-visible message. After a compatible Vela release is available, operators can query privacy-safe tool-execution lifecycle diagnostics in persisted run events and Langfuse, plus bounded low-cardinality fields on run_finished.\n\nRaw tool IDs are hashed. Commands, paths, output, stderr, headers, arbitrary adapter metadata, and error messages are not persisted by this diagnostic.\n\n## Surface area\n\n- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in apps/web or apps/desktop (including Electron menu bar)\n- [ ] **Keyboard shortcut** — new or changed\n- [ ] **CLI / env var** — new od subcommand or flag, new tools-dev / tools-pack flag, or new OD_* env var\n- [x] **API / contract** — new /api/* endpoint, new SSE event, or changed shape in packages/contracts\n- [ ] **Extension point** — new entry under skills/, design-systems/, design-templates/, or craft/, or change to the skills protocol\n- [ ] **i18n keys** — added new translation keys\n- [ ] **New top-level dependency** — adding any new entry to the root package.json\n- [ ] **Default behavior change** — changes what existing users experience without opting in\n- [ ] **None** — internal refactor, docs, tests, or translation update only\n\n## Screenshots\n\nNot applicable: this is a private daemon diagnostics and analytics change with no UI surface.\n\n## Bug fix verification\n\n- Test paths: apps/daemon/tests/acp.test.ts and apps/daemon/tests/agent-protocol/tool-execution-lifecycle.test.ts\n- The fake production-shaped Vela event went red before the consumer existed and green after implementation.\n- Additional regression coverage verifies duplicate suppression, privacy allowlists, no status/tool-result projection, failure isolation, bounded aggregation, Langfuse projection, and restart-time terminal reconciliation without replay.\n\n## Validation\n\n- corepack pnpm --filter @open-design/daemon exec vitest run tests/agent-protocol/tool-execution-lifecycle.test.ts tests/acp.test.ts tests/run-diagnostics.test.ts tests/langfuse-bridge.test.ts tests/runtimes/run-terminal-reconciliation.test.ts — 160 passed\n- corepack pnpm --filter @open-design/contracts test — 508 passed\n- corepack pnpm --filter @open-design/daemon typecheck — passed\n- corepack pnpm guard — passed\n- git diff --check upstream/main...HEAD — passed\n- Full daemon suite: 735 files passed, 2 skipped; 9,763 tests passed, 13 skipped. Three existing load-sensitive files failed in the full run and each passed when rerun independently: executable-fallback (1/1), brand-prefetch (1/1), acp-stdio-mcp-wiring (6/6).\n\n## Dependency and delivery boundary\n\n- Producer dependencies: powerformer/opencode#15 and powerformer/vela#1857.\n- This PR does not merge, release, deploy, or claim end-to-end production availability. Cross-repository release validation remains a later gate.