### PR TITLE
feat(web): add recent projects and run status to the entry rail

### DIFF
--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -52,6 +52,7 @@ import {
   getFirstProjectConversation,
   getConversation,
   getProject,
+  listProjectsAwaitingInput,
   normalizeConversationSessionMode,
   updateProject,
   upsertMessage,
@@ -3129,7 +3130,27 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         'projectId is required when listing Workspace-bound runs',
       );
     }
-    const body = { runs: visibleRuns.map(statusWithStrategyTask) };
+    // `ChatRunStatus` cannot say "waiting on the user": the run that asked the
+    // question reports `succeeded` and exits, while the project stays blocked.
+    // Clients rendering a per-project status off this feed would show such a
+    // project as finished, so ship the awaiting-input set alongside — the same
+    // one `GET /api/projects` composes `awaiting_input` from.
+    //
+    // Intersected with the projects `visibleRuns` already reveals: the query
+    // itself is unscoped, and returning it raw would leak the ids of projects
+    // this caller is not authorized to see.
+    const visibleProjectIds = new Set(
+      visibleRuns
+        .map((run) => run.projectId)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0),
+    );
+    const awaitingInputProjectIds = visibleProjectIds.size
+      ? [...listProjectsAwaitingInput(db)].filter((id) => visibleProjectIds.has(id))
+      : [];
+    const body = {
+      runs: visibleRuns.map(statusWithStrategyTask),
+      awaitingInputProjectIds,
+    };
     res.json(body);
   });
 

