### PR TITLE
test(e2e): swallow navigation-race evaluate errors in wireOnboardingMocks (fixes #7657)

### DIFF
--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -1322,7 +1322,7 @@ async function wireOnboardingMocks(
       }, statusResponses);
       return;
     }
-    if (loginInFlight && await page.evaluate(() => (
+    if (loginInFlight && await safeEvaluate(() => (
       window.__amrOnboardingCompleteLogin === true
     ))) {
       loggedIn = true;
@@ -1335,7 +1335,7 @@ async function wireOnboardingMocks(
       (!loggedIn &&
         typeof options.delaySignedOutStatusMs === 'number' &&
         options.delaySignedOutStatusMs > 0 &&
-        (await page.evaluate(() => {
+        (await safeEvaluate(() => {
           if (!window.__amrOnboardingDelayNextSignedOutStatus) return false;
           window.__amrOnboardingDelayNextSignedOutStatus = false;
           return true;
@@ -1400,7 +1400,7 @@ async function wireOnboardingMocks(
       loggedIn = true;
       loginInFlight = false;
     }
-    await page.evaluate((calls) => {
+    await safeEvaluate((calls) => {
       window.__amrOnboardingLoginCalls = calls;
     }, loginCalls);
     await route.fulfill({
@@ -1418,7 +1418,7 @@ async function wireOnboardingMocks(
     expect(route.request().postDataJSON()).toEqual({ authAttemptId });
     cancelCalls += 1;
     loginInFlight = false;
-    await page.evaluate((calls) => {
+    await safeEvaluate((calls) => {
       window.__amrOnboardingCancelCalls = calls;
     }, cancelCalls);
     await route.fulfill({ json: { canceled: true, pids: [4242] } });

--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -1219,6 +1219,34 @@ async function wireOnboardingMocks(
     ? '11111111-1111-4111-8111-111111111111'
     : null;
 
+  /**
+   * Route handlers are async but the Playwright route interceptor does not wait
+   * for a pending handler before the page navigates (e.g. page.reload()).
+   * If the handler calls page.evaluate() while the old document is being
+   * destroyed it throws:
+   *   "Execution context was destroyed, most likely because of a navigation"
+   *
+   * Instrumenting the test state from inside a route handler should not crash
+   * the test — it is not a test assertion.  Swallow only the navigation-race
+   * flavour of error; every other failure should still surface.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const safeEvaluate = async (fn: (...args: any[]) => void, ...args: any[]) => {
+    try {
+      await page.evaluate(fn, ...args);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (
+        message.includes('Execution context was destroyed') ||
+        message.includes('Target page, context or browser has been closed') ||
+        message.includes('Cannot find context with specified id')
+      ) {
+        return;
+      }
+      throw error;
+    }
+  };
+
   await page.route('**/api/health', async (route) => {
     await route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' });
   });
@@ -1276,7 +1304,7 @@ async function wireOnboardingMocks(
 
   await page.route('**/api/integrations/vela/status', async (route) => {
     statusCalls += 1;
-    await page.evaluate((calls) => {
+    await safeEvaluate((calls) => {
       window.__amrOnboardingStatusCalls = calls;
     }, statusCalls);
     if (options.statusGate) {
@@ -1289,7 +1317,7 @@ async function wireOnboardingMocks(
         body: JSON.stringify({ error: 'status unavailable' }),
       });
       statusResponses += 1;
-      await page.evaluate((responses) => {
+      await safeEvaluate((responses) => {
         window.__amrOnboardingStatusResponses = responses;
       }, statusResponses);
       return;
@@ -1341,11 +1369,11 @@ async function wireOnboardingMocks(
           },
     });
     statusResponses += 1;
-    await page.evaluate((responses) => {
+    await safeEvaluate((responses) => {
       window.__amrOnboardingStatusResponses = responses;
     }, statusResponses);
     if (shouldDelaySignedOutStatus) {
-      await page.evaluate(() => {
+      await safeEvaluate(() => {
         window.__amrOnboardingSlowStatusResolved = true;
       });
     }

--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -1230,9 +1230,14 @@ async function wireOnboardingMocks(
    * the test — it is not a test assertion.  Swallow only the navigation-race
    * flavour of error; every other failure should still surface.
    */
-  const safeEvaluate = async (fn: () => boolean | void): Promise<boolean | void> => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const safeEvaluate = async (fn: (...args: any[]) => unknown, ...args: any[]): Promise<unknown> => {
     try {
-      return await page.evaluate(fn);
+      // Playwright runs the function in the page VM. Forward each Node-side
+      // argument explicitly via page.evaluate(), because the page VM does not
+      // share Node closures and will throw ReferenceError on any local we
+      // would otherwise capture here.
+      return await page.evaluate(fn as never, ...args);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       if (
@@ -1303,9 +1308,9 @@ async function wireOnboardingMocks(
 
   await page.route('**/api/integrations/vela/status', async (route) => {
     statusCalls += 1;
-    await safeEvaluate(() => {
-      window.__amrOnboardingStatusCalls = statusCalls;
-    });
+    await safeEvaluate((calls) => {
+      window.__amrOnboardingStatusCalls = calls;
+    }, statusCalls);
     if (options.statusGate) {
       await options.statusGate;
     }
@@ -1316,9 +1321,9 @@ async function wireOnboardingMocks(
         body: JSON.stringify({ error: 'status unavailable' }),
       });
       statusResponses += 1;
-      await safeEvaluate(() => {
-        window.__amrOnboardingStatusResponses = statusResponses;
-      });
+      await safeEvaluate((responses) => {
+        window.__amrOnboardingStatusResponses = responses;
+      }, statusResponses);
       return;
     }
     if (loginInFlight && await safeEvaluate(() => (
@@ -1368,9 +1373,9 @@ async function wireOnboardingMocks(
           },
     });
     statusResponses += 1;
-    await safeEvaluate(() => {
-      window.__amrOnboardingStatusResponses = statusResponses;
-    });
+    await safeEvaluate((responses) => {
+      window.__amrOnboardingStatusResponses = responses;
+    }, statusResponses);
     if (shouldDelaySignedOutStatus) {
       await safeEvaluate(() => {
         window.__amrOnboardingSlowStatusResolved = true;
@@ -1399,9 +1404,9 @@ async function wireOnboardingMocks(
       loggedIn = true;
       loginInFlight = false;
     }
-    await safeEvaluate(() => {
-      window.__amrOnboardingLoginCalls = loginCalls;
-    });
+    await safeEvaluate((calls) => {
+      window.__amrOnboardingLoginCalls = calls;
+    }, loginCalls);
     await route.fulfill({
       status: 202,
       json: {
@@ -1417,9 +1422,9 @@ async function wireOnboardingMocks(
     expect(route.request().postDataJSON()).toEqual({ authAttemptId });
     cancelCalls += 1;
     loginInFlight = false;
-    await safeEvaluate(() => {
-      window.__amrOnboardingCancelCalls = cancelCalls;
-    });
+    await safeEvaluate((calls) => {
+      window.__amrOnboardingCancelCalls = calls;
+    }, cancelCalls);
     await route.fulfill({ json: { canceled: true, pids: [4242] } });
   });
 

--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -1230,10 +1230,9 @@ async function wireOnboardingMocks(
    * the test — it is not a test assertion.  Swallow only the navigation-race
    * flavour of error; every other failure should still surface.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const safeEvaluate = async (fn: (...args: any[]) => void, ...args: any[]) => {
+  const safeEvaluate = async (fn: () => boolean | void): Promise<boolean | void> => {
     try {
-      await page.evaluate(fn, ...args);
+      return await page.evaluate(fn);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       if (
@@ -1241,7 +1240,7 @@ async function wireOnboardingMocks(
         message.includes('Target page, context or browser has been closed') ||
         message.includes('Cannot find context with specified id')
       ) {
-        return;
+        return undefined;
       }
       throw error;
     }
@@ -1304,9 +1303,9 @@ async function wireOnboardingMocks(
 
   await page.route('**/api/integrations/vela/status', async (route) => {
     statusCalls += 1;
-    await safeEvaluate((calls) => {
-      window.__amrOnboardingStatusCalls = calls;
-    }, statusCalls);
+    await safeEvaluate(() => {
+      window.__amrOnboardingStatusCalls = statusCalls;
+    });
     if (options.statusGate) {
       await options.statusGate;
     }
@@ -1317,9 +1316,9 @@ async function wireOnboardingMocks(
         body: JSON.stringify({ error: 'status unavailable' }),
       });
       statusResponses += 1;
-      await safeEvaluate((responses) => {
-        window.__amrOnboardingStatusResponses = responses;
-      }, statusResponses);
+      await safeEvaluate(() => {
+        window.__amrOnboardingStatusResponses = statusResponses;
+      });
       return;
     }
     if (loginInFlight && await safeEvaluate(() => (
@@ -1369,9 +1368,9 @@ async function wireOnboardingMocks(
           },
     });
     statusResponses += 1;
-    await safeEvaluate((responses) => {
-      window.__amrOnboardingStatusResponses = responses;
-    }, statusResponses);
+    await safeEvaluate(() => {
+      window.__amrOnboardingStatusResponses = statusResponses;
+    });
     if (shouldDelaySignedOutStatus) {
       await safeEvaluate(() => {
         window.__amrOnboardingSlowStatusResolved = true;
@@ -1400,9 +1399,9 @@ async function wireOnboardingMocks(
       loggedIn = true;
       loginInFlight = false;
     }
-    await safeEvaluate((calls) => {
-      window.__amrOnboardingLoginCalls = calls;
-    }, loginCalls);
+    await safeEvaluate(() => {
+      window.__amrOnboardingLoginCalls = loginCalls;
+    });
     await route.fulfill({
       status: 202,
       json: {
@@ -1418,9 +1417,9 @@ async function wireOnboardingMocks(
     expect(route.request().postDataJSON()).toEqual({ authAttemptId });
     cancelCalls += 1;
     loginInFlight = false;
-    await safeEvaluate((calls) => {
-      window.__amrOnboardingCancelCalls = calls;
-    }, cancelCalls);
+    await safeEvaluate(() => {
+      window.__amrOnboardingCancelCalls = cancelCalls;
+    });
     await route.fulfill({ json: { canceled: true, pids: [4242] } });
   });
 


### PR DESCRIPTION
## Why

While validating another PR's loading-shell fix, the [P0] onboarding reload test failed once with:

```
Error: page.evaluate: Execution context was destroyed, most likely because of a navigation
```

The stack pointed at `wireOnboardingMocks()`'s `/api/integrations/vela/status` route callback, which writes counters via `page.evaluate()`. The retry passed, but that is retry-only evidence — not proof the navigation race is repaired.

## Root cause

`wireOnboardingMocks()` registers route handlers via `page.route()` that call `page.evaluate()` to record counters like `window.__amrOnboardingStatusCalls`. Playwright does not wait for the pending handler before a navigation event (`page.reload()`, `page.goto()`). When the document is destroyed mid-handler, `page.evaluate()` throws because its execution context no longer exists.

The instrumentation is not a test assertion — failing it should not crash the test. But the bare `await page.evaluate()` propagates the error to Playwright, which surfaces it as the test's own failure.

## What users will see

Nothing — this is an internal e2e test instrumentation change only. The production app is untouched. End users of OpenDesign never see `wireOnboardingMocks`, `page.evaluate`, or any of the e2e fixtures.

Test authors will see: route handlers in `wireOnboardingMocks()` can no longer crash a passing assertion when the page is reloaded mid-flight.

## What changes

Add a small `safeEvaluate()` helper inside `wireOnboardingMocks()`. Wrap every `page.evaluate()` call inside the vela/status route handler (and the related login / cancel instrumentation) with it. The helper:

1. Catches only the three known navigation-race error messages:
   - `Execution context was destroyed`
   - `Target page, context or browser has been closed`
   - `Cannot find context with specified id`
2. Silently returns in those cases.
3. Re-throws every other error unchanged.

No functional test changes. All other `page.evaluate()` calls outside route handlers are untouched.

## Surface area

- [ ] **UI** — none
- [ ] **Keyboard shortcut** — none
- [ ] **CLI / env var** — none
- [ ] **API / contract** — none
- [ ] **Extension point** — none
- [ ] **i18n keys** — none
- [ ] **New top-level dependency** — none
- [x] **Default behavior change** — none
- [x] **None** — internal e2e test instrumentation only

## Verification

Local focused run of the two affected reload tests (single-worker, no full pool):

- `pnpm exec playwright test e2e/ui/amr-onboarding.test.ts -g 'reload restores'` — green (no flake).
- `pnpm exec playwright test e2e/ui/amr-onboarding.test.ts -g 'reload resumes'` — green (no flake).

The full pool of the entry-settings group is exercised in CI on this PR branch.