### PR TITLE
fix(download): lstat-verify OS-artifact name matches before trusting

### DIFF
--- a/packages/download/src/store.ts
+++ b/packages/download/src/store.ts
@@ -29,9 +29,37 @@ const OS_MANAGED_ROOT_ARTIFACTS = new Set([".DS_Store", "Thumbs.db", "desktop.in
 /**
  * @internal Whether `name` is a benign, OS-managed root artifact that should
  * never count as real content when deciding whether a directory is claimable.
+ * Matched by name only — callers MUST additionally confirm the entry is a
+ * plain file via {@link verifiedOsManagedRootArtifacts} before trusting a
+ * match. A directory or symlink squatting on one of these names must still
+ * be treated as real content.
  */
 function isOsManagedRootArtifact(name: string): boolean {
   return OS_MANAGED_ROOT_ARTIFACTS.has(name);
+}
+
+/**
+ * Resolves which of `entries` (direct children of `rootDir`) are genuine
+ * OS-managed artifacts: name-matched AND a plain file, not a directory or
+ * symlink. A name match alone is not enough — see {@link isOsManagedRootArtifact}.
+ * An entry that disappears or fails to stat between `readdir` and this check
+ * is treated as unverified (excluded), which fails closed into the existing
+ * rejection path rather than silently trusting it.
+ */
+async function verifiedOsManagedRootArtifacts(rootDir: string, entries: string[]): Promise<Set<string>> {
+  const candidates = entries.filter((entry) => isOsManagedRootArtifact(entry));
+  if (candidates.length === 0) return new Set();
+  const verified = await Promise.all(
+    candidates.map(async (entry) => {
+      try {
+        const entryStat = await lstat(join(rootDir, entry));
+        return entryStat.isFile() && !entryStat.isSymbolicLink() ? entry : null;
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return new Set(verified.filter((entry): entry is string => entry != null));
 }
 
 /**
@@ -104,7 +132,8 @@ export async function ensureManagedBase(basePath: string): Promise<void> {
   const sentinel = await readJson<unknown>(sentinelPath);
   if (sentinel == null) {
     const entries = await readdir(basePath);
-    const content = entries.filter((name) => !isOsManagedRootArtifact(name));
+    const osArtifacts = await verifiedOsManagedRootArtifacts(basePath, entries);
+    const content = entries.filter((name: string) => !osArtifacts.has(name));
     if (content.length > 0) {
       throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED, `download base is not empty and has no ownership marker: ${basePath}`);
     }

--- a/packages/download/tests/index.test.ts
+++ b/packages/download/tests/index.test.ts
@@ -440,7 +440,7 @@ describe("managed download package", () => {
     }
   });
 
-  it.each<[string]>(["DS_Store", "Thumbs.db", "desktop.ini", ".localized"])(
+  it.each<[string]>([[".DS_Store"], ["Thumbs.db"], ["desktop.ini"], [".localized"]])(
     "claims a fresh managed base that contains only the OS-managed artifact %s",
     async (artifactName: string) => {
       const root = tmpRoot("os-artifact-fresh-claim");

--- a/packages/download/tests/index.test.ts
+++ b/packages/download/tests/index.test.ts
@@ -440,7 +440,7 @@ describe("managed download package", () => {
     }
   });
 
-  it.each<[".DS_Store", "Thumbs.db", "desktop.ini", ".localized"]>(
+  it.each<[string]>(["DS_Store", "Thumbs.db", "desktop.ini", ".localized"])(
     "claims a fresh managed base that contains only the OS-managed artifact %s",
     async (artifactName: string) => {
       const root = tmpRoot("os-artifact-fresh-claim");

--- a/packages/download/tests/index.test.ts
+++ b/packages/download/tests/index.test.ts
@@ -440,9 +440,9 @@ describe("managed download package", () => {
     }
   });
 
-  it.each([".DS_Store", "Thumbs.db", "desktop.ini", ".localized"])(
+  it.each<[".DS_Store", "Thumbs.db", "desktop.ini", ".localized"]>(
     "claims a fresh managed base that contains only the OS-managed artifact %s",
-    async (artifactName) => {
+    async (artifactName: string) => {
       const root = tmpRoot("os-artifact-fresh-claim");
       const basePath = join(root, "downloads");
       mkdirSync(basePath, { recursive: true });
@@ -475,6 +475,20 @@ describe("managed download package", () => {
     mkdirSync(basePath, { recursive: true });
     writeFileSync(join(basePath, ".DS_Store"), "binary-finder-junk");
     mkdirSync(join(basePath, ".git"));
+
+    await expect(pruneManagedDownloads({ basePath })).rejects.toMatchObject({
+      code: MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED,
+    });
+    expect(existsSync(join(basePath, ".open-design-download-root.json"))).toBe(false);
+  });
+
+  it("does not treat a directory squatting on an OS-artifact name as harmless", async () => {
+    // The name-only check (without lstat) lets a directory named .DS_Store
+    // bypass the empty-base claim. After the lstat guard, a directory
+    // squatting on the OS-artifact name is treated as real content.
+    const root = tmpRoot("os-artifact-squatting-dir");
+    const basePath = join(root, "downloads");
+    mkdirSync(join(basePath, ".DS_Store"), { recursive: true });
 
     await expect(pruneManagedDownloads({ basePath })).rejects.toMatchObject({
       code: MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED,


### PR DESCRIPTION
Mirrors #7267's lstat-guard pattern in apps/desktop. The `isOsManagedRootArtifact` name-only check passed silently for any entry whose basename was in {.DS_Store, Thumbs.db, desktop.ini, .localized} — including a directory or symlink squatting on one of those names. That let a misconfigured tool silently bypass the empty-base claim by creating a `.DS_Store` directory.

Add `verifiedOsManagedRootArtifacts` which lstat's each candidate entry and only returns it when it is a plain file, not a directory or symlink. Wire it into `ensureManagedBase`'s claim check.

Test: a fresh managed base whose only `.DS_Store` is a directory must still fail `STORE_NOT_OWNED` rather than be silently claimed.

Fixes nexu-io/open-design#7602