--- a/apps/daemon/tests/headless-runs.test.ts
+++ b/apps/daemon/tests/headless-runs.test.ts
@@ -98,7 +98,9 @@ describe('POST /api/runs headless fallbacks', () => {
 
     const runsResponse = await fetch(`${started.url}/api/runs`);
     expect(runsResponse.status).toBe(200);
-    await expect(runsResponse.json()).resolves.toEqual({ runs: [] });
+    // The awaiting-input set rides along with every list (see
+    // runs-list-awaiting-input.test.ts); with no runs it is simply empty.
+    await expect(runsResponse.json()).resolves.toEqual({ runs: [], awaitingInputProjectIds: [] });
   });
 
   it('binds omitted conversationId to the seeded project conversation', async () => {

--- a/apps/daemon/tests/runs-list-awaiting-input.test.ts
+++ b/apps/daemon/tests/runs-list-awaiting-input.test.ts
@@ -1,0 +1,311 @@
+// `GET /api/runs` ships `awaitingInputProjectIds` beside the runs.
+//
+// `ChatRunStatus` cannot express "waiting on the user": the run that emitted a
+// `<question-form>` reports `succeeded` and exits while the project stays
+// blocked, so a client folding this feed into a per-project status would show
+// such a project as finished. The route composes the set from the same
+// `listProjectsAwaitingInput` read `GET /api/projects` uses, intersected with
+// the projects the returned runs already reveal so it can never widen what a
+// caller may see.
+
+import http from 'node:http';
+import express from 'express';
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  closeDatabase,
+  ensureWorkspaceProject,
+  getWorkspaceProject,
+  getWorkspaceProjectByProjectId,
+  insertConversation,
+  insertProject,
+  openDatabase,
+  upsertMessage,
+} from '../src/db.js';
+import { createAuthorizeProjectRequest } from '../src/collab/project-request-authority.js';
+import { createEnforceWorkspaceProjectMutation } from '../src/routes/project/index.js';
+import { workspaceContextFromDirectoryItem } from '../src/collab/vela-workspace-context.js';
+import { registerRunRoutes } from '../src/routes/runs.js';
+import { connectorService } from '../src/connectors/service.js';
+
+let server: http.Server | null = null;
+let tempDir: string | null = null;
+
+afterEach(async () => {
+  if (server) {
+    const toClose = server;
+    server = null;
+    await new Promise<void>((resolve) => toClose.close(() => resolve()));
+  }
+  closeDatabase();
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  tempDir = null;
+});
+
+const TEAM_PROJECT = 'p-team-awaiting';
+const UNBOUND_PROJECT = 'p-unbound-awaiting';
+const ANSWERED_PROJECT = 'p-unbound-answered';
+const QUIET_PROJECT = 'p-unbound-quiet';
+/** Awaiting input, but no run of its own — must never surface through another
+ *  project's query. */
+const RUNLESS_PROJECT = 'p-unbound-runless';
+const WORKSPACE_ID = 'ws-awaiting';
+const OWNER_MEMBER_ID = 'member-owner-awaiting';
+
+const RENDERABLE_FORM =
+  'Which direction? <question-form>{"questions":[{"id":"dir","label":"Direction?"}]}</question-form>';
+
+function sendApiError(
+  res: any,
+  status: number,
+  code: string,
+  message: string,
+  details: Record<string, unknown> = {},
+) {
+  return res.status(status).json({ error: { code, message, ...details } });
+}
+
+function workspaceHeaders(memberId: string, role: 'owner' | 'admin' | 'member') {
+  return {
+    'x-od-workspace-id': WORKSPACE_ID,
+    'x-od-workspace-member-id': memberId,
+    'x-od-workspace-role': role,
+  };
+}
+
+function seedRun(runs: Map<string, any>, input: Record<string, unknown>) {
+  const run: Record<string, any> = {
+    conversationId: null,
+    assistantMessageId: null,
+    clientRequestId: null,
+    requestFingerprint: null,
+    workspaceScope: null,
+    message: null,
+    currentPrompt: null,
+    status: 'succeeded',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    events: [],
+    clients: new Set(),
+    ...input,
+  };
+  runs.set(String(run.id), run);
+  return run;
+}
+
+/** An assistant turn that asked, optionally followed by the user's answer. */
+function seedConversation(
+  db: ReturnType<typeof openDatabase>,
+  projectId: string,
+  options: { asked: boolean; answered?: boolean },
+) {
+  const conversationId = `conv-${projectId}`;
+  insertConversation(db, { id: conversationId, projectId, createdAt: 1, updatedAt: 1 });
+  if (!options.asked) return;
+  upsertMessage(db, conversationId, {
+    id: `msg-${projectId}-ask`,
+    role: 'assistant',
+    content: RENDERABLE_FORM,
+    createdAt: 10,
+  });
+  if (options.answered) {
+    upsertMessage(db, conversationId, {
+      id: `msg-${projectId}-answer`,
+      role: 'user',
+      content: 'Left.',
+      createdAt: 20,
+    });
+  }
+}
+
+async function startServer() {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-runs-awaiting-'));
+  const db = openDatabase(tempDir);
+  const now = Date.now();
+  for (const id of [TEAM_PROJECT, UNBOUND_PROJECT, ANSWERED_PROJECT, QUIET_PROJECT, RUNLESS_PROJECT]) {
+    insertProject(db, { id, name: id, createdAt: now, updatedAt: now });
+  }
+  ensureWorkspaceProject(db, {
+    projectId: TEAM_PROJECT,
+    workspaceId: WORKSPACE_ID,
+    visibility: 'team',
+    resourceState: 'active',
+    createdByWorkspaceMemberId: OWNER_MEMBER_ID,
+  });
+  seedConversation(db, TEAM_PROJECT, { asked: true });
+  seedConversation(db, UNBOUND_PROJECT, { asked: true });
+  seedConversation(db, ANSWERED_PROJECT, { asked: true, answered: true });
+  seedConversation(db, QUIET_PROJECT, { asked: false });
+  seedConversation(db, RUNLESS_PROJECT, { asked: true });
+
+  const runs = new Map<string, any>();
+  seedRun(runs, { id: 'run-team-amr', projectId: TEAM_PROJECT, agentId: 'amr' });
+  seedRun(runs, { id: 'run-unbound', projectId: UNBOUND_PROJECT, agentId: 'claude' });
+  seedRun(runs, { id: 'run-answered', projectId: ANSWERED_PROJECT, agentId: 'claude' });
+  seedRun(runs, { id: 'run-quiet', projectId: QUIET_PROJECT, agentId: 'claude' });
+
+  const runsService = {
+    get: (id: string) => runs.get(id) ?? null,
+    list: (filters: { projectId?: unknown } = {}) =>
+      Array.from(runs.values()).filter(
+        (run) => typeof filters.projectId !== 'string' || run.projectId === filters.projectId,
+      ),
+    statusBody: (run: any) => ({ ...run }),
+    fail: (run: any, code: string, message: string) => {
+      run.status = 'failed';
+      run.errorCode = code;
+      run.error = message;
+    },
+    isTerminal: (status: string) =>
+      status === 'succeeded' || status === 'failed' || status === 'canceled',
+  };
+
+  // Loosely typed on purpose, like the run-create gate harness: the route
+  // deps are cast to `any` below and the literal union is not worth spelling.
+  const verifyWorkspaceRequestAuthority = async (req: any): Promise<any> => {
+    const workspaceId = req.get('x-od-workspace-id');
+    const memberId = req.get('x-od-workspace-member-id');
+    if (!workspaceId || !memberId) {
+      return {
+        ok: false,
+        status: 400,
+        code: 'WORKSPACE_CONTEXT_REQUIRED',
+        message: 'an explicit workspace context is required',
+      };
+    }
+    return {
+      ok: true,
+      context: workspaceContextFromDirectoryItem({
+        workspaceId,
+        workspaceName: workspaceId,
+        workspaceType: 'team',
+        workspaceMemberId: memberId,
+        role: memberId === OWNER_MEMBER_ID ? 'owner' : 'member',
+        memberStatus: 'active',
+        lifecycleState: 'active',
+      }),
+    };
+  };
+
+  const app = express();
+  app.use(express.json());
+  registerRunRoutes(app, {
+    db,
+    design: {
+      runs: runsService,
+      analytics: { capture: () => {} },
+      getAppVersion: () => 'test',
+    },
+    http: {
+      createSseResponse: () => ({ send() {}, end() {}, cleanup() {} }),
+      sendApiError,
+    },
+    paths: { PROJECTS_DIR: tempDir, RUNTIME_DATA_DIR: tempDir },
+    agents: {
+      detectAgents: async () => [],
+      getAgentDef: () => null,
+    },
+    chat: { startChatRun: async () => undefined },
+    byokCredentials: { has: async () => false },
+    lifecycle: { isDaemonShuttingDown: () => false },
+    plugins: {
+      connectorService,
+      detectSkillPluginCandidateOnRunSuccess: () => {},
+      firePipelineForRun: () => {},
+      loadPluginRegistryView: async () => ({} as any),
+      renderPluginBriefTemplate: (template: string) => template,
+    },
+    telemetry: {
+      reportRunCompletionTelemetryFallback: () => {},
+      resolveRunProjectKindForAnalytics: () => null,
+      runArtifactBaselines: { take: () => undefined },
+      runRetryEventsForAnalytics: () => [],
+    },
+    messages: {
+      pinAssistantMessageOnRunCreate: () => ({ ok: true }),
+      reconcileAssistantMessageOnRunEnd: () => {},
+    },
+    enforceWorkspaceProjectMutation: createEnforceWorkspaceProjectMutation(
+      verifyWorkspaceRequestAuthority,
+    ),
+    amrWorkspaceScope: { isSignedIn: () => false },
+    authorizeProjectRequest: createAuthorizeProjectRequest({
+      db,
+      getWorkspaceProject: (dbArg: unknown, workspaceId: string, projectId: string) =>
+        getWorkspaceProject(dbArg as ReturnType<typeof openDatabase>, workspaceId, projectId),
+      getWorkspaceProjectByProjectId: (dbArg: unknown, projectId: string) =>
+        getWorkspaceProjectByProjectId(dbArg as ReturnType<typeof openDatabase>, projectId),
+      verifyWorkspaceRequestAuthority,
+      sendApiError,
+    }),
+    projectStore: {
+      getWorkspaceProject,
+      getWorkspaceProjectByProjectId,
+      ensureWorkspaceProject: (dbArg: any, input: any) => ensureWorkspaceProject(dbArg, input),
+    },
+  } as any);
+  const created = http.createServer(app);
+  server = created;
+  await new Promise<void>((resolve) => created.listen(0, resolve));
+  const address = created.address();
+  const port = typeof address === 'object' && address ? address.port : 0;
+  return `http://127.0.0.1:${port}`;
+}
+
+type RunListBody = {
+  runs: Array<{ id: string; projectId: string | null; status: string }>;
+  awaitingInputProjectIds?: string[];
+};
+
+describe('GET /api/runs — awaitingInputProjectIds', () => {
+  it('flags a project whose succeeded run left a question the user has not answered', async () => {
+    const baseUrl = await startServer();
+    const response = await fetch(`${baseUrl}/api/runs?projectId=${UNBOUND_PROJECT}`);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as RunListBody;
+    expect(body.runs.map((run) => run.status)).toEqual(['succeeded']);
+    expect(body.awaitingInputProjectIds).toEqual([UNBOUND_PROJECT]);
+  });
+
+  it('always sends the field, empty when nothing is pending', async () => {
+    const baseUrl = await startServer();
+    const quiet = (await (await fetch(`${baseUrl}/api/runs?projectId=${QUIET_PROJECT}`)).json()) as RunListBody;
+    expect(quiet.runs).toHaveLength(1);
+    expect(quiet.awaitingInputProjectIds).toEqual([]);
+
+    // A later user reply answers the form, so the project is no longer blocked.
+    const answered = (await (await fetch(`${baseUrl}/api/runs?projectId=${ANSWERED_PROJECT}`)).json()) as RunListBody;
+    expect(answered.runs).toHaveLength(1);
+    expect(answered.awaitingInputProjectIds).toEqual([]);
+  });
+
+  it('never names a project the returned runs do not reveal', async () => {
+    const baseUrl = await startServer();
+    // RUNLESS_PROJECT is awaiting input in the database, but it has no run in
+    // this feed — so a query for another project must not leak its id.
+    const body = (await (await fetch(`${baseUrl}/api/runs?projectId=${UNBOUND_PROJECT}`)).json()) as RunListBody;
+    expect(body.awaitingInputProjectIds).not.toContain(RUNLESS_PROJECT);
+    expect(body.awaitingInputProjectIds).not.toContain(TEAM_PROJECT);
+
+    // Nor when the caller's own project has no visible run at all: the
+    // headerless view of the Team project hides its AMR run, and the set
+    // follows the runs rather than the query.
+    const headerless = (await (await fetch(`${baseUrl}/api/runs?projectId=${TEAM_PROJECT}`)).json()) as RunListBody;
+    expect(headerless.runs).toEqual([]);
+    expect(headerless.awaitingInputProjectIds).toEqual([]);
+  });
+
+  it('reports the Team project once its run is visible to an authorized member', async () => {
+    const baseUrl = await startServer();
+    const response = await fetch(`${baseUrl}/api/runs?projectId=${TEAM_PROJECT}`, {
+      headers: workspaceHeaders(OWNER_MEMBER_ID, 'owner'),
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as RunListBody;
+    expect(body.runs.map((run) => run.id)).toEqual(['run-team-amr']);
+    expect(body.awaitingInputProjectIds).toEqual([TEAM_PROJECT]);
+  });
+});

--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -59,7 +59,7 @@ import { PlanWordmark, planBadgeTierForWorkspace } from './PlanWordmark';
 import { RemixIcon } from './RemixIcon';
 import { InviteDialog } from './InviteDialog';
 import { RailRecentRow } from './entry-nav-rail/RailRecentRow';
-import { useProjectRunStatuses } from '../hooks/useProjectRunStatuses';
+import { useProjectRunSummaries } from '../hooks/useProjectRunStatuses';
 import { MessageCenter } from './MessageCenter';
 import type { EntrySettingsSection } from './EntrySettingsMenu';
 import type { Project } from '../types';
@@ -339,14 +339,15 @@ function readStoredRecentOpen(): boolean {
 }
 
 /**
- * Projects whose finished run the user has already gone in and looked at (per
- * product: 点进去之后对号换回默认 icon).
+ * Which finished run the user has already looked at, per project (per product:
+ * 点进去之后对号换回默认 icon).
  *
- * The ✓ is a NOTICE — "a run finished here since you last looked" — not a
- * permanent property of the project, so opening the project spends it and the
- * row falls back to its default chat mark. The acknowledgement is dropped again
- * the moment that project starts working (`queued` / `running`), so the NEXT
- * completion is announced like the first.
+ * Invariant: a ✓ is acknowledged for ONE specific finished run — the value is
+ * that run's id — and a newer finished run is a new notice. Keyed on the run
+ * rather than the project so the acknowledgement stays correct even when the
+ * section was collapsed (and not polling) for the whole of the next run: on
+ * re-expanding, the newest terminal run's id no longer matches and the ✓ shows
+ * again. Only a project whose live status is `succeeded` consults this at all.
  *
  * Persisted next to the section's own open/closed flag: a reload re-reads the
  * same runs feed and would otherwise re-raise every ✓ the user has already
@@ -354,23 +355,31 @@ function readStoredRecentOpen(): boolean {
  */
 const RECENT_SEEN_DONE_STORAGE_KEY = 'od.entry.railRecentSeenDone';
 
-function readStoredSeenDone(): ReadonlySet<string> {
-  if (typeof window === 'undefined') return new Set();
+type AcknowledgedRuns = Readonly<Record<string, string>>;
+
+function readStoredSeenDone(): AcknowledgedRuns {
+  if (typeof window === 'undefined') return {};
   try {
     const raw = window.localStorage.getItem(RECENT_SEEN_DONE_STORAGE_KEY);
     const parsed: unknown = raw ? JSON.parse(raw) : null;
-    if (!Array.isArray(parsed)) return new Set();
-    return new Set(parsed.filter((id): id is string => typeof id === 'string'));
+    // Anything but a plain object of run ids — including a bare list of
+    // project ids, which cannot say which run it meant — reads as "nothing
+    // acknowledged". The worst case is one ✓ the user has already seen, never a
+    // missing one.
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const acknowledged: Record<string, string> = {};
+    for (const [projectId, runId] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof runId === 'string' && runId) acknowledged[projectId] = runId;
+    }
+    return acknowledged;
   } catch {
-    // Corrupt or unavailable storage: start from "nothing acknowledged". The
-    // worst case is one ✓ the user has already seen, never a missing one.
-    return new Set();
+    return {};
   }
 }
 
-function writeStoredSeenDone(ids: ReadonlySet<string>): void {
+function writeStoredSeenDone(acknowledged: AcknowledgedRuns): void {
   try {
-    window.localStorage.setItem(RECENT_SEEN_DONE_STORAGE_KEY, JSON.stringify([...ids]));
+    window.localStorage.setItem(RECENT_SEEN_DONE_STORAGE_KEY, JSON.stringify(acknowledged));
   } catch {
     // Private mode / storage disabled: the ✓ still clears for this session.
   }
@@ -413,44 +422,31 @@ function RailRecentSection({
   // Only polled while the disclosure is open: it costs one request per listed
   // project (≤ RAIL_RECENT_LIMIT), and a collapsed section shows no glyphs.
   const runStatusProjectIds = useMemo(() => items.map((item) => item.id), [items]);
-  const runStatusByProjectId = useProjectRunStatuses(runStatusProjectIds, {
+  const runSummaryByProjectId = useProjectRunSummaries(runStatusProjectIds, {
     enabled: open,
     workspaceContext,
   });
-  const [seenDone, setSeenDone] = useState<ReadonlySet<string>>(readStoredSeenDone);
-  // A project that is working again has something new to announce when it
-  // finishes, so its old acknowledgement is spent. Only a LIVE status clears it
-  // — never a missing one, or the first render (statuses arrive one fetch
-  // later) would wipe every ✓ the user had already cleared.
-  useEffect(() => {
-    setSeenDone((prev) => {
-      const next = new Set(prev);
-      for (const id of prev) {
-        const status = runStatusByProjectId.get(id);
-        if (status === 'queued' || status === 'running') next.delete(id);
-      }
-      if (next.size === prev.size) return prev;
-      writeStoredSeenDone(next);
-      return next;
-    });
-  }, [runStatusByProjectId]);
+  const [seenDone, setSeenDone] = useState<AcknowledgedRuns>(readStoredSeenDone);
 
-  // Opening a project is what spends its ✓ (per product). Recorded only when
-  // there is actually one on screen, so the stored set stays the list of
-  // notices the user has dismissed rather than of every project ever opened.
+  // Opening a project is what spends its ✓ (per product): the finished run on
+  // screen is recorded as seen. Recorded only when there is actually one, so
+  // the store stays the list of notices the user has dismissed rather than of
+  // every project ever opened.
   const openProject = useCallback(
     (id: string) => {
-      if (runStatusByProjectId.get(id) === 'succeeded') {
+      const summary = runSummaryByProjectId.get(id);
+      if (summary?.status === 'succeeded' && summary.latestTerminalRunId) {
+        const runId = summary.latestTerminalRunId;
         setSeenDone((prev) => {
-          if (prev.has(id)) return prev;
-          const next = new Set(prev).add(id);
+          if (prev[id] === runId) return prev;
+          const next = { ...prev, [id]: runId };
           writeStoredSeenDone(next);
           return next;
         });
       }
       return onOpen?.(id);
     },
-    [onOpen, runStatusByProjectId],
+    [onOpen, runSummaryByProjectId],
   );
 
   function toggle() {
@@ -494,11 +490,16 @@ function RailRecentSection({
         <div className="accordion-collapsible-inner">
           <ul className="entry-nav-rail__recent-list">
             {items.map((project) => {
-              const status = runStatusByProjectId.get(project.id);
+              const summary = runSummaryByProjectId.get(project.id);
+              const status = summary?.status;
               // An acknowledged ✓ is DROPPED, not drawn quieter: the row goes
               // back to its default chat mark (per product). Every other status
-              // is live and stays.
-              const acknowledged = status === 'succeeded' && seenDone.has(project.id);
+              // is live and stays. Acknowledged means THIS finished run was
+              // seen; a newer one is a new notice.
+              const acknowledged =
+                status === 'succeeded'
+                && summary?.latestTerminalRunId !== undefined
+                && seenDone[project.id] === summary.latestTerminalRunId;
               return (
                 <li key={project.id}>
                   <RailRecentRow

--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -25,8 +25,10 @@
 // personal_byok workspace still has full team features.
 
 import {
+  useCallback,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
@@ -56,8 +58,11 @@ import { GITHUB_STARS_FALLBACK_LABEL, formatStars, useGithubStars } from './useG
 import { PlanWordmark, planBadgeTierForWorkspace } from './PlanWordmark';
 import { RemixIcon } from './RemixIcon';
 import { InviteDialog } from './InviteDialog';
+import { RailRecentRow } from './entry-nav-rail/RailRecentRow';
+import { useProjectRunStatuses } from '../hooks/useProjectRunStatuses';
 import { MessageCenter } from './MessageCenter';
 import type { EntrySettingsSection } from './EntrySettingsMenu';
+import type { Project } from '../types';
 import { isRtlLocale, useI18n } from '../i18n';
 import { useDismissOnOutsideInteraction } from '../hooks/useDismissOnOutsideInteraction';
 import { ENTRY_RAIL_TOGGLE_EVENT } from './entryRailBridge';
@@ -241,6 +246,18 @@ interface Props {
   updaterSlot?: ReactNode;
   /** Optional notice shown above the footer controls. */
   footerNotice?: ReactNode;
+  /** Projects for the rail's 最近浏览过 section (per product: 在插件下边新增一个
+   *  类型). The SAME catalog and the SAME order 全部项目's 最近浏览过 tab shows —
+   *  EntryShell hands over the one it already feeds that grid, so the two can
+   *  never drift; this list only takes the head of it. Empty (or absent) hides
+   *  the section entirely. */
+  recentProjects?: Project[];
+  /** Row actions for the 最近浏览过 list's ⋮ menu. Omit either to drop its item. */
+  onRenameRecentProject?: (id: string, name: string) => void;
+  onDeleteRecentProject?: (id: string) => Promise<boolean | void> | boolean | void;
+  /** Opens one of those projects — the pull-first opener, so a shared project
+   *  that is not local yet still lands. */
+  onOpenRecentProject?: (id: string) => void | Promise<unknown>;
   /** One-off targeted announcement coordination owned by the Home shell. */
   priorityAnnouncementActive?: boolean;
   onPriorityAnnouncementPendingChange?: (pending: boolean) => void;
@@ -295,6 +312,210 @@ function NavButton({
       <span className="entry-nav-rail__btn-icon" aria-hidden>{children}</span>
       <span className="entry-nav-rail__btn-label">{label}</span>
     </button>
+  );
+}
+
+/** How many of the recent projects the rail lists. The rail is navigation, not
+ *  a grid: past ~8 rows the section outgrows the destinations above it and the
+ *  whole rail starts to scroll. 全部项目 is one click away for the rest, and the
+ *  section's own footer row goes there. */
+const RAIL_RECENT_LIMIT = 8;
+
+/** Remembers the section's open/closed state across launches, next to the
+ *  rail's own `od.entry.railOpen`. A disclosure the user closed should stay
+ *  closed — re-opening it on every boot is the whole reason to have the
+ *  control. */
+const RECENT_SECTION_STORAGE_KEY = 'od.entry.railRecentOpen';
+
+function readStoredRecentOpen(): boolean {
+  if (typeof window === 'undefined') return true;
+  try {
+    // Default OPEN: the section is new and a collapsed-by-default disclosure
+    // reads as a missing feature.
+    return window.localStorage.getItem(RECENT_SECTION_STORAGE_KEY) !== 'false';
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Projects whose finished run the user has already gone in and looked at (per
+ * product: 点进去之后对号换回默认 icon).
+ *
+ * The ✓ is a NOTICE — "a run finished here since you last looked" — not a
+ * permanent property of the project, so opening the project spends it and the
+ * row falls back to its default chat mark. The acknowledgement is dropped again
+ * the moment that project starts working (`queued` / `running`), so the NEXT
+ * completion is announced like the first.
+ *
+ * Persisted next to the section's own open/closed flag: a reload re-reads the
+ * same runs feed and would otherwise re-raise every ✓ the user has already
+ * cleared.
+ */
+const RECENT_SEEN_DONE_STORAGE_KEY = 'od.entry.railRecentSeenDone';
+
+function readStoredSeenDone(): ReadonlySet<string> {
+  if (typeof window === 'undefined') return new Set();
+  try {
+    const raw = window.localStorage.getItem(RECENT_SEEN_DONE_STORAGE_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : null;
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((id): id is string => typeof id === 'string'));
+  } catch {
+    // Corrupt or unavailable storage: start from "nothing acknowledged". The
+    // worst case is one ✓ the user has already seen, never a missing one.
+    return new Set();
+  }
+}
+
+function writeStoredSeenDone(ids: ReadonlySet<string>): void {
+  try {
+    window.localStorage.setItem(RECENT_SEEN_DONE_STORAGE_KEY, JSON.stringify([...ids]));
+  } catch {
+    // Private mode / storage disabled: the ✓ still clears for this session.
+  }
+}
+
+/**
+ * 最近浏览过 — a collapsible list of the projects the 全部项目 view's own
+ * 最近浏览过 tab would show, sitting under 插件 in the rail (per product).
+ *
+ * It takes the catalog EntryShell already feeds that grid and shows the head of
+ * it in the same order (most recently touched first), so the rail and the grid
+ * can never disagree about what "recent" means. Rows open the project through
+ * the same pull-first opener the grid uses.
+ */
+function RailRecentSection({
+  projects,
+  onOpen,
+  onRename,
+  onDelete,
+  workspaceContext,
+  label,
+}: {
+  projects: Project[];
+  onOpen?: (id: string) => void | Promise<unknown>;
+  onRename?: (id: string, name: string) => void;
+  onDelete?: (id: string) => Promise<boolean | void> | boolean | void;
+  workspaceContext?: WorkspaceCollabContext | null;
+  label: string;
+}) {
+  const [open, setOpen] = useState(readStoredRecentOpen);
+  const items = useMemo(
+    () => [...projects].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, RAIL_RECENT_LIMIT),
+    [projects],
+  );
+  // Run status for the rows' leading glyph. `Project.status` cannot serve it —
+  // it only arrives on the UNSCOPED project list, so it is absent for every
+  // workspace-bound project (see the hook's own note) — and this is the same
+  // feed the workspace tab dropdown reads, which is what keeps the two glyph
+  // columns telling one story.
+  // Only polled while the disclosure is open: it costs one request per listed
+  // project (≤ RAIL_RECENT_LIMIT), and a collapsed section shows no glyphs.
+  const runStatusProjectIds = useMemo(() => items.map((item) => item.id), [items]);
+  const runStatusByProjectId = useProjectRunStatuses(runStatusProjectIds, {
+    enabled: open,
+    workspaceContext,
+  });
+  const [seenDone, setSeenDone] = useState<ReadonlySet<string>>(readStoredSeenDone);
+  // A project that is working again has something new to announce when it
+  // finishes, so its old acknowledgement is spent. Only a LIVE status clears it
+  // — never a missing one, or the first render (statuses arrive one fetch
+  // later) would wipe every ✓ the user had already cleared.
+  useEffect(() => {
+    setSeenDone((prev) => {
+      const next = new Set(prev);
+      for (const id of prev) {
+        const status = runStatusByProjectId.get(id);
+        if (status === 'queued' || status === 'running') next.delete(id);
+      }
+      if (next.size === prev.size) return prev;
+      writeStoredSeenDone(next);
+      return next;
+    });
+  }, [runStatusByProjectId]);
+
+  // Opening a project is what spends its ✓ (per product). Recorded only when
+  // there is actually one on screen, so the stored set stays the list of
+  // notices the user has dismissed rather than of every project ever opened.
+  const openProject = useCallback(
+    (id: string) => {
+      if (runStatusByProjectId.get(id) === 'succeeded') {
+        setSeenDone((prev) => {
+          if (prev.has(id)) return prev;
+          const next = new Set(prev).add(id);
+          writeStoredSeenDone(next);
+          return next;
+        });
+      }
+      return onOpen?.(id);
+    },
+    [onOpen, runStatusByProjectId],
+  );
+
+  function toggle() {
+    setOpen((wasOpen) => {
+      const next = !wasOpen;
+      try {
+        window.localStorage.setItem(RECENT_SECTION_STORAGE_KEY, String(next));
+      } catch {
+        // Private mode / storage disabled: the section still toggles, it just
+        // forgets. Never let a storage failure swallow the interaction.
+      }
+      return next;
+    });
+  }
+
+  // Nothing to list is not an empty state worth a row: a workspace with no
+  // projects yet should see the rail it had before this section existed.
+  if (items.length === 0) return null;
+
+  return (
+    <div className="entry-nav-rail__recent">
+      <button
+        type="button"
+        className="entry-nav-rail__recent-head"
+        onClick={toggle}
+        aria-expanded={open}
+        data-testid="entry-nav-recent-toggle"
+      >
+        {/* Title first, chevron trailing (per product: 展开和收起的按钮在最右侧).
+            DOM order follows the visual one rather than an `order` swap, so the
+            reading order matches too. */}
+        <span className="entry-nav-rail__recent-title">{label}</span>
+        <span className="entry-nav-rail__recent-chevron" aria-hidden>
+          <Icon name={open ? 'chevron-down' : 'chevron-right'} size={14} />
+        </span>
+      </button>
+      {/* The canonical disclosure pair (index.css / composio.css): the outer
+          grid animates 0fr → 1fr, the inner box carries the clip. `hidden` on
+          the wrapper would skip the transition entirely. */}
+      <div className={`accordion-collapsible${open ? ' open' : ''}`}>
+        <div className="accordion-collapsible-inner">
+          <ul className="entry-nav-rail__recent-list">
+            {items.map((project) => {
+              const status = runStatusByProjectId.get(project.id);
+              // An acknowledged ✓ is DROPPED, not drawn quieter: the row goes
+              // back to its default chat mark (per product). Every other status
+              // is live and stays.
+              const acknowledged = status === 'succeeded' && seenDone.has(project.id);
+              return (
+                <li key={project.id}>
+                  <RailRecentRow
+                    project={project}
+                    workspaceContext={workspaceContext}
+                    runStatus={acknowledged ? undefined : status}
+                    onOpen={openProject}
+                    onRename={onRename}
+                    onDelete={onDelete}
+                  />
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -1276,6 +1497,10 @@ export function EntryNavRail({
   onSignedOut,
   updaterSlot,
   footerNotice,
+  recentProjects,
+  onOpenRecentProject,
+  onRenameRecentProject,
+  onDeleteRecentProject,
   priorityAnnouncementActive,
   onPriorityAnnouncementPendingChange,
   priorityAnnouncementCurrentPlanId,
@@ -1804,6 +2029,17 @@ export function EntryNavRail({
             >
               <Icon name="puzzle" size={16} />
             </NavButton>
+            {/* 最近浏览过 sits under 插件 (per product) — the last thing in the
+                destination list, because it is a list of CONTENT rather than a
+                place to go. */}
+            <RailRecentSection
+              projects={recentProjects ?? []}
+              onOpen={onOpenRecentProject}
+              onRename={onRenameRecentProject}
+              onDelete={onDeleteRecentProject}
+              workspaceContext={context}
+              label={t('recentProjects.collectionRecent')}
+            />
             {/* Product decision (2026-07-20): 成员 and 数据大盘 leave the rail
                 entirely — both surfaces live in B's console and the rail should
                 not advertise them. Workspace 设置 stays, and still links OUT to

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -1650,6 +1650,15 @@ export function EntryShell({
           // only a successful null context (or known local sign-out) may show
           // the sign-in card.
           footerNotice={accountFooterNotice}
+          /* Same catalog and same opener the 全部项目 grid uses below, so the
+             rail's 最近浏览过 list and that view's 最近浏览过 tab are two views of
+             ONE list rather than two sorts of two lists. */
+          recentProjects={projectSearchProjects}
+          onOpenRecentProject={handleOpenAllProjects}
+          /* Same handlers the projects grid drives its own row menu with, so a
+             rename or a delete from the rail lands in exactly one place. */
+          onRenameRecentProject={onRenameProject}
+          onDeleteRecentProject={onDeleteProject}
           priorityAnnouncementActive={
             view === 'home'
             && goPlanSunsetMessagePending

--- a/apps/web/src/components/ProjectRunStatusIcon.tsx
+++ b/apps/web/src/components/ProjectRunStatusIcon.tsx
@@ -1,0 +1,102 @@
+/**
+ * The one place a `ProjectDisplayStatus` becomes a glyph.
+ *
+ * Finished work is a static badge; anything still moving — or stalled in a way
+ * the user has to act on — is the same rotating orb in a different colour, so
+ * the row reads as one object changing state rather than four unrelated icons.
+ *
+ * Returns `null` for the statuses that have nothing to say (`not_started`,
+ * `canceled`). Callers must still reserve the slot so names stay aligned; that
+ * is the caller's layout concern, not this component's.
+ */
+import type { ProjectDisplayStatus } from '@open-design/contracts';
+import { SiriOrb } from './SiriOrb';
+
+/**
+ * Recolouring the orb means moving BOTH accent slots, not just `--c1`.
+ * `--c2` is the second accent and the outer glow, and the stock palette pairs
+ * green `#00FF08` with spring-green `#00FFAE` — a neighbouring hue. Leaving it
+ * green while `--c1` turns orange mixes the two into a muddy red-green dot; the
+ * pairs below keep each state's two slots in one hue family, the way the
+ * original does. Both stay chromatic, as `--c2` requires.
+ */
+/** Awaiting a reply, or finished with declared work left undone. */
+const ATTENTION = { c1: '#EDC337', c2: '#FFE066' };
+/** The run failed. */
+const FAILED = { c1: '#F8672F', c2: '#FFA94D' };
+
+/**
+ * Whether this status draws anything at all.
+ *
+ * Callers need to know BEFORE rendering: the dropdown only reserves its icon
+ * column when at least one row will fill it, so an all-quiet list is not left
+ * indented past an empty gutter.
+ */
+export function hasRunStatusGlyph(status: ProjectDisplayStatus | undefined): boolean {
+  return status !== undefined && status !== 'not_started' && status !== 'canceled';
+}
+
+interface Props {
+  status: ProjectDisplayStatus;
+  size?: number;
+  /** Localized status name, announced to assistive tech. */
+  label?: string;
+}
+
+/**
+ * Completed: a dark disc with the checkmark knocked out of it. Two hardcoded
+ * fills, so it cannot go through `Icon` — that component emits a single
+ * `currentColor` path. Standalone two-colour marks are the repo's convention
+ * here (see PlanWordmark, EditorIcon).
+ *
+ * The viewBox is the disc's own bounds (a circle of r=10 centred at 12,12),
+ * NOT the artwork's 24-unit frame: at `size` 14 that frame left the disc
+ * drawing 11.7px while the running orb — which fills its box edge to edge —
+ * drew the full 14, so "running" and "done" were visibly different sizes in
+ * the same column (per product: 运行中和完成的 icon 大小一样 14px). Cropping to
+ * the ink makes `size` mean the same thing for both.
+ */
+function SucceededBadge({ size, label }: { size: number; label?: string }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="2 2 20 20"
+      fill="none"
+      focusable="false"
+      {...(label ? { role: 'img', 'aria-label': label } : { 'aria-hidden': true })}
+    >
+      <path
+        d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
+        fill="#202020"
+      />
+      <path
+        d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22ZM17.4571 9.45711L11 15.9142L6.79289 11.7071L8.20711 10.2929L11 13.0858L16.0429 8.04289L17.4571 9.45711Z"
+        fill="#00FF08"
+      />
+    </svg>
+  );
+}
+
+export function ProjectRunStatusIcon({ status, size = 14, label }: Props) {
+  switch (status) {
+    case 'succeeded':
+      return <SucceededBadge size={size} label={label} />;
+    case 'running':
+      return <SiriOrb size={size} state="thinking" label={label} />;
+    case 'queued':
+      // Same green: it is the same "not finished" family. Only the speed says
+      // this one has not actually started turning over yet.
+      return <SiriOrb size={size} state="idle" label={label} />;
+    case 'awaiting_input':
+    case 'incomplete':
+      return <SiriOrb size={size} state="idle" colors={ATTENTION} label={label} />;
+    case 'failed':
+      return <SiriOrb size={size} state="idle" colors={FAILED} label={label} />;
+    case 'not_started':
+    case 'canceled':
+      return null;
+    default:
+      return null;
+  }
+}

--- a/apps/web/src/components/SiriOrb.module.css
+++ b/apps/web/src/components/SiriOrb.module.css
@@ -1,0 +1,208 @@
+/* Siri Orb — neon build.
+ *
+ * Adapted from SmoothUI's Siri Orb, © Edu Calvo (educlopez), MIT licence.
+ * https://github.com/educlopez/smoothui
+ *
+ * Every quantity the orb draws comes from a custom property, so the component
+ * beside this file only does the size math CSS cannot express (contrast is
+ * unitless and cannot be derived from a length).
+ *
+ * `--siri-orb-angle` is namespaced deliberately: CSS Modules scope class and
+ * keyframe names but NOT custom properties, so `@property --angle` would
+ * register a global of that name. The repo's other registered properties are
+ * namespaced for the same reason (see `--project-chat-panel-width` in
+ * shell.css).
+ */
+
+@property --siri-orb-angle {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 0deg;
+}
+
+.orb {
+  /* Palette. Three constraints from the original, none of them negotiable:
+     `--c3` may occupy at most 2 of the 8 layers (more and the orb turns into a
+     black disc at some rotations); black must never be `--c2`, which doubles
+     as the outer glow colour and has to stay chromatic; `--c4` cannot be
+     dropped — it bridges 24% lightness to 87% and without it `contrast()`
+     bites a hard-edged chunk out of the sphere. Recolouring goes through
+     `--c1` (and `--c2` if the bloom needs to follow). */
+  --c1: #00ff08;
+  --c2: #00ffae;
+  --c3: #202020;
+  --c4: oklch(48% 0.13 152);
+  --c5: #eaffeb;
+  --bg: #202020;
+  --fill: oklch(48% 0.12 158);
+
+  --sat: 1.12;
+  --duration: 20s;
+  --drift: 9.6s;
+  --glow-opacity: 0.5;
+
+  /* Size-derived; the component overwrites all of these inline. */
+  --size: 24px;
+  --blur: 1px;
+  --contrast: 1.1;
+  --dot: 0.1px;
+  --shadow: 0.5px;
+  --rim: 1.5px;
+  --mask: 0%;
+
+  position: relative;
+  display: inline-block;
+  width: var(--size);
+  height: var(--size);
+  vertical-align: middle;
+}
+
+/* The bloom lives outside the disc, which clips its own overflow. */
+.glow {
+  position: absolute;
+  inset: -12%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 50%, var(--c2) 0%, transparent 64%);
+  filter: blur(calc(var(--size) * 0.28));
+  opacity: var(--glow-opacity);
+  pointer-events: none;
+}
+
+.disc {
+  position: relative;
+  display: grid;
+  grid-template-areas: "stack";
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  border-radius: 50%;
+  isolation: isolate;
+  /* Without this the transparent wedges punch through to the page. */
+  background: var(--fill);
+}
+
+.disc::before,
+.disc::after,
+.layer {
+  content: "";
+  display: block;
+  grid-area: stack;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+}
+
+/* Eight conic gradients turning at different speeds. The c5 highlight sits
+   third so the neons paint over its edges — on top it cuts a hard white
+   wedge. Long-hand `animation-*` rather than the shorthand, per the lesson
+   recorded in MatrixLoader.module.css: the shorthand resets siblings. */
+.disc::before {
+  background:
+    conic-gradient(from calc(var(--siri-orb-angle) *  2)   at 25% 70%, var(--c3), transparent 20% 80%, var(--c3)),
+    conic-gradient(from calc(var(--siri-orb-angle) *  2)   at 45% 75%, var(--c2), transparent 30% 60%, var(--c2)),
+    conic-gradient(from calc(var(--siri-orb-angle) * -1.5) at 32% 26%, var(--c5), transparent 14% 86%, var(--c5)),
+    conic-gradient(from calc(var(--siri-orb-angle) * -3)   at 80% 20%, var(--c1), transparent 40% 60%, var(--c1)),
+    conic-gradient(from calc(var(--siri-orb-angle) *  1.5) at 60% 35%, var(--c4), transparent 25% 75%, var(--c4)),
+    conic-gradient(from calc(var(--siri-orb-angle) *  2)   at 15% 5%,  var(--c2), transparent 10% 90%, var(--c2)),
+    conic-gradient(from calc(var(--siri-orb-angle) *  1)   at 20% 80%, var(--c1), transparent 10% 90%, var(--c1)),
+    conic-gradient(from calc(var(--siri-orb-angle) * -2)   at 85% 10%, var(--c3), transparent 20% 80%, var(--c3));
+  box-shadow: inset var(--bg) 0 0 var(--shadow) calc(var(--shadow) * 0.2);
+  filter: blur(var(--blur)) contrast(var(--contrast)) saturate(var(--sat));
+  animation-name: siri-orb-rotate;
+  animation-duration: var(--duration);
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}
+
+/* Fine dot texture, multiplied into the mesh. */
+.disc::after {
+  background-image: radial-gradient(circle at center, var(--bg) var(--dot), transparent var(--dot));
+  background-size: calc(var(--dot) * 2) calc(var(--dot) * 2);
+  backdrop-filter: blur(calc(var(--blur) * 2)) contrast(calc(var(--contrast) * 2));
+  mix-blend-mode: overlay;
+  mask-image: radial-gradient(black var(--mask), transparent 75%);
+}
+
+/* At icon sizes the mask has nothing left to grade, and keeping it only dims
+   the centre. The component sets `.isTiny` below 30px. */
+.isTiny .disc::after {
+  mask-image: none;
+}
+
+/* Icon-size palette. At 192px the near-black dark side reads as a sphere
+   turning away from the light; at 14px it is ~half of a 150-pixel dot, and the
+   orb stops looking like its own colour — a failed one reads "dark red blob",
+   not orange. Re-tint the two dark slots to a deep shade of the accent so the
+   whole dot stays in its colour family while keeping the light/dark modelling
+   the `contrast()` pass needs.
+   `--c3` is still exactly 2 of the 8 layers and `--c4` is still present, so
+   both of the original's structural constraints hold; only the hue changes.
+   `--c1` may be set inline by the component, and custom properties resolve at
+   computed-value time, so these mixes follow whatever colour it was given. */
+.isTiny {
+  --c3: color-mix(in srgb, var(--c1) 42%, #101010);
+  --c4: color-mix(in srgb, var(--c1) 62%, #123018);
+  --bg: color-mix(in srgb, var(--c1) 24%, #101010);
+}
+
+/* Drifting specular sheen — keeps the highlight from reading as printed on. */
+.sheen {
+  background:
+    radial-gradient(circle at 30% 24%, hsl(0 0% 100% / 0.32), transparent 34%),
+    radial-gradient(circle at 72% 80%, hsl(0 0% 100% / 0.07), transparent 48%);
+  mix-blend-mode: screen;
+  animation-name: siri-orb-drift;
+  animation-duration: var(--drift);
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
+  animation-direction: alternate;
+}
+
+/* Lit top edge, shaded bottom, thin inner ring. */
+.rim {
+  box-shadow:
+    inset 0 0 0 1px hsl(0 0% 100% / 0.16),
+    inset 0 calc(var(--rim) *  1)   calc(var(--rim) * 2)   hsl(0 0% 100% / 0.22),
+    inset 0 calc(var(--rim) * -1.2) calc(var(--rim) * 2.4) hsl(0 0% 0% / 0.4);
+  pointer-events: none;
+}
+
+@keyframes siri-orb-rotate {
+  to { --siri-orb-angle: 360deg; }
+}
+
+@keyframes siri-orb-drift {
+  0%   { transform: translate(-6%, -4%) scale(1.05); }
+  100% { transform: translate(7%, 6%)   scale(1.12); }
+}
+
+/* Speed only — the palette never changes with state, so the orb stays
+   recognisably the same object while it works. */
+.isThinking { --duration: 6s; --drift: 5s; }
+.isThinking .disc { transform: scale(1.02); }
+
+.isStreaming { --duration: 9s; --drift: 6.5s; }
+
+.isIdle {
+  --duration: 20s;
+  --glow-opacity: 0.32;
+  animation-name: siri-orb-breathe;
+  animation-duration: 5.5s;
+  animation-timing-function: cubic-bezier(0.645, 0.045, 0.355, 1);
+  animation-iteration-count: infinite;
+}
+
+@keyframes siri-orb-breathe {
+  0%, 100% { transform: scale(1); }
+  50%      { transform: scale(1.035); }
+}
+
+/* base.css already ships a global reduced-motion killswitch; this keeps the
+   component honest on its own terms too. The orb stays visible, just still. */
+@media (prefers-reduced-motion: reduce) {
+  .orb,
+  .disc::before,
+  .sheen {
+    animation: none;
+  }
+}

--- a/apps/web/src/components/SiriOrb.tsx
+++ b/apps/web/src/components/SiriOrb.tsx
@@ -1,0 +1,89 @@
+/**
+ * Siri Orb — a rotating neon sphere used as a "this is working" indicator.
+ *
+ * Adapted from SmoothUI's Siri Orb, © Edu Calvo (educlopez), MIT licence.
+ * https://github.com/educlopez/smoothui
+ *
+ * All the drawing lives in SiriOrb.module.css; this file only computes the
+ * size-derived quantities the stylesheet cannot (contrast is unitless, so it
+ * cannot be derived from a length in CSS).
+ */
+import type { CSSProperties } from 'react';
+import styles from './SiriOrb.module.css';
+
+/** Speed presets. The palette is deliberately NOT part of the state. */
+export type SiriOrbState = 'idle' | 'thinking' | 'streaming';
+
+interface Props {
+  /** Rendered edge length in px. */
+  size?: number;
+  state?: SiriOrbState;
+  /**
+   * Palette overrides. Only `c1` (and `c2`, the bloom) are meant to change —
+   * see the constraints documented in the stylesheet before touching the rest.
+   */
+  colors?: { c1?: string; c2?: string };
+  className?: string;
+  /** Announced to assistive tech; omit to keep the orb decorative. */
+  label?: string;
+}
+
+/** Mirrors the original component's responsive math. */
+function metrics(size: number) {
+  const small = size < 50;
+  const tiny = size < 30;
+  const blur = small ? Math.max(size * 0.008, 1) : Math.max(size * 0.015, 4);
+  const contrastBase = small ? Math.max(size * 0.004, 1.2) : Math.max(size * 0.008, 1.5);
+  return {
+    blur: `${blur}px`,
+    contrast: tiny ? 1.1 : small ? Math.max(contrastBase * 1.2, 1.3) : contrastBase,
+    dot: `${small ? Math.max(size * 0.004, 0.05) : Math.max(size * 0.008, 0.1)}px`,
+    shadow: `${small ? Math.max(size * 0.004, 0.5) : Math.max(size * 0.008, 2)}px`,
+    rim: `${Math.max(size * 0.06, 1.5)}px`,
+    mask: tiny ? '0%' : small ? '5%' : size < 100 ? '15%' : '25%',
+    tiny,
+  };
+}
+
+const STATE_CLASS: Record<SiriOrbState, string | undefined> = {
+  idle: styles.isIdle,
+  thinking: styles.isThinking,
+  streaming: styles.isStreaming,
+};
+
+export function SiriOrb({
+  size = 24,
+  state = 'thinking',
+  colors,
+  className,
+  label,
+}: Props) {
+  const m = metrics(size);
+  const style = {
+    '--size': `${size}px`,
+    '--blur': m.blur,
+    '--contrast': m.contrast,
+    '--dot': m.dot,
+    '--shadow': m.shadow,
+    '--rim': m.rim,
+    '--mask': m.mask,
+    ...(colors?.c1 ? { '--c1': colors.c1 } : {}),
+    ...(colors?.c2 ? { '--c2': colors.c2 } : {}),
+  } as CSSProperties;
+
+  return (
+    <span
+      className={[styles.orb, STATE_CLASS[state], m.tiny ? styles.isTiny : '', className]
+        .filter(Boolean)
+        .join(' ')}
+      style={style}
+      {...(label ? { role: 'img', 'aria-label': label } : { 'aria-hidden': true })}
+    >
+      <span className={styles.glow} aria-hidden />
+      <span className={styles.disc}>
+        <span className={`${styles.layer} ${styles.sheen}`} aria-hidden />
+        <span className={`${styles.layer} ${styles.rim}`} aria-hidden />
+      </span>
+    </span>
+  );
+}

--- a/apps/web/src/components/entry-nav-rail/RailRecentRow.tsx
+++ b/apps/web/src/components/entry-nav-rail/RailRecentRow.tsx
@@ -1,0 +1,522 @@
+// One row of the nav rail's 最近浏览过 list: the project name, a hover preview
+// that floats out to the right of the rail, and a ⋮ menu.
+//
+// The preview reuses the SAME cover decision the projects grid renders
+// (`lib/project-cover-cache`): the grid resolves a cover per (workspace,
+// project, version) and stores it in a process-wide LRU, so a rail row usually
+// has one already and paints instantly. When the cache misses — the user landed
+// on a surface that never rendered the grid — the row resolves it once on hover
+// with the cheap half of the grid's pipeline (files read + `selectProjectFileCover`)
+// and writes the result back through the same key, so the grid inherits it too.
+// Deliberately NOT ported: the grid's HEAD probe, deck-document preload and
+// design-system special cases. Those exist to avoid a broken <img> in a large
+// visible card; here a cover that fails to load simply falls back to the tinted
+// glyph the same component already draws.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import type { ProjectDisplayStatus, WorkspaceCollabContext } from '@open-design/contracts';
+
+import { useT } from '../../i18n';
+import { RemixIcon } from '../RemixIcon';
+import { hasRunStatusGlyph, ProjectRunStatusIcon } from '../ProjectRunStatusIcon';
+import { STATUS_LABEL_KEYS } from '../../state/projectRunStatus';
+import { exportProjectAsZip } from '../../runtime/exports';
+import { fetchProjectFiles } from '../../providers/registry';
+import { workspaceIdentityCacheKey } from '../../collab/workspace-identity';
+import {
+  getProjectCoverSnapshot,
+  projectCoverSnapshotKey,
+  setProjectCoverSnapshot,
+} from '../../lib/project-cover-cache';
+import {
+  projectCoverUrl,
+  selectProjectFileCover,
+  type ProjectCoverOverride,
+} from '../project-cover';
+import type { Project } from '../../types';
+
+/** `undefined` = not resolved yet; `null` = resolved, this project has none. */
+type CoverState = ProjectCoverOverride | null | undefined;
+
+/**
+ * Which row currently owns a popup, and which one (per product: 两个弹窗互斥
+ * 原则 — one at a time).
+ *
+ * It has to be module-level rather than per-row state: the preview and the menu
+ * are both PORTALLED to <body>, and a menu opened on row A stayed on screen
+ * while row B painted its preview beside it, because neither row could see the
+ * other's state. One claim arbitrates both kinds across every row, so opening
+ * anything closes whatever was open.
+ */
+type PopupClaim = { rowId: string; kind: 'preview' | 'menu' } | null;
+let popupClaim: PopupClaim = null;
+const popupClaimListeners = new Set<() => void>();
+
+function claimPopup(next: PopupClaim) {
+  popupClaim = next;
+  for (const listener of popupClaimListeners) listener();
+}
+
+/** Release only if this row still holds it — a later claim must not be undone
+ *  by an earlier row's pointer-leave arriving afterwards. */
+function releasePopup(rowId: string, kind: 'preview' | 'menu') {
+  if (popupClaim?.rowId === rowId && popupClaim.kind === kind) claimPopup(null);
+}
+
+/** Gap between the rail's right edge and the popup that hangs off it (per
+ *  product: 预览的卡片左边的间距大一点). The rows are full-bleed inside the rail
+ *  panel, so this is measured from the ROW's right edge — which is the panel's —
+ *  and the content column starts 12px past it. 24 therefore clears the rail by a
+ *  visible margin and still reads as attached to the row rather than floating
+ *  loose over the page. */
+const POPUP_GAP_PX = 24;
+
+/**
+ * The ⋮ mark (supplied artwork; Remix's `more-2-line`). Inlined rather than
+ * added to the shared icon set: no `IconName` maps to that glyph today, and
+ * this is the only place it appears.
+ */
+function MoreDotsMark() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      width={16}
+      height={16}
+      fill="currentColor"
+      aria-hidden
+      focusable="false"
+    >
+      <path d="M12 3C11.175 3 10.5 3.675 10.5 4.5C10.5 5.325 11.175 6 12 6C12.825 6 13.5 5.325 13.5 4.5C13.5 3.675 12.825 3 12 3ZM12 18C11.175 18 10.5 18.675 10.5 19.5C10.5 20.325 11.175 21 12 21C12.825 21 13.5 20.325 13.5 19.5C13.5 18.675 12.825 18 12 18ZM12 10.5C11.175 10.5 10.5 11.175 10.5 12C10.5 12.825 11.175 13.5 12 13.5C12.825 13.5 13.5 12.825 13.5 12C13.5 11.175 12.825 10.5 12 10.5Z" />
+    </svg>
+  );
+}
+
+/**
+ * Menu marks (supplied artwork). Inlined for the same reason as the ⋮ above:
+ * neither glyph exists in the shared icon set — `pencil`/`trash` are close but
+ * not these drawings, and product asked for these.
+ */
+function RenameMark() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      width={14}
+      height={14}
+      fill="currentColor"
+      aria-hidden
+      focusable="false"
+    >
+      <path d="M18.5293 15.3193C18.7058 14.8934 19.2942 14.8934 19.4707 15.3193L19.7236 15.9307C20.1556 16.9735 20.9615 17.8062 21.9746 18.2568L22.6914 18.5762C23.1022 18.7589 23.1022 19.3564 22.6914 19.5391L21.9326 19.877C20.9449 20.3163 20.1534 21.1194 19.7139 22.1279L19.4668 22.6934C19.2863 23.1075 18.7136 23.1075 18.5332 22.6934L18.2861 22.1279C17.8466 21.1194 17.0551 20.3163 16.0674 19.877L15.3076 19.5391C14.8974 19.3562 14.8974 18.759 15.3076 18.5762L16.0254 18.2568C17.0385 17.8062 17.8444 16.9735 18.2764 15.9307L18.5293 15.3193ZM16.4346 3.21193C16.8251 2.82141 17.4591 2.82141 17.8496 3.21193L20.6777 6.04103C21.0681 6.43157 21.0682 7.06464 20.6777 7.45509L7.24219 20.8897H3V16.6475L16.4346 3.21193ZM5 17.4756V18.8897H6.41406L15.7275 9.57618L14.3135 8.16212L5 17.4756ZM15.7275 6.74806L17.1426 8.16212L18.5566 6.74806L17.1426 5.334L15.7275 6.74806Z" />
+    </svg>
+  );
+}
+
+function DeleteMark() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      width={14}
+      height={14}
+      fill="currentColor"
+      aria-hidden
+      focusable="false"
+    >
+      <path d="M20 7V20C20 21.1046 19.1046 22 18 22H6C4.89543 22 4 21.1046 4 20V7H2V5H22V7H20ZM6 7V20H18V7H6ZM11 9H13V11H11V9ZM11 12H13V14H11V12ZM11 15H13V17H11V15ZM7 2H17V4H7V2Z" />
+    </svg>
+  );
+}
+
+/**
+ * The mark every recent row leads with (supplied artwork): a chat bubble with a
+ * spark, i.e. "a conversation with the agent lives in here" — which is what a
+ * project is from the rail's point of view.
+ *
+ * Inlined for the same reason as the marks above: the shared icon set has no
+ * glyph for it, and this is the only place it appears. `currentColor` is what
+ * lets it take the row's ink, including the darker hover one.
+ */
+function ChatMark() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      width={16}
+      height={16}
+      fill="currentColor"
+      aria-hidden
+      focusable="false"
+    >
+      <path d="M7.0009 4.00001C3.6869 4.00001 1 6.69522 1 9.99416V22.0001H14.999C18.3131 22.0001 21 19.3049 21 16.0059V12.0001H19V16.0059C19 18.2043 17.2045 20.0001 14.999 20.0001H3V9.99416C3 7.79582 4.7954 6.00001 7.0009 6.00001H13V4.00001H7.0009ZM13 14.0001H15V12.0001H13V14.0001ZM7 14.0001H9V12.0001H7V14.0001ZM19.4707 2.31934C19.2942 1.89355 18.7058 1.89355 18.5293 2.31934L18.2764 2.93067C17.8445 3.97346 17.0385 4.80618 16.0254 5.25685L15.3076 5.57618C14.8973 5.759 14.8974 6.35621 15.3076 6.53908L16.0674 6.87697C17.055 7.31625 17.8466 8.11947 18.2861 9.12795L18.5332 9.69338C18.7136 10.1075 19.2863 10.1075 19.4668 9.69338L19.7139 9.12795C20.1534 8.11948 20.9449 7.31625 21.9326 6.87697L22.6924 6.53908C23.1025 6.35621 23.1026 5.759 22.6924 5.57618L21.9746 5.25685C20.9615 4.80619 20.1555 3.97349 19.7236 2.93067L19.4707 2.31934Z" />
+    </svg>
+  );
+}
+
+export function RailRecentRow({
+  project,
+  workspaceContext,
+  runStatus,
+  onOpen,
+  onRename,
+  onDelete,
+}: {
+  project: Project;
+  workspaceContext?: WorkspaceCollabContext | null;
+  /** This project's live run status, when it has one (per product: 如果有项目在
+   *  进行，这个 icon 换成状态). Drives the leading glyph and nothing else. */
+  runStatus?: ProjectDisplayStatus;
+  onOpen?: (id: string) => void | Promise<unknown>;
+  onRename?: (id: string, name: string) => void;
+  onDelete?: (id: string) => Promise<boolean | void> | boolean | void;
+}) {
+  const t = useT();
+  const snapshotKey = projectCoverSnapshotKey(
+    workspaceIdentityCacheKey(workspaceContext),
+    project.id,
+    project.updatedAt,
+  );
+  const [cover, setCover] = useState<CoverState>(
+    () => getProjectCoverSnapshot(snapshotKey)?.cover,
+  );
+  // Where the portalled preview should sit, measured off the row at hover time.
+  const [anchor, setAnchor] = useState<{ top: number; left: number } | null>(null);
+  // This row's view of the shared claim (see `claimPopup`). Both popups render
+  // off it, so "one at a time" holds across rows rather than only within one.
+  const [claim, setClaim] = useState<PopupClaim>(popupClaim);
+  useEffect(() => {
+    const listener = () => setClaim(popupClaim);
+    popupClaimListeners.add(listener);
+    return () => { popupClaimListeners.delete(listener); };
+  }, []);
+  const ownsPreview = claim?.rowId === project.id && claim.kind === 'preview';
+  const menuOpen = claim?.rowId === project.id && claim.kind === 'menu';
+  // The menu opens where the preview would have been (per product), which puts
+  // it outside the rail — so it needs its own anchor, frozen at click time.
+  // `anchor` cannot serve: it is cleared the moment the pointer leaves the row,
+  // which happens on the way to the menu itself.
+  const [menuAnchor, setMenuAnchor] = useState<{ top: number; left: number } | null>(null);
+  // Delete asks in place rather than through a dialog: the rail is a narrow
+  // column and a modal over it to confirm a one-line row is heavier than the
+  // action. The menu swaps to a confirm row and the click that destroys is a
+  // second, differently-labelled one.
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [renaming, setRenaming] = useState(false);
+  const [draftName, setDraftName] = useState(project.name);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const renameInputRef = useRef<HTMLInputElement | null>(null);
+  const activeRef = useRef(true);
+  useEffect(() => {
+    activeRef.current = true;
+    return () => {
+      activeRef.current = false;
+      // A row that leaves (the list re-sorts, the rail closes) must not leave
+      // its popup claimed, or nothing else could ever open one.
+      if (popupClaim?.rowId === project.id) claimPopup(null);
+    };
+  }, [project.id]);
+
+  // A newer version of the project (rename, new content) misses the old key, so
+  // the row drops back to unresolved and re-reads on the next hover.
+  useEffect(() => {
+    setCover(getProjectCoverSnapshot(snapshotKey)?.cover);
+  }, [snapshotKey]);
+
+  const resolveCover = useCallback(async () => {
+    if (getProjectCoverSnapshot(snapshotKey) !== undefined) return;
+    // An imported-folder project has no artifact of its own to show.
+    if (project.metadata?.entryFile) {
+      setProjectCoverSnapshot(snapshotKey, null);
+      if (activeRef.current) setCover(null);
+      return;
+    }
+    try {
+      const files = await fetchProjectFiles(project.id, { workspaceContext });
+      const next = selectProjectFileCover(files);
+      setProjectCoverSnapshot(snapshotKey, next);
+      if (activeRef.current) setCover(next);
+    } catch {
+      // Leave it unresolved: a failed read is not an authoritative "no cover",
+      // and the next hover should be allowed to try again.
+    }
+  }, [project.id, project.metadata?.entryFile, snapshotKey, workspaceContext]);
+
+  // Close the menu on an outside click, the way every other rail popover does.
+  useEffect(() => {
+    if (!menuOpen) return undefined;
+    function close() {
+      releasePopup(project.id, 'menu');
+      setConfirmingDelete(false);
+    }
+    function onDocPointerDown(event: PointerEvent) {
+      const target = event.target as Node;
+      if (rootRef.current?.contains(target) || menuRef.current?.contains(target)) return;
+      close();
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') close();
+    }
+    document.addEventListener('pointerdown', onDocPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    // Its anchor is a snapshot of the row's position, so anything that moves
+    // the row (the rail list scrolling, the page behind it) would leave the
+    // menu stranded. Dismiss instead of chasing.
+    document.addEventListener('scroll', close, true);
+    window.addEventListener('resize', close);
+    return () => {
+      document.removeEventListener('pointerdown', onDocPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('scroll', close, true);
+      window.removeEventListener('resize', close);
+    };
+  }, [menuOpen, project.id]);
+
+  useEffect(() => {
+    if (!renaming) return;
+    renameInputRef.current?.focus();
+    renameInputRef.current?.select();
+  }, [renaming]);
+
+  function commitRename() {
+    const next = draftName.trim();
+    setRenaming(false);
+    if (!next || next === project.name) return;
+    onRename?.(project.id, next);
+  }
+
+  const coverSrc = cover
+    ? projectCoverUrl(project.id, cover.name, cover.mtime, workspaceContext)
+    : null;
+  // `html` covers are documents, not pictures: the grid mounts a sandboxed frame
+  // for those. A floating rail preview is not worth a second iframe per hover,
+  // so only real media paints here and everything else takes the glyph.
+  const showsImage = Boolean(coverSrc && (cover?.kind === 'image' || cover?.kind === 'logo'));
+  const showsVideo = Boolean(coverSrc && cover?.kind === 'video');
+
+  return (
+    <div
+      ref={rootRef}
+      className="entry-nav-rail__recent-row"
+      onPointerEnter={(event) => {
+        // Touch has no hover to leave; the panel would stick until the next tap.
+        if (event.pointerType !== 'mouse' && event.pointerType !== 'pen') return;
+        // An OPEN MENU OUTRANKS A HOVER (per product: 弹窗和 hover 的预览互斥,
+        // and the menu is the one the user asked for by clicking). Without this
+        // the two fought: the menu is portalled clear of the rail, so the trip
+        // to it re-crossed rows, each of which claimed the slot back for its
+        // preview and closed the menu out from under the pointer. A menu now
+        // ends only when it is dismissed.
+        if (popupClaim?.kind === 'menu') return;
+        const rect = event.currentTarget.getBoundingClientRect();
+        setAnchor({ top: rect.top + rect.height / 2, left: rect.right + POPUP_GAP_PX });
+        claimPopup({ rowId: project.id, kind: 'preview' });
+        void resolveCover();
+      }}
+      onPointerLeave={() => {
+        setAnchor(null);
+        releasePopup(project.id, 'preview');
+      }}
+    >
+      {renaming ? (
+        <input
+          ref={renameInputRef}
+          className="entry-nav-rail__recent-rename"
+          value={draftName}
+          onChange={(event) => setDraftName(event.target.value)}
+          onBlur={commitRename}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              commitRename();
+            } else if (event.key === 'Escape') {
+              event.preventDefault();
+              setDraftName(project.name);
+              setRenaming(false);
+            }
+          }}
+          aria-label={t('designs.menuRename')}
+        />
+      ) : (
+        <button
+          type="button"
+          className="entry-nav-rail__recent-item"
+          onClick={() => { void onOpen?.(project.id); }}
+          /* No `title`: the OS tooltip it produced opened right where the hover
+             preview does and covered it (per product: hover 这的文本的气泡去掉).
+             The full name lives in that preview now — a surface we control,
+             which can also wrap it instead of ellipsizing. */
+          data-testid="entry-nav-recent-item"
+        >
+          {/* The row's leading glyph, in the SAME column the destinations put
+              their icons in, so the rail stays one left edge. A project with a
+              run to report shows that run's status instead of the chat mark
+              (per product: 和项目切换器里的状态对齐) — the very same component
+              the workspace tab dropdown leads its rows with
+              (`leadGlyphFor` in WorkspaceTabsBar), so the two can never tell
+              different stories about the same project. */}
+          <span className="entry-nav-rail__recent-icon">
+            {runStatus && hasRunStatusGlyph(runStatus) ? (
+              <ProjectRunStatusIcon
+                status={runStatus}
+                size={14}
+                label={t(STATUS_LABEL_KEYS[runStatus])}
+              />
+            ) : (
+              <ChatMark />
+            )}
+          </span>
+          <span className="entry-nav-rail__recent-name">{project.name}</span>
+        </button>
+      )}
+      {onRename || onDelete ? (
+        <button
+          type="button"
+          className="entry-nav-rail__recent-more"
+          aria-label={t('designs.menuMore')}
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
+          data-testid="entry-nav-recent-more"
+          /* Click only (per product: 点击那三个小点之后才展开弹窗). Opening on
+             hover put the menu one stray pointer-move away from closing, which
+             is what made it impossible to click through to. */
+          onClick={(event) => {
+            event.stopPropagation();
+            setConfirmingDelete(false);
+            const rect = rootRef.current?.getBoundingClientRect();
+            if (rect) setMenuAnchor({ top: rect.top + rect.height / 2, left: rect.right + POPUP_GAP_PX });
+            if (menuOpen) releasePopup(project.id, 'menu');
+            else claimPopup({ rowId: project.id, kind: 'menu' });
+          }}
+        >
+          <MoreDotsMark />
+        </button>
+      ) : null}
+      {/* Same slot as the hover preview — beside the row, clear of the rail
+          (per product: 弹窗的位置就是预览图的位置). Portalled for the same
+          reason the preview is: inside the rail it would sit behind the content
+          column whatever its z-index. */}
+      {menuOpen && menuAnchor && typeof document !== 'undefined' ? createPortal(
+        <div
+          ref={menuRef}
+          className="entry-nav-rail__recent-menu"
+          role="menu"
+          style={{ top: menuAnchor.top, left: menuAnchor.left }}
+          /* The pointer arriving here is what cancels the close the ⋮ scheduled
+             when it left; leaving the menu closes it. */
+        >
+          {onRename ? (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                releasePopup(project.id, 'menu');
+                setDraftName(project.name);
+                setRenaming(true);
+              }}
+            >
+              <RenameMark />
+              <span>{t('designs.menuRename')}</span>
+            </button>
+          ) : null}
+          {/* Export sits between Rename and Delete (per product: 增加一个导出，
+              在删除上边). It is the ONE export a list row can honestly offer:
+              the project is not open here, so there is no rendered file to turn
+              into a PDF / image / standalone HTML — those four rows in the
+              viewer all need a loaded source. The whole-project archive needs
+              nothing but the id, so that is what this is.
+              Calls the shared runtime helper directly rather than taking an
+              `onExport` prop like its neighbours: Rename and Delete mutate
+              state the parent owns, while this one is a download — no parent
+              has anything to do with it.
+              `preview.exportMenu` is the bare word "Export" already translated
+              in all 19 locales (导出 / 匯出 / Exporter …); same reasoning as the
+              `designs.renameSave` reuse below, rather than a 20th copy of one
+              word in every file. */}
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              releasePopup(project.id, 'menu');
+              // No file scope: an empty `filePath` leaves `root` off the
+              // archive URL, which is what asks for the whole project.
+              void exportProjectAsZip({
+                projectId: project.id,
+                filePath: '',
+                fallbackHtml: '',
+                fallbackTitle: project.name,
+                workspaceContext,
+              });
+            }}
+          >
+            {/* The viewer's Export button glyph (per product), from the same
+                shared set it uses there — `RemixIcon name="download-line"`,
+                sized to this menu's 14px marks. */}
+            <RemixIcon name="download-line" size={14} />
+            <span>{t('preview.exportMenu')}</span>
+          </button>
+          {onDelete ? (
+            <button
+              type="button"
+              role="menuitem"
+              className={confirmingDelete ? 'is-danger' : undefined}
+              onClick={() => {
+                if (!confirmingDelete) {
+                  setConfirmingDelete(true);
+                  return;
+                }
+                releasePopup(project.id, 'menu');
+                setConfirmingDelete(false);
+                void onDelete(project.id);
+              }}
+            >
+              <DeleteMark />
+              {/* `designs.renameSave` is the generic confirm word in every
+                  locale (确定 / OK) — it just happens to live under the rename
+                  dialog. Reused rather than adding a 20th copy of the same
+                  string to all 19 locale files. */}
+              <span>{confirmingDelete ? t('designs.renameSave') : t('designs.menuDelete')}</span>
+            </button>
+          ) : null}
+        </div>,
+        document.body,
+      ) : null}
+      {/* The preview hangs OUTSIDE the rail, over the content column — and is
+          portalled to <body> to get there. Inside the rail it stayed BEHIND the
+          content column no matter its z-index: the column is a positioned,
+          backdrop-filtered box and the rail's own z-index traps its children in
+          a local stacking context (the same reason the community preview modal
+          portals out). Rendered only while hovered, so a rail full of rows never
+          holds a dozen idle <img> elements alive. */}
+      {anchor && ownsPreview && typeof document !== 'undefined' ? createPortal(
+        <div
+          className="entry-nav-rail__recent-preview"
+          style={{ top: anchor.top, left: anchor.left }}
+          aria-hidden
+        >
+          <div className="entry-nav-rail__recent-preview-plate">
+            {showsImage ? (
+              <img src={coverSrc ?? ''} alt="" draggable={false} decoding="async" />
+            ) : showsVideo ? (
+              <video src={coverSrc ?? ''} muted playsInline preload="metadata" />
+            ) : (
+              <span className="entry-nav-rail__recent-preview-glyph" aria-hidden>
+                {(Array.from(project.name.trim())[0] ?? '?').toUpperCase()}
+              </span>
+            )}
+          </div>
+          {/* The name the row had to ellipsize, given room to wrap — that is
+              the whole job of this card. The "last touched" line that used to
+              sit under it is gone (per product: 时间去掉，最多两行名称): a hover
+              preview answers "which project is this", and the timestamp was
+              answering a question nobody had asked it. */}
+          <p className="entry-nav-rail__recent-preview-name">{project.name}</p>
+        </div>,
+        document.body,
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/useProjectRunStatuses.ts
+++ b/apps/web/src/hooks/useProjectRunStatuses.ts
@@ -13,20 +13,32 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ProjectDisplayStatus, WorkspaceCollabContext } from '@open-design/contracts';
 import { listRunsForProject, RUNS_CHANGED_EVENT } from '../providers/daemon';
-import { foldRunsToProjectStatuses } from '../state/projectRunStatus';
+import {
+  foldRunsToProjectRunSummaries,
+  type ProjectRunSummary,
+} from '../state/projectRunStatus';
 
 /** Backstop only — `RUNS_CHANGED_EVENT` is what makes this feel immediate. */
 const POLL_MS = 4000;
 
-const EMPTY: ReadonlyMap<string, ProjectDisplayStatus> = new Map();
+const EMPTY: ReadonlyMap<string, ProjectRunSummary> = new Map();
 
-export function useProjectRunStatuses(
+export interface UseProjectRunStatusesOptions {
+  enabled?: boolean;
+  workspaceContext?: WorkspaceCollabContext | null;
+}
+
+/**
+ * Live `Map<projectId, ProjectRunSummary>`: the status plus the newest
+ * finished run's identity, for a consumer that acknowledges notices per run.
+ */
+export function useProjectRunSummaries(
   projectIds: readonly string[],
-  options?: { enabled?: boolean; workspaceContext?: WorkspaceCollabContext | null },
-): ReadonlyMap<string, ProjectDisplayStatus> {
+  options?: UseProjectRunStatusesOptions,
+): ReadonlyMap<string, ProjectRunSummary> {
   const enabled = options?.enabled ?? true;
   const workspaceContext = options?.workspaceContext ?? null;
-  const [statuses, setStatuses] = useState<ReadonlyMap<string, ProjectDisplayStatus>>(EMPTY);
+  const [summaries, setSummaries] = useState<ReadonlyMap<string, ProjectRunSummary>>(EMPTY);
 
   // One request per id, so the effect must not re-run just because the caller
   // rebuilt the array. Sorted + joined is the identity that actually matters.
@@ -39,7 +51,7 @@ export function useProjectRunStatuses(
   useEffect(() => {
     const ids = idsKey ? idsKey.split('\u0000') : [];
     if (!enabled || ids.length === 0) {
-      setStatuses(EMPTY);
+      setSummaries(EMPTY);
       return undefined;
     }
     let cancelled = false;
@@ -53,7 +65,7 @@ export function useProjectRunStatuses(
       // rather than asserting a status nobody verified.
       const runs = results.flatMap((result) => result?.runs ?? []);
       const awaiting = results.flatMap((result) => result?.awaitingInputProjectIds ?? []);
-      setStatuses(foldRunsToProjectStatuses(runs, awaiting));
+      setSummaries(foldRunsToProjectRunSummaries(runs, awaiting));
     };
 
     void refresh();
@@ -67,5 +79,18 @@ export function useProjectRunStatuses(
     };
   }, [idsKey, enabled]);
 
-  return statuses;
+  return summaries;
+}
+
+/** The status half of {@link useProjectRunSummaries}, for glyph-only consumers. */
+export function useProjectRunStatuses(
+  projectIds: readonly string[],
+  options?: UseProjectRunStatusesOptions,
+): ReadonlyMap<string, ProjectDisplayStatus> {
+  const summaries = useProjectRunSummaries(projectIds, options);
+  return useMemo(() => {
+    const statuses = new Map<string, ProjectDisplayStatus>();
+    for (const [projectId, summary] of summaries) statuses.set(projectId, summary.status);
+    return statuses;
+  }, [summaries]);
 }

--- a/apps/web/src/hooks/useProjectRunStatuses.ts
+++ b/apps/web/src/hooks/useProjectRunStatuses.ts
@@ -1,0 +1,71 @@
+/**
+ * Live `Map<projectId, ProjectDisplayStatus>` for a known set of projects.
+ *
+ * Exists because `Project.status` is unreadable in a workspace-scoped session:
+ * only the unscoped `GET /api/projects` attaches it, and that endpoint lists
+ * unbound projects only — none, once every project belongs to a workspace. So
+ * the status has to be derived from the runs feed instead.
+ *
+ * Asks per project id rather than for the whole catalogue: the unscoped
+ * `GET /api/runs` answers 400 `PROJECT_SCOPE_REQUIRED` as soon as one run
+ * belongs to a workspace-bound project. See `listRunsForProject`.
+ */
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { ProjectDisplayStatus, WorkspaceCollabContext } from '@open-design/contracts';
+import { listRunsForProject, RUNS_CHANGED_EVENT } from '../providers/daemon';
+import { foldRunsToProjectStatuses } from '../state/projectRunStatus';
+
+/** Backstop only — `RUNS_CHANGED_EVENT` is what makes this feel immediate. */
+const POLL_MS = 4000;
+
+const EMPTY: ReadonlyMap<string, ProjectDisplayStatus> = new Map();
+
+export function useProjectRunStatuses(
+  projectIds: readonly string[],
+  options?: { enabled?: boolean; workspaceContext?: WorkspaceCollabContext | null },
+): ReadonlyMap<string, ProjectDisplayStatus> {
+  const enabled = options?.enabled ?? true;
+  const workspaceContext = options?.workspaceContext ?? null;
+  const [statuses, setStatuses] = useState<ReadonlyMap<string, ProjectDisplayStatus>>(EMPTY);
+
+  // One request per id, so the effect must not re-run just because the caller
+  // rebuilt the array. Sorted + joined is the identity that actually matters.
+  const idsKey = useMemo(() => [...projectIds].sort().join('\u0000'), [projectIds]);
+  // Read inside the effect without making it a dependency: the context object
+  // is rebuilt on unrelated renders and would restart polling each time.
+  const workspaceContextRef = useRef(workspaceContext);
+  workspaceContextRef.current = workspaceContext;
+
+  useEffect(() => {
+    const ids = idsKey ? idsKey.split('\u0000') : [];
+    if (!enabled || ids.length === 0) {
+      setStatuses(EMPTY);
+      return undefined;
+    }
+    let cancelled = false;
+
+    const refresh = async () => {
+      const results = await Promise.all(
+        ids.map((id) => listRunsForProject(id, workspaceContextRef.current)),
+      );
+      if (cancelled) return;
+      // An unreadable project yields null; skipping it leaves that row blank
+      // rather than asserting a status nobody verified.
+      const runs = results.flatMap((result) => result?.runs ?? []);
+      const awaiting = results.flatMap((result) => result?.awaitingInputProjectIds ?? []);
+      setStatuses(foldRunsToProjectStatuses(runs, awaiting));
+    };
+
+    void refresh();
+    const onRunsChanged = () => void refresh();
+    window.addEventListener(RUNS_CHANGED_EVENT, onRunsChanged);
+    const timer = window.setInterval(() => void refresh(), POLL_MS);
+    return () => {
+      cancelled = true;
+      window.removeEventListener(RUNS_CHANGED_EVENT, onRunsChanged);
+      window.clearInterval(timer);
+    };
+  }, [idsKey, enabled]);
+
+  return statuses;
+}

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1090,6 +1090,7 @@ export const ar: Dict = {
   'recentProjects.sortNewest': 'Newest first',
   'recentProjects.sortOldest': 'Oldest first',
   'recentProjects.sortName': 'Name',
+  'recentProjects.collectionRecent': 'Recently viewed',
   'recentProjects.viewList': 'List view',
   'recentProjects.sharedBadge': 'Shared',
   'recentProjects.sharedProjectFallbackName': 'Shared project',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -1090,6 +1090,7 @@ export const de: Dict = {
   'recentProjects.sortNewest': 'Newest first',
   'recentProjects.sortOldest': 'Oldest first',
   'recentProjects.sortName': 'Name',
+  'recentProjects.collectionRecent': 'Recently viewed',
   'recentProjects.viewList': 'List view',
   'recentProjects.sharedBadge': 'Shared',
   'recentProjects.sharedProjectFallbackName': 'Shared project',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1090,6 +1090,7 @@ export const en: Dict = {
   'recentProjects.sortNewest': 'Newest first',
   'recentProjects.sortOldest': 'Oldest first',
   'recentProjects.sortName': 'Name',
+  'recentProjects.collectionRecent': 'Recently viewed',
   'recentProjects.viewList': 'List view',
   'recentProjects.sharedBadge': 'Shared',
   'recentProjects.sharedProjectFallbackName': 'Shared project',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -1090,6 +1090,7 @@ export const esES: Dict = {
   'recentProjects.sortNewest': 'Newest first',
   'recentProjects.sortOldest': 'Oldest first',
   'recentProjects.sortName': 'Name',
+  'recentProjects.collectionRecent': 'Recently viewed',
   'recentProjects.viewList': 'List view',
   'recentProjects.sharedBadge': 'Shared',
   'recentProjects.sharedProjectFallbackName': 'Shared project',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1090,6 +1090,7 @@ export const fa: Dict = {
   'recentProjects.sortNewest': 'Newest first',
   'recentProjects.sortOldest': 'Oldest first',
   'recentProjects.sortName': 'Name',
+  'recentProjects.collectionRecent': 'Recently viewed',
   'recentProjects.viewList': 'List view',
   'recentProjects.sharedBadge': 'Shared',
   'recentProjects.sharedProjectFallbackName': 'Shared project',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -1090,6 +1090,7 @@ export const fr: Dict = {
   'recentProjects.sortNewest': 'Plus récents d’abord',
   'recentProjects.sortOldest': 'Plus anciens d’abord',
   'recentProjects.sortName': 'Nom',
+  'recentProjects.collectionRecent': 'Consultés récemment',
   'recentProjects.viewList': 'Vue liste',
   'recentProjects.sharedBadge': 'Partagé',
   'recentProjects.sharedProjectFallbackName': 'Projet partagé',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1090,6 +1090,7 @@ export const hu: Dict = {
   'recentProjects.sortNewest': 'Newest first',
   'recentProjects.sortOldest': 'Oldest first',
   'recentProjects.sortName': 'Name',
+  'recentProjects.collectionRecent': 'Recently viewed',
   'recentProjects.viewList': 'List view',
   'recentProjects.sharedBadge': 'Shared',
   'recentProjects.sharedProjectFallbackName': 'Shared project',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1090,6 +1090,7 @@ export const id: Dict = {
   'recentProjects.sortNewest': 'Newest first',
   'recentProjects.sortOldest': 'Oldest first',
   'recentProjects.sortName': 'Name',
+  'recentProjects.collectionRecent': 'Recently viewed',
   'recentProjects.viewList': 'List view',
   'recentProjects.sharedBadge': 'Shared',
   'recentProjects.sharedProjectFallbackName': 'Shared project',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -1090,6 +1090,7 @@ export const it: Dict = {
   'recentProjects.sortNewest': 'Newest first',
   'recentProjects.sortOldest': 'Oldest first',
   'recentProjects.sortName': 'Name',
+  'recentProjects.collectionRecent': 'Recently viewed',
   'recentProjects.viewList': 'List view',
   'recentProjects.sharedBadge': 'Shared',
   'recentProjects.sharedProjectFallbackName': 'Shared project',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -1090,6 +1090,7 @@ export const ja: Dict = {
   'recentProjects.sortNewest': 'Newest first',
   'recentProjects.sortOldest': 'Oldest first',
   'recentProjects.sortName': 'Name',
+  'recentProjects.collectionRecent': 'Recently viewed',
   'recentProjects.viewList': 'List view',
   'recentProjects.sharedBadge': 'Shared',
   'recentProjects.sharedProjectFallbackName': 'Shared project',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1090,6 +1090,7 @@ export const ko: Dict = {
   'recentProjects.sortNewest': 'Newest first',
   'recentProjects.sortOldest': 'Oldest first',
   'recentProjects.sortName': 'Name',
+  'recentProjects.collectionRecent': 'Recently viewed',
   'recentProjects.viewList': 'List view',
   'recentProjects.sharedBadge': 'Shared',
   'recentProjects.sharedProjectFallbackName': 'Shared project',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1090,6 +1090,7 @@ export const pl: Dict = {
   'recentProjects.sortNewest': 'Newest first',
   'recentProjects.sortOldest': 'Oldest first',
   'recentProjects.sortName': 'Name',
+  'recentProjects.collectionRecent': 'Recently viewed',
   'recentProjects.viewList': 'List view',
   'recentProjects.sharedBadge': 'Shared',
   'recentProjects.sharedProjectFallbackName': 'Shared project',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1090,6 +1090,7 @@ export const ptBR: Dict = {
   'recentProjects.sortNewest': 'Newest first',
   'recentProjects.sortOldest': 'Oldest first',
   'recentProjects.sortName': 'Name',
+  'recentProjects.collectionRecent': 'Recently viewed',
   'recentProjects.viewList': 'List view',
   'recentProjects.sharedBadge': 'Shared',
   'recentProjects.sharedProjectFallbackName': 'Shared project',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1090,6 +1090,7 @@ export const ru: Dict = {
   'recentProjects.sortNewest': 'Newest first',
   'recentProjects.sortOldest': 'Oldest first',
   'recentProjects.sortName': 'Name',
+  'recentProjects.collectionRecent': 'Recently viewed',
   'recentProjects.viewList': 'List view',
   'recentProjects.sharedBadge': 'Shared',
   'recentProjects.sharedProjectFallbackName': 'Shared project',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -1090,6 +1090,7 @@ export const th: Dict = {
   'recentProjects.sortNewest': 'Newest first',
   'recentProjects.sortOldest': 'Oldest first',
   'recentProjects.sortName': 'Name',
+  'recentProjects.collectionRecent': 'Recently viewed',
   'recentProjects.viewList': 'List view',
   'recentProjects.sharedBadge': 'Shared',
   'recentProjects.sharedProjectFallbackName': 'Shared project',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1090,6 +1090,7 @@ export const tr: Dict = {
   'recentProjects.sortNewest': 'Newest first',
   'recentProjects.sortOldest': 'Oldest first',
   'recentProjects.sortName': 'Name',
+  'recentProjects.collectionRecent': 'Recently viewed',
   'recentProjects.viewList': 'List view',
   'recentProjects.sharedBadge': 'Shared',
   'recentProjects.sharedProjectFallbackName': 'Shared project',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1090,6 +1090,7 @@ export const uk: Dict = {
   'recentProjects.sortNewest': 'Newest first',
   'recentProjects.sortOldest': 'Oldest first',
   'recentProjects.sortName': 'Name',
+  'recentProjects.collectionRecent': 'Recently viewed',
   'recentProjects.viewList': 'List view',
   'recentProjects.sharedBadge': 'Shared',
   'recentProjects.sharedProjectFallbackName': 'Shared project',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1105,6 +1105,7 @@ export const zhCN: Dict = {
   "recentProjects.sortNewest": "最近更新",
   "recentProjects.sortOldest": "最早更新",
   "recentProjects.sortName": "名称",
+  "recentProjects.collectionRecent": "最近浏览过",
   "recentProjects.viewList": "列表视图",
   "recentProjects.sharedBadge": "共享",
   "recentProjects.sharedProjectFallbackName": "共享项目",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1107,6 +1107,7 @@ export const zhTW: Dict = {
   "recentProjects.sortNewest": "最近更新",
   "recentProjects.sortOldest": "最早更新",
   "recentProjects.sortName": "名稱",
+  "recentProjects.collectionRecent": "最近瀏覽過",
   "recentProjects.viewList": "列表檢視",
   "recentProjects.sharedBadge": "共享",
   "recentProjects.sharedProjectFallbackName": "共享專案",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -1483,6 +1483,8 @@ export interface Dict {
   'recentProjects.sortNewest': string;
   'recentProjects.sortOldest': string;
   'recentProjects.sortName': string;
+  /** Heading of the rail's recent-projects disclosure (最近浏览过). */
+  'recentProjects.collectionRecent': string;
   'recentProjects.viewList': string;
   'recentProjects.sharedBadge': string;
   'recentProjects.sharedProjectFallbackName': string;

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -1242,6 +1242,41 @@ export async function listProjectRuns(
   }
 }
 
+/**
+ * One project's runs plus the awaiting-input flag the run bodies cannot carry.
+ *
+ * Scoped to a single project ON PURPOSE. The catalogue-wide `listProjectRuns`
+ * above 400s (`PROJECT_SCOPE_REQUIRED`) the moment any run belongs to a
+ * workspace-bound project — which, in a workspace session, is all of them — so
+ * it silently returns `[]` there. Asking per project id takes the route's
+ * authorized branch instead and actually works.
+ *
+ * Returns `null` when the project is unreadable or the daemon is unreachable,
+ * so a caller can tell "no runs" apart from "could not ask".
+ */
+export async function listRunsForProject(
+  projectId: string,
+  workspaceContext?: WorkspaceCollabContext | null,
+): Promise<{ runs: ChatRunStatusResponse[]; awaitingInputProjectIds: string[] } | null> {
+  try {
+    const resp = await fetch(`/api/runs?projectId=${encodeURIComponent(projectId)}`, {
+      ...(workspaceContext
+        ? { headers: workspaceProjectHeaders(workspaceContext) }
+        : {}),
+    });
+    if (!resp.ok) return null;
+    const body = (await resp.json()) as ChatRunListResponse;
+    return {
+      runs: body.runs ?? [],
+      // Absent on daemons older than this field; treat as "no pending
+      // question" rather than failing the whole read.
+      awaitingInputProjectIds: body.awaitingInputProjectIds ?? [],
+    };
+  } catch {
+    return null;
+  }
+}
+
 interface DaemonPhysicalRunResult {
   nextRunId?: string;
   strategyTask?: StrategyTaskProjectionV2;

--- a/apps/web/src/runtime/latest-user-prompt.ts
+++ b/apps/web/src/runtime/latest-user-prompt.ts
@@ -1,0 +1,29 @@
+import type { ChatMessage } from '../types';
+
+/** Longest prompt the Design Files empty state will echo before eliding. */
+const MAX_PROMPT_CHARS = 160;
+
+/**
+ * The last thing the user actually asked for, as a single tidy line.
+ *
+ * The Design Files panel's empty state echoes this back while the agent works,
+ * so the right pane says "working on THIS" instead of sitting blank. Mirrors
+ * `latestTodoWriteInputFromMessages` in `./todos.ts`: a pure reducer over the
+ * conversation, so the panel needs no chat wiring of its own.
+ *
+ * Returns null when the conversation has no user turn yet (a freshly created
+ * project), which the caller renders as "no prompt line at all" rather than an
+ * empty paragraph.
+ */
+export function latestUserPromptText(messages: ChatMessage[]): string | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (!message || message.role !== 'user') continue;
+    // Pasted prompts routinely carry hard-wrapped newlines and run long; the
+    // empty state has one clamped block, so collapse first and elide second.
+    const text = (message.content ?? '').replace(/\s+/g, ' ').trim();
+    if (!text) continue;
+    return text.length > MAX_PROMPT_CHARS ? `${text.slice(0, MAX_PROMPT_CHARS).trimEnd()}…` : text;
+  }
+  return null;
+}

--- a/apps/web/src/runtime/run-progress.ts
+++ b/apps/web/src/runtime/run-progress.ts
@@ -1,0 +1,122 @@
+import type { AgentEvent, ChatMessage } from '../types';
+import { toolCategoryForName } from '../components/ToolCard';
+
+/** One tool call, reduced to the line the Design Files empty state shows. */
+export interface RunProgressStep {
+  /** The `tool_use` id — stable across re-renders of the same streamed turn. */
+  id: string;
+  /** Drives the verb ("Editing" / "Running" / …) the caller renders. */
+  category: ReturnType<typeof toolCategoryForName>;
+  /** Raw tool name, so an unclassified call can still name itself. */
+  toolName: string;
+  /** What the step acted on — file basename, command, query — already short. */
+  target: string | null;
+}
+
+/** Steps kept for the trail. Older ones are off-screen behind the fade anyway. */
+const MAX_STEPS = 12;
+/** A target longer than this is a command line or a URL; elide the tail. */
+const MAX_TARGET_CHARS = 44;
+
+/**
+ * What the agent is doing right now, newest first.
+ *
+ * The Design Files empty state echoes the user's prompt while the agent works
+ * (see `./latest-user-prompt`); this is the other half — the progress under it.
+ * The head of the list is the current step and the rest is the trail below it,
+ * so the pane says "editing index.html, after reading two files" instead of a
+ * static "thinking".
+ *
+ * A pure reducer over the conversation, same as `latestUserPromptText`: the
+ * panel needs no chat wiring of its own, and a streamed `tool_use` shows up as
+ * soon as it lands in the message's events.
+ *
+ * Only the LAST assistant turn is read. Steps from the turn before are history,
+ * not progress, and the panel would be claiming work it is no longer doing.
+ */
+export function runProgressSteps(messages: ChatMessage[]): RunProgressStep[] {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (!message) continue;
+    if (message.role === 'user') return [];
+    if (message.role !== 'assistant') continue;
+    return stepsFromEvents(message.events ?? []);
+  }
+  return [];
+}
+
+function stepsFromEvents(events: AgentEvent[]): RunProgressStep[] {
+  const steps: RunProgressStep[] = [];
+  // Backwards: the newest step leads, and the cap then drops the oldest.
+  for (let i = events.length - 1; i >= 0 && steps.length < MAX_STEPS; i--) {
+    const event = events[i];
+    if (!event || event.kind !== 'tool_use') continue;
+    const category = toolCategoryForName(event.name);
+    // The todo list has its own pinned card above the composer; repeating it
+    // here would spend trail lines on a state the user is already watching.
+    if (category === 'todo') continue;
+    steps.push({
+      id: event.id,
+      category,
+      toolName: event.name,
+      target: targetFor(category, event.input),
+    });
+  }
+  return steps;
+}
+
+function targetFor(
+  category: ReturnType<typeof toolCategoryForName>,
+  input: unknown,
+): string | null {
+  if (!input || typeof input !== 'object') return null;
+  const fields = input as Record<string, unknown>;
+  if (category === 'write' || category === 'edit' || category === 'read') {
+    const path = firstString(fields, ['file_path', 'filePath', 'path', 'notebook_path']);
+    return path ? shorten(basename(path)) : null;
+  }
+  if (category === 'run') {
+    const command = firstString(fields, ['command', 'cmd', 'script']);
+    // Multi-line scripts are heredocs and pipelines; the first line names it.
+    return command ? shorten(command.split('\n')[0]!.trim()) : null;
+  }
+  if (category === 'search') {
+    const query = firstString(fields, ['pattern', 'query', 'q', 'path']);
+    return query ? shorten(query) : null;
+  }
+  if (category === 'fetch') {
+    const url = firstString(fields, ['url', 'uri']);
+    return url ? shorten(hostAndPath(url)) : null;
+  }
+  return null;
+}
+
+function firstString(fields: Record<string, unknown>, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = fields[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function basename(path: string): string {
+  const parts = path.split(/[\\/]/);
+  return parts[parts.length - 1] || path;
+}
+
+/** `https://example.com/a/b?c=1` → `example.com/a/b`. Falls back to the raw
+ *  string when the value is not a parseable absolute URL. */
+function hostAndPath(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.host}${parsed.pathname === '/' ? '' : parsed.pathname}`;
+  } catch {
+    return url;
+  }
+}
+
+function shorten(value: string): string {
+  return value.length > MAX_TARGET_CHARS
+    ? `${value.slice(0, MAX_TARGET_CHARS).trimEnd()}…`
+    : value;
+}

--- a/apps/web/src/state/projectRunStatus.ts
+++ b/apps/web/src/state/projectRunStatus.ts
@@ -1,0 +1,115 @@
+/**
+ * Fold a project's runs down to the one status a UI should show for it.
+ *
+ * This mirrors the daemon's own composition (`normalizeProjectDisplayStatus` /
+ * `composeProjectDisplayStatus` in `apps/daemon/src/server.ts`, which
+ * `GET /api/projects` uses) because the web app cannot always read that
+ * result: `Project.status` is attached ONLY by the unscoped `GET /api/projects`,
+ * and a workspace-scoped session never sees it. Those sessions have to derive
+ * the same answer from the runs feed instead — hence this module.
+ *
+ * Keep the two in step. Where they intentionally differ, it is called out
+ * below.
+ */
+import type { ChatRunStatusResponse, ProjectDisplayStatus } from '@open-design/contracts';
+import type { Dict } from '../i18n/types';
+
+/**
+ * Localized name per status — the single source for every surface that spells
+ * one out. Lives here rather than in a component so the app shell can label a
+ * status without importing a whole page module.
+ */
+export const STATUS_LABEL_KEYS = {
+  not_started: 'designs.status.notStarted',
+  queued: 'designs.status.queued',
+  running: 'designs.status.running',
+  awaiting_input: 'designs.status.awaitingInput',
+  incomplete: 'designs.status.incomplete',
+  succeeded: 'designs.status.succeeded',
+  failed: 'designs.status.failed',
+  canceled: 'designs.status.canceled',
+} as const satisfies Record<ProjectDisplayStatus, keyof Dict>;
+
+const TERMINAL_RUN_STATUSES = new Set(['succeeded', 'failed', 'canceled']);
+
+/** Whether a run has stopped for good, as opposed to queued or in flight. */
+export function isTerminalRunStatus(status: string): boolean {
+  return TERMINAL_RUN_STATUSES.has(status);
+}
+
+/** The newest run per project, split by whether it has finished. */
+interface RunFold {
+  /** Newest non-terminal run — an in-flight run outranks any history. */
+  active?: { status: 'queued' | 'running'; updatedAt: number };
+  /** Newest terminal run, already resolved to its display status. */
+  terminal?: { status: ProjectDisplayStatus; updatedAt: number };
+}
+
+/**
+ * What a finished run should be called.
+ *
+ * A `succeeded` run that ended with unfinished declared work must not read as
+ * plain "done" — that is the exact lie #1247 / #1060 reported. The daemon draws
+ * the same distinction in `projectDisplayStatusForRunRow`. Exported so the one
+ * other surface that groups runs by outcome (the desktop pet's task centre)
+ * applies the identical rule instead of restating it.
+ */
+export function terminalRunDisplayStatus(
+  run: ChatRunStatusResponse,
+): 'succeeded' | 'incomplete' | 'failed' | 'canceled' {
+  if (run.status === 'succeeded' && run.endedWithUnfinishedWork) return 'incomplete';
+  return run.status as 'succeeded' | 'failed' | 'canceled';
+}
+
+/**
+ * `Map<projectId, ProjectDisplayStatus>` for every project the runs cover.
+ *
+ * `awaitingInputProjectIds` comes from the same `/api/runs` response and is
+ * what lets a blocked project be told apart from a finished one; the run that
+ * asked the question reports `succeeded` and exits. Pass an empty list when the
+ * daemon is too old to send it — the result then simply never says
+ * `awaiting_input`, which is the pre-existing behaviour, not a regression.
+ */
+export function foldRunsToProjectStatuses(
+  runs: ChatRunStatusResponse[],
+  awaitingInputProjectIds: readonly string[] = [],
+): Map<string, ProjectDisplayStatus> {
+  const folds = new Map<string, RunFold>();
+
+  for (const run of runs) {
+    if (!run.projectId) continue;
+    const fold = folds.get(run.projectId) ?? {};
+    if (TERMINAL_RUN_STATUSES.has(run.status)) {
+      if (!fold.terminal || run.updatedAt > fold.terminal.updatedAt) {
+        fold.terminal = { status: terminalRunDisplayStatus(run), updatedAt: run.updatedAt };
+      }
+      // Deliberate divergence from the daemon: `normalizeProjectDisplayStatus`
+      // folds `queued` into `running`, because its consumers only ever needed
+      // "is it working". `queued` is kept distinct here so a caller can pace
+      // its indicator differently (a queued project has not started yet). Both
+      // still mean the same thing to anyone who only checks for `running`, and
+      // nothing downstream may colour them apart.
+    } else if (run.status === 'queued' || run.status === 'running') {
+      if (!fold.active || run.updatedAt > fold.active.updatedAt) {
+        fold.active = { status: run.status, updatedAt: run.updatedAt };
+      }
+    }
+    folds.set(run.projectId, fold);
+  }
+
+  const awaitingInput = new Set(awaitingInputProjectIds);
+  const statuses = new Map<string, ProjectDisplayStatus>();
+  for (const [projectId, fold] of folds) {
+    // An in-flight run outranks history, matching the daemon's
+    // `activeRunStatuses ?? latestRunStatuses` precedence.
+    const base = fold.active?.status ?? fold.terminal?.status ?? 'not_started';
+    // Only `succeeded` is superseded by a pending question — a failed or
+    // canceled run leaves nothing to answer. Same narrow rule as
+    // `composeProjectDisplayStatus`.
+    statuses.set(
+      projectId,
+      base === 'succeeded' && awaitingInput.has(projectId) ? 'awaiting_input' : base,
+    );
+  }
+  return statuses;
+}

--- a/apps/web/src/state/projectRunStatus.ts
+++ b/apps/web/src/state/projectRunStatus.ts
@@ -42,7 +42,7 @@ interface RunFold {
   /** Newest non-terminal run — an in-flight run outranks any history. */
   active?: { status: 'queued' | 'running'; updatedAt: number };
   /** Newest terminal run, already resolved to its display status. */
-  terminal?: { status: ProjectDisplayStatus; updatedAt: number };
+  terminal?: { status: ProjectDisplayStatus; updatedAt: number; runId: string };
 }
 
 /**
@@ -62,7 +62,22 @@ export function terminalRunDisplayStatus(
 }
 
 /**
- * `Map<projectId, ProjectDisplayStatus>` for every project the runs cover.
+ * A project's folded status plus the identity of the finished run behind it.
+ *
+ * The run id is what lets a consumer acknowledge a notice PER RUN rather than
+ * per project: "the user has seen that r1 finished" stays true after r2
+ * finishes, and r2 is a new notice. A project-keyed acknowledgement cannot tell
+ * the two apart once the running phase in between goes unobserved.
+ */
+export interface ProjectRunSummary {
+  status: ProjectDisplayStatus;
+  /** The newest terminal run, when the project has one. */
+  latestTerminalRunId?: string;
+  latestTerminalUpdatedAt?: number;
+}
+
+/**
+ * `Map<projectId, ProjectRunSummary>` for every project the runs cover.
  *
  * `awaitingInputProjectIds` comes from the same `/api/runs` response and is
  * what lets a blocked project be told apart from a finished one; the run that
@@ -70,10 +85,10 @@ export function terminalRunDisplayStatus(
  * daemon is too old to send it — the result then simply never says
  * `awaiting_input`, which is the pre-existing behaviour, not a regression.
  */
-export function foldRunsToProjectStatuses(
+export function foldRunsToProjectRunSummaries(
   runs: ChatRunStatusResponse[],
   awaitingInputProjectIds: readonly string[] = [],
-): Map<string, ProjectDisplayStatus> {
+): Map<string, ProjectRunSummary> {
   const folds = new Map<string, RunFold>();
 
   for (const run of runs) {
@@ -81,7 +96,11 @@ export function foldRunsToProjectStatuses(
     const fold = folds.get(run.projectId) ?? {};
     if (TERMINAL_RUN_STATUSES.has(run.status)) {
       if (!fold.terminal || run.updatedAt > fold.terminal.updatedAt) {
-        fold.terminal = { status: terminalRunDisplayStatus(run), updatedAt: run.updatedAt };
+        fold.terminal = {
+          status: terminalRunDisplayStatus(run),
+          updatedAt: run.updatedAt,
+          runId: run.id,
+        };
       }
       // Deliberate divergence from the daemon: `normalizeProjectDisplayStatus`
       // folds `queued` into `running`, because its consumers only ever needed
@@ -98,7 +117,7 @@ export function foldRunsToProjectStatuses(
   }
 
   const awaitingInput = new Set(awaitingInputProjectIds);
-  const statuses = new Map<string, ProjectDisplayStatus>();
+  const summaries = new Map<string, ProjectRunSummary>();
   for (const [projectId, fold] of folds) {
     // An in-flight run outranks history, matching the daemon's
     // `activeRunStatuses ?? latestRunStatuses` precedence.
@@ -106,10 +125,34 @@ export function foldRunsToProjectStatuses(
     // Only `succeeded` is superseded by a pending question — a failed or
     // canceled run leaves nothing to answer. Same narrow rule as
     // `composeProjectDisplayStatus`.
-    statuses.set(
-      projectId,
-      base === 'succeeded' && awaitingInput.has(projectId) ? 'awaiting_input' : base,
-    );
+    const status = base === 'succeeded' && awaitingInput.has(projectId) ? 'awaiting_input' : base;
+    // The terminal run is reported even while a newer run is in flight: it is
+    // still the newest FINISHED run, which is what an acknowledgement names.
+    summaries.set(projectId, {
+      status,
+      ...(fold.terminal
+        ? {
+            latestTerminalRunId: fold.terminal.runId,
+            latestTerminalUpdatedAt: fold.terminal.updatedAt,
+          }
+        : {}),
+    });
+  }
+  return summaries;
+}
+
+/**
+ * `Map<projectId, ProjectDisplayStatus>` for every project the runs cover —
+ * the status half of {@link foldRunsToProjectRunSummaries}, for consumers that
+ * only draw a glyph and never acknowledge anything.
+ */
+export function foldRunsToProjectStatuses(
+  runs: ChatRunStatusResponse[],
+  awaitingInputProjectIds: readonly string[] = [],
+): Map<string, ProjectDisplayStatus> {
+  const statuses = new Map<string, ProjectDisplayStatus>();
+  for (const [projectId, summary] of foldRunsToProjectRunSummaries(runs, awaitingInputProjectIds)) {
+    statuses.set(projectId, summary.status);
   }
   return statuses;
 }

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -64,6 +64,13 @@
    track is 0-wide so the rail is clipped away, expanded it occupies the rail
    width. */
 .entry-nav-rail {
+  /* The ink the 最近浏览过 heading and the project rows under it share (per
+     product: 未选中的颜色和「最近浏览过」这一档一样). #5c5c5c (per product), a
+     flat opaque grey rather than an alpha: the rail is a frosted panel, so a
+     translucent ink took its tone from whatever scrolled under it and read
+     washed-out over the pale page. Dark mode keeps the alpha below; #5c5c5c is
+     far too dark on that ground. */
+  --rail-ink-quiet: #5c5c5c;
   /* Fill the grid track (0 collapsed → rail width expanded) rather than a
      fixed width, so a 0-wide track truly hides the rail instead of letting a
      56px rail overflow it. The rail box itself is a transparent container; the
@@ -81,6 +88,16 @@
      the overflow clip below — no opacity fade, which previously crossed with
      the topbar toggle's fade-out and caused a flash on expand. */
   pointer-events: none;
+}
+/* Dark mode keeps a derived alpha: over the dark panel a mix off --text
+   (#ededed) lands where it should. Only the light theme pins a literal. */
+[data-theme="dark"] .entry-nav-rail {
+  --rail-ink-quiet: color-mix(in srgb, var(--text) 52%, transparent);
+}
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme]) .entry-nav-rail {
+    --rail-ink-quiet: color-mix(in srgb, var(--text) 52%, transparent);
+  }
 }
 /* The whole sidebar reads as one floating layer: the content sits in a panel
    inset from the grid-track edges (margin) with rounded corners + elevation,
@@ -780,6 +797,368 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* ── 最近浏览过 (rail section under 插件) ─────────────────────────────────
+   A disclosure, not a destination: the head row toggles, the rows below open
+   projects. It borrows the nav row's geometry so the section reads as part of
+   the same list rather than a panel dropped into it. */
+.entry-nav-rail__recent {
+  display: flex;
+  flex-direction: column;
+  /* 16px between 插件 and this heading (per product, down from 24). The group
+     above already puts 2px between its children (`.entry-nav-rail__group`'s
+     gap), so the margin carries the remainder — written as the subtraction so
+     the total stays 16 if that gap ever moves. */
+  margin-top: calc(16px - 2px);
+}
+.entry-nav-rail__recent-head {
+  appearance: none;
+  width: 100%;
+  /* Same leading inset as a destination row (per product: 左边对齐和首页的
+     选项) — the heading starts on 插件's icon column, not indented under its
+     label. The chevron is no longer in that column either; it moved to the
+     row's trailing edge. */
+  height: auto;
+  /* 38 tall, the destinations' own row height (per product: 整个的高度都是 38).
+     A min-height rather than a fixed one: the box is a flex row that centres
+     its contents, so it grows rather than clipping if the title ever wraps. */
+  min-height: 38px;
+  padding: 8px 10px 8px 16px;
+  border: 0;
+  border-radius: 12px;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  /* Title left, chevron hard right. */
+  justify-content: space-between;
+  gap: 9px;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+  /* The rail's shared quiet ink — this heading is where that tone came from
+     (per product), and the unselected rows above and below now match it. */
+  color: var(--rail-ink-quiet);
+  transition: background-color 120ms var(--ease-out), color 120ms var(--ease-out);
+}
+.entry-nav-rail__recent-head:hover:not(:disabled) {
+  /* The same fill 首页 wears when it is the selected destination (per product):
+     the ink at 10%, not --bg-subtle. See `.entry-nav-rail__btn.is-active`. */
+  background: color-mix(in srgb, var(--text-strong) 10%, transparent);
+  color: var(--text-strong);
+}
+.entry-nav-rail__recent-chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 14px;
+}
+.entry-nav-rail__recent-title {
+  /* 13/500 (per product) — the destinations above read 13/600, so this sits on
+     the same size and one weight lighter: a heading for the rows under it, not
+     another place to go. */
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.entry-nav-rail__recent-list {
+  list-style: none;
+  margin: 0;
+  padding: 2px 0 0;
+  display: flex;
+  flex-direction: column;
+  /* 2px between the rows (per product) — the same rhythm the destinations
+     above keep. */
+  gap: 2px;
+}
+/* One recent row: the name button, the ⋮ trigger that overlays its trailing
+   edge, and the hover preview that escapes the rail. `position: relative` is
+   what the last two anchor to. */
+.entry-nav-rail__recent-row {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+/* ⋮ appears on hover / while its own menu is open. It OVERLAYS the name rather
+   than taking a column, so a row's text keeps the full width when the pointer
+   is elsewhere — the names are long and already ellipsized. */
+.entry-nav-rail__recent-more {
+  position: absolute;
+  right: 6px;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 120ms var(--ease-out), visibility 0s linear 120ms;
+}
+.entry-nav-rail__recent-row:hover .entry-nav-rail__recent-more,
+.entry-nav-rail__recent-more:focus-visible,
+.entry-nav-rail__recent-more[aria-expanded='true'] {
+  opacity: 1;
+  visibility: visible;
+  transition-delay: 0s;
+}
+/* The ⋮ clears its own space by SHORTENING the name (per product: 为最右侧的
+   按钮预留位置), so the name simply ellipsizes earlier while the row is hovered
+   or its menu is open. This replaced a right-to-left mask ramp: a mask applies
+   to the whole button, which faded the row's own hover fill out with the text
+   and made the pill look cut short — the fill has to stay whole, and the ink
+   that remains has to stay at full strength. */
+.entry-nav-rail__recent-row:hover .entry-nav-rail__recent-item,
+.entry-nav-rail__recent-row:focus-within .entry-nav-rail__recent-item {
+  /* 6 (the ⋮'s own inset) + 24 (its box) + 6 of air. */
+  padding-right: 36px;
+}
+.entry-nav-rail__recent-more:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--text) 8%, transparent);
+  color: var(--text-strong);
+}
+/* Inline rename: the input stands in the row's own box so committing does not
+   shift the list. */
+.entry-nav-rail__recent-rename {
+  width: 100%;
+  height: 38px;
+  padding: 10px 10px 10px 16px;
+  /* #DBDBDB (per product) — written as `--border`, the token that already holds
+     exactly that value, rather than as a literal. */
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  /* No fill of its own (per product: 修改名称的时候不要下边的白底) — the rail's
+     frosted panel shows through and the ring alone marks the field. --bg-app is
+     opaque white, which cut a solid card into a translucent column. */
+  background: transparent;
+  color: var(--text-strong);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 18px;
+  outline: none;
+}
+/* The ring you actually SEE, because this field is autofocused the moment it
+   opens — and primitives.css carries a blanket `input:focus { border-color:
+   var(--selected) }` (#353535), which at (0,1,1) out-ranks the (0,1,0) class
+   rule above. That near-black is what made the field read as a black-outlined
+   box; the rule above was never the one on screen. `.class:focus` is (0,2,0)
+   and takes it back. Same token as the resting state — the field marks itself
+   by being a field, not by darkening on focus. */
+.entry-nav-rail__recent-rename:focus {
+  border-color: var(--border);
+}
+/* Opens in the hover preview's slot — beside the row, over the content column
+   (per product: 弹窗的位置就是预览图的位置). Fixed + portalled to <body>, with
+   `top`/`left` measured off the row when the ⋮ is pressed, exactly like the
+   preview it replaces. */
+.entry-nav-rail__recent-menu {
+  position: fixed;
+  transform: translateY(-50%);
+  z-index: 1200;
+  min-width: 140px;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border: 1px solid var(--material-separator);
+  /* 12px (per product) — `--radius-lg`, the same corner the hover preview that
+     shares this slot takes, so the two popups cannot read as different
+     surfaces. It was `--radius` (8). */
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated, var(--bg-panel));
+  box-shadow: var(--shadow-md);
+}
+.entry-nav-rail__recent-menu button {
+  display: flex;
+  align-items: center;
+  /* primitives.css centres every button's content; a menu row reads as a list,
+     so it starts at the leading edge instead. */
+  justify-content: flex-start;
+  gap: 8px;
+  width: 100%;
+  height: auto;
+  padding: 7px 8px;
+  border: 0;
+  /* The hover fill takes the CARD's corner, not a tighter one of its own (per
+     product: hover 的按钮圆角和外边白色框一致) — same token as the menu above,
+     so the two can never drift apart. */
+  border-radius: var(--radius-lg);
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  /* 13 (per product, was 12). The marks beside it are already 14 — see
+     `RenameMark` / `DeleteMark` / the export glyph in RailRecentRow.tsx, all
+     drawn at that size — so the row now reads label-and-mark at one weight
+     instead of a 14px glyph over a 12px word. */
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+}
+.entry-nav-rail__recent-menu button:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--text-strong) 10%, transparent);
+  color: var(--text-strong);
+}
+/* Armed delete: the second click is the destructive one, so it says so. */
+.entry-nav-rail__recent-menu button.is-danger,
+.entry-nav-rail__recent-menu button.is-danger:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--red, #f04142) 12%, transparent);
+  color: var(--red, #f04142);
+}
+/* The preview floats OUT of the rail, over the content column: the rail panel
+   is only ~212px wide and a legible cover needs more than that. `left: 100%`
+   anchors it to the row's trailing edge; the panel above it does not clip
+   (the rail's overflow is only clamped while collapsed, and a collapsed rail
+   has no rows to hover). */
+.entry-nav-rail__recent-preview {
+  /* Fixed + portalled to <body>: `top`/`left` come from the row's own rect at
+     hover time (see RailRecentRow). Absolute inside the rail put it behind the
+     content column whatever its z-index. */
+  position: fixed;
+  transform: translateY(-50%);
+  z-index: 1200;
+  /* 216 — 180 + 20% (per product), 180 itself having come down from 232. */
+  width: 216px;
+  /* A card again, because it has something to say now (per product: 和这个一样
+     样式): the row's ellipsized name wraps in here with the last-touched time
+     under it, which is what the removed OS tooltip used to answer. It spent a
+     round as a bare plate — right while the popup was only a picture. Radius
+     16 outside / 8 inside with 8px of padding keeps the two concentric. */
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border: 1px solid var(--material-separator);
+  border-radius: var(--radius-xxlarge);
+  background: var(--bg-elevated, var(--bg-panel));
+  box-shadow: var(--shadow-md);
+  pointer-events: none;
+}
+.entry-nav-rail__recent-preview-plate {
+  aspect-ratio: 16 / 10;
+  overflow: hidden;
+  /* Inside the card again: no edge or lift of its own (the card carries both),
+     and the inner half of the concentric pair — 8 + the card's 8px padding =
+     the card's 16. */
+  border-radius: var(--radius);
+  background: var(--bg-subtle);
+  display: grid;
+  place-items: center;
+}
+.entry-nav-rail__recent-preview-plate img,
+.entry-nav-rail__recent-preview-plate video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: top center;
+  display: block;
+}
+.entry-nav-rail__recent-preview-glyph {
+  color: var(--text-faint);
+  font-size: 28px;
+  font-weight: 600;
+  line-height: 1;
+}
+/* Up to TWO lines of the full name, then an ellipsis (per product: 最多两行
+   名称). Long names are the reason this card exists at all — the row can only
+   ever show a prefix — but a card that grew without bound would cover the
+   column it floats over, and with the timestamp line gone the name is the
+   card's whole text. */
+.entry-nav-rail__recent-preview-name {
+  margin: 0;
+  /* 4px in from the plate's edges on both sides (per product: 文本向内收 4px
+     和预览图比). The plate is a filled rectangle and the text is loose ink —
+     sharing an edge, the ink reads as if it were sticking out. */
+  padding: 0 4px;
+  /* #848484 (per product) — written as the token that already IS that value
+     (tokens.css `--text-soft`), not as a literal, so the one definition keeps
+     carrying it. Two steps down from --text-strong: the card is a read-out of
+     a name the row had to clip, not a heading. */
+  color: var(--text-soft);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  /* Project names are often one unbroken token (a slug, a path); without this
+     they would overflow the clamp instead of wrapping inside it. */
+  overflow-wrap: anywhere;
+}
+.entry-nav-rail__recent-item {
+  appearance: none;
+  width: 100%;
+  /* A LEFT-ALIGNED flex row (glyph + name), spelled out rather than inherited:
+     primitives.css sets every button to `inline-flex` + `justify-content:
+     center`, which would centre the pair in the row. The name's truncation
+     moved onto `__recent-name` with it — a flex item has no line box of its
+     own to ellipsize, so the rule has to sit on the span that holds the text. */
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  /* The destinations' icon→label gap, so a project name lands on the same
+     column as 插件's label. */
+  gap: 9px;
+  height: auto;
+  /* Flush with the destinations' own leading inset (per product: 左边对齐和
+     首页的选项), so the row's GLYPH starts on the same column as 插件's puzzle
+     mark — and, since the glyph slot repeats the destinations' 18 + 9, the name
+     behind it lands on the labels' column. One left edge either way. */
+  /* 38 tall, matching the destinations and the heading above (per product).
+     This row is `display: block` (see above), so the height comes from an
+     explicit line box plus symmetric padding — 10 + 18 + 10 — rather than from
+     a flex centre it cannot use. */
+  padding: 10px 10px 10px 16px;
+  line-height: 18px;
+  border: 0;
+  border-radius: 12px;
+  background: transparent;
+  /* Same ink as the UNSELECTED destinations above (per product: 未选中的和最近
+     浏览过的颜色一致) — one quiet column from 首页 down to the last project;
+     only `.entry-nav-rail__btn.is-active` sits darker than it. */
+  color: var(--rail-ink-quiet);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  text-align: left;
+  overflow: hidden;
+  transition: background-color 120ms var(--ease-out), color 120ms var(--ease-out);
+}
+/* The leading glyph's slot: the chat mark, or this project's run status when it
+   has one (RailRecentRow). Same 18px box the destinations' icons occupy
+   (`.entry-nav-rail__btn-icon`) — that is what puts both columns of glyphs, and
+   therefore both columns of text, on one edge. Fixed width so a 14px status orb
+   and a 16px chat mark never shift the name sideways as a run starts. */
+.entry-nav-rail__recent-icon {
+  flex: 0 0 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  /* Tracks the row's ink, hover included. */
+  color: inherit;
+}
+.entry-nav-rail__recent-name {
+  min-width: 0;
+  flex: 1 1 auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.entry-nav-rail__recent-item:hover:not(:disabled) {
+  /* Same fill as the section heading above it and as 首页 when it is the
+     selected destination (per product): the ink at 10%, not --bg-subtle. See
+     `.entry-nav-rail__btn.is-active`. */
+  background: color-mix(in srgb, var(--text-strong) 10%, transparent);
+  color: var(--text-strong);
 }
 .entry-nav-rail__btn.is-active .entry-nav-rail__btn-icon {
   color: var(--selected);

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -76,6 +76,7 @@
   --radius-medium: 4px;
   --radius-large: 8px;
   --radius-xlarge: 12px;
+  --radius-xxlarge: 16px;
   --radius-circular: 50%;
   --stroke-thin: 1px;
   --stroke-thick: 2px;
@@ -86,6 +87,7 @@
   --radius: var(--radius-large);
   --radius-md: var(--radius-large);
   --radius-lg: var(--radius-xlarge);
+  --radius-xl: var(--radius-xxlarge);
   --radius-pill: 999px;
 
   --duration-ultra-fast: 50ms;

--- a/apps/web/tests/components/EntryNavRail.recent-section.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.recent-section.test.tsx
@@ -33,14 +33,17 @@ function project(id: string, updatedAt: number, name = `Project ${id}`): Project
   } as Project;
 }
 
-type RunFixture = { status: string; awaiting?: boolean };
+type RunFixture = { status: string; awaiting?: boolean; runId?: string };
 
-const RUNS: Record<string, RunFixture> = {
+const DEFAULT_RUNS: Record<string, RunFixture> = {
   p1: { status: 'running' },
   p2: { status: 'succeeded', awaiting: true },
   p3: { status: 'failed' },
   p4: { status: 'succeeded' },
 };
+
+/** What the runs feed answers per project; tests mutate it between polls. */
+let RUNS: Record<string, RunFixture> = { ...DEFAULT_RUNS };
 
 const originalFetch = globalThis.fetch;
 
@@ -53,7 +56,7 @@ function stubFetch() {
       const fixture = RUNS[id];
       const runs = fixture
         ? [{
-            id: `run-${id}`,
+            id: fixture.runId ?? `run-${id}`,
             projectId: id,
             conversationId: null,
             assistantMessageId: null,
@@ -98,6 +101,7 @@ function renderRail(overrides: Partial<Parameters<typeof EntryNavRail>[0]> = {})
 
 beforeEach(() => {
   window.localStorage.clear();
+  RUNS = { ...DEFAULT_RUNS };
   stubFetch();
 });
 
@@ -151,7 +155,49 @@ describe('EntryNavRail 最近浏览过 section', () => {
     await waitFor(() => {
       expect(within(screen.getAllByTestId('entry-nav-recent-item')[3]!).queryByRole('img')).toBeNull();
     });
-    expect(JSON.parse(window.localStorage.getItem('od.entry.railRecentSeenDone') ?? '[]')).toEqual(['p4']);
+    expect(JSON.parse(window.localStorage.getItem('od.entry.railRecentSeenDone') ?? '{}')).toEqual({
+      p4: 'run-p4',
+    });
+  });
+
+  it('re-raises the ✓ for a newer finished run even when its running phase was never seen', async () => {
+    // r1 finished; the user looks at it, which spends its ✓.
+    RUNS = { ...DEFAULT_RUNS, p4: { status: 'succeeded', runId: 'r1' } };
+    const { onOpen } = renderRail();
+    const rowFor = (id: string) =>
+      screen.getAllByTestId('entry-nav-recent-item').find((row) => row.textContent === `Project ${id}`)!;
+    await waitFor(() => {
+      expect(within(rowFor('p4')).getByRole('img', { name: 'Completed' })).toBeTruthy();
+    });
+    fireEvent.click(rowFor('p4'));
+    expect(onOpen).toHaveBeenCalledWith('p4');
+    await waitFor(() => {
+      expect(within(rowFor('p4')).queryByRole('img')).toBeNull();
+    });
+
+    // Collapse: the section stops polling, so the next run's queued/running
+    // phase is never observed. By the time it is expanded again, a NEW run r2
+    // has finished.
+    fireEvent.click(screen.getByTestId('entry-nav-recent-toggle'));
+    RUNS = { ...DEFAULT_RUNS, p4: { status: 'succeeded', runId: 'r2' } };
+    fireEvent.click(screen.getByTestId('entry-nav-recent-toggle'));
+
+    // r2 is a new notice: its ✓ must show even though r1's was acknowledged.
+    await waitFor(() => {
+      expect(within(rowFor('p4')).getByRole('img', { name: 'Completed' })).toBeTruthy();
+    });
+  });
+
+  it('ignores the legacy array shape of the acknowledgement store', async () => {
+    // Older builds stored a bare list of project ids. That shape cannot say
+    // WHICH run was acknowledged, so it must read as "nothing acknowledged":
+    // the ✓ shows once more rather than a fresh completion being swallowed.
+    window.localStorage.setItem('od.entry.railRecentSeenDone', JSON.stringify(['p4']));
+    renderRail();
+    const rows = screen.getAllByTestId('entry-nav-recent-item');
+    await waitFor(() => {
+      expect(within(rows[3]!).getByRole('img', { name: 'Completed' })).toBeTruthy();
+    });
   });
 
   it('collapses on the head row and remembers the choice', () => {

--- a/apps/web/tests/components/EntryNavRail.recent-section.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.recent-section.test.tsx
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+//
+// The rail's 最近浏览过 section: the head of the recent catalog under 插件, each
+// row leading with the project's live run status (the same feed the projects
+// grid reads) and opening through the shell's pull-first opener.
+
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import type { WorkspaceCollabContext } from '@open-design/contracts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EntryNavRail } from '../../src/components/EntryNavRail';
+import { I18nProvider } from '../../src/i18n';
+import type { Project } from '../../src/types';
+
+const signedInContext = {
+  workspaceId: 'ws-personal',
+  workspaceType: 'personal',
+  workspaceMemberId: 'wm-1',
+  role: 'owner',
+  memberStatus: 'active',
+  lifecycleState: 'active',
+  permissions: { canInviteMembers: false, canViewWorkspaceSettings: false },
+} as unknown as WorkspaceCollabContext;
+
+function project(id: string, updatedAt: number, name = `Project ${id}`): Project {
+  return {
+    id,
+    name,
+    skillId: null,
+    designSystemId: null,
+    createdAt: updatedAt,
+    updatedAt,
+  } as Project;
+}
+
+type RunFixture = { status: string; awaiting?: boolean };
+
+const RUNS: Record<string, RunFixture> = {
+  p1: { status: 'running' },
+  p2: { status: 'succeeded', awaiting: true },
+  p3: { status: 'failed' },
+  p4: { status: 'succeeded' },
+};
+
+const originalFetch = globalThis.fetch;
+
+function stubFetch() {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    const match = /^\/api\/runs\?projectId=([^&]+)$/.exec(url);
+    if (match) {
+      const id = decodeURIComponent(match[1]!);
+      const fixture = RUNS[id];
+      const runs = fixture
+        ? [{
+            id: `run-${id}`,
+            projectId: id,
+            conversationId: null,
+            assistantMessageId: null,
+            agentId: 'claude',
+            status: fixture.status,
+            createdAt: 1,
+            updatedAt: 2,
+          }]
+        : [];
+      return new Response(
+        JSON.stringify({ runs, awaitingInputProjectIds: fixture?.awaiting ? [id] : [] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+    return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+  }) as unknown as typeof fetch;
+}
+
+function renderRail(overrides: Partial<Parameters<typeof EntryNavRail>[0]> = {}) {
+  const onOpen = vi.fn();
+  const onRename = vi.fn();
+  const onDelete = vi.fn(async () => true);
+  render(
+    <I18nProvider initial="en">
+      <EntryNavRail
+        view="home"
+        onViewChange={() => {}}
+        onNewProject={() => {}}
+        open
+        context={signedInContext}
+        recentProjects={Array.from({ length: 10 }, (_, index) =>
+          project(`p${index + 1}`, 1_000 - index))}
+        onOpenRecentProject={onOpen}
+        onRenameRecentProject={onRename}
+        onDeleteRecentProject={onDelete}
+        {...overrides}
+      />
+    </I18nProvider>,
+  );
+  return { onOpen, onRename, onDelete };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  stubFetch();
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = originalFetch;
+});
+
+describe('EntryNavRail 最近浏览过 section', () => {
+  it('lists the eight most recent projects, newest first, under a disclosure that starts open', () => {
+    renderRail();
+    const toggle = screen.getByTestId('entry-nav-recent-toggle');
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(toggle.textContent).toContain('Recently viewed');
+    const rows = screen.getAllByTestId('entry-nav-recent-item');
+    expect(rows.map((row) => row.textContent)).toEqual(
+      ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'].map((id) => `Project ${id}`),
+    );
+  });
+
+  it('renders nothing without projects or without a cloud identity', () => {
+    renderRail({ recentProjects: [] });
+    expect(screen.queryByTestId('entry-nav-recent-toggle')).toBeNull();
+    cleanup();
+    renderRail({ context: null });
+    expect(screen.queryByTestId('entry-nav-recent-toggle')).toBeNull();
+  });
+
+  it('leads each row with its live run status from the runs feed', async () => {
+    renderRail();
+    const rows = screen.getAllByTestId('entry-nav-recent-item');
+    await waitFor(() => {
+      expect(within(rows[0]!).getByRole('img', { name: 'Running' })).toBeTruthy();
+    });
+    // A pending question outranks the succeeded run that asked it.
+    expect(within(rows[1]!).getByRole('img', { name: 'Needs input' })).toBeTruthy();
+    expect(within(rows[2]!).getByRole('img', { name: 'Failed' })).toBeTruthy();
+    expect(within(rows[3]!).getByRole('img', { name: 'Completed' })).toBeTruthy();
+    // No run at all: the default chat mark, which is decorative.
+    expect(within(rows[4]!).queryByRole('img')).toBeNull();
+  });
+
+  it('opens a project through the pull-first opener and spends its ✓ once looked at', async () => {
+    const { onOpen } = renderRail();
+    const rows = screen.getAllByTestId('entry-nav-recent-item');
+    await waitFor(() => {
+      expect(within(rows[3]!).getByRole('img', { name: 'Completed' })).toBeTruthy();
+    });
+    fireEvent.click(rows[3]!);
+    expect(onOpen).toHaveBeenCalledWith('p4');
+    await waitFor(() => {
+      expect(within(screen.getAllByTestId('entry-nav-recent-item')[3]!).queryByRole('img')).toBeNull();
+    });
+    expect(JSON.parse(window.localStorage.getItem('od.entry.railRecentSeenDone') ?? '[]')).toEqual(['p4']);
+  });
+
+  it('collapses on the head row and remembers the choice', () => {
+    renderRail();
+    const toggle = screen.getByTestId('entry-nav-recent-toggle');
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(window.localStorage.getItem('od.entry.railRecentOpen')).toBe('false');
+    cleanup();
+    renderRail();
+    expect(screen.getByTestId('entry-nav-recent-toggle').getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('offers rename and a two-step delete from the row menu', async () => {
+    const { onDelete, onRename } = renderRail();
+    const more = screen.getAllByTestId('entry-nav-recent-more')[0]!;
+    fireEvent.click(more);
+    const menu = screen.getByRole('menu');
+    const items = within(menu).getAllByRole('menuitem').map((item) => item.textContent);
+    expect(items).toEqual(['Rename', 'Export', 'Delete']);
+
+    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Delete' }));
+    // First click only arms the destructive action.
+    expect(onDelete).not.toHaveBeenCalled();
+    fireEvent.click(within(screen.getByRole('menu')).getByRole('menuitem', { name: 'OK' }));
+    expect(onDelete).toHaveBeenCalledWith('p1');
+
+    fireEvent.click(screen.getAllByTestId('entry-nav-recent-more')[1]!);
+    fireEvent.click(within(screen.getByRole('menu')).getByRole('menuitem', { name: 'Rename' }));
+    const input = screen.getByRole('textbox', { name: 'Rename' }) as HTMLInputElement;
+    expect(input.value).toBe('Project p2');
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Renamed' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+    });
+    expect(onRename).toHaveBeenCalledWith('p2', 'Renamed');
+  });
+});

--- a/apps/web/tests/components/EntryShell.blank-project-naming.test.tsx
+++ b/apps/web/tests/components/EntryShell.blank-project-naming.test.tsx
@@ -10,7 +10,7 @@
 // no-name create path (`handleCreateProjectFromDesignSystem`, the New Project
 // panel's blank pick), which already tag `nameSource: 'generated'`.
 
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import {
   buildWorkspacePermissions,
   buildWorkspaceSeatSummary,
@@ -293,9 +293,12 @@ describe('EntryShell team project content readiness', () => {
       onTeamProjectContentReady,
     });
 
-    const activeCard = await screen.findByRole('button', {
-      name: /Ready shared project/,
-    });
+    // Scoped to the project grid: the rail's 最近浏览过 list names the same
+    // projects, so an unscoped lookup matches the card AND its rail row.
+    const activeCard = await within(document.querySelector('main') as HTMLElement).findByRole(
+      'button',
+      { name: /Ready shared project/ },
+    );
     fireEvent.click(activeCard);
 
     await waitFor(() => {
@@ -440,7 +443,10 @@ describe('EntryShell team project content readiness', () => {
       onTeamProjectContentReady,
     });
 
-    expect(await screen.findByText('Ready shared project')).toBeTruthy();
+    // Scoped to the grid: the rail's 最近浏览过 list names the same project.
+    expect(
+      await within(document.querySelector('main') as HTMLElement).findByText('Ready shared project'),
+    ).toBeTruthy();
     expect(MockWorkspaceEventSource.instances).toHaveLength(1);
     act(() => {
       MockWorkspaceEventSource.instances[0]!.dispatch('team-project-content-ready', {
@@ -558,7 +564,10 @@ describe('EntryShell team project content readiness', () => {
       fresh: true,
     })).resolves.toEqual([]);
 
-    expect(await screen.findByText('Ready shared project')).toBeTruthy();
+    // Scoped to the grid: the rail's 最近浏览过 list names the same project.
+    expect(
+      await within(document.querySelector('main') as HTMLElement).findByText('Ready shared project'),
+    ).toBeTruthy();
     act(() => {
       MockWorkspaceEventSource.instances[0]!.dispatch('team-project-content-ready', {
         type: 'team-project-content-ready',
@@ -648,7 +657,10 @@ describe('EntryShell team project content readiness', () => {
       onTeamProjectContentReady,
     });
 
-    expect(await screen.findByText('Ready shared project')).toBeTruthy();
+    // Scoped to the grid: the rail's 最近浏览过 list names the same project.
+    expect(
+      await within(document.querySelector('main') as HTMLElement).findByText('Ready shared project'),
+    ).toBeTruthy();
     act(() => {
       MockWorkspaceEventSource.instances[0]!.dispatch('team-project-content-ready', {
         type: 'team-project-content-ready',
@@ -742,7 +754,10 @@ describe('EntryShell team project content readiness', () => {
         name: 'Ready shared project',
       }],
     }));
-    expect(await screen.findByText('Ready shared project')).toBeTruthy();
+    // Scoped to the grid: the rail's 最近浏览过 list names the same project.
+    expect(
+      await within(document.querySelector('main') as HTMLElement).findByText('Ready shared project'),
+    ).toBeTruthy();
     await waitFor(() => {
       expect(onTeamProjectContentReady).toHaveBeenCalledWith('shared-ready', 'ws-1', 'wm-1');
     });

--- a/apps/web/tests/components/ProjectRunStatusIcon.test.tsx
+++ b/apps/web/tests/components/ProjectRunStatusIcon.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ProjectDisplayStatus } from '@open-design/contracts';
+
+import { ProjectRunStatusIcon } from '../../src/components/ProjectRunStatusIcon';
+
+afterEach(cleanup);
+
+/** The orb is a span tree; the succeeded badge is an svg. */
+function shapeOf(status: ProjectDisplayStatus) {
+  const { container } = render(<ProjectRunStatusIcon status={status} />);
+  const root = container.firstElementChild;
+  if (!root) return { kind: 'none' as const };
+  if (root.tagName.toLowerCase() === 'svg') return { kind: 'badge' as const, root };
+  return { kind: 'orb' as const, root: root as HTMLElement };
+}
+
+describe('ProjectRunStatusIcon', () => {
+  it('draws finished work as the static badge, not the orb', () => {
+    const result = shapeOf('succeeded');
+    expect(result.kind).toBe('badge');
+    // The two hardcoded fills are the whole point of it not going through Icon.
+    const fills = [...result.root!.querySelectorAll('path')].map((p) => p.getAttribute('fill'));
+    expect(fills).toEqual(['#202020', '#00FF08']);
+  });
+
+  it.each<[ProjectDisplayStatus]>([['running'], ['queued'], ['awaiting_input'], ['incomplete'], ['failed']])(
+    'draws %s as the orb',
+    (status) => {
+      expect(shapeOf(status).kind).toBe('orb');
+    },
+  );
+
+  it('leaves running and queued on the default green', () => {
+    // Same family, same colour — only the speed differs, so neither may set a
+    // palette override.
+    for (const status of ['running', 'queued'] as const) {
+      const { root } = shapeOf(status) as { root: HTMLElement };
+      expect(root.style.getPropertyValue('--c1')).toBe('');
+    }
+  });
+
+  it('recolours the orb per the states that need attention', () => {
+    const attention = (shapeOf('awaiting_input') as { root: HTMLElement }).root;
+    const incomplete = (shapeOf('incomplete') as { root: HTMLElement }).root;
+    const failed = (shapeOf('failed') as { root: HTMLElement }).root;
+
+    expect(attention.style.getPropertyValue('--c1')).toBe('#EDC337');
+    expect(incomplete.style.getPropertyValue('--c1')).toBe('#EDC337');
+    expect(failed.style.getPropertyValue('--c1')).toBe('#F8672F');
+  });
+
+  it('moves the second accent with the first', () => {
+    // `--c2` is the other accent AND the glow. Left on the stock spring-green
+    // it blends with an orange `--c1` into a muddy red-green dot, which is
+    // exactly what the first pass shipped.
+    for (const status of ['awaiting_input', 'incomplete', 'failed'] as const) {
+      const { root } = shapeOf(status) as { root: HTMLElement };
+      const c2 = root.style.getPropertyValue('--c2');
+      expect(c2).not.toBe('');
+      expect(c2.toLowerCase()).not.toBe('#00ffae');
+    }
+  });
+
+  it('renders nothing for the statuses with nothing to say', () => {
+    // The caller reserves the slot; this must not fill it with a placeholder.
+    expect(shapeOf('not_started').kind).toBe('none');
+    expect(shapeOf('canceled').kind).toBe('none');
+  });
+
+  it('is decorative unless given a label', () => {
+    const bare = render(<ProjectRunStatusIcon status="running" />).container.firstElementChild;
+    expect(bare?.getAttribute('aria-hidden')).toBe('true');
+    cleanup();
+
+    const labelled = render(
+      <ProjectRunStatusIcon status="running" label="Running" />,
+    ).container.firstElementChild;
+    expect(labelled?.getAttribute('role')).toBe('img');
+    expect(labelled?.getAttribute('aria-label')).toBe('Running');
+  });
+
+  it('sizes both shapes from the same prop', () => {
+    const orb = render(<ProjectRunStatusIcon status="running" size={14} />)
+      .container.firstElementChild as HTMLElement;
+    expect(orb.style.getPropertyValue('--size')).toBe('14px');
+    cleanup();
+
+    const badge = render(<ProjectRunStatusIcon status="succeeded" size={14} />)
+      .container.firstElementChild;
+    expect(badge?.getAttribute('width')).toBe('14');
+    expect(badge?.getAttribute('height')).toBe('14');
+  });
+});

--- a/apps/web/tests/runtime/latest-user-prompt.test.ts
+++ b/apps/web/tests/runtime/latest-user-prompt.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { latestUserPromptText } from '../../src/runtime/latest-user-prompt';
+import type { ChatMessage } from '../../src/types';
+
+function message(role: ChatMessage['role'], content: string, id = content): ChatMessage {
+  return { id, role, content };
+}
+
+describe('latestUserPromptText', () => {
+  it('returns null for an empty conversation', () => {
+    expect(latestUserPromptText([])).toBeNull();
+  });
+
+  it('returns null when the assistant has spoken but the user has not', () => {
+    expect(latestUserPromptText([message('assistant', 'Ready when you are.')])).toBeNull();
+  });
+
+  it('picks the most recent user turn, not the first', () => {
+    const messages = [
+      message('user', 'Build a portfolio'),
+      message('assistant', 'On it.'),
+      message('user', 'Actually make it a landing page'),
+    ];
+    expect(latestUserPromptText(messages)).toBe('Actually make it a landing page');
+  });
+
+  it('collapses hard-wrapped whitespace into one line', () => {
+    expect(latestUserPromptText([message('user', '  Build   a\n\nportfolio  ')])).toBe(
+      'Build a portfolio',
+    );
+  });
+
+  it('skips a blank user turn and falls back to the previous one', () => {
+    const messages = [message('user', 'Build a portfolio'), message('user', '   ', 'blank')];
+    expect(latestUserPromptText(messages)).toBe('Build a portfolio');
+  });
+
+  it('elides a prompt that would overrun the empty state', () => {
+    const long = 'a'.repeat(400);
+    const result = latestUserPromptText([message('user', long)]);
+    expect(result).toHaveLength(161);
+    expect(result?.endsWith('…')).toBe(true);
+  });
+});

--- a/apps/web/tests/runtime/run-progress.test.ts
+++ b/apps/web/tests/runtime/run-progress.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { runProgressSteps } from '../../src/runtime/run-progress';
+import type { AgentEvent, ChatMessage } from '../../src/types';
+
+function toolUse(id: string, name: string, input: unknown): AgentEvent {
+  return { kind: 'tool_use', id, name, input };
+}
+
+function assistant(events: AgentEvent[], id = 'a1'): ChatMessage {
+  return { id, role: 'assistant', content: '', events };
+}
+
+function user(content: string, id = 'u1'): ChatMessage {
+  return { id, role: 'user', content };
+}
+
+describe('runProgressSteps', () => {
+  it('returns nothing for a conversation with no assistant turn', () => {
+    expect(runProgressSteps([])).toEqual([]);
+    expect(runProgressSteps([user('Build a portfolio')])).toEqual([]);
+  });
+
+  it('reads the newest tool call first', () => {
+    const steps = runProgressSteps([
+      assistant([
+        toolUse('1', 'Read', { file_path: '/tmp/project/index.html' }),
+        toolUse('2', 'Edit', { file_path: '/tmp/project/styles/site.css' }),
+      ]),
+    ]);
+    expect(steps.map((step) => [step.category, step.target])).toEqual([
+      ['edit', 'site.css'],
+      ['read', 'index.html'],
+    ]);
+  });
+
+  it('reads only the last assistant turn, not the one before it', () => {
+    const steps = runProgressSteps([
+      assistant([toolUse('1', 'Write', { file_path: 'old.html' })], 'first'),
+      user('Now make it dark'),
+      assistant([toolUse('2', 'Write', { file_path: 'new.html' })], 'second'),
+    ]);
+    expect(steps.map((step) => step.target)).toEqual(['new.html']);
+  });
+
+  it('returns nothing once the user has spoken after the assistant', () => {
+    const steps = runProgressSteps([
+      assistant([toolUse('1', 'Write', { file_path: 'old.html' })]),
+      user('Now make it dark', 'u2'),
+    ]);
+    expect(steps).toEqual([]);
+  });
+
+  it('names a command by its first line and a fetch by host + path', () => {
+    const steps = runProgressSteps([
+      assistant([
+        toolUse('1', 'WebFetch', { url: 'https://example.com/docs/intro?utm=1' }),
+        toolUse('2', 'Bash', { command: 'pnpm build\necho done' }),
+      ]),
+    ]);
+    expect(steps.map((step) => [step.category, step.target])).toEqual([
+      ['run', 'pnpm build'],
+      ['fetch', 'example.com/docs/intro'],
+    ]);
+  });
+
+  it('skips TodoWrite — the pinned todo card already shows that state', () => {
+    const steps = runProgressSteps([
+      assistant([
+        toolUse('1', 'TodoWrite', { todos: [] }),
+        toolUse('2', 'Read', { file_path: 'index.html' }),
+      ]),
+    ]);
+    expect(steps.map((step) => step.id)).toEqual(['2']);
+  });
+
+  it('keeps an unclassified tool, with its name for the caller to render', () => {
+    const steps = runProgressSteps([assistant([toolUse('1', 'mcp__figma__export', {})])]);
+    expect(steps).toEqual([
+      { id: '1', category: 'other', toolName: 'mcp__figma__export', target: null },
+    ]);
+  });
+
+  it('elides a target that would overrun the line', () => {
+    const long = `${'a'.repeat(200)}.html`;
+    const steps = runProgressSteps([assistant([toolUse('1', 'Write', { file_path: long })])]);
+    expect(steps[0]?.target).toHaveLength(45);
+    expect(steps[0]?.target?.endsWith('…')).toBe(true);
+  });
+
+  it('caps the trail so a long turn cannot grow it without bound', () => {
+    const events = Array.from({ length: 40 }, (_, i) =>
+      toolUse(String(i), 'Read', { file_path: `file-${i}.html` }),
+    );
+    const steps = runProgressSteps([assistant(events)]);
+    expect(steps).toHaveLength(12);
+    // Newest first: the cap drops the oldest calls, not the current one.
+    expect(steps[0]?.target).toBe('file-39.html');
+  });
+});

--- a/apps/web/tests/state/projectRunStatus.test.ts
+++ b/apps/web/tests/state/projectRunStatus.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import type { ChatRunStatusResponse } from '@open-design/contracts';
 
-import { foldRunsToProjectStatuses } from '../../src/state/projectRunStatus';
+import {
+  foldRunsToProjectRunSummaries,
+  foldRunsToProjectStatuses,
+} from '../../src/state/projectRunStatus';
 
 function run(over: Partial<ChatRunStatusResponse> & { status: ChatRunStatusResponse['status'] }) {
   return {
@@ -103,5 +106,59 @@ describe('foldRunsToProjectStatuses', () => {
 
   it('ignores runs with no project', () => {
     expect(foldRunsToProjectStatuses([run({ projectId: null, status: 'running' })]).size).toBe(0);
+  });
+});
+
+describe('foldRunsToProjectRunSummaries', () => {
+  it('names the newest finished run behind the status', () => {
+    const summaries = foldRunsToProjectRunSummaries([
+      run({ id: 'r1', status: 'succeeded', updatedAt: 1 }),
+      run({ id: 'r2', status: 'succeeded', updatedAt: 2 }),
+    ]);
+
+    expect(summaries.get('p1')).toEqual({
+      status: 'succeeded',
+      latestTerminalRunId: 'r2',
+      latestTerminalUpdatedAt: 2,
+    });
+  });
+
+  it('keeps the finished run while a newer run is in flight', () => {
+    // The status follows the live run; the acknowledgement still names the
+    // run that last finished, which is the notice the user may have seen.
+    const summaries = foldRunsToProjectRunSummaries([
+      run({ id: 'r1', status: 'succeeded', updatedAt: 1 }),
+      run({ id: 'r2', status: 'running', updatedAt: 2 }),
+    ]);
+
+    expect(summaries.get('p1')).toEqual({
+      status: 'running',
+      latestTerminalRunId: 'r1',
+      latestTerminalUpdatedAt: 1,
+    });
+  });
+
+  it('carries no run identity for a project that never finished a run', () => {
+    expect(foldRunsToProjectRunSummaries([run({ id: 'r1', status: 'queued' })]).get('p1')).toEqual({
+      status: 'queued',
+    });
+  });
+
+  it('composes awaiting_input the same way the status fold does', () => {
+    const runs = [run({ id: 'r1', status: 'succeeded' })];
+    expect(foldRunsToProjectRunSummaries(runs, ['p1']).get('p1')?.status).toBe('awaiting_input');
+    expect(foldRunsToProjectStatuses(runs, ['p1']).get('p1')).toBe('awaiting_input');
+  });
+
+  it('agrees with foldRunsToProjectStatuses on every project', () => {
+    const runs = [
+      run({ id: 'a', projectId: 'ok', status: 'succeeded' }),
+      run({ id: 'b', projectId: 'bad', status: 'failed' }),
+      run({ id: 'c', projectId: 'busy', status: 'running' }),
+      run({ id: 'd', projectId: 'part', status: 'succeeded', endedWithUnfinishedWork: true }),
+    ];
+    const statuses = foldRunsToProjectStatuses(runs, ['ok']);
+    const summaries = foldRunsToProjectRunSummaries(runs, ['ok']);
+    expect([...summaries].map(([id, summary]) => [id, summary.status])).toEqual([...statuses]);
   });
 });

--- a/apps/web/tests/state/projectRunStatus.test.ts
+++ b/apps/web/tests/state/projectRunStatus.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import type { ChatRunStatusResponse } from '@open-design/contracts';
+
+import { foldRunsToProjectStatuses } from '../../src/state/projectRunStatus';
+
+function run(over: Partial<ChatRunStatusResponse> & { status: ChatRunStatusResponse['status'] }) {
+  return {
+    id: `run-${Math.random()}`,
+    projectId: 'p1',
+    conversationId: null,
+    assistantMessageId: null,
+    agentId: 'claude',
+    createdAt: 0,
+    updatedAt: 1,
+    ...over,
+  } as ChatRunStatusResponse;
+}
+
+describe('foldRunsToProjectStatuses', () => {
+  it('reports each terminal outcome under its own name', () => {
+    const statuses = foldRunsToProjectStatuses([
+      run({ projectId: 'ok', status: 'succeeded' }),
+      run({ projectId: 'bad', status: 'failed' }),
+      run({ projectId: 'stopped', status: 'canceled' }),
+    ]);
+
+    expect(statuses.get('ok')).toBe('succeeded');
+    expect(statuses.get('bad')).toBe('failed');
+    expect(statuses.get('stopped')).toBe('canceled');
+  });
+
+  it('keeps queued distinct from running', () => {
+    // The daemon folds queued into running for its own consumers; this one
+    // paces its indicator differently, so the distinction has to survive.
+    const statuses = foldRunsToProjectStatuses([
+      run({ projectId: 'waiting', status: 'queued' }),
+      run({ projectId: 'working', status: 'running' }),
+    ]);
+
+    expect(statuses.get('waiting')).toBe('queued');
+    expect(statuses.get('working')).toBe('running');
+  });
+
+  it('calls a succeeded run with unfinished declared work incomplete (#1247 / #1060)', () => {
+    const statuses = foldRunsToProjectStatuses([
+      run({ status: 'succeeded', endedWithUnfinishedWork: true }),
+    ]);
+
+    expect(statuses.get('p1')).toBe('incomplete');
+  });
+
+  it('lets a pending question outrank a succeeded run', () => {
+    // The run that asked reports `succeeded` and exits, so without the
+    // awaiting-input set a blocked project reads as finished.
+    const runs = [run({ status: 'succeeded' })];
+
+    expect(foldRunsToProjectStatuses(runs).get('p1')).toBe('succeeded');
+    expect(foldRunsToProjectStatuses(runs, ['p1']).get('p1')).toBe('awaiting_input');
+  });
+
+  it('does not let a pending question mask a failure', () => {
+    // Only `succeeded` is superseded — a failed or canceled run leaves nothing
+    // to answer, and hiding the failure behind "needs input" would misdirect.
+    expect(foldRunsToProjectStatuses([run({ status: 'failed' })], ['p1']).get('p1')).toBe('failed');
+    expect(foldRunsToProjectStatuses([run({ status: 'canceled' })], ['p1']).get('p1')).toBe(
+      'canceled',
+    );
+  });
+
+  it('lets an in-flight run outrank finished history', () => {
+    const statuses = foldRunsToProjectStatuses([
+      run({ status: 'succeeded', updatedAt: 99 }),
+      run({ status: 'running', updatedAt: 1 }),
+    ]);
+
+    expect(statuses.get('p1')).toBe('running');
+  });
+
+  it('picks the newest run within each of active and terminal', () => {
+    expect(
+      foldRunsToProjectStatuses([
+        run({ status: 'succeeded', updatedAt: 1 }),
+        run({ status: 'failed', updatedAt: 2 }),
+      ]).get('p1'),
+    ).toBe('failed');
+
+    expect(
+      foldRunsToProjectStatuses([
+        run({ status: 'queued', updatedAt: 2 }),
+        run({ status: 'running', updatedAt: 1 }),
+      ]).get('p1'),
+    ).toBe('queued');
+  });
+
+  it('omits projects it was told nothing about', () => {
+    // A missing entry means "unknown", which the UI renders as an empty slot.
+    // Defaulting to not_started here would assert something unverified.
+    const statuses = foldRunsToProjectStatuses([run({ projectId: 'known', status: 'running' })]);
+
+    expect(statuses.has('unknown')).toBe(false);
+    expect(foldRunsToProjectStatuses([]).size).toBe(0);
+  });
+
+  it('ignores runs with no project', () => {
+    expect(foldRunsToProjectStatuses([run({ projectId: null, status: 'running' })]).size).toBe(0);
+  });
+});

--- a/apps/web/tests/styles/entry-rail-recent.test.ts
+++ b/apps/web/tests/styles/entry-rail-recent.test.ts
@@ -1,0 +1,109 @@
+// Measurement spec for the rail's 最近浏览过 rows (OPEND-2553, ported from
+// upstream #7635). The values are pinned to the Demo's, so a drift in either
+// direction fails here before it reaches a screenshot.
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const entryLayoutCss = readFileSync(
+  new URL('../../src/styles/home/entry-layout.css', import.meta.url),
+  'utf8',
+);
+
+function declarations(selector: string): string {
+  const cssWithoutComments = entryLayoutCss.replace(/\/\*[\s\S]*?\*\//g, '');
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  const blocks: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  return blocks.join('\n');
+}
+
+describe('entry rail — 最近浏览过 rows', () => {
+  it('pins the shared quiet ink the heading and rows carry', () => {
+    expect(declarations('.entry-nav-rail')).toMatch(/--rail-ink-quiet:\s*#5c5c5c/);
+    expect(declarations('[data-theme="dark"] .entry-nav-rail')).toMatch(
+      /--rail-ink-quiet:\s*color-mix\(in srgb, var\(--text\) 52%, transparent\)/,
+    );
+  });
+
+  it('gives the section the destinations\' geometry: 16px above, 38px rows, 12px corners', () => {
+    expect(declarations('.entry-nav-rail__recent')).toMatch(/margin-top:\s*calc\(16px - 2px\)/);
+
+    const head = declarations('.entry-nav-rail__recent-head');
+    expect(head).toMatch(/min-height:\s*38px/);
+    expect(head).toMatch(/padding:\s*8px 10px 8px 16px/);
+    expect(head).toMatch(/border-radius:\s*12px/);
+    expect(head).toMatch(/justify-content:\s*space-between/);
+    expect(head).toMatch(/color:\s*var\(--rail-ink-quiet\)/);
+    expect(head).toMatch(
+      /transition:\s*background-color 120ms var\(--ease-out\), color 120ms var\(--ease-out\)/,
+    );
+
+    const title = declarations('.entry-nav-rail__recent-title');
+    expect(title).toMatch(/font-size:\s*13px/);
+    expect(title).toMatch(/font-weight:\s*500/);
+
+    const list = declarations('.entry-nav-rail__recent-list');
+    expect(list).toMatch(/gap:\s*2px/);
+    expect(list).toMatch(/padding:\s*2px 0 0/);
+
+    const item = declarations('.entry-nav-rail__recent-item');
+    expect(item).toMatch(/padding:\s*10px 10px 10px 16px/);
+    expect(item).toMatch(/line-height:\s*18px/);
+    expect(item).toMatch(/gap:\s*9px/);
+    expect(item).toMatch(/border-radius:\s*12px/);
+    expect(item).toMatch(/font-size:\s*13px/);
+    expect(item).toMatch(/font-weight:\s*500/);
+    expect(item).toMatch(/color:\s*var\(--rail-ink-quiet\)/);
+
+    expect(declarations('.entry-nav-rail__recent-icon')).toMatch(/flex:\s*0 0 18px/);
+  });
+
+  it('hover paints the selected-row fill and clears room for the ⋮', () => {
+    const hover = declarations('.entry-nav-rail__recent-item:hover:not(:disabled)');
+    expect(hover).toMatch(/background:\s*color-mix\(in srgb, var\(--text-strong\) 10%, transparent\)/);
+    expect(hover).toMatch(/color:\s*var\(--text-strong\)/);
+
+    expect(declarations('.entry-nav-rail__recent-row:hover .entry-nav-rail__recent-item')).toMatch(
+      /padding-right:\s*36px/,
+    );
+
+    const more = declarations('.entry-nav-rail__recent-more');
+    expect(more).toMatch(/right:\s*6px/);
+    expect(more).toMatch(/width:\s*24px/);
+    expect(more).toMatch(/height:\s*24px/);
+    expect(more).toMatch(/opacity:\s*0/);
+    expect(more).toMatch(/transition:\s*opacity 120ms var\(--ease-out\), visibility 0s linear 120ms/);
+  });
+
+  it('floats the preview card and the row menu beside the rail on the same slot', () => {
+    const preview = declarations('.entry-nav-rail__recent-preview');
+    expect(preview).toMatch(/position:\s*fixed/);
+    expect(preview).toMatch(/width:\s*216px/);
+    expect(preview).toMatch(/padding:\s*8px/);
+    expect(preview).toMatch(/border-radius:\s*var\(--radius-xxlarge\)/);
+    expect(preview).toMatch(/z-index:\s*1200/);
+
+    expect(declarations('.entry-nav-rail__recent-preview-plate')).toMatch(/aspect-ratio:\s*16 \/ 10/);
+    const name = declarations('.entry-nav-rail__recent-preview-name');
+    expect(name).toMatch(/-webkit-line-clamp:\s*2/);
+    expect(name).toMatch(/color:\s*var\(--text-soft\)/);
+
+    const menu = declarations('.entry-nav-rail__recent-menu');
+    expect(menu).toMatch(/position:\s*fixed/);
+    expect(menu).toMatch(/min-width:\s*140px/);
+    expect(menu).toMatch(/border-radius:\s*var\(--radius-lg\)/);
+    expect(declarations('.entry-nav-rail__recent-menu button')).toMatch(/font-size:\s*13px/);
+  });
+
+  it('keeps the inline rename inside the row box on the frosted panel', () => {
+    const rename = declarations('.entry-nav-rail__recent-rename');
+    expect(rename).toMatch(/height:\s*38px/);
+    expect(rename).toMatch(/background:\s*transparent/);
+    expect(rename).toMatch(/border-radius:\s*12px/);
+    expect(declarations('.entry-nav-rail__recent-rename:focus')).toMatch(/border-color:\s*var\(--border\)/);
+  });
+});

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -766,6 +766,24 @@ export type ChatRunResultPackageResponse = RunResultPackageResponse;
 
 export interface ChatRunListResponse {
   runs: ChatRunStatusResponse[];
+  /**
+   * Projects holding an unanswered `<question-form>` / `<ask-question>`.
+   *
+   * `ChatRunStatus` cannot express "waiting on the user": that state outlives
+   * the run that asked, so the run itself reads `succeeded` while the project
+   * is still blocked — see `ProjectDisplayStatus.awaiting_input`, which the
+   * daemon composes from exactly this set. Callers that render a per-project
+   * status from the runs feed need it or they will show such a project as
+   * finished.
+   *
+   * Always a subset of the projects the accompanying `runs` already expose —
+   * never the raw query — so it cannot widen what a caller can see. A project
+   * that has no visible run therefore never appears here, which is harmless:
+   * awaiting_input only arises from a run that asked.
+   *
+   * Optional: older daemons omit it, and absent means "unknown", not "none".
+   */
+  awaitingInputProjectIds?: string[];
 }
 
 export interface ChatRunCancelResponse {


### PR DESCRIPTION
<!-- OPEND-2553 PR-A — no GitHub issue is closed by this PR; the Plane task is the tracker. -->

Companion Draft PR: #7731 (Home hero and composer). These are independent slices, not a stacked PR chain.

## Why

**Use case.** Plane task [OPEND-2553](https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/fb89d9f8-dce8-4b41-b6e7-a9e621b89fcb) "首页链路 Demo 一比一复刻与分阶段交付" delivers upstream PR #7635 (`feat(web): refresh the home and entry surfaces`, head `61dba5242`) onto current `main` in stages instead of one 295-file merge. This is **PR-A**: the run-status infrastructure and the rail's 最近浏览过 (Recently viewed) section — the slice that has no dependency on the Home hero / composer rewrite (PR-B) and that the later Home-grid removal (PR-C) builds on. A and B both target `main` independently; neither requires the other to land first.

**Pain.**
- A signed-in workspace session cannot read `Project.status`: it is attached only by the unscoped `GET /api/projects`, which lists unbound projects only. Any surface that wants to say "this project is running / needs input / done" has to derive it from the runs feed — and `GET /api/runs` cannot express "waiting on the user" (the run that asked a `<question-form>` reads `succeeded` while the project is still blocked). PR #7635 solved both; `main` has neither.
- Getting back to a recent project from the entry shell means scrolling the Home grid. The Demo puts the eight most recent projects, with their live status, one click away in the rail.

## What users will see

- **Left rail (signed in), under 插件:** a new **最近浏览过 / Recently viewed** disclosure listing the eight most recently touched projects, newest first. It starts open and remembers being collapsed (`od.entry.railRecentOpen`).
- **Each row** leads with the project's live run status instead of the chat mark: a green orb while running, yellow while it needs input (an unanswered `<question-form>`), red when the last run failed, and a ✓ badge once a run completed. Opening a completed project clears its ✓ for **that** run; every later completed run raises a fresh ✓ — including one that started and finished while the section was collapsed.
- **Hover** a row: the ⋮ appears at the trailing edge and a cover preview card (216px, project name wrapped to two lines) floats beside the rail. **Click ⋮**: Rename (inline), Export (whole-project zip), Delete (second click confirms).
- **Clicking a row** opens the project through the same pull-first opener the projects grid uses.
- The Home page's existing **Recent projects grid is unchanged** in this PR (its removal is PR-C).
- Nothing changes for a signed-out shell (no cloud identity): the section only renders inside the signed-in rail, exactly as in the Demo.

## Behavior differences from the Demo

- **✓ acknowledgement is per finished run, not per project.** The Demo (#7635) remembers acknowledged *project ids* and only forgets one after observing a live `queued`/`running` status — but the section polls only while open, so a run that starts and finishes while it is collapsed is never observed, the stale acknowledgement survives, and the new completion's ✓ is never shown. This PR stores `{ projectId: acknowledgedRunId }` (same key `od.entry.railRecentSeenDone`; the old array shape reads as "nothing acknowledged") and compares it with the newest terminal run's id from the runs feed, so a newer finished run is always a new notice. The glyphs, timing and geometry are untouched — the measurement below was re-run after the fix with no change in the succeeded / running / awaiting-input rows.

## Surface area

- [x] **UI** — new rail section `apps/web/src/components/entry-nav-rail/RailRecentRow.tsx` + `EntryNavRail.tsx` (`RailRecentSection`), new `ProjectRunStatusIcon` / `SiriOrb` glyphs
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — *not applicable*: this PR adds no capability. `GET /api/runs` already backs `od run list` (`apps/daemon/src/cli.ts`, `SUBCOMMAND_MAP`), and the new optional `awaitingInputProjectIds` field rides along in its `--json` output with no new flag; the rail section is a navigation affordance over `GET /api/projects` / `GET /api/workspaces/:id/projects?view=recent`, which `od project list` already exposes. There is no new endpoint and no new verb for the CLI to mirror.
- [x] **API / contract** — `packages/contracts/src/api/chat.ts`: `ChatRunListResponse.awaitingInputProjectIds?: string[]` (optional; absent = unknown, never widens visibility), populated by `GET /api/runs` in `apps/daemon/src/routes/runs.ts`
- [ ] **Extension point**
- [x] **i18n keys** — `recentProjects.collectionRecent` added to `types.ts` and all 19 locales (values taken verbatim from #7635)
- [ ] **New top-level dependency**
- [x] **Default behavior change** — signed-in users see the recent-project section expanded by default; its run-status feed refreshes while expanded.
- [ ] **None**

## Screenshots

Screenshots are intentionally not attached to this Draft PR, at the author's request. Local Demo/branch captures and geometry measurements covered the signed-in Home rail entry point, default run states, hover preview, active row, action menu, collapsed section, and empty catalog. See Validation for the measured scope and remaining differences; this is not a claim of completed overall visual acceptance.

## Bug fix verification

- Rail ✓ acknowledgement (the divergence above): red spec `apps/web/tests/components/EntryNavRail.recent-section.test.tsx › "re-raises the ✓ for a newer finished run even when its running phase was never seen"` — reproduces r1 finished → open (✓ spent) → collapse → feed now reports a new finished r2 with no running phase observed → expand → ✓ must show. Red before `fix(web): acknowledge the rail ✓ per finished run` (3 failed | 5 passed in the file, the ✓ never re-appearing), green after (8/8). The same file covers the legacy array store shape; `apps/web/tests/state/projectRunStatus.test.ts` covers the new `foldRunsToProjectRunSummaries` (5 cases) and its agreement with the status-only fold.
- The daemon field is also delivered red-first: `apps/daemon/tests/runs-list-awaiting-input.test.ts` — 4/4 red on `main` (field absent), 4/4 green on this branch.

## Validation

- Latest full Web run after the acknowledgement fix: **681 files passed / 1 failed; 7217 tests passed / 1 failed / 1 expected fail / 11 skipped**. The remaining failure was `tests/host-boundary.test.ts` exceeding its 5-second timeout. A standalone rerun passed (1/1); this is not a claim that the full run was green. The two acknowledgement/status suites were rerun on final head `9716290e3`: **22/22 passed**. Earlier full-run findings and their fixes are retained below for traceability.
- `pnpm guard` — pass (all design-system / guard checks green)
- `pnpm typecheck` — pass (30 package typechecks `Done`, 0 `error TS`)
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm --filter @open-design/web test` — full suite: `Test Files 1 failed | 681 passed (682)`, `Tests 4 failed | 7207 passed | 1 expected fail | 11 skipped (7223)` on the first run. The one failing file (`tests/components/EntryShell.blank-project-naming.test.tsx`, 9/9 green on `main`) failed only because `getByText('Ready shared project')` now matches the Home card **and** its new rail row; the four lookups are scoped to `<main>` exactly the way #7635 scoped them, and the file is 9/9 green again on the branch. New specs (all green): `tests/state/projectRunStatus.test.ts` (9), `tests/runtime/run-progress.test.ts` (9), `tests/runtime/latest-user-prompt.test.ts` (6), `tests/components/ProjectRunStatusIcon.test.tsx` (12), `tests/components/EntryNavRail.recent-section.test.tsx` (6), `tests/styles/entry-rail-recent.test.ts` (5).
- `pnpm --filter @open-design/daemon typecheck` — pass
- `pnpm --filter @open-design/daemon test` — full suite: `Test Files 4 failed | 736 passed | 2 skipped (742)`, `Tests 11 failed | 9763 passed | 8 skipped (9782)`. Diffed against clean `main` (`09bd500d4`, same machine, same four files re-run in isolation):
  - `tests/chat-route.test.ts` (1) and `tests/connection-test.test.ts` (4): identical failures on `main` — local Claude CLI auth environment, pre-existing.
  - `tests/od-next-automatic-simple-server.test.ts`: 5 failed in the branch's full run, 0 in isolation on the branch, 4 in isolation on `main` — timing-flaky, pre-existing.
  - `tests/headless-runs.test.ts` (1): a real consequence of this PR — it asserted `GET /api/runs` deep-equals `{ runs: [] }`; updated to include `awaitingInputProjectIds: []`, 16/16 green.
  - `tests/runs-list-awaiting-input.test.ts` (new): 4/4 green; 4/4 red with the route change stashed.
- `pnpm --filter @open-design/contracts typecheck` — pass; `pnpm --filter @open-design/contracts test` — `Test Files 55 passed (55)`, `Tests 508 passed (508)`
- **1:1 measurement against the Demo.** Ad-hoc Playwright script (`scratchpad/measure-rail.mjs`) drove both runtimes (Demo: `tools-dev` namespace `demo-a`, ports 17801/17901; branch: `work-a`, 17811/17911), seeded with identical projects through `POST /api/projects` (`scratchpad/seed-projects.sh`), at 1280 / 1440 / 1728 for states default / hover / active / running / awaiting-input / succeeded / failed / menu / collapsed / empty, dumping `getBoundingClientRect` + computed styles for the section, head, title, chevron, list, every row (item / icon / glyph / name / ⋮), the preview card and the menu. Output: `rail-demo.json`, `rail-work.json`, `rail-diff.txt` (raw, 1724 differing properties), `rail-diff-filtered.txt` (144 after dropping panel chrome / width / inherited font-weight).
  - **Every row-level value matches at all three widths**: section 354px, head 38px, rows 37.5px on a 2px rhythm, icon slot at relX 16 / 18px wide, name at relX 43, hover fill `color-mix(--text-strong 10%)` + ink `#202020`, hover `padding-right: 36px`, ⋮ 24×24 at right 6px (opacity 0 → 1), preview 216×165.3 at a 24px gap from the row, menu 140×108.5 with Rename / Export / Delete, `--rail-ink-quiet` `#5c5c5c`, orb palettes identical after normalising the animation phase (36 orbs, 0 mismatches), ✓ badge `viewBox 2 2 20 20` with `#202020` / `#00FF08`, chat mark 16px `currentColor`, collapsed disclosure 0px, empty catalog → no section on either side.
  - **Remaining differences, all outside the rows and all deliberate for PR-A's scope:**
    1. Row *width* 194px vs Demo 212px, and every `relX` of trailing elements (⋮, chevron) by the same 18px: `main`'s `.entry-nav-rail__group` keeps `padding: 0 10px` and its frosted `__panel` card (216px, radius 12, 10px margin); the Demo flattened the panel (transparent, 212px, no padding). That is the rail-chrome restyle, not the rows.
    2. Inherited `font-weight` (600 in the Demo vs 400/500 here) on containers that carry no text of their own (`row`, `list`, `collapsible`, `chevron`, ⋮): #7635's global font-weight normalisation in `primitives.css` / `base.css`. The rows' own text is explicit (`__recent-item` 500, `__recent-title` 500) and matches.
    3. Absolute `x`/`y`/`top`/`right` of the portalled preview and menu follow the row's absolute position, which differs because the destinations above the section are still `main`'s 33px rows (Demo: 38px) and the Demo's rail has no search row. Relative geometry (24px gap, vertical centring on the row) is identical.
    4. Orb rotation angle / breathe scale in the dumps differ by animation phase only.
  - **Re-run after the ✓ fix** (`rail-demo2.json`, `rail-work2.json`): the running / awaiting-input / succeeded / failed rows (item, icon, glyph, name) show 0 differences against the Demo (same filter as above) and 0 differences against the pre-fix branch dump — the glyph rendering is untouched.

## Adjacent issues (not addressed here)

- The rail's destination rows (`.entry-nav-rail__btn`) are still `main`'s 33px / radius 8 / 68%-alpha ink; the Demo's 38px / radius 12 / `--rail-ink-quiet` rows, the removed search row, the 设置 rail item on the signed-in branch and the account dock at the bottom of the rail are the rail-chrome part of #7635 and belong to a later PR of OPEND-2553 (PR-C or its own slice). `--rail-ink-quiet` is introduced here on `.entry-nav-rail` so that slice can switch the destinations to it without touching the rows again.
- `useProjectRunStatuses` is also what #7635's `WorkspaceTabsBar` dropdown (`leadGlyphFor`) and the Design Files empty state (`latestUserPromptText` / `runProgressSteps`) consume; those consumers are not ported here, the reducers are (with their tests) so the later PRs are pure UI.
- `MarqueeLabel` / `.od-marquee` (workspace switcher name) is not part of the rows and is left to the rail-chrome slice.
- `state/projects.ts` in #7635 only carries an unrelated create-timeout change; nothing from it is needed by the rail and it was deliberately not ported.
