### PR TITLE
chore(amr): use default Vela agent runtime

### DIFF
--- a/apps/daemon/scripts/verify-amr-real-vela.mjs
+++ b/apps/daemon/scripts/verify-amr-real-vela.mjs
@@ -46,7 +46,7 @@ if (
   process.exit(2);
 }
 
-const child = spawn(velaBin, ['agent', 'run', '--runtime', 'opencode'], {
+const child = spawn(velaBin, ['agent', 'run'], {
   stdio: ['pipe', 'pipe', 'pipe'],
   env: process.env,
 });

--- a/apps/daemon/src/runtimes/defs/amr.ts
+++ b/apps/daemon/src/runtimes/defs/amr.ts
@@ -23,7 +23,7 @@ const OPENCODE_MODEL_PRICE_PROVIDER_PRIORITY = [
   'openrouter',
 ] as const;
 
-// AMR is the vela CLI's ACP stdio mode. `vela agent run --runtime opencode`
+// AMR is the vela CLI's ACP stdio mode. `vela agent run`
 // starts a private OpenCode server and forwards stream-json over ACP JSON-RPC.
 // Required env (set on the daemon process or via Settings → CLI env):
 //   VELA_RUNTIME_KEY  — OpenRouter (or compatible) API key
@@ -673,7 +673,7 @@ export const amrAgentDef = {
   // Fail closed when Vela's live catalog is unavailable. Stale static
   // fallbacks let users select models that link/opencode no longer accepts.
   fallbackModels: [] as RuntimeModelOption[],
-  buildArgs: () => ['agent', 'run', '--runtime', 'opencode'],
+  buildArgs: () => ['agent', 'run'],
   streamFormat: 'acp-json-rpc',
   // vela resumes the upstream OpenCode session via ACP session/load across
   // turns (the OpenCode session store persists per conversation), so the daemon

--- a/apps/daemon/tests/amr-acp-integration.test.ts
+++ b/apps/daemon/tests/amr-acp-integration.test.ts
@@ -148,13 +148,8 @@ describe('AMR runtime def', () => {
     expect(def?.streamFormat).toBe('acp-json-rpc');
   });
 
-  it('builds the documented `vela agent run --runtime opencode` argv', () => {
-    expect(amrAgentDef.buildArgs()).toEqual([
-      'agent',
-      'run',
-      '--runtime',
-      'opencode',
-    ]);
+  it('builds the documented `vela agent run` argv', () => {
+    expect(amrAgentDef.buildArgs()).toEqual(['agent', 'run']);
   });
 
   it('fails closed instead of exposing static stale fallback models', () => {

--- a/apps/daemon/tests/fixtures/fake-vela.mjs
+++ b/apps/daemon/tests/fixtures/fake-vela.mjs
@@ -22,7 +22,7 @@
  *   `vela models`                       → prints production-shaped public
  *                                         model ids from the Vela catalog.
  *
- *   `vela agent run --runtime opencode` → ACP stdio runtime. Speaks just
+ *   `vela agent run` → ACP stdio runtime. Speaks just
  *                                         enough of the protocol to drive
  *                                         OpenDesign's `detectAcpModels`
  *                                         and `attachAcpSession` through a
@@ -173,7 +173,7 @@ const DEFAULT_MODEL_LIST_JSON = JSON.stringify({
   ],
 });
 
-// Real `vela agent run --runtime opencode` rejects session/prompt until
+// Real `vela agent run` rejects session/prompt until
 // session/set_model has been called for the current session — see the
 // AMR runtime def docblock and the integration test for the negative case.
 // The stub mirrors that contract so a regression in attachAcpSession that

--- a/e2e/tests/amr/turn.test.ts
+++ b/e2e/tests/amr/turn.test.ts
@@ -49,7 +49,7 @@ type ProjectResponse = {
 //   `vela model preset --format json`   — print the fast preset catalog.
 //   `vela model list --format json`     — print the live link model catalog.
 //   `vela login`                        — write ~/.amr/config.json and exit 0.
-//   `vela agent run --runtime opencode` — ACP stdio runtime (initialize →
+//   `vela agent run` — ACP stdio runtime (initialize →
 //                                          session/new → session/set_model →
 //                                          session/prompt → session/update*).
 //

--- a/mocks/bin/vela
+++ b/mocks/bin/vela
@@ -2,7 +2,7 @@
 # vela mock CLI — dispatches by first argv:
 #   vela login    → write ~/.amr/config.json (fake credentials)
 #   vela models   → print public model catalog
-#   vela agent run --runtime opencode → ACP JSON-RPC server (default)
+#   vela agent run → ACP JSON-RPC server (default)
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 exec node "$HERE/../mock-agent.mjs" --as vela "$@"

--- a/mocks/mock-agent.mjs
+++ b/mocks/mock-agent.mjs
@@ -91,7 +91,7 @@ async function main() {
     const cmd = (opts.positionals[0] || '').trim();
     if (cmd === 'login')  return runVelaLogin();
     if (cmd === 'models') return runVelaModels();
-    // Default: `agent run --runtime opencode` — fall through to the ACP
+    // Default: `agent run` — fall through to the ACP
     // server below with the vela-flavored protocol.
   }
 

--- a/mocks/scripts/smoke-test.sh
+++ b/mocks/scripts/smoke-test.sh
@@ -114,7 +114,7 @@ else
 fi
 
 # vela ACP roundtrip (strict set_model gate enforced).
-vela_acp_out=$(cat <<EOF | vela agent run --runtime opencode 2>/dev/null
+vela_acp_out=$(cat <<EOF | vela agent run 2>/dev/null
 {"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
 {"jsonrpc":"2.0","id":2,"method":"session/new","params":{"cwd":"/tmp"}}
 {"jsonrpc":"2.0","id":3,"method":"session/set_model","params":{"sessionId":"fake-vela-session-1","modelId":"deepseek-v3.2"}}
@@ -132,7 +132,7 @@ else
 fi
 
 # vela strict set_model gate — skipping set_model must reject prompt.
-vela_gate_out=$(cat <<EOF | vela agent run --runtime opencode 2>/dev/null
+vela_gate_out=$(cat <<EOF | vela agent run 2>/dev/null
 {"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
 {"jsonrpc":"2.0","id":2,"method":"session/new","params":{"cwd":"/tmp"}}
 {"jsonrpc":"2.0","id":3,"method":"session/prompt","params":{"sessionId":"fake-vela-session-1","prompt":[{"type":"text","text":"hi"}]}}

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -115,7 +115,7 @@ const residualAllowedExactPaths = new Set([
   // `dist/acp.js` and drives a real `vela agent run` against a live model.
   // Kept as .mjs so it can be invoked directly via Node without any transform.
   "apps/daemon/scripts/verify-amr-real-vela.mjs",
-  // Fake `vela agent run --runtime opencode` ACP stdio stub used by the AMR
+  // Fake `vela agent run` ACP stdio stub used by the AMR
   // integration tests. The Vitest test spawns it via `child_process.spawn`,
   // which needs a directly-executable file (shebang + .mjs).
   "apps/daemon/tests/fixtures/fake-vela.mjs",

--- a/specs/change/20260601-amr-model-loading-cache/spec.md
+++ b/specs/change/20260601-amr-model-loading-cache/spec.md
@@ -42,7 +42,7 @@ on `/api/agents` for the AMR model list.
 - Do not remove `/api/agents` AMR model fields in this change.
 - Do not add new glossary terms to `CONTEXT.md`.
 - Do not implement a broader generic runtime model endpoint.
-- Do not change AMR execution away from `vela agent run --runtime opencode`.
+- Do not change AMR execution away from `vela agent run`.
 
 ### Success Criteria
 
@@ -65,7 +65,7 @@ on `/api/agents` for the AMR model list.
   filters media model prefixes, deduplicates, and orders preferred chat
   models. Source: `apps/daemon/src/runtimes/defs/amr.ts:39-117,120-132`.
 - AMR declares `fallbackModels: []`, disables custom model ids, and keeps
-  execution on `vela agent run --runtime opencode`. Source:
+  execution on `vela agent run`. Source:
   `apps/daemon/src/runtimes/defs/amr.ts:188-208`.
 - Generic runtime probing calls each runtime's `fetchModels` during
   `detectAgents`, maps successful results to `modelsSource: "live"`, and


### PR DESCRIPTION
Summary:
- invoke the AMR runtime as vela agent run and rely on Vela's validated OpenCode default
- update the real-runtime verifier, daemon and e2e fixtures, and mock smoke coverage
- remove explicit --runtime opencode from repository examples and historical guidance

Related Vela command-surface cleanup:
- https://github.com/powerformer/vela/pull/1882

Validation:
- pnpm --filter @open-design/daemon typecheck
- pnpm exec vitest run -c vitest.config.ts tests/amr-acp-integration.test.ts (40 tests passed)
- Biome, shell syntax, and Node syntax checks passed

Known unrelated repository issue:
- pnpm guard is currently blocked because apps/telemetry-worker/package.json is missing; the guard also reports pre-existing project-owned JavaScript files.