### PR TITLE
fix(media): harden packaged image dispatch and Vela task recovery

### DIFF
--- a/apps/daemon/src/integrations/vela-command.ts
+++ b/apps/daemon/src/integrations/vela-command.ts
@@ -43,6 +43,16 @@ function withCommandStdout(error: unknown, stdout: string): unknown {
   return error;
 }
 
+function withCommandStderr(error: unknown, stderr: string): unknown {
+  if (!stderr || typeof error !== 'object' || error === null) return error;
+  try {
+    (error as { stderr?: string }).stderr = stderr;
+  } catch {
+    // See withCommandStdout: diagnostics must never replace the real failure.
+  }
+  return error;
+}
+
 /**
  * Read the stdout captured by `withCommandStdout` off a rejected Vela command.
  * Returns an empty string when the failure carried none (a crash before any
@@ -52,6 +62,13 @@ export function velaCommandStdout(error: unknown): string {
   if (typeof error !== 'object' || error === null) return '';
   const stdout = (error as { stdout?: unknown }).stdout;
   return typeof stdout === 'string' ? stdout : '';
+}
+
+/** Read the exact stderr produced by a rejected Vela command. */
+export function velaCommandStderr(error: unknown): string {
+  if (typeof error !== 'object' || error === null) return '';
+  const stderr = (error as { stderr?: unknown }).stderr;
+  return typeof stderr === 'string' ? stderr : '';
 }
 
 export interface VelaCommandOptions {
@@ -312,8 +329,13 @@ export function runVelaCommand(
             // Diagnostics are observational and must never change transport.
           }
         }
-        if (error) settle({ error: withCommandStdout(error, stdout) });
-        else settle({ stdout });
+        if (error) {
+          settle({
+            error: withCommandStderr(withCommandStdout(error, stdout), stderr),
+          });
+        } else {
+          settle({ stdout });
+        }
       },
     );
     childPid = child.pid;

--- a/apps/daemon/src/media/vela.ts
+++ b/apps/daemon/src/media/vela.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 import {
   runVelaCommand,
+  velaCommandStderr,
   velaCommandStdout,
   velaWorkspaceCommandOptions,
 } from '../integrations/vela-command.js';
@@ -92,6 +93,15 @@ function parseJsonObject(stdout: string, command: string): JsonRecord {
 
 function nonEmptyString(value: unknown): string | null {
   return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function submittedImageTaskIdFromPollingFailure(
+  error: unknown,
+): string | undefined {
+  const match = velaCommandStderr(error).match(
+    /(?:^|\r?\n)Error: perform media request GET \/api\/v1\/media\/images\/tasks\/(mit_[A-Za-z0-9_-]+):/,
+  );
+  return match?.[1];
 }
 
 function positiveIntegerFromEnv(name: string, fallback: number): number {
@@ -387,8 +397,37 @@ export async function renderVelaImage(
       });
     } catch (error) {
       // A refused request is a verdict the user can act on, so it must reach
-      // them as one. Everything else keeps its original error untouched.
-      throw velaMediaErrorFromFailure(error, `image ${command}`) ?? error;
+      // them as one. Decode it before transport recovery so a provider verdict
+      // can never be mistaken for a retryable polling failure.
+      const providerError = velaMediaErrorFromFailure(error, `image ${command}`);
+      if (providerError) throw providerError;
+
+      const submittedTaskId = submittedImageTaskIdFromPollingFailure(error);
+      if (!submittedTaskId) throw error;
+
+      // `vela image gen --wait` has already submitted (and potentially charged)
+      // the remote task before its status GET can time out. Resume that exact
+      // task instead of calling `gen` again, which avoids duplicate work and
+      // duplicate billing while tolerating a transient poll failure.
+      try {
+        stdout = await runCommand(
+          [
+            'image',
+            'get',
+            submittedTaskId,
+            '--wait',
+            '--output',
+            outputPath,
+            '--json',
+          ],
+          {
+            ...velaWorkspaceCommandOptions(input.workspaceId),
+            timeoutMs: VELA_IMAGE_TIMEOUT_MS,
+          },
+        );
+      } catch (recoveryError) {
+        throw velaMediaErrorFromFailure(recoveryError, 'image get') ?? recoveryError;
+      }
     }
     const asset = parseJsonObject(stdout, `image ${command}`);
     const assetId = nonEmptyString(asset.asset_id);

--- a/apps/daemon/src/prompts/media-contract.ts
+++ b/apps/daemon/src/prompts/media-contract.ts
@@ -487,8 +487,9 @@ path is given.
    or the user asks for "best"):
    - **Image, best quality (user says "best", "highest quality", "most realistic")**:
      use \`flux-pro-ultra\` — but tell the user it takes 60–180s
-   - **Image, default / no preference stated**: use the project metadata's
-     \`imageModel\` if set; otherwise use \`gpt-image-2\`
+   - **Image, default / no preference stated**: use an explicitly named model
+     in the current user message, then the run-scoped BYOK image default, then the project metadata's
+     \`imageModel\` if set; otherwise use \`vela/gpt-image-2\`
    - **Video, best quality**: use project metadata \`videoModel\` if set; otherwise
      \`doubao-seedance-2-0-260128\`
 

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -1895,7 +1895,13 @@ function renderMetadataBlock(
     lines.push(`### Reference prompt template — "${tpl.title ?? 'untitled'}"`);
     const meta = [];
     if (tpl.category) meta.push(`category: ${tpl.category}`);
