### PR TITLE
fix(pack): prune Linux ONNX package payload

### DIFF
--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -46,6 +46,12 @@ const CONTAINER_PNPM_PATH = "/tmp/pnpm";
 const CONTAINER_PNPM_HOME = "/tmp/pnpm-home";
 const CONTAINER_NODE_VERSION = "24.14.1";
 const CONTAINER_TOOLS_PACK_CLI_PATH = "tools/pack/bin/tools-pack.mjs";
+const LINUX_GPU_ONNX_PROVIDER_FILES = [
+  "libonnxruntime_providers_cuda.so",
+  "libonnxruntime_providers_tensorrt.so",
+] as const;
+
+export const LINUX_APPIMAGE_MAX_BYTES = 525_000_000;
 
 export const INTERNAL_PACKAGES = [
   { directory: "packages/release", name: "@open-design/release" },
@@ -456,6 +462,74 @@ async function runProductionInstall(appRoot: string): Promise<void> {
   });
 }
 
+export async function pruneLinuxOnnxRuntime(
+  appRoot: string,
+  architecture = process.arch,
+): Promise<string[]> {
+  const runtimeRoot = join(
+    appRoot,
+    "node_modules",
+    "onnxruntime-node",
+    "bin",
+    "napi-v3",
+  );
+  const linuxRuntimeRoot = join(runtimeRoot, "linux");
+  const targetRuntimeDirectory = join(linuxRuntimeRoot, architecture);
+  if (!(await pathExists(targetRuntimeDirectory))) {
+    throw new Error(`Linux ONNX runtime not found after production install: ${targetRuntimeDirectory}`);
+  }
+  const removed: string[] = [];
+
+  for (const platformName of ["darwin", "win32"]) {
+    const platformPath = join(runtimeRoot, platformName);
+    if (await pathExists(platformPath)) {
+      await rm(platformPath, { recursive: true });
+      removed.push(platformPath);
+    }
+  }
+  const architectureEntries = await readdir(linuxRuntimeRoot, { withFileTypes: true });
+  for (const architectureEntry of architectureEntries) {
+    if (!architectureEntry.isDirectory()) continue;
+    const runtimeDirectory = join(linuxRuntimeRoot, architectureEntry.name);
+    if (architectureEntry.name !== architecture) {
+      await rm(runtimeDirectory, { recursive: true });
+      removed.push(runtimeDirectory);
+    }
+  }
+
+  for (const fileName of LINUX_GPU_ONNX_PROVIDER_FILES) {
+    const filePath = join(targetRuntimeDirectory, fileName);
+    if (await pathExists(filePath)) {
+      await rm(filePath);
+      removed.push(filePath);
+    }
+  }
+
+  const remainingFiles = await readdir(targetRuntimeDirectory);
+  if (!remainingFiles.includes("onnxruntime_binding.node")) {
+    throw new Error(
+      `CPU ONNX runtime is incomplete after Linux packaging prune: ${join(targetRuntimeDirectory, "onnxruntime_binding.node")}`,
+    );
+  }
+  if (!remainingFiles.some((fileName) => fileName.startsWith("libonnxruntime.so."))) {
+    throw new Error(`CPU ONNX runtime library is missing after Linux packaging prune: ${targetRuntimeDirectory}`);
+  }
+  for (const fileName of LINUX_GPU_ONNX_PROVIDER_FILES) {
+    if (remainingFiles.includes(fileName)) {
+      throw new Error(`GPU ONNX provider remains in CPU-only Linux package: ${join(targetRuntimeDirectory, fileName)}`);
+    }
+  }
+  return removed;
+}
+
+export function assertLinuxAppImageSize(bytes: number, appImagePath: string): void {
+  if (bytes > LINUX_APPIMAGE_MAX_BYTES) {
+    throw new Error(
+      `Linux AppImage exceeds ${LINUX_APPIMAGE_MAX_BYTES} byte size budget: ${appImagePath} is ${bytes} bytes`,
+    );
+  }
+}
+
 async function readPackagedVersion(config: ToolPackConfig): Promise<string> {
   return readRuntimeAppVersion(config);
 }
@@ -608,6 +682,7 @@ async function writeAssembledApp(
   );
 
   await runProductionInstall(paths.assembledAppRoot);
