### PR TITLE
fix(plugins): enforce HTML preview contracts

### DIFF
--- a/e2e/tests/scripts/check-html-plugin-preview-contracts.test.ts
+++ b/e2e/tests/scripts/check-html-plugin-preview-contracts.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { test } from "vitest";
 
-import { validateHtmlPluginPreviewContract } from "../../../scripts/check-html-plugin-preview-contracts.ts";
+import {
+  checkHtmlPluginPreviewContracts,
+  validateHtmlPluginPreviewContract,
+} from "../../../scripts/check-html-plugin-preview-contracts.ts";
 
 const REFERENCE_HTML = "<!doctype html>\n<html>\n  <body>Report</body>\n</html>\n";
 
@@ -83,4 +89,18 @@ test("allows line-ending and trailing-whitespace normalization without treating 
     template: htmlTemplate(),
     exampleHtml: exampleWithFormattingNoise,
   }), []);
+});
+
+test("fails closed when a template path exists but cannot be read as a file", async () => {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "open-design-html-preview-contract-"));
+  const templatePath = path.join(
+    repoRoot,
+    "plugins/_official/examples/document-report/template.json",
+  );
+  try {
+    await mkdir(templatePath, { recursive: true });
+    assert.equal(await checkHtmlPluginPreviewContracts(repoRoot), false);
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true });
+  }
 });

--- a/e2e/tests/scripts/check-html-plugin-preview-contracts.test.ts
+++ b/e2e/tests/scripts/check-html-plugin-preview-contracts.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+
+import { validateHtmlPluginPreviewContract } from "../../../scripts/check-html-plugin-preview-contracts.ts";
+
+const REFERENCE_HTML = "<!doctype html>\n<html>\n  <body>Report</body>\n</html>\n";
+
+function validManifest(): unknown {
+  return {
+    od: {
+      scenario: "documents",
+      preview: { type: "html", entry: "./example.html", motion: "scroll" },
+      useCase: { exampleOutputs: [{ path: "./example.html", title: "Report" }] },
+      context: { assets: ["./template.json", "./example.html", "./example.webp"] },
+    },
+  };
+}
+
+function htmlTemplate(): unknown {
+  return { format: "html", surface: "document", referenceHtml: REFERENCE_HTML };
+}
+
+test("accepts a document whose canonical preview is materialized from referenceHtml", () => {
+  assert.deepEqual(validateHtmlPluginPreviewContract({
+    pluginId: "document-report",
+    manifest: validManifest(),
+    template: htmlTemplate(),
+    exampleHtml: REFERENCE_HTML,
+  }), []);
+});
+
+test("ignores a template whose actual output is not HTML", () => {
+  assert.deepEqual(validateHtmlPluginPreviewContract({
+    pluginId: "image-poster",
+    manifest: { od: { preview: { type: "image", poster: "./example.webp" } } },
+    template: { format: "png", surface: "image" },
+    exampleHtml: undefined,
+  }), []);
+});
+
+test("rejects the image-placeholder shape that makes an HTML document bake as a 404 skip", () => {
+  const violations = validateHtmlPluginPreviewContract({
+    pluginId: "document-report",
+    manifest: {
+      od: {
+        scenario: "documents",
+        preview: { type: "image", poster: "./example.webp" },
+        useCase: { exampleOutputs: [{ path: "./example.webp" }] },
+        context: { assets: ["./template.json", "./example.webp"] },
+      },
+    },
+    template: htmlTemplate(),
+    exampleHtml: undefined,
+  });
+
+  assert.equal(violations.length, 5);
+  assert.ok(violations.some((violation) => /preview must use type "html"/.test(violation)));
+  assert.ok(violations.some((violation) => /motion "scroll"/.test(violation)));
+  assert.ok(violations.some((violation) => /exampleOutputs must include/.test(violation)));
+  assert.ok(violations.some((violation) => /context\.assets must include/.test(violation)));
+  assert.ok(violations.some((violation) => /must ship a non-empty canonical preview/.test(violation)));
+});
+
+test("rejects example.html content that drifts from referenceHtml", () => {
+  const violations = validateHtmlPluginPreviewContract({
+    pluginId: "document-report",
+    manifest: validManifest(),
+    template: htmlTemplate(),
+    exampleHtml: "<!doctype html><html><body>Different report</body></html>",
+  });
+  assert.deepEqual(violations, [
+    "plugins/_official/examples/document-report/example.html: content has drifted from template.json referenceHtml",
+  ]);
+});
+
+test("allows line-ending and trailing-whitespace normalization without treating the preview as drifted", () => {
+  const exampleWithFormattingNoise = REFERENCE_HTML
+    .replace(/\n/g, "\r\n")
+    .replace("<body>Report</body>", "<body>Report</body>   ");
+  assert.deepEqual(validateHtmlPluginPreviewContract({
+    pluginId: "document-report",
+    manifest: validManifest(),
+    template: htmlTemplate(),
+    exampleHtml: exampleWithFormattingNoise,
+  }), []);
+});

