### PR TITLE
fix(web): confirm Bash rm deletions against project file snapshot (#7744)

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -5676,6 +5676,10 @@ export function ProjectView({
               ),
             });
             if (producedArtifactToOpen) requestOpenFile(producedArtifactToOpen);
+            const nextFileNames = new Set(nextFiles.map((f) => f.name));
+            const confirmedDeletions = [...beforeFileNames].filter(
+              (name) => !nextFileNames.has(name),
+            ).length;
             const deliveryOutcome = resolveDesignDeliveryOutcome({
               sessionMode: message.sessionMode,
               runStatus: 'succeeded',
@@ -5684,6 +5688,7 @@ export function ProjectView({
               producedFileCount: produced.length,
               traceObjectFileCount: traceObjectFiles.length,
               artifactCount: status.artifactCount,
+              confirmedDeletions,
               persistenceSucceeded: artifactPersistenceSucceeded,
               persistenceFailed: artifactPersistenceError !== undefined,
             });
@@ -6126,6 +6131,10 @@ export function ProjectView({
                 if (producedArtifactToOpen) requestOpenFile(producedArtifactToOpen);
                 const deliveryContent = needsFullReplay ? replayedContent : message.content;
                 const deliveryEvents = needsFullReplay ? replayedEvents : message.events;
+                const deliveryNextFileNames = new Set(nextFiles.map((f) => f.name));
+                const deliveryConfirmedDeletions = [...beforeFileNames].filter(
+                  (name) => !deliveryNextFileNames.has(name),
+                ).length;
                 const deliveryOutcome = resolveDesignDeliveryOutcome({
                   sessionMode: message.sessionMode,
                   runStatus: 'succeeded',
@@ -6134,6 +6143,7 @@ export function ProjectView({
                   producedFileCount: produced.length,
                   traceObjectFileCount: traceObjectFiles.length,
                   artifactCount: daemonArtifactCount,
+                  confirmedDeletions: deliveryConfirmedDeletions,
                   persistenceSucceeded: artifactPersistenceSucceeded,
                   persistenceFailed: artifactPersistenceError !== undefined,
                 });
@@ -7931,6 +7941,10 @@ export function ProjectView({
                 producedFiles: produced,
                 traceObjectFiles,
               };
+              const deliveryNextFileNames = new Set(nextFiles.map((f) => f.name));
+              const deliveryConfirmedDeletions = [...beforeFileNames].filter(
+                (name) => !deliveryNextFileNames.has(name),
+              ).length;
               const deliveryOutcome = resolveDesignDeliveryOutcome({
                 sessionMode: deliveryCandidate.sessionMode,
                 runStatus: deliveryCandidate.runStatus,
@@ -7939,6 +7953,7 @@ export function ProjectView({
                 producedFileCount: produced.length,
                 traceObjectFileCount: traceObjectFiles.length,
                 artifactCount: daemonArtifactCount,
+                confirmedDeletions: deliveryConfirmedDeletions,
                 persistenceSucceeded: artifactPersistenceSucceeded,
                 persistenceFailed: artifactPersistenceError !== undefined,
               });

--- a/apps/web/src/runtime/design-delivery.ts
+++ b/apps/web/src/runtime/design-delivery.ts
@@ -21,6 +21,14 @@ export interface DesignDeliveryInput {
   traceObjectFileCount: number;
   /** Authoritative artifact count reported by the daemon at run finalization. */
   artifactCount?: number;
+  /**
+   * Count of project files that existed before the turn and are confirmed
+   * missing from the post-turn snapshot. Distinct from `producedFileCount`,
+   * which only includes files that survived the turn. Lets a Bash `rm`-only
+   * turn or an in-place Edit that deletes project files qualify as a real
+   * delivery even when the post-turn `producedFileCount` is zero — #7744.
+   */
+  confirmedDeletions?: number;
   persistenceSucceeded?: boolean;
   persistenceFailed?: boolean;
 }
@@ -80,6 +88,13 @@ function hasLiveArtifactDelivery(events: AgentEvent[] | undefined): boolean {
  * be downgraded to ARTIFACT_NOT_FOUND. The known cost: an agent that merely
  * claims completion without ever calling a write tool now passes as text; the
  * text itself makes that visible to the user.
+ *
+ * Turns that mutated files (Write / Edit / Delete / Bash rm) but produced
+ * zero new files are still deliveries — the mutation itself was the work.
+ * For example: an agent deleting stale scaffolding, renaming a file via
+ * Bash mv, or editing config in-place without adding new files. Skipping
+ * the mutation check for these cases incorrectly marks them as no_result
+ * even though the run accomplished its task.
  */
 export function resolveDesignDeliveryOutcome(
   input: DesignDeliveryInput,
@@ -94,13 +109,22 @@ export function resolveDesignDeliveryOutcome(
     input.producedFileCount > 0 ||
     input.traceObjectFileCount > 0 ||
     (input.artifactCount ?? 0) > 0 ||
+    (input.confirmedDeletions ?? 0) > 0 ||
     input.persistenceSucceeded ||
     hasLiveArtifactDelivery(input.events)
   ) {
     return 'delivered';
   }
   if (input.persistenceFailed) return 'delivery_failed';
-  if (!hasFileMutationToolUse(input.events) && input.content.trim().length > 0) {
+  // A zero-mutation, text-only turn is a report-only result (image
+  // analysis, audit-style reports). A mutation-only turn with no new files
+  // — e.g. Bash `rm stale.html` or an in-place Edit that doesn't add files —
+  // is a real project change. Treat those as delivered when the project
+  // file snapshot can confirm the deletion landed (a path existed pre-turn
+  // and is missing post-turn). When the snapshot cannot prove the mutation
+  // happened, fall through to `no_result` so the user can still retry.
+  const mutated = hasFileMutationToolUse(input.events);
+  if (!mutated && input.content.trim().length > 0) {
     return 'report_only';
   }
   return 'no_result';

--- a/apps/web/tests/runtime/design-delivery.test.ts
+++ b/apps/web/tests/runtime/design-delivery.test.ts
@@ -50,9 +50,63 @@ describe('resolveDesignDeliveryOutcome', () => {
           events: [attempt],
           producedFileCount: 0,
           traceObjectFileCount: 0,
+          // Snapshot could not confirm any deletion — the attempt was
+          // a Write/Edit (no in-tree file left to verify) or a Bash whose
+          // targets weren't tracked. Without confirmation, the run stays a
+          // `no_result` so the user can retry instead of seeing a phantom
+          // success card (#7744).
+          confirmedDeletions: 0,
         }),
       ).toBe('no_result');
     }
+  });
+
+  // #7744 — a Bash `rm` of an existing project file. The file snapshot
+  // proves the deletion landed (the path was listed pre-turn and is missing
+  // post-turn), so the run should be `delivered`, not `no_result`.
+  it('treats a snapshot-confirmed Bash deletion as delivered', () => {
+    expect(
+      resolveDesignDeliveryOutcome({
+        sessionMode: 'design',
+        runStatus: 'succeeded',
+        content: 'Removed two stale scaffolding files.',
+        events: [
+          {
+            kind: 'tool_use',
+            id: 'b-1',
+            name: 'Bash',
+            input: {
+              command:
+                'rm -f scripts/sketch-i2i.py tests/texture/prompt-fox-refs.txt',
+            },
+          },
+        ],
+        producedFileCount: 0,
+        traceObjectFileCount: 0,
+        confirmedDeletions: 2,
+      }),
+    ).toBe('delivered');
+  });
+
+  it('does not treat unconfirmed mutation attempts as delivered', () => {
+    // A Bash `rm` whose targets the project file snapshot cannot confirm
+    // (e.g. outside the project root, or already absent pre-turn) must not
+    // silently become a delivery. The run stays `no_result` so the user
+    // can retry, and the call site can inspect the snapshot diff to surface
+    // a better error if the agent actually accomplished its task.
+    expect(
+      resolveDesignDeliveryOutcome({
+        sessionMode: 'design',
+        runStatus: 'succeeded',
+        content: 'Tried to clean up.',
+        events: [
+          { kind: 'tool_use', id: 'b-1', name: 'Bash', input: { command: 'rm /tmp/outside.js' } },
+        ],
+        producedFileCount: 0,
+        traceObjectFileCount: 0,
+        confirmedDeletions: 0,
+      }),
+    ).toBe('no_result');
   });
 
   it('does not accept an empty answer as a report-only result', () => {

--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -1322,7 +1322,7 @@ async function wireOnboardingMocks(
       }, statusResponses);
       return;
     }
-    if (loginInFlight && await page.evaluate(() => (
+    if (loginInFlight && await safeEvaluate(() => (
       window.__amrOnboardingCompleteLogin === true
     ))) {
       loggedIn = true;
@@ -1335,7 +1335,7 @@ async function wireOnboardingMocks(
       (!loggedIn &&
         typeof options.delaySignedOutStatusMs === 'number' &&
         options.delaySignedOutStatusMs > 0 &&
-        (await page.evaluate(() => {
+        (await safeEvaluate(() => {
           if (!window.__amrOnboardingDelayNextSignedOutStatus) return false;
           window.__amrOnboardingDelayNextSignedOutStatus = false;
           return true;
@@ -1400,7 +1400,7 @@ async function wireOnboardingMocks(
       loggedIn = true;
       loginInFlight = false;
     }
-    await page.evaluate((calls) => {
+    await safeEvaluate((calls) => {
       window.__amrOnboardingLoginCalls = calls;
     }, loginCalls);
     await route.fulfill({
@@ -1418,7 +1418,7 @@ async function wireOnboardingMocks(
     expect(route.request().postDataJSON()).toEqual({ authAttemptId });
     cancelCalls += 1;
     loginInFlight = false;
-    await page.evaluate((calls) => {
+    await safeEvaluate((calls) => {
       window.__amrOnboardingCancelCalls = calls;
     }, cancelCalls);
     await route.fulfill({ json: { canceled: true, pids: [4242] } });

--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -1219,6 +1219,34 @@ async function wireOnboardingMocks(
     ? '11111111-1111-4111-8111-111111111111'
     : null;
 
+  /**
+   * Route handlers are async but the Playwright route interceptor does not wait
+   * for a pending handler before the page navigates (e.g. page.reload()).
+   * If the handler calls page.evaluate() while the old document is being
+   * destroyed it throws:
+   *   "Execution context was destroyed, most likely because of a navigation"
+   *
+   * Instrumenting the test state from inside a route handler should not crash
+   * the test — it is not a test assertion.  Swallow only the navigation-race
+   * flavour of error; every other failure should still surface.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const safeEvaluate = async (fn: (...args: any[]) => void, ...args: any[]) => {
+    try {
+      await page.evaluate(fn, ...args);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (
+        message.includes('Execution context was destroyed') ||
+        message.includes('Target page, context or browser has been closed') ||
+        message.includes('Cannot find context with specified id')
+      ) {
+        return;
+      }
+      throw error;
+    }
+  };
+
   await page.route('**/api/health', async (route) => {
     await route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' });
   });
@@ -1276,7 +1304,7 @@ async function wireOnboardingMocks(
 
   await page.route('**/api/integrations/vela/status', async (route) => {
     statusCalls += 1;
-    await page.evaluate((calls) => {
+    await safeEvaluate((calls) => {
       window.__amrOnboardingStatusCalls = calls;
     }, statusCalls);
     if (options.statusGate) {
@@ -1289,7 +1317,7 @@ async function wireOnboardingMocks(
         body: JSON.stringify({ error: 'status unavailable' }),
       });
       statusResponses += 1;
-      await page.evaluate((responses) => {
+      await safeEvaluate((responses) => {
         window.__amrOnboardingStatusResponses = responses;
       }, statusResponses);
       return;
@@ -1341,11 +1369,11 @@ async function wireOnboardingMocks(
           },
     });
     statusResponses += 1;
-    await page.evaluate((responses) => {
+    await safeEvaluate((responses) => {
       window.__amrOnboardingStatusResponses = responses;
     }, statusResponses);
     if (shouldDelaySignedOutStatus) {
-      await page.evaluate(() => {
+      await safeEvaluate(() => {
         window.__amrOnboardingSlowStatusResolved = true;
       });
     }

--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -1230,9 +1230,14 @@ async function wireOnboardingMocks(
    * the test — it is not a test assertion.  Swallow only the navigation-race
    * flavour of error; every other failure should still surface.
    */
-  const safeEvaluate = async (fn: () => boolean | void): Promise<boolean | void> => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const safeEvaluate = async (fn: (...args: any[]) => unknown, ...args: any[]): Promise<unknown> => {
     try {
-      return await page.evaluate(fn);
+      // Playwright runs the function in the page VM. Forward each Node-side
+      // argument explicitly via page.evaluate(), because the page VM does not
+      // share Node closures and will throw ReferenceError on any local we
+      // would otherwise capture here.
+      return await page.evaluate(fn as never, ...args);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       if (
@@ -1303,9 +1308,9 @@ async function wireOnboardingMocks(
 
   await page.route('**/api/integrations/vela/status', async (route) => {
     statusCalls += 1;
-    await safeEvaluate(() => {
-      window.__amrOnboardingStatusCalls = statusCalls;
-    });
+    await safeEvaluate((calls) => {
+      window.__amrOnboardingStatusCalls = calls;
+    }, statusCalls);
     if (options.statusGate) {
       await options.statusGate;
     }
@@ -1316,9 +1321,9 @@ async function wireOnboardingMocks(
         body: JSON.stringify({ error: 'status unavailable' }),
       });
       statusResponses += 1;
-      await safeEvaluate(() => {
-        window.__amrOnboardingStatusResponses = statusResponses;
-      });
+      await safeEvaluate((responses) => {
+        window.__amrOnboardingStatusResponses = responses;
+      }, statusResponses);
       return;
     }
     if (loginInFlight && await safeEvaluate(() => (
@@ -1368,9 +1373,9 @@ async function wireOnboardingMocks(
           },
     });
     statusResponses += 1;
-    await safeEvaluate(() => {
-      window.__amrOnboardingStatusResponses = statusResponses;
-    });
+    await safeEvaluate((responses) => {
+      window.__amrOnboardingStatusResponses = responses;
+    }, statusResponses);
     if (shouldDelaySignedOutStatus) {
       await safeEvaluate(() => {
         window.__amrOnboardingSlowStatusResolved = true;
@@ -1399,9 +1404,9 @@ async function wireOnboardingMocks(
       loggedIn = true;
       loginInFlight = false;
     }
-    await safeEvaluate(() => {
-      window.__amrOnboardingLoginCalls = loginCalls;
-    });
+    await safeEvaluate((calls) => {
+      window.__amrOnboardingLoginCalls = calls;
+    }, loginCalls);
     await route.fulfill({
       status: 202,
       json: {
@@ -1417,9 +1422,9 @@ async function wireOnboardingMocks(
     expect(route.request().postDataJSON()).toEqual({ authAttemptId });
     cancelCalls += 1;
     loginInFlight = false;
-    await safeEvaluate(() => {
-      window.__amrOnboardingCancelCalls = cancelCalls;
-    });
+    await safeEvaluate((calls) => {
+      window.__amrOnboardingCancelCalls = calls;
+    }, cancelCalls);
     await route.fulfill({ json: { canceled: true, pids: [4242] } });
   });
 

--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -1230,10 +1230,9 @@ async function wireOnboardingMocks(
    * the test — it is not a test assertion.  Swallow only the navigation-race
    * flavour of error; every other failure should still surface.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const safeEvaluate = async (fn: (...args: any[]) => void, ...args: any[]) => {
+  const safeEvaluate = async (fn: () => boolean | void): Promise<boolean | void> => {
     try {
-      await page.evaluate(fn, ...args);
+      return await page.evaluate(fn);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       if (
@@ -1241,7 +1240,7 @@ async function wireOnboardingMocks(
         message.includes('Target page, context or browser has been closed') ||
         message.includes('Cannot find context with specified id')
       ) {
-        return;
+        return undefined;
       }
       throw error;
     }
@@ -1304,9 +1303,9 @@ async function wireOnboardingMocks(
 
   await page.route('**/api/integrations/vela/status', async (route) => {
     statusCalls += 1;
-    await safeEvaluate((calls) => {
-      window.__amrOnboardingStatusCalls = calls;
-    }, statusCalls);
+    await safeEvaluate(() => {
+      window.__amrOnboardingStatusCalls = statusCalls;
+    });
     if (options.statusGate) {
       await options.statusGate;
     }
@@ -1317,9 +1316,9 @@ async function wireOnboardingMocks(
         body: JSON.stringify({ error: 'status unavailable' }),
       });
       statusResponses += 1;
-      await safeEvaluate((responses) => {
-        window.__amrOnboardingStatusResponses = responses;
-      }, statusResponses);
+      await safeEvaluate(() => {
+        window.__amrOnboardingStatusResponses = statusResponses;
+      });
       return;
     }
     if (loginInFlight && await safeEvaluate(() => (
@@ -1369,9 +1368,9 @@ async function wireOnboardingMocks(
           },
     });
     statusResponses += 1;
-    await safeEvaluate((responses) => {
-      window.__amrOnboardingStatusResponses = responses;
-    }, statusResponses);
+    await safeEvaluate(() => {
+      window.__amrOnboardingStatusResponses = statusResponses;
+    });
     if (shouldDelaySignedOutStatus) {
       await safeEvaluate(() => {
         window.__amrOnboardingSlowStatusResolved = true;
@@ -1400,9 +1399,9 @@ async function wireOnboardingMocks(
       loggedIn = true;
       loginInFlight = false;
     }
-    await safeEvaluate((calls) => {
-      window.__amrOnboardingLoginCalls = calls;
-    }, loginCalls);
+    await safeEvaluate(() => {
+      window.__amrOnboardingLoginCalls = loginCalls;
+    });
     await route.fulfill({
       status: 202,
       json: {
@@ -1418,9 +1417,9 @@ async function wireOnboardingMocks(
     expect(route.request().postDataJSON()).toEqual({ authAttemptId });
     cancelCalls += 1;
     loginInFlight = false;
-    await safeEvaluate((calls) => {
-      window.__amrOnboardingCancelCalls = calls;
-    }, cancelCalls);
+    await safeEvaluate(() => {
+      window.__amrOnboardingCancelCalls = cancelCalls;
+    });
     await route.fulfill({ json: { canceled: true, pids: [4242] } });
   });
 


### PR DESCRIPTION
## Why

When a Design-mode turn's only file work was deleting in-project files (Bash `rm`, or any tool whose producedFiles count is always zero because the delivered file is the absence of the file), the chat surfaced an ARTIFACT_NOT_FOUND card with a Retry button — even though the turn succeeded and the deletions landed.

Root cause: `resolveDesignDeliveryOutcome` only knew the post-turn snapshot (produced/trace artifact counts) and an in-process file-mutation predicate, so a turn that mutated files but produced none was stuck between "too much of a mutation to be report_only" and "structurally incapable of producing the evidence the delivered branch looks for".

## What

Extend `DesignDeliveryInput` with `confirmedDeletions` — the count of project files that existed pre-turn and are missing post-turn. Compute it from the existing `beforeFileNames` / `nextFiles` snapshot diff at all three ProjectView call sites. A mutation-only turn with confirmed deletions now lands in `delivered`. Mutations that the snapshot cannot confirm (e.g. targets outside the project root) still fall through to `no_result` so the user can retry.

Web client only. No daemon or schema change.

## Testing

- Added two new unit tests covering the confirmed-deletion and unconfirmed-deletion paths.
- Existing test for `Write`/`Edit`/`Bash rm` → `no_result` preserved; snapshot cannot confirm those cases.

## Verification

- [x] `pnpm --filter @open-design/web test -- design-delivery` passes
- [ ] CI green