+  await pruneLinuxOnnxRuntime(paths.assembledAppRoot);
 }
 
 async function writeLinuxAppImageAppRun(paths: LinuxPaths): Promise<void> {
@@ -754,6 +829,9 @@ export async function packLinux(config: ToolPackConfig): Promise<LinuxPackResult
   await runElectronBuilderLinux(config, paths);
 
   const appImagePath = config.to === "dir" ? null : await findBuiltAppImage(paths);
+  if (appImagePath != null) {
+    assertLinuxAppImageSize((await stat(appImagePath)).size, appImagePath);
+  }
   return {
     appImagePath,
     outputRoot: paths.appBuilderOutputRoot,

--- a/tools/pack/tests/linux.test.ts
+++ b/tools/pack/tests/linux.test.ts
@@ -27,12 +27,15 @@ vi.mock("@open-design/sidecar", async (importOriginal) => {
 
 import type { ToolPackConfig } from "@/config/index.js";
 import {
+  assertLinuxAppImageSize,
   buildDockerArgs,
   cleanupPackedLinuxNamespace,
   createLinuxDesktopLaunchEnv,
   inspectPackedLinuxApp,
+  LINUX_APPIMAGE_MAX_BYTES,
   LINUX_APPIMAGE_EXECUTABLE_ARGS,
   matchesAppImageProcess,
+  pruneLinuxOnnxRuntime,
   renderDesktopTemplate,
   renderLinuxAppImageAppRun,
   renderLinuxPackagedMainEntry,
@@ -656,6 +659,77 @@ describe("resolveProductionInstallCommand", () => {
       args: ["install", "--prod", "--no-lockfile", "--config.node-linker=hoisted"],
     });
     expect(resolved.command).not.toBe("npm");
+  });
+});
+
+describe("Linux CPU-only ONNX packaging", () => {
+  it("removes GPU providers while preserving the CPU runtime", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-linux-onnx-prune-"));
+    const napiRoot = join(root, "node_modules", "onnxruntime-node", "bin", "napi-v3");
+    const runtimeRoot = join(napiRoot, "linux", "x64");
+    const armRuntimeRoot = join(napiRoot, "linux", "arm64");
+    const retainedFiles = [
+      "libonnxruntime.so.1",
+      "libonnxruntime.so.1.21.1",
+      "libonnxruntime_providers_shared.so",
+      "onnxruntime_binding.node",
+    ];
+    const removedFiles = [
+      "libonnxruntime_providers_cuda.so",
+      "libonnxruntime_providers_tensorrt.so",
+    ];
+
+    try {
+      await mkdir(runtimeRoot, { recursive: true });
+      await mkdir(armRuntimeRoot, { recursive: true });
+      await mkdir(join(napiRoot, "darwin", "x64"), { recursive: true });
+      await mkdir(join(napiRoot, "win32", "x64"), { recursive: true });
+      await Promise.all([...retainedFiles, ...removedFiles].map((fileName) => writeFile(join(runtimeRoot, fileName), fileName)));
+      await Promise.all([
+        writeFile(join(armRuntimeRoot, "libonnxruntime.so.1"), "runtime"),
+        writeFile(join(armRuntimeRoot, "onnxruntime_binding.node"), "binding"),
+      ]);
+
+      await pruneLinuxOnnxRuntime(root, "x64");
+
+      for (const fileName of retainedFiles) {
+        expect(await pathExists(join(runtimeRoot, fileName))).toBe(true);
+      }
+      for (const fileName of removedFiles) {
+        expect(await pathExists(join(runtimeRoot, fileName))).toBe(false);
+      }
+      expect(await pathExists(armRuntimeRoot)).toBe(false);
+      expect(await pathExists(join(napiRoot, "darwin"))).toBe(false);
+      expect(await pathExists(join(napiRoot, "win32"))).toBe(false);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("fails closed when the CPU runtime is incomplete", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-linux-onnx-incomplete-"));
+    const runtimeRoot = join(root, "node_modules", "onnxruntime-node", "bin", "napi-v3", "linux", "x64");
+
+    try {
+      await mkdir(runtimeRoot, { recursive: true });
+      await writeFile(join(runtimeRoot, "onnxruntime_binding.node"), "binding");
+
+      await expect(pruneLinuxOnnxRuntime(root, "x64")).rejects.toThrow("CPU ONNX runtime library is missing");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("Linux AppImage size budget", () => {
+  it("accepts an artifact at the Stage 1 size limit", () => {
+    expect(() => assertLinuxAppImageSize(LINUX_APPIMAGE_MAX_BYTES, "/tmp/Open Design.AppImage")).not.toThrow();
+  });
+
+  it("rejects an artifact over the Stage 1 size limit", () => {
+    expect(() => assertLinuxAppImageSize(LINUX_APPIMAGE_MAX_BYTES + 1, "/tmp/Open Design.AppImage")).toThrow(
+      `exceeds ${LINUX_APPIMAGE_MAX_BYTES} byte size budget`,
+    );
   });
 });
 


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #

## Why

<!-- Why are you opening this PR? Cover two things:
       - Your use case — what made you write this today? Did you hit it yourself
         while building on top of OD, are you scratching an itch for a team, or
         are you speculatively adding for others? All are fine, but say which.
       - The pain being addressed — user-facing problem, technical debt, a prod
         issue, or unblocking another change.
     For non-trivial features, please open a discussion or issue first to align
     on scope and UX before writing code. -->


## What users will see

<!-- Describe the change from a user's perspective, not in code terms. Examples:
       - "Settings → AI Providers has a new 'Custom endpoint' field, off by default"
       - "Right-clicking a design file shows a new 'Duplicate' option"
       - "Default model changed from X to Y — existing users will notice on first launch"
       - "New `od skills install <name>` subcommand"
     Skip this section only if you check "None" below. -->


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

<!-- If you checked "UI" above, attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->


## Bug fix verification

<!-- Skip if this PR isn't a bug fix.

     Per AGENTS.md → "Bug follow-up workflow", bugs should be encoded as a
     falsifiable test that goes red before the source change. Confirm:
       - Test path that reproduces the bug:
       - Did the test go red on `main` and green on this branch? (yes / no)
       - If a red spec wasn't cheap to write, explain why and what verification
         you did instead. -->

-


## Validation

<!-- What you actually ran. Default minimum: `pnpm guard` + `pnpm typecheck`,
     plus the package-scoped tests/build for the files you changed
     (e.g. `pnpm --filter @open-design/web test`). -->

-