--- a/plugins/AGENTS.md
+++ b/plugins/AGENTS.md
@@ -19,6 +19,25 @@ This directory owns OpenDesign plugin content and plugin authoring material.
 - Prefer TypeScript for project-owned scripts. Avoid adding new `.js`, `.mjs`, or `.cjs` files unless they are generated, vendored, or explicitly allowlisted by `scripts/guard.ts`.
 - Keep example plugins concise and agent-readable. Move long reference material to `references/` and tell the agent when to load it.
 
+### HTML-backed preview contract
+
+- When a bundled example's `template.json` declares `format: "html"` or carries
+  `referenceHtml`, commit the real rendered sample as `example.html`. Do not use
+  a screenshot or placeholder image as the canonical preview for an HTML
+  artifact.
+- Point `od.preview` at that source with `type: "html"` and
+  `entry: "./example.html"`. Use `motion: "scroll"` for documents,
+  `motion: "deck"` for slide navigation, and `motion: "static"` only for a
+  fixed, non-scrolling surface.
+- Keep `od.useCase.exampleOutputs` and `od.context.assets` aligned with
+  `./example.html`. A poster such as `example.webp` may remain as a secondary or
+  derived asset, but it must not replace the HTML preview source.
+- When `referenceHtml` is present, materialize `example.html` from it (or from
+  the same deterministic generator) and keep their rendered source in sync.
+- Before submitting, verify `/api/plugins/<id>/preview` returns `200` with an
+  HTML content type. In preview-baker output, the plugin must render as
+  `+ <id>`, not `skip (status 404)`.
+
 ## Validation
 
 For plugin content changes, run:

--- a/plugins/spec/AGENT-DEVELOPMENT.md
+++ b/plugins/spec/AGENT-DEVELOPMENT.md
@@ -40,6 +40,12 @@ Read these files before editing:
 5. Add `examples/`, `preview/`, `assets/`, or `references/` only when they materially help the agent produce better results.
 6. Add `evals/evals.json` when the plugin has enough behavior to regress.
 7. If publishing externally, prepare registry-safe README sections for skills.sh, ClawHub, and canonical GitHub source.
+8. For an HTML-backed visual artifact, ship the real sample as `example.html`
+   and declare `od.preview.type: "html"` with `entry: "./example.html"`. Keep
+   `od.useCase.exampleOutputs` and `od.context.assets` aligned with that file.
+   A poster image may be secondary, but it must not replace the HTML preview.
+   When `template.json` carries `referenceHtml`, materialize the sample from
+   that source (or the same deterministic generator) and keep them in sync.
 
 ## Quality Bar
 
@@ -51,6 +57,9 @@ The plugin is not done until:
 - The declared atoms are known first-party atoms or clearly marked future work.
 - The declared capabilities are the minimum needed.
 - Visual plugins include a preview or concrete example output.
+- HTML-backed previews load from the declared entry as `200 text/html`; a
+  preview-baker `skip (status 404)` is a failure for that plugin, even when the
+  overall bake job remains green.
 - Share, deploy, connector, and network plugins require explicit confirmation before externally visible actions.
 
 ## Validation Commands

--- a/plugins/spec/AGENT-DEVELOPMENT.zh-CN.md
+++ b/plugins/spec/AGENT-DEVELOPMENT.zh-CN.md
@@ -40,6 +40,11 @@
 5. 只有在能明显提升 agent 输出质量时，才添加 `examples/`、`preview/`、`assets/` 或 `references/`。
 6. 当插件行为足够复杂、容易回归时，添加 `evals/evals.json`。
 7. 如果要对外发布，准备适配 skills.sh、ClawHub 和 canonical GitHub source 的 registry-safe README 段落。
+8. 对于以 HTML 为真实产物的视觉插件，必须提交真实的 `example.html`，并将
+   `od.preview.type` 声明为 `"html"`、`entry` 指向 `"./example.html"`。
+   `od.useCase.exampleOutputs` 和 `od.context.assets` 也必须包含该文件。海报图
+   可以作为辅助资源保留，但不能代替 HTML 预览；如果 `template.json` 包含
+   `referenceHtml`，应从它（或同一个确定性生成器）生成样例，并保持同步。
 
 ## 完成标准
 
