### PR TITLE
fix(web): keep Local CLI and BYOK enabled while Cloud status loads

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -3357,6 +3357,12 @@ function OnboardingView({
 
   // Cloud remains the primary identity path. Local CLI and BYOK are independent
   // direct setup paths; authenticated users keep the full source chooser.
+  // INVARIANT: Cloud status loading (amrStatusResolving) blocks only the
+  // primary Cloud button. Local CLI / BYOK must remain enabled while
+  // signed-out so users can set up without Cloud authorization. Regression
+  // guard: e2e/ui/amr-onboarding.test.ts "Cloud status loading does not block
+  // signed-out Local CLI or BYOK setup" asserts primary disabled while alts
+  // are enabled during delayAllStatusMs.
   if (step === 0) {
     const cloudBusy = amrLoginBusy;
     const amrStatusResolving = !amrStatusResolved;
@@ -3453,9 +3459,11 @@ function OnboardingView({
               </button>
             ) : (
               <div className="onboarding-cloud__alts">
+                {/* INVARIANT: Local CLI / BYOK must NOT be disabled by amrStatusResolving — only the Cloud primary is gated by that. */}
                 <Button
                   variant="subtle"
                   className="onboarding-cloud__alt-btn"
+                  disabled={false}
                   onClick={() => {
                     emitOnboardingClick('local_coding_agent', 'select_runtime', {
                       runtime_type: 'local_cli',
@@ -3475,6 +3483,7 @@ function OnboardingView({
                 <Button
                   variant="subtle"
                   className="onboarding-cloud__alt-btn"
+                  disabled={false}
                   onClick={() => {
                     emitOnboardingClick('byok', 'select_runtime', { runtime_type: 'byok' });
                     setRuntime('byok');


### PR DESCRIPTION
Fixes #7608

## Why

During first-run onboarding the Cloud status check (`/api/integrations/vela/status`) can take seconds to settle, and only the primary Cloud button should be gated while it loads. Local CLI and BYOK are independent setup paths that do not require Cloud identity, so a slow Cloud response must not hide the ways a signed-out user can complete setup.

## What users will see

No behavior change. The primary Cloud button still shows loading/disabled while status resolves, and "Local CLI" and "Bring Your Own Key" remain enabled and navigate to their setup panels immediately. This PR makes that contract explicit on the alternatives so an accidental gate on them is caught by the existing E2E assertions.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — no visual change.

## Bug fix verification

- Test path: `e2e/ui/amr-onboarding.test.ts` — "Cloud status loading does not block signed-out Local CLI or BYOK setup"
- Did the test go red on `main` and green on this branch? No. The alternatives were already enabled on `main`, so this diff changes no runtime behavior: it adds explicit `disabled={false}` values plus an inline invariant comment to the Local CLI and BYOK buttons. The code path that could disable those buttons while Cloud status resolves was not identified.

## Validation

- `git diff --check` (exit 0)
- `bash scripts/fingerprint.sh` on the submitter worktree
- `e2e/ui/amr-onboarding.test.ts` asserts both alternatives stay enabled while the primary Cloud button is disabled during the delayed status window