-    if (tpl.model) meta.push(`suggested model: ${tpl.model}`);
+    const suggestedModel =
+      metadata.kind === 'image' &&
+      !metadata.imageModel?.trim() &&
+      tpl.model === 'gpt-image-2'
+        ? 'vela/gpt-image-2'
+        : tpl.model;
+    if (suggestedModel) meta.push(`suggested model: ${suggestedModel}`);
     if (tpl.aspect) meta.push(`aspect: ${tpl.aspect}`);
     if (Array.isArray(tpl.tags) && tpl.tags.length > 0) {
       meta.push(`tags: ${tpl.tags.join(', ')}`);

--- a/apps/daemon/src/runtimes/defs/codex.ts
+++ b/apps/daemon/src/runtimes/defs/codex.ts
@@ -150,6 +150,9 @@ const CODEX_SHELL_ENVIRONMENT_INCLUDE_KEYS = [
   'OD_BIN',
   'OD_HYPERFRAMES_BIN',
   'OD_NODE_BIN',
+  // macOS packages use Electron Helper as OD_NODE_BIN. Preserve its Node mode
+  // when Codex applies this second environment filter to tool shell commands.
+  'ELECTRON_RUN_AS_NODE',
   'OD_DAEMON_URL',
   'OD_TOOL_TOKEN',
   'OD_DATA_DIR',

--- a/apps/daemon/tests/media/models.test.ts
+++ b/apps/daemon/tests/media/models.test.ts
@@ -4,6 +4,7 @@ import {
   IMAGE_MODELS,
   MEDIA_PROVIDERS,
   canonicalMediaModelId,
+  findMediaModel,
 } from '../../src/media/models.js';
 
 describe('image model defaults', () => {
@@ -17,5 +18,10 @@ describe('image model defaults', () => {
 
   it('migrates the removed Codex image model id to Vela', () => {
     expect(canonicalMediaModelId('codex-gpt-image-2')).toBe('vela/gpt-image-2');
+  });
+
+  it('preserves explicit OpenAI BYOK model selection', () => {
+    expect(canonicalMediaModelId('gpt-image-2')).toBe('gpt-image-2');
+    expect(findMediaModel('gpt-image-2')?.provider).toBe('openai');
   });
 });

--- a/apps/daemon/tests/prompts/__snapshots__/system-prompt-matrix.test.ts.snap
+++ b/apps/daemon/tests/prompts/__snapshots__/system-prompt-matrix.test.ts.snap
@@ -48,7 +48,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 48046,
+    "totalChars": 48156,
   },
   "critique-enabled": {
     "sections": [
@@ -237,7 +237,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 48044,
+    "totalChars": 48154,
   },
   "memory-hooks-off": {
     "sections": [

--- a/apps/daemon/tests/prompts/media-contract-mirror.test.ts
+++ b/apps/daemon/tests/prompts/media-contract-mirror.test.ts
@@ -13,11 +13,11 @@ import { describe, expect, it } from 'vitest';
 // content-safety refusal as a temporary outage. This test is the cheap guard
 // against a repeat. Delete it only by deleting one of the two copies.
 
-function templateBody(path: string): string {
+function templateBody(path: string, exportName = 'MEDIA_USER_REPLY_CONTRACT'): string {
   const source = readFileSync(fileURLToPath(new URL(path, import.meta.url)), 'utf8');
-  const marker = 'export const MEDIA_USER_REPLY_CONTRACT = `';
+  const marker = `export const ${exportName} = \``;
   const start = source.indexOf(marker);
-  if (start < 0) throw new Error(`MEDIA_USER_REPLY_CONTRACT not found in ${path}`);
+  if (start < 0) throw new Error(`${exportName} not found in ${path}`);
   let index = start + marker.length;
   // Scan for the terminating backtick, skipping escaped ones -- the body
   // itself contains \` around inline code, so a naive search truncates it.
@@ -36,6 +36,10 @@ describe('MEDIA_USER_REPLY_CONTRACT mirrors', () => {
   const daemonBody = templateBody('../../src/prompts/media-contract.ts');
   const contractsBody = templateBody(
     '../../../../packages/contracts/src/prompts/media-contract.ts',
+  );
+  const generationBody = templateBody(
+    '../../src/prompts/media-contract.ts',
+    'MEDIA_GENERATION_CONTRACT',
   );
 
   it('keeps the daemon copy and the contracts copy identical', () => {
@@ -66,5 +70,10 @@ describe('MEDIA_USER_REPLY_CONTRACT mirrors', () => {
     expect(daemonBody).toContain('错误代码：\\`{code}\\`');
     expect(normalized).toContain('structured dispatcher or provider error');
     expect(daemonBody).not.toContain('图片生成服务暂时不可用');
+  });
+
+  it('routes an unspecified image model through the managed Cloud default', () => {
+    expect(generationBody).toContain('otherwise use \\`vela/gpt-image-2\\`');
+    expect(generationBody).not.toContain('otherwise use \\`gpt-image-2\\`');
   });
 });

--- a/apps/daemon/tests/runtimes/codex-resume-args.test.ts
+++ b/apps/daemon/tests/runtimes/codex-resume-args.test.ts
@@ -112,6 +112,7 @@ describe('codex buildArgs session resume', () => {
     );
     expect(includeOnly).toContain('"PATH"');
     expect(includeOnly).toContain('"OD_NODE_BIN"');
+    expect(includeOnly).toContain('"ELECTRON_RUN_AS_NODE"');
     expect(includeOnly).toContain('"OD_HYPERFRAMES_BIN"');
     expect(includeOnly).toContain('"OD_BIN"');
     expect(includeOnly).toContain('"OD_DAEMON_URL"');

--- a/apps/daemon/tests/system-prompt-template.test.ts
+++ b/apps/daemon/tests/system-prompt-template.test.ts
@@ -111,6 +111,19 @@ describe('composeSystemPrompt — metadata.promptTemplate', () => {
     expect(out).not.toContain('1:1 (default');
   });
 
+  it('normalizes a legacy template recommendation to Cloud when no image model is explicit', () => {
+    const out = composeSystemPrompt({
+      metadata: {
+        kind: 'image',
+        promptTemplate: { ...baseSummary, model: 'gpt-image-2' },
+      },
+    });
+
+    expect(out).toContain('**imageModel**: (not provided)');
+    expect(out).toContain('suggested model: vela/gpt-image-2');
+    expect(out).not.toContain('suggested model: gpt-image-2');
+  });
+
   it('inlines the prompt body for video projects too', () => {
     const out = composeSystemPrompt({
       metadata: {
@@ -357,6 +370,25 @@ describe('composeSystemPrompt — metadata.promptTemplate', () => {
     expect(out).toContain('- Speech model: `aihubmix-gpt-4o-mini-tts`');
     expect(out).toContain('- Speech voice: `nova`');
     expect(out).toContain('### Allowed model IDs (per surface)');
+  });
+
+  it('gives a run-scoped BYOK image default precedence over project metadata', () => {
+    const out = composeSystemPrompt({
+      metadata: {
+        kind: 'image',
+        imageModel: 'vela/gpt-image-2',
+        imageAspect: '1:1',
+      },
+      byokMediaDefaults: {
+        imageModel: 'gpt-image-2',
+      },
+    });
+
+    expect(out).toContain('**imageModel**: vela/gpt-image-2');
+    expect(out).toContain('- Image model: `gpt-image-2`');
+    expect(out.replace(/\s+/g, ' ')).toContain(
+      'current user message, then the run-scoped BYOK image default, then the project metadata',
+    );
   });
 
   it('renders BYOK media defaults in the non-media dispatch hint', () => {

--- a/apps/daemon/tests/vela-media-safety-error.test.ts
+++ b/apps/daemon/tests/vela-media-safety-error.test.ts
@@ -1,5 +1,9 @@
+import { writeFile } from 'node:fs/promises';
 import { describe, expect, it } from 'vitest';
-import { velaCommandStdout } from '../src/integrations/vela-command.js';
+import {
+  velaCommandStderr,
+  velaCommandStdout,
+} from '../src/integrations/vela-command.js';
 import {
   VELA_SAFETY_REJECTION_CODE,
   VelaMediaError,
@@ -26,13 +30,18 @@ function velaTaskJson(
 }
 
 /** An exec rejection carrying the CLI's stdout, as vela-command now attaches it. */
-function failedCommand(stdout: string): Error & { stdout?: string; code?: number } {
+function failedCommand(
+  stdout: string,
+  stderr = '',
+): Error & { stdout?: string; stderr?: string; code?: number } {
   const error = new Error('Command failed: vela image gen') as Error & {
     stdout?: string;
+    stderr?: string;
     code?: number;
   };
   error.code = 1;
   error.stdout = stdout;
+  error.stderr = stderr;
   return error;
 }
 
@@ -46,6 +55,18 @@ describe('velaCommandStdout', () => {
     expect(velaCommandStdout(undefined)).toBe('');
     expect(velaCommandStdout(null)).toBe('');
     expect(velaCommandStdout('a string rejection')).toBe('');
+  });
+});
+
+describe('velaCommandStderr', () => {
+  it('reads back the stderr a failed command carried', () => {
+    expect(velaCommandStderr(failedCommand('', 'network timeout'))).toBe(
+      'network timeout',
+    );
+  });
+
+  it('returns an empty string when the failure carried none', () => {
+    expect(velaCommandStderr(new Error('boom'))).toBe('');
   });
 });
 
@@ -215,5 +236,115 @@ describe('renderVelaImage', () => {
 
     expect(thrown).toBe(original);
     expect(thrown).not.toBeInstanceOf(VelaMediaError);
+  });
+
+  it('resumes a submitted image task after a polling timeout without resubmitting', async () => {
+    const timedOut = failedCommand(
+      '',
+      'Error: perform media request GET /api/v1/media/images/tasks/mit_recover_once: ' +
+      'dial tcp 198.18.1.87:443: connect: operation timed out',
+    );
+    const calls: string[][] = [];
+    const optionsSeen: Array<Record<string, unknown> | undefined> = [];
+    const runCommand = (async (
+      args: string[],
+      options?: Record<string, unknown>,
+    ) => {
+      calls.push(args);
+      optionsSeen.push(options);
+      if (args[0] === 'image' && args[1] === 'gen') throw timedOut;
+      if (args[0] === 'image' && args[1] === 'get') {
+        const outputIndex = args.indexOf('--output');
+        const output = args[outputIndex + 1];
+        if (!output) throw new Error('missing recovery output path');
+        await writeFile(output, Buffer.from('recovered-image'));
+        return JSON.stringify({
+          asset_id: 'ma_recovered',
+          status: 'ready',
+          kind: 'image',
+          mime_type: 'image/png',
+        });
+      }
+      throw new Error(`unexpected command: ${args.join(' ')}`);
+    }) as unknown as Parameters<typeof renderVelaImage>[1];
+
+    const result = await renderVelaImage(input, runCommand);
+
+    expect(result.bytes).toEqual(Buffer.from('recovered-image'));
+    expect(
+      calls.filter((args) => args[0] === 'image' && args[1] === 'gen'),
+    ).toHaveLength(1);
+    expect(calls[1]?.slice(0, 4)).toEqual([
+      'image',
+      'get',
+      'mit_recover_once',
+      '--wait',
+    ]);
+    expect(calls[1]).toContain('--json');
+    expect(optionsSeen[1]).toEqual(optionsSeen[0]);
+    expect(optionsSeen[1]).toMatchObject({
+      configuredEnv: {
+        VELA_INVOCATION_SOURCE: 'open-design',
+        VELA_WORKSPACE_ID: 'team-1',
+      },
+      timeoutMs: 330_000,
+    });
+  });
+
+  it('does not recover from a task path that appears only in the command message', async () => {
+    const original = new Error(
+      'Command failed: vela image gen --prompt ' +
+      '/api/v1/media/images/tasks/mit_prompt_injection',
+    );
+    const calls: string[][] = [];
+    const runCommand = (async (args: string[]) => {
+      calls.push(args);
+      throw original;
+    }) as unknown as Parameters<typeof renderVelaImage>[1];
+
+    const thrown = await renderVelaImage(input, runCommand).catch(
+      (error: unknown) => error,
+    );
+
+    expect(thrown).toBe(original);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.slice(0, 2)).toEqual(['image', 'gen']);
+  });
+
+  it('preserves a structured provider verdict returned by the recovery command', async () => {
+    const initialFailure = failedCommand(
+      '',
+      'Error: perform media request GET /api/v1/media/images/tasks/mit_recover_refused: operation timed out',
+    );
+    const recoveryFailure = failedCommand(
+      velaTaskJson({
+        code: 'safety_rejection',
+        message: 'the request was rejected by a content safety policy',
+        subject: 'output_image',
+        retryable: false,
+      }),
+    );
+    const calls: string[][] = [];
+    const runCommand = (async (args: string[]) => {
+      calls.push(args);
+      if (calls.length === 1) throw initialFailure;
+      throw recoveryFailure;
+    }) as unknown as Parameters<typeof renderVelaImage>[1];
+
+    const thrown = await renderVelaImage(input, runCommand).catch(
+      (error: unknown) => error,
+    );
+
+    expect(thrown).toBeInstanceOf(VelaMediaError);
+    expect((thrown as VelaMediaError).code).toBe(VELA_SAFETY_REJECTION_CODE);
+    expect((thrown as VelaMediaError).subject).toBe('output_image');
+    expect((thrown as VelaMediaError).retryable).toBe(false);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.slice(0, 2)).toEqual(['image', 'gen']);
+    expect(calls[1]?.slice(0, 3)).toEqual([
+      'image',
+      'get',
+      'mit_recover_refused',
+    ]);
   });
 });

--- a/apps/daemon/tests/vela-media-safety-process.test.ts
+++ b/apps/daemon/tests/vela-media-safety-process.test.ts
@@ -2,7 +2,10 @@ import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { runVelaCommand } from '../src/integrations/vela-command.js';
+import {
+  runVelaCommand,
+  velaCommandStderr,
+} from '../src/integrations/vela-command.js';
 import {
   VELA_SAFETY_REJECTION_CODE,
   VelaMediaError,
@@ -65,6 +68,17 @@ afterEach(() => {
 });
 
 describe('a real vela process that refuses and exits non-zero', () => {
+	it('preserves stderr separately from the exec error message', async () => {
+		const bin = writeFakeVela(
+			'#!/bin/sh\necho "Error: perform media request GET /api/v1/media/images/tasks/mit_process_timeout: operation timed out" >&2\nexit 1\n',
+		);
+		const thrown = await runVelaCommand(['image', 'gen'], {
+			env: { ...process.env, VELA_BIN: bin },
+		}).catch((error: unknown) => error);
+
+		expect(velaCommandStderr(thrown)).toContain('mit_process_timeout');
+	});
+
 	it('preserves an arbitrary provider code and safe message across the process boundary', async () => {
 		const providerTask = JSON.stringify({
 			task_id: 'mit_process_test',

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -43,6 +43,7 @@ import {
   DEFAULT_IMAGE_MODEL,
   DEFAULT_VIDEO_MODEL,
   findProvider,
+  imageModelIdForPromptTemplate,
   IMAGE_MODELS,
   MEDIA_ASPECTS,
   type MediaModel,
@@ -565,8 +566,16 @@ export function NewProjectPanel({
   // stays on the default seedance — the agent then dispatches the wrong
   // model and the render path mismatches the prompt.
   function handleImagePromptTemplate(pick: PromptTemplatePick | null) {
-    setImagePromptTemplate(pick);
-    const m = pick?.summary.model;
+    const rawModel = pick?.summary.model;
+    const normalizedModel = rawModel
+      ? imageModelIdForPromptTemplate(rawModel)
+      : undefined;
+    const normalizedPick =
+      pick && normalizedModel && normalizedModel !== rawModel
+        ? { ...pick, summary: { ...pick.summary, model: normalizedModel } }
+        : pick;
+    setImagePromptTemplate(normalizedPick);
+    const m = normalizedModel;
     // Accept catalogued ids plus any live AIHubMix catalogue id (aihubmix-*),
     // which renders dynamically and won't appear in the static IMAGE_MODELS.
     if (m && (IMAGE_MODELS.some((x) => x.id === m) || m.startsWith('aihubmix-'))) setImageModel(m);

--- a/apps/web/src/media/models.ts
+++ b/apps/web/src/media/models.ts
@@ -700,6 +700,18 @@ export function canonicalMediaModelId(id: string): string {
   return MEDIA_MODEL_ALIASES[id] ?? id;
 }
 
+/**
+ * A prompt template recommends a model family; it is not an explicit BYOK
+ * provider choice. Legacy first-party templates used the unqualified
+ * `gpt-image-2` family id, so keep those on the managed Cloud route while
+ * preserving `gpt-image-2` for users who select OpenAI directly.
+ */
+export function imageModelIdForPromptTemplate(id: string): string {
+  const normalized = id.trim();
+  if (normalized === 'gpt-image-2') return 'vela/gpt-image-2';
+  return canonicalMediaModelId(normalized);
+}
+
 export function findMediaModel(id: string): MediaModel | null {
   const all: MediaModel[] = [
     ...IMAGE_MODELS,

--- a/apps/web/tests/components/NewProjectPanel.media.test.tsx
+++ b/apps/web/tests/components/NewProjectPanel.media.test.tsx
@@ -109,6 +109,120 @@ describe('NewProjectPanel media provider badges', () => {
     );
   });
 
+  it('treats a legacy template gpt-image-2 recommendation as the managed Cloud route', async () => {
+    const template = {
+      id: 'legacy-gpt-image-template',
+      surface: 'image' as const,
+      title: 'Legacy GPT image template',
+      summary: 'A legacy first-party image template.',
+      category: 'Poster',
+      tags: ['legacy'],
+      model: 'gpt-image-2',
+      aspect: '16:9' as const,
+      source: {
+        repo: 'example/templates',
+        license: 'MIT',
+      },
+    };
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      promptTemplate: {
+        ...template,
+        prompt: 'A detailed cinematic image prompt with enough content for validation.',
+      },
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })));
+    const onCreate = vi.fn();
+
+    render(
+      <NewProjectPanel
+        skills={[]}
+        designSystems={[]}
+        defaultDesignSystemId={null}
+        templates={[]}
+        onDeleteTemplate={vi.fn()}
+        promptTemplates={[template]}
+        onCreate={onCreate}
+        mediaProviders={{
+          openai: {
+            apiKey: '',
+            apiKeyConfigured: true,
+            apiKeyTail: '1234',
+            baseUrl: '',
+          },
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Media' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Image' }));
+    fireEvent.click(screen.getByTestId('prompt-template-trigger'));
+    fireEvent.click(screen.getByRole('option', { name: /Legacy GPT image template/ }));
+    await waitFor(() => {
+      expect(screen.getByTestId('prompt-template-body')).toHaveValue(
+        'A detailed cinematic image prompt with enough content for validation.',
+      );
+    });
+    fireEvent.change(screen.getByTestId('new-project-name'), {
+      target: { value: 'Managed template image' },
+    });
+    fireEvent.click(screen.getByTestId('create-project'));
+
+    expect(onCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          kind: 'image',
+          imageModel: 'vela/gpt-image-2',
+          imageAspect: '16:9',
+          promptTemplate: expect.objectContaining({
+            model: 'vela/gpt-image-2',
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('preserves an explicit OpenAI model picker selection as BYOK', () => {
+    const onCreate = vi.fn();
+    render(
+      <NewProjectPanel
+        skills={[]}
+        designSystems={[]}
+        defaultDesignSystemId={null}
+        templates={[]}
+        onDeleteTemplate={vi.fn()}
+        promptTemplates={[]}
+        onCreate={onCreate}
+        mediaProviders={{
+          openai: {
+            apiKey: '',
+            apiKeyConfigured: true,
+            apiKeyTail: '1234',
+            baseUrl: '',
+          },
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Media' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Image' }));
+    fireEvent.click(screen.getByTestId('model-picker-trigger'));
+    fireEvent.click(screen.getByTestId('model-picker-option-gpt-image-2'));
+    fireEvent.change(screen.getByTestId('new-project-name'), {
+      target: { value: 'Explicit BYOK image' },
+    });
+    fireEvent.click(screen.getByTestId('create-project'));
+
+    expect(onCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          imageModel: 'gpt-image-2',
+        }),
+      }),
+    );
+  });
+
   it('does not treat OpenAI OAuth-only markers as usable image credentials', () => {
     render(
       <NewProjectPanel

--- a/packages/contracts/src/prompts/system.ts
+++ b/packages/contracts/src/prompts/system.ts
@@ -986,7 +986,13 @@ function promptTemplateReferenceLines(
     out.push(`### Reference prompt template — "${tpl.title}"`);
     const meta: string[] = [];
     if (tpl.category) meta.push(`category: ${tpl.category}`);
-    if (tpl.model) meta.push(`suggested model: ${tpl.model}`);
+    const suggestedModel =
+      metadata.kind === 'image' &&
+      !metadata.imageModel?.trim() &&
+      tpl.model === 'gpt-image-2'
+        ? 'vela/gpt-image-2'
+        : tpl.model;
+    if (suggestedModel) meta.push(`suggested model: ${suggestedModel}`);
     if (tpl.aspect) meta.push(`aspect: ${tpl.aspect}`);
     if (tpl.tags && tpl.tags.length > 0) {
       meta.push(`tags: ${tpl.tags.join(', ')}`);


### PR DESCRIPTION
## Why

I reproduced a packaged Codex image-generation run where the agent prepared the image prompt but delivered no artifact and the UI collapsed the result into `MEDIA_DISPATCH_FAILED`.

The same user-visible failure had three independent causes along the managed image path:

1. Legacy image templates could persist bare `gpt-image-2`, which means explicit OpenAI/BYOK rather than OpenDesign's managed Vela route.
2. Packaged Codex tool shells did not preserve Electron's Node mode for the bundled helper used as `OD_NODE_BIN`, so the media dispatcher could exit before it ran.
3. Vela could submit an image task successfully and then hit a transient error while polling that task. OpenDesign treated the poll failure as final even when stderr contained the exact submitted Task ID.

## What users will see

- Legacy/inherited image-template defaults are normalized to `vela/gpt-image-2`; an explicit current-message or BYOK OpenAI selection remains bare `gpt-image-2` and continues to use OpenAI.
- Packaged Codex media calls retain the Node-mode environment required by the bundled helper.
- If a Vela image task was demonstrably submitted and the status poll fails, OpenDesign makes one `vela image get` call for that same Task ID and output path. It never submits a second generation request.
- Safety/provider verdicts keep their structured error codes. Failures without a trustworthy Task ID still fail closed.

The recovery is intentionally image-only and only trusts the strict Vela GET-failure line from child-process stderr; Task-like text in a user prompt cannot trigger recovery.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — this changes dispatch defaults and recovery behavior, not a visual surface.

## Bug fix verification

Falsifiable coverage:

- `apps/web/tests/components/NewProjectPanel.media.test.tsx`
- `apps/daemon/tests/prompts/media-contract-mirror.test.ts`
- `apps/daemon/tests/prompts/system-prompt-matrix.test.ts`
- `apps/daemon/tests/system-prompt-template.test.ts`
- `apps/daemon/tests/runtimes/codex-resume-args.test.ts`
- `apps/daemon/tests/vela-media-safety-error.test.ts`
- `apps/daemon/tests/vela-media-safety-process.test.ts`

Yes, the new specs went red on `main@c92276a61` (the parent of the subsequent Vela-only dependency bump):

- daemon prompt/Vela specs: 8 failed, 55 passed
- web legacy-template spec: 1 failed, 6 passed
- Codex environment spec: 1 failed, 8 passed

They are green on this branch atop current `main@349748ee3`:

- daemon focused suite: 75/75
- web focused suite: 7/7
- contracts suite: 508/508

The Vela recovery tests prove exactly one generation call plus one same-Task retrieval, no third call or resubmission, preserved workspace/timeout/output path, preserved safety verdicts, and no recovery from prompt-injected Task-like text. A child-process test also proves stderr survives the process boundary.

## Validation

- `corepack pnpm guard`
- `corepack pnpm typecheck`
- `corepack pnpm --filter @open-design/daemon build`
- `corepack pnpm --filter @open-design/web build`
- `corepack pnpm --filter @open-design/web test` — 676 files passed; 7,166 tests passed, 1 expected failure, 11 skipped
- focused daemon/web suites and full contracts suite listed above
- `git diff --check origin/main...HEAD`

An exploratory daemon full-suite run reached 9,780 passing tests. Its prompt-length snapshot failure was updated and then passed in the focused 75-test suite; an OD Next 20-second timeout passed when rerun alone. `export-tool-token-nonloopback-authority.test.ts` still times out while probing/starting on a non-loopback interface on this machine; the unchanged `main` baseline fails in the same setup hook, including with no media patch applied.

Local verification used Node 24.19.0 while the repo requests 24.18.0; pnpm reported this as an engine warning only.

## Validation report

- [OpenDesign 生图 MEDIA_DISPATCH_FAILED 修复与验证报告](https://powerformer.feishu.cn/wiki/Alpnw0Scbi77GxkypRQcD4GYneb) — Chinese root-cause analysis, screenshots, technical design, and local verification evidence.

## Evidence boundary

A real packaged run verified the normal managed `vela/gpt-image-2` path through final image delivery. The transient post-submission GET recovery is covered by deterministic process and adapter tests, but has not yet been proven by a final fault-injected packaged E2E. This PR does not claim that normal-path run exercised recovery.

## Adjacent PRs

- #7388 contains the same Codex `ELECTRON_RUN_AS_NODE` allowlist invariant inside a broader packaged single-instance/lifecycle fix. It is intentionally retained here because this narrower media reproduction requires it and #7388 is currently `CHANGES_REQUESTED`/`DIRTY`; whichever PR lands second should drop or rebase the duplicate hunk.
- #7601 changes configured-provider defaults and touches adjacent routing code. This PR preserves explicit picker/BYOK precedence and adds legacy-template normalization plus Vela same-Task recovery; it does not replace #7601's configured-provider work.