@@ -51,6 +56,8 @@
 - 声明的 atoms 是已知一方 atoms，或明确标注为未来工作。
 - capabilities 是最小必要集合。
 - 视觉类插件包含 preview 或具体示例输出。
+- HTML 预览入口能以 `200 text/html` 正常加载；对该插件而言，preview baker
+  中的 `skip (status 404)` 必须视为失败，即使整个烘焙任务仍显示绿色。
 - share、deploy、connector、network 类插件在对外可见操作前要求用户确认。
 
 ## 验证命令

--- a/scripts/check-html-plugin-preview-contracts.ts
+++ b/scripts/check-html-plugin-preview-contracts.ts
@@ -1,0 +1,183 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * Guard the source contract for bundled HTML-backed example plugins.
+ *
+ * The preview baker treats non-HTML preview routes that return 404 as routine
+ * skips. That is correct for image/video plugins, but it can hide a malformed
+ * document template whose real source is HTML while its manifest points at a
+ * placeholder poster. This guard catches that mismatch before the baker runs.
+ *
+ * Run standalone: `pnpm exec tsx scripts/check-html-plugin-preview-contracts.ts`
+ * Or as part of `pnpm guard` (registered in scripts/guard.ts).
+ * ─────────────────────────────────────────────────────────────────────── */
+
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const defaultRepoRoot = path.resolve(import.meta.dirname, "..");
+const EXAMPLES_REPO_PATH = "plugins/_official/examples";
+const EXAMPLE_ENTRY = "./example.html";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeHtmlSource(value: string): string {
+  return value.replace(/\r\n/g, "\n").replace(/[ \t]+$/gm, "");
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function isHtmlBackedTemplate(template: unknown): boolean {
+  return (
+    isRecord(template)
+    && (template.format === "html" || typeof template.referenceHtml === "string")
+  );
+}
+
+export type HtmlPluginPreviewContractInput = {
+  pluginId: string;
+  manifest: unknown;
+  template: unknown;
+  exampleHtml: string | undefined;
+};
+
+/** Validate one plugin without filesystem access so regression tests stay tiny. */
+export function validateHtmlPluginPreviewContract({
+  pluginId,
+  manifest,
+  template,
+  exampleHtml,
+}: HtmlPluginPreviewContractInput): string[] {
+  if (!isHtmlBackedTemplate(template)) return [];
+
+  const prefix = `${EXAMPLES_REPO_PATH}/${pluginId}`;
+  const violations: string[] = [];
+  if (!isRecord(manifest) || !isRecord(manifest.od)) {
+    return [`${prefix}/open-design.json: HTML-backed template requires an od manifest object`];
+  }
+
+  const od = manifest.od;
+  const preview = isRecord(od.preview) ? od.preview : undefined;
+  if (preview?.type !== "html" || preview.entry !== EXAMPLE_ENTRY) {
+    violations.push(
+      `${prefix}/open-design.json: HTML-backed template preview must use type "html" and entry "${EXAMPLE_ENTRY}"`,
+    );
+  }
+
+  const documentSurface = (
+    isRecord(template)
+    && (template.surface === "document" || od.scenario === "documents")
+  );
+  if (documentSurface && preview?.motion !== "scroll") {
+    violations.push(`${prefix}/open-design.json: document HTML preview must declare motion "scroll"`);
+  }
+
+  const useCase = isRecord(od.useCase) ? od.useCase : undefined;
+  const outputPaths = Array.isArray(useCase?.exampleOutputs)
+    ? useCase.exampleOutputs.flatMap((output) => {
+        if (!isRecord(output) || typeof output.path !== "string") return [];
+        return [output.path];
+      })
+    : [];
+  if (!outputPaths.includes(EXAMPLE_ENTRY)) {
+    violations.push(`${prefix}/open-design.json: od.useCase.exampleOutputs must include "${EXAMPLE_ENTRY}"`);
+  }
+
+  const context = isRecord(od.context) ? od.context : undefined;
+  if (!stringArray(context?.assets).includes(EXAMPLE_ENTRY)) {
+    violations.push(`${prefix}/open-design.json: od.context.assets must include "${EXAMPLE_ENTRY}"`);
+  }
+
+  if (exampleHtml === undefined || exampleHtml.trim().length === 0) {
+    violations.push(`${prefix}/example.html: HTML-backed template must ship a non-empty canonical preview`);
+  } else if (
+    isRecord(template)
+    && typeof template.referenceHtml === "string"
+    && normalizeHtmlSource(exampleHtml) !== normalizeHtmlSource(template.referenceHtml)
+  ) {
+    violations.push(`${prefix}/example.html: content has drifted from template.json referenceHtml`);
+  }
+
+  return violations;
+}
+
+async function readOptional(filePath: string): Promise<string | undefined> {
+  try {
+    return await readFile(filePath, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+export async function checkHtmlPluginPreviewContracts(repoRoot: string = defaultRepoRoot): Promise<boolean> {
+  const examplesRoot = path.join(repoRoot, EXAMPLES_REPO_PATH);
+  let entries;
+  try {
+    entries = await readdir(examplesRoot, { withFileTypes: true });
+  } catch {
+    console.log("HTML plugin preview contract check passed: no bundled examples directory.");
+    return true;
+  }
+
+  const violations: string[] = [];
+  let checked = 0;
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (!entry.isDirectory()) continue;
+    const pluginRoot = path.join(examplesRoot, entry.name);
+    const templateText = await readOptional(path.join(pluginRoot, "template.json"));
+    if (templateText === undefined) continue;
+
+    let template: unknown;
+    try {
+      template = JSON.parse(templateText) as unknown;
+    } catch (error) {
+      violations.push(
+        `${EXAMPLES_REPO_PATH}/${entry.name}/template.json: could not be parsed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      continue;
+    }
+    if (!isHtmlBackedTemplate(template)) continue;
+    checked += 1;
+
+    const manifestText = await readOptional(path.join(pluginRoot, "open-design.json"));
+    let manifest: unknown;
+    try {
+      manifest = manifestText === undefined ? undefined : JSON.parse(manifestText) as unknown;
+    } catch (error) {
+      violations.push(
+        `${EXAMPLES_REPO_PATH}/${entry.name}/open-design.json: could not be parsed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      continue;
+    }
+    violations.push(...validateHtmlPluginPreviewContract({
+      pluginId: entry.name,
+      manifest,
+      template,
+      exampleHtml: await readOptional(path.join(pluginRoot, "example.html")),
+    }));
+  }
+
+  if (violations.length > 0) {
+    console.error("HTML plugin preview contract violations:");
+    for (const violation of violations) console.error(`- ${violation}`);
+    return false;
+  }
+
+  console.log(
+    `HTML plugin preview contract check passed: ${checked} HTML-backed example${checked === 1 ? "" : "s"} valid.`,
+  );
+  return true;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const ok = await checkHtmlPluginPreviewContracts();
+  if (!ok) process.exitCode = 1;
+}

--- a/scripts/check-html-plugin-preview-contracts.ts
+++ b/scripts/check-html-plugin-preview-contracts.ts
@@ -108,9 +108,14 @@ export function validateHtmlPluginPreviewContract({
 async function readOptional(filePath: string): Promise<string | undefined> {
   try {
     return await readFile(filePath, "utf8");
-  } catch {
-    return undefined;
+  } catch (error) {
+    if (isRecord(error) && error.code === "ENOENT") return undefined;
+    throw error;
   }
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 export async function checkHtmlPluginPreviewContracts(repoRoot: string = defaultRepoRoot): Promise<boolean> {
@@ -118,9 +123,14 @@ export async function checkHtmlPluginPreviewContracts(repoRoot: string = default
   let entries;
   try {
     entries = await readdir(examplesRoot, { withFileTypes: true });
-  } catch {
-    console.log("HTML plugin preview contract check passed: no bundled examples directory.");
-    return true;
+  } catch (error) {
+    if (isRecord(error) && error.code === "ENOENT") {
+      console.log("HTML plugin preview contract check passed: no bundled examples directory.");
+      return true;
+    }
+    console.error("HTML plugin preview contract violations:");
+    console.error(`- ${EXAMPLES_REPO_PATH}: could not be read: ${formatError(error)}`);
+    return false;
   }
 
   const violations: string[] = [];
@@ -128,7 +138,15 @@ export async function checkHtmlPluginPreviewContracts(repoRoot: string = default
   for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
     if (!entry.isDirectory()) continue;
     const pluginRoot = path.join(examplesRoot, entry.name);
-    const templateText = await readOptional(path.join(pluginRoot, "template.json"));
+    let templateText: string | undefined;
+    try {
+      templateText = await readOptional(path.join(pluginRoot, "template.json"));
+    } catch (error) {
+      violations.push(
+        `${EXAMPLES_REPO_PATH}/${entry.name}/template.json: could not be read: ${formatError(error)}`,
+      );
+      continue;
+    }
     if (templateText === undefined) continue;
 
     let template: unknown;
@@ -145,7 +163,15 @@ export async function checkHtmlPluginPreviewContracts(repoRoot: string = default
     if (!isHtmlBackedTemplate(template)) continue;
     checked += 1;
 
-    const manifestText = await readOptional(path.join(pluginRoot, "open-design.json"));
+    let manifestText: string | undefined;
+    try {
+      manifestText = await readOptional(path.join(pluginRoot, "open-design.json"));
+    } catch (error) {
+      violations.push(
+        `${EXAMPLES_REPO_PATH}/${entry.name}/open-design.json: could not be read: ${formatError(error)}`,
+      );
+      continue;
+    }
     let manifest: unknown;
     try {
       manifest = manifestText === undefined ? undefined : JSON.parse(manifestText) as unknown;
@@ -157,11 +183,20 @@ export async function checkHtmlPluginPreviewContracts(repoRoot: string = default
       );
       continue;
     }
+    let exampleHtml: string | undefined;
+    try {
+      exampleHtml = await readOptional(path.join(pluginRoot, "example.html"));
+    } catch (error) {
+      violations.push(
+        `${EXAMPLES_REPO_PATH}/${entry.name}/example.html: could not be read: ${formatError(error)}`,
+      );
+      continue;
+    }
     violations.push(...validateHtmlPluginPreviewContract({
       pluginId: entry.name,
       manifest,
       template,
-      exampleHtml: await readOptional(path.join(pluginRoot, "example.html")),
+      exampleHtml,
     }));
   }
 

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -10,6 +10,7 @@ import { checkDesignSystemPackageQuality } from "./check-design-system-package-q
 import { checkDesignSystemComponentFixtureReport } from "./check-components-fixtures.ts";
 import { checkDesignSystemFlagParity } from "./check-design-system-flag-parity.ts";
 import { checkComponentsManifestExtraction } from "./check-components-manifest-extraction.ts";
+import { checkHtmlPluginPreviewContracts } from "./check-html-plugin-preview-contracts.ts";
 import { checkPluginPreviewManifest } from "./check-plugin-preview-manifest.ts";
 import {
   checkDesignSystemA1RequiredTokens,
@@ -1508,6 +1509,7 @@ const checks: GuardCheck[] = [
   { name: "tools layout", run: checkToolsLayout },
   { name: "style policy", run: checkStylePolicy },
   { name: "craft references", run: checkCraftReferences },
+  { name: "HTML plugin preview contracts", run: ({ repoRoot: root }) => checkHtmlPluginPreviewContracts(root) },
   { name: "plugin preview manifest", run: checkPluginPreviewManifest },
   { name: "design system manifests", run: checkDesignSystemManifests },
   { name: "design system package quality", run: checkDesignSystemPackageQuality },


### PR DESCRIPTION
## Why

While reviewing [PR #7678](https://github.com/nexu-io/open-design/pull/7678), I found that HTML document templates could declare an image preview even though their canonical artifact was embedded HTML. The preview baker then returned a green job while silently logging `skip (status 404)`, leaving broken placeholder cards in the gallery.

This adds a source-level contract so contributor agents receive the correct authoring rule and CI rejects the mismatched manifest shape before the expensive baker runs.

## What users will see

There is no direct product UI change. Future bundled HTML-backed templates must ship a real `example.html`; malformed contributions now fail `pnpm guard` with actionable errors instead of reaching the gallery as broken image placeholders.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this PR changes contributor guidance and repository validation only.

## Bug fix verification

- Test path: `e2e/tests/scripts/check-html-plugin-preview-contracts.test.ts`
- Red on `main`: not directly runnable because the offending templates are on unmerged PR #7678 rather than `main`. The regression fixture reproduces that PR's image-placeholder manifest shape and asserts all five contract violations.
- Green on this branch: yes. The new checker was also run against all eight actual HTML templates from PR #7678 commit `497d8b7e9c7180f32d797b72edde4b58902eae83`.

## Validation

- `pnpm --filter @open-design/e2e test tests/scripts/check-html-plugin-preview-contracts.test.ts`
- `pnpm exec tsx scripts/check-html-plugin-preview-contracts.ts`
- `pnpm --filter @open-design/plugin-runtime typecheck`
- `pnpm guard`
- `pnpm typecheck`
- Validated the checker against all eight HTML-backed document templates in PR #7678