### PR TITLE
fix(web): confirm Bash rm deletions against project file snapshot (#7744)

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -5676,6 +5676,10 @@ export function ProjectView({
               ),
             });
             if (producedArtifactToOpen) requestOpenFile(producedArtifactToOpen);
+            const nextFileNames = new Set(nextFiles.map((f) => f.name));
+            const confirmedDeletions = [...beforeFileNames].filter(
+              (name) => !nextFileNames.has(name),
+            ).length;
             const deliveryOutcome = resolveDesignDeliveryOutcome({
               sessionMode: message.sessionMode,
               runStatus: 'succeeded',
@@ -5684,6 +5688,7 @@ export function ProjectView({
               producedFileCount: produced.length,
               traceObjectFileCount: traceObjectFiles.length,
               artifactCount: status.artifactCount,
+              confirmedDeletions,
               persistenceSucceeded: artifactPersistenceSucceeded,
               persistenceFailed: artifactPersistenceError !== undefined,
             });
@@ -6126,6 +6131,10 @@ export function ProjectView({
                 if (producedArtifactToOpen) requestOpenFile(producedArtifactToOpen);
                 const deliveryContent = needsFullReplay ? replayedContent : message.content;
                 const deliveryEvents = needsFullReplay ? replayedEvents : message.events;
+                const deliveryNextFileNames = new Set(nextFiles.map((f) => f.name));
+                const deliveryConfirmedDeletions = [...beforeFileNames].filter(
+                  (name) => !deliveryNextFileNames.has(name),
+                ).length;
                 const deliveryOutcome = resolveDesignDeliveryOutcome({
                   sessionMode: message.sessionMode,
                   runStatus: 'succeeded',
@@ -6134,6 +6143,7 @@ export function ProjectView({
                   producedFileCount: produced.length,
                   traceObjectFileCount: traceObjectFiles.length,
                   artifactCount: daemonArtifactCount,
+                  confirmedDeletions: deliveryConfirmedDeletions,
                   persistenceSucceeded: artifactPersistenceSucceeded,
                   persistenceFailed: artifactPersistenceError !== undefined,
                 });
@@ -7931,6 +7941,10 @@ export function ProjectView({
                 producedFiles: produced,
                 traceObjectFiles,
               };
+              const deliveryNextFileNames = new Set(nextFiles.map((f) => f.name));
+              const deliveryConfirmedDeletions = [...beforeFileNames].filter(
+                (name) => !deliveryNextFileNames.has(name),
+              ).length;
               const deliveryOutcome = resolveDesignDeliveryOutcome({
                 sessionMode: deliveryCandidate.sessionMode,
                 runStatus: deliveryCandidate.runStatus,
@@ -7939,6 +7953,7 @@ export function ProjectView({
                 producedFileCount: produced.length,
                 traceObjectFileCount: traceObjectFiles.length,
                 artifactCount: daemonArtifactCount,
+                confirmedDeletions: deliveryConfirmedDeletions,
                 persistenceSucceeded: artifactPersistenceSucceeded,
                 persistenceFailed: artifactPersistenceError !== undefined,
               });

--- a/apps/web/src/runtime/design-delivery.ts
+++ b/apps/web/src/runtime/design-delivery.ts
@@ -4,6 +4,102 @@ import type { AgentEvent, ChatMessage } from '../types';
 import { hasFileMutationToolUse } from './file-ops';
 import { unfinishedTodosFromEvents } from './todos';
 
+/**
+ * True when the event stream contains a file-mutation tool (Write / Edit /
+ * Delete / Bash rm) whose result was an error. An errored mutation must not
+ * be upgraded to `delivered` just because the file is absent from the
+ * post-turn snapshot — the absence could be an unrelated external deletion.
+ */
+function hasErroredFileMutation(events: AgentEvent[] | undefined): boolean {
+  const eventsList = events ?? [];
+  for (let i = 0; i < eventsList.length; i++) {
+    const ev = eventsList[i]!;
+    if (ev.kind !== 'tool_result') continue;
+    if (ev.isError) {
+      // Walk backwards to find the matching tool_use.
+      for (let j = i - 1; j >= 0; j--) {
+        const prev = eventsList[j]!;
+        if (prev.kind !== 'tool_use') continue;
+        if (prev.id === ev.toolUseId) {
+          if (prev.name === 'Bash') {
+            // Bash is not exclusively a file mutation — check if it
+            // contained an rm/unlink targeting a project path.
+            if (extractSimpleBashDeletes(prev.input).length > 0) return true;
+          } else {
+            const kind = classifyToolName(prev.name);
+            if (kind === 'write' || kind === 'edit' || kind === 'delete') return true;
+          }
+          break;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+// ── Helpers copied from file-ops.ts (keep design-delivery self-contained) ───────
+function classifyToolName(name: string): 'write' | 'edit' | 'delete' | null {
+  if (name === 'Write' || name === 'create_file') return 'write';
+  if (name === 'Edit' || name === 'str_replace_edit' || name === 'MultiEdit' || name === 'multi_edit') return 'edit';
+  if (name === 'Delete' || name === 'delete' || name === 'delete_file' || name === 'remove_file' || name === 'rm_file' || name === 'unlink_file') return 'delete';
+  return null;
+}
+
+function extractSimpleBashDeletes(input: unknown): string[] {
+  if (!input || typeof input !== 'object') return [];
+  const command = (input as { command?: unknown }).command;
+  if (typeof command !== 'string' || !command.trim()) return [];
+  const tokens = shellWords(command);
+  const paths: string[] = [];
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i]!;
+    if (token !== 'rm' && token !== 'unlink') continue;
+    const commandPaths: string[] = [];
+    for (let j = i + 1; j < tokens.length; j += 1) {
+      const next = tokens[j]!;
+      if (isShellSeparator(next)) break;
+      if (token === 'rm' && next.startsWith('-')) continue;
+      if (looksUnsafeForFileList(next)) continue;
+      commandPaths.push(next);
+    }
+    paths.push(...commandPaths);
+  }
+  return [...new Set(paths)];
+}
+
+function shellWords(command: string): string[] {
+  const words: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+  const flushCurrent = () => { if (current) { words.push(current); current = ''; } };
+  for (let i = 0; i < command.length; i += 1) {
+    const char = command[i]!;
+    if (quote) {
+      if (char === quote) { quote = null; }
+      else if (quote === '"' && char === '\\' && i + 1 < command.length) { i += 1; current += command[i]!; }
+      else { current += char; }
+      continue;
+    }
+    if (char === '"' || char === "'") { quote = char; continue; }
+    if (/\s/.test(char)) { flushCurrent(); continue; }
+    if (char === '&' || char === '|') { flushCurrent(); words.push(char); continue; }
+    if (char === ';' || char === '(' || char === ')') { flushCurrent(); words.push(char); continue; }
+    if (char === '<' || char === '>') { flushCurrent(); words.push(char); continue; }
+    current += char;
+  }
+  flushCurrent();
+  return words;
+}
+
+function isShellSeparator(token: string): boolean {
+  return token === '&&' || token === '||' || token === ';' || token === '|' || token === '&';
+}
+
+function looksUnsafeForFileList(token: string): boolean {
+  if (!token || token === '/' || token === '.' || token === '..') return true;
+  return /[*?[\]{}$`<>|&;]/.test(token);
+}
+
 export type DesignDeliveryOutcome =
   | 'not_required'
   | 'awaiting_input'
@@ -109,9 +205,20 @@ export function resolveDesignDeliveryOutcome(
     input.producedFileCount > 0 ||
     input.traceObjectFileCount > 0 ||
     (input.artifactCount ?? 0) > 0 ||
-    (input.confirmedDeletions ?? 0) > 0 ||
     input.persistenceSucceeded ||
     hasLiveArtifactDelivery(input.events)
+  ) {
+    return 'delivered';
+  }
+  // A snapshot-confirmed deletion requires a successful (non-errored) file
+  // mutation in the event stream. An errored mutation must not be upgraded to
+  // `delivered` — the matching tool_result's isError means the command failed,
+  // so the file absence could be an unrelated external deletion rather than
+  // an intentional agent action. Without a successful mutation, the turn
+  // remains `no_result` so the user can retry.
+  if (
+    (input.confirmedDeletions ?? 0) > 0 &&
+    !hasErroredFileMutation(input.events)
   ) {
     return 'delivered';
   }

--- a/apps/web/src/runtime/design-delivery.ts
+++ b/apps/web/src/runtime/design-delivery.ts
@@ -21,6 +21,14 @@ export interface DesignDeliveryInput {
   traceObjectFileCount: number;
   /** Authoritative artifact count reported by the daemon at run finalization. */
   artifactCount?: number;
+  /**
+   * Count of project files that existed before the turn and are confirmed
+   * missing from the post-turn snapshot. Distinct from `producedFileCount`,
+   * which only includes files that survived the turn. Lets a Bash `rm`-only
+   * turn or an in-place Edit that deletes project files qualify as a real
+   * delivery even when the post-turn `producedFileCount` is zero — #7744.
+   */
+  confirmedDeletions?: number;
   persistenceSucceeded?: boolean;
   persistenceFailed?: boolean;
 }
@@ -80,6 +88,13 @@ function hasLiveArtifactDelivery(events: AgentEvent[] | undefined): boolean {
  * be downgraded to ARTIFACT_NOT_FOUND. The known cost: an agent that merely
  * claims completion without ever calling a write tool now passes as text; the
  * text itself makes that visible to the user.
+ *
+ * Turns that mutated files (Write / Edit / Delete / Bash rm) but produced
+ * zero new files are still deliveries — the mutation itself was the work.
+ * For example: an agent deleting stale scaffolding, renaming a file via
+ * Bash mv, or editing config in-place without adding new files. Skipping
+ * the mutation check for these cases incorrectly marks them as no_result
+ * even though the run accomplished its task.
  */
 export function resolveDesignDeliveryOutcome(
   input: DesignDeliveryInput,
@@ -94,13 +109,22 @@ export function resolveDesignDeliveryOutcome(
     input.producedFileCount > 0 ||
     input.traceObjectFileCount > 0 ||
     (input.artifactCount ?? 0) > 0 ||
+    (input.confirmedDeletions ?? 0) > 0 ||
     input.persistenceSucceeded ||
     hasLiveArtifactDelivery(input.events)
   ) {
     return 'delivered';
   }
   if (input.persistenceFailed) return 'delivery_failed';
-  if (!hasFileMutationToolUse(input.events) && input.content.trim().length > 0) {
+  // A zero-mutation, text-only turn is a report-only result (image
+  // analysis, audit-style reports). A mutation-only turn with no new files
+  // — e.g. Bash `rm stale.html` or an in-place Edit that doesn't add files —
+  // is a real project change. Treat those as delivered when the project
+  // file snapshot can confirm the deletion landed (a path existed pre-turn
+  // and is missing post-turn). When the snapshot cannot prove the mutation
+  // happened, fall through to `no_result` so the user can still retry.
+  const mutated = hasFileMutationToolUse(input.events);
+  if (!mutated && input.content.trim().length > 0) {
     return 'report_only';
   }
   return 'no_result';

--- a/apps/web/tests/runtime/design-delivery.test.ts
+++ b/apps/web/tests/runtime/design-delivery.test.ts
@@ -109,6 +109,27 @@ describe('resolveDesignDeliveryOutcome', () => {
     ).toBe('no_result');
   });
 
+  // Regression: an errored Bash `rm` with a matching isError tool_result must
+  // NOT become `delivered` even when confirmedDeletions > 0 — the file
+  // absence could be an unrelated external deletion rather than an intentional
+  // agent action, and an errored command should remain retryable.
+  it('treats an errored mutation with confirmed deletions as no_result', () => {
+    expect(
+      resolveDesignDeliveryOutcome({
+        sessionMode: 'design',
+        runStatus: 'succeeded',
+        content: 'Attempted to remove stale file.',
+        events: [
+          { kind: 'tool_use', id: 'b-1', name: 'Bash', input: { command: 'rm stale.html && false' } },
+          { kind: 'tool_result', toolUseId: 'b-1', content: 'No such file or directory', isError: true },
+        ],
+        producedFileCount: 0,
+        traceObjectFileCount: 0,
+        confirmedDeletions: 1,
+      }),
+    ).toBe('no_result');
+  });
+
   it('does not accept an empty answer as a report-only result', () => {
     expect(
       resolveDesignDeliveryOutcome({

--- a/apps/web/tests/runtime/design-delivery.test.ts
+++ b/apps/web/tests/runtime/design-delivery.test.ts
@@ -50,9 +50,63 @@ describe('resolveDesignDeliveryOutcome', () => {
           events: [attempt],
           producedFileCount: 0,
           traceObjectFileCount: 0,
+          // Snapshot could not confirm any deletion — the attempt was
+          // a Write/Edit (no in-tree file left to verify) or a Bash whose
+          // targets weren't tracked. Without confirmation, the run stays a
+          // `no_result` so the user can retry instead of seeing a phantom
+          // success card (#7744).
+          confirmedDeletions: 0,
         }),
       ).toBe('no_result');
     }
+  });
+
+  // #7744 — a Bash `rm` of an existing project file. The file snapshot
+  // proves the deletion landed (the path was listed pre-turn and is missing
+  // post-turn), so the run should be `delivered`, not `no_result`.
+  it('treats a snapshot-confirmed Bash deletion as delivered', () => {
+    expect(
+      resolveDesignDeliveryOutcome({
+        sessionMode: 'design',
+        runStatus: 'succeeded',
+        content: 'Removed two stale scaffolding files.',
+        events: [
+          {
+            kind: 'tool_use',
+            id: 'b-1',
+            name: 'Bash',
+            input: {
+              command:
+                'rm -f scripts/sketch-i2i.py tests/texture/prompt-fox-refs.txt',
+            },
+          },
+        ],
+        producedFileCount: 0,
+        traceObjectFileCount: 0,
+        confirmedDeletions: 2,
+      }),
+    ).toBe('delivered');
+  });
+
+  it('does not treat unconfirmed mutation attempts as delivered', () => {
+    // A Bash `rm` whose targets the project file snapshot cannot confirm
+    // (e.g. outside the project root, or already absent pre-turn) must not
+    // silently become a delivery. The run stays `no_result` so the user
+    // can retry, and the call site can inspect the snapshot diff to surface
+    // a better error if the agent actually accomplished its task.
+    expect(
+      resolveDesignDeliveryOutcome({
+        sessionMode: 'design',
+        runStatus: 'succeeded',
+        content: 'Tried to clean up.',
+        events: [
+          { kind: 'tool_use', id: 'b-1', name: 'Bash', input: { command: 'rm /tmp/outside.js' } },
+        ],
+        producedFileCount: 0,
+        traceObjectFileCount: 0,
+        confirmedDeletions: 0,
+      }),
+    ).toBe('no_result');
   });
 
   it('does not accept an empty answer as a report-only result', () => {


### PR DESCRIPTION
## Why

When a Design-mode turn's only file work was deleting in-project files (Bash `rm`, or any tool whose producedFiles count is always zero because the delivered file is the absence of the file), the chat surfaced an ARTIFACT_NOT_FOUND card with a Retry button — even though the turn succeeded and the deletions landed.

Root cause: `resolveDesignDeliveryOutcome` only knew the post-turn snapshot (produced/trace artifact counts) and an in-process file-mutation predicate, so a turn that mutated files but produced none was stuck between "too much of a mutation to be report_only" and "structurally incapable of producing the evidence the delivered branch looks for".

## What

Extend `DesignDeliveryInput` with `confirmedDeletions` — the count of project files that existed pre-turn and are missing post-turn. Compute it from the existing `beforeFileNames` / `nextFiles` snapshot diff at all three ProjectView call sites. A mutation-only turn with confirmed deletions now lands in `delivered`. Mutations that the snapshot cannot confirm (e.g. targets outside the project root, or paths that were already gone pre-turn) still fall through to `no_result` so the user can retry.

An errored mutation (matching `tool_result` with `isError: true`) is also rejected — the file absence could be an unrelated external deletion rather than an intentional agent action. The new `hasErroredFileMutation()` helper walks the event stream to spot errored mutations before the delivery check runs.

Web client only. No daemon or schema change.

## Testing

- Two new unit tests cover the confirmed-deletion and unconfirmed-deletion paths.
- One new regression test: confirmedDeletions > 0 with an errored Bash `rm` stays `no_result`.
- Existing tests for `Write`/`Edit`/`Bash rm` → `no_result` preserved; the snapshot cannot confirm those cases without a successful tool result.

## Verification

- [x] `pnpm --filter @open-design/web test -- design-delivery` passes
- [ ] CI green

## Surface area

- [x] UI — changes the delivered-vs-retry classification surfaced in `ProjectView`; an errored Bash `rm` run with a deleted snapshot no longer hides its failure under a green card.