### PR TITLE
fix(download): verify OS-managed root artifacts are plain files

### DIFF
--- a/packages/download/src/store.ts
+++ b/packages/download/src/store.ts
@@ -23,6 +23,11 @@ import { readJson, writeJson } from "./fs-io.js";
  * Thumbs.db/desktop.ini. Mirrors apps/desktop's isOsManagedRootArtifact —
  * duplicated rather than shared since apps/desktop depends on this package,
  * not the reverse.
+ *
+ * Matched by name only — callers MUST additionally confirm the entry is a
+ * plain file via {@link verifiedOsManagedRootArtifacts} before trusting a
+ * match. A directory or symlink squatting on one of these names must still
+ * be treated as real content, not waved through as harmless OS litter.
  */
 const OS_MANAGED_ROOT_ARTIFACTS = new Set([".DS_Store", "Thumbs.db", "desktop.ini", ".localized"]);
 
@@ -32,6 +37,31 @@ const OS_MANAGED_ROOT_ARTIFACTS = new Set([".DS_Store", "Thumbs.db", "desktop.in
  */
 function isOsManagedRootArtifact(name: string): boolean {
   return OS_MANAGED_ROOT_ARTIFACTS.has(name);
+}
+
+/**
+ * @internal Resolves which of `entries` (direct children of `basePath`) are
+ * genuine OS-managed artifacts: name-matched AND a plain file, not a
+ * directory or symlink. A name match alone is not enough — see {@link
+ * isOsManagedRootArtifact}. An entry that disappears or fails to stat
+ * between `readdir` and this check is treated as unverified (excluded),
+ * which fails closed into the existing rejection path rather than silently
+ * trusting it. Mirrors apps/desktop's verifiedOsManagedRootArtifacts.
+ */
+async function verifiedOsManagedRootArtifacts(basePath: string, entries: string[]): Promise<Set<string>> {
+  const candidates = entries.filter((entry) => isOsManagedRootArtifact(entry));
+  if (candidates.length === 0) return new Set();
+  const verified = await Promise.all(
+    candidates.map(async (entry) => {
+      try {
+        const entryStat = await lstat(join(basePath, entry));
+        return entryStat.isFile() && !entryStat.isSymbolicLink() ? entry : null;
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return new Set(verified.filter((entry): entry is string => entry != null));
 }
 
 /**
@@ -104,7 +134,8 @@ export async function ensureManagedBase(basePath: string): Promise<void> {
   const sentinel = await readJson<unknown>(sentinelPath);
   if (sentinel == null) {
     const entries = await readdir(basePath);
-    const content = entries.filter((name) => !isOsManagedRootArtifact(name));
+    const osArtifacts = await verifiedOsManagedRootArtifacts(basePath, entries);
+    const content = entries.filter((name) => !osArtifacts.has(name));
     if (content.length > 0) {
       throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED, `download base is not empty and has no ownership marker: ${basePath}`);
     }

--- a/packages/download/tests/index.test.ts
+++ b/packages/download/tests/index.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -480,5 +480,35 @@ describe("managed download package", () => {
       code: MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED,
     });
     expect(existsSync(join(basePath, ".open-design-download-root.json"))).toBe(false);
+  });
+
+  it("does not claim a fresh managed base whose only entry is a directory named .DS_Store", async () => {
+    const root = tmpRoot("os-artifact-dir-not-file");
+    const basePath = join(root, "downloads");
+    mkdirSync(basePath, { recursive: true });
+    mkdirSync(join(basePath, ".DS_Store"));
+    writeFileSync(join(basePath, ".DS_Store", "hidden.txt"), "not actually OS litter");
+
+    await expect(pruneManagedDownloads({ basePath })).rejects.toMatchObject({
+      code: MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED,
+    });
+    expect(existsSync(join(basePath, ".open-design-download-root.json"))).toBe(false);
+    expect(existsSync(join(basePath, ".DS_Store", "hidden.txt"))).toBe(true);
+  });
+
+  const symlinkOsArtifactIt = process.platform === "win32" ? it.skip : it;
+  symlinkOsArtifactIt("does not extend the OS-artifact allowance to a symlink named .DS_Store", async () => {
+    const root = tmpRoot("os-artifact-symlink-not-file");
+    const basePath = join(root, "downloads");
+    const outsideTarget = join(root, "outside.txt");
+    mkdirSync(basePath, { recursive: true });
+    writeFileSync(outsideTarget, "outside content");
+    symlinkSync(outsideTarget, join(basePath, ".DS_Store"));
+
+    await expect(pruneManagedDownloads({ basePath })).rejects.toMatchObject({
+      code: MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED,
+    });
+    expect(existsSync(join(basePath, ".open-design-download-root.json"))).toBe(false);
+    expect(existsSync(outsideTarget)).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #7602

## Why

`packages/download` ignored `.DS_Store`, `Thumbs.db`, `desktop.ini`, and `.localized` entries by name alone when claiming a fresh managed download base. A directory or symlink using one of those names could therefore be mistaken for harmless OS metadata, allowing a non-empty root to be claimed unexpectedly.

This mirrors the type-verification hardening already used by the desktop updater. The helper remains local to `packages/download` because the dependency direction does not allow importing the desktop implementation.

## What users will see

Genuine OS-created artifact files remain ignored in fresh managed download roots. Directories and symlinks with those names are now treated as real content, so the root is rejected instead of being silently claimed.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — only for unsafe non-file entries in fresh managed download roots
- [ ] **None**

## Screenshots

Not applicable.

## Bug fix verification

- Test path that reproduces the bug: `packages/download/tests/index.test.ts`.
- The regression suite covers a fresh base containing an OS-artifact directory and a symlink; both reject with `STORE_NOT_OWNED` and do not write the ownership sentinel.
- The existing plain-file cases remain covered and continue to be claimable.

## Validation

- `pnpm --filter @open-design/platform build` — passed.
- `pnpm --filter @open-design/download test` — passed: 20 tests passed, 1 Windows symlink test skipped by platform.
- `pnpm --filter @open-design/download typecheck` — passed.
- `pnpm --filter @open-design/download build` — passed.
- Manual Windows symlink regression against the built package — passed.
- `git diff --check` — passed.
- Root `pnpm guard` and the final root script typecheck could not complete in this local partial checkout because unrelated repository paths are intentionally not materialized; the package-scoped checks above are complete, and CI will run the full repository checks.
