### PR TITLE
fix(runtimes): pass pi skill directories through --skill

### DIFF
--- a/apps/daemon/src/runtimes/defs/pi.ts
+++ b/apps/daemon/src/runtimes/defs/pi.ts
@@ -70,19 +70,25 @@ export const piAgentDef = {
       if (options.reasoning && options.reasoning !== 'default') {
         args.push('--thinking', options.reasoning);
       }
-      // pi supports --append-system-prompt for cwd and extra context.
-      // For now we rely on the composed prompt containing the cwd hint
-      // (same pattern as other agents) rather than using system-prompt flags.
-      //
-      // extraAllowedDirs carries skill seed and design-system directories
-      // that live outside the project cwd. pi doesn't have an --add-dir
-      // sandbox flag (it uses OS cwd), so we use --append-system-prompt to
-      // hint that these directories exist. The agent can then use its Read
-      // tool to access files inside them. Without this, pi runs inside the
-      // project cwd and has no way to discover or reach skill/design-system
-      // assets that live elsewhere.
+      // extraAllowedDirs mixes skill seed and design-system directories that
+      // live outside the project cwd. pi has no --add-dir sandbox flag (it
+      // uses OS cwd). Skill directories have a dedicated --skill flag; a
+      // directory passed to --append-system-prompt logs a read error because
+      // that flag expects text or a readable file. Design-system and other
+      // non-skill dirs still use --append-system-prompt so the agent can
+      // discover them via Read. The split is explicit via runtimeContext
+      // (not a path heuristic): skillDirs → --skill, remaining dirs →
+      // --append-system-prompt.
+      const skillDirSet = new Set(
+        (runtimeContext.skillDirs || []).filter(
+          (d) => typeof d === 'string' && path.isAbsolute(d),
+        ),
+      );
+      for (const d of skillDirSet) {
+        args.push('--skill', d);
+      }
       const dirs = (extraAllowedDirs || []).filter(
-        (d) => typeof d === 'string' && path.isAbsolute(d),
+        (d) => typeof d === 'string' && path.isAbsolute(d) && !skillDirSet.has(d),
       );
       for (const d of dirs) {
         args.push('--append-system-prompt', d);

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -83,6 +83,12 @@ export type RuntimeContext = {
    * than forwarding Child text into the parent UI stream.
    */
   observeNativeChildBehavior?: boolean;
+  /**
+   * Absolute skill-package directories to load via a runtime-native skill
+   * flag (today: `pi --skill`). Distinct from `extraAllowedDirs`, which also
+   * carries design-system and linked directories that are not skills.
+   */
+  skillDirs?: string[];
 };
 
 // Marker on a RuntimeAgentDef declaring that the adapter's CLI maintains

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11239,6 +11239,10 @@ export async function startServer({
         ? [odNextTaskInputSnapshot.projectionAccessRoot]
         : []),
     ];
+    const skillDirs = resolveChatExtraAllowedDirs({
+      agentId,
+      skillsDir: SKILLS_DIR,
+    });
     const researchCommandContract = resolveResearchCommandContract(
       research,
       isOdNextRequestStage
@@ -12852,6 +12856,7 @@ export async function startServer({
           hasPriorAssistantTurn,
           agentLogFilePath,
           promptFilePath: promptFile?.path,
+          skillDirs,
           resumeSessionId: agentResumePromptPolicy.resumeSessionId,
           newSessionId: agentResumeCtx.newSessionId,
           disablePlugins:

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -423,52 +423,51 @@ test('pi fetchModels reads the model table from stdout', async () => {
   }
 });
 
-test('pi args forward extraAllowedDirs as --append-system-prompt flags', () => {
+test('pi args pass skill dirs through --skill and design-system dirs through --append-system-prompt', () => {
   const args = pi.buildArgs(
     '',
     [],
     ['/tmp/skills', '/tmp/design-systems'],
     {},
-    {},
+    { skillDirs: ['/tmp/skills'] },
   );
 
   assert.deepEqual(args, [
     '--mode',
     'rpc',
-    '--append-system-prompt',
+    '--skill',
     '/tmp/skills',
     '--append-system-prompt',
     '/tmp/design-systems',
   ]);
 });
 
-test('pi args filter relative paths from extraAllowedDirs', () => {
+test('pi args filter relative paths from skill and extra allowed dirs', () => {
   const args = pi.buildArgs(
     '',
     [],
     ['/tmp/skills', 'relative/path', '/tmp/design-systems'],
     {},
-    {},
+    { skillDirs: ['/tmp/skills', 'relative/skill'] },
   );
 
-  // Relative paths should be filtered out.
   assert.deepEqual(args, [
     '--mode',
     'rpc',
-    '--append-system-prompt',
+    '--skill',
     '/tmp/skills',
     '--append-system-prompt',
     '/tmp/design-systems',
   ]);
 });
 
-test('pi args combine model, thinking, and extraAllowedDirs', () => {
+test('pi args combine model, thinking, skill dirs, and design-system dirs', () => {
   const args = pi.buildArgs(
     '',
     [],
-    ['/tmp/skills'],
+    ['/tmp/skills', '/tmp/design-systems'],
     { model: 'openai/gpt-5', reasoning: 'medium' },
-    {},
+    { skillDirs: ['/tmp/skills'] },
   );
 
   assert.deepEqual(args, [
@@ -478,8 +477,10 @@ test('pi args combine model, thinking, and extraAllowedDirs', () => {
     'openai/gpt-5',
     '--thinking',
     'medium',
-    '--append-system-prompt',
+    '--skill',
     '/tmp/skills',
+    '--append-system-prompt',
+    '/tmp/design-systems',
   ]);
 });
 


### PR DESCRIPTION
Closes TreeTreeDi/open-design#4

## Why

The pi adapter handed skill and design-system directories to `--append-system-prompt`, which expects text or a readable file. Each skill directory logged a read error and the path was embedded as prose. pi already has `--skill` for skill directories.

This unblocks a hosted Instance image that uses pi with team skills on a shared volume, without teaching the daemon about tenants.

## What users will see

- [ ] **None** — pi runs that stage a skill no longer log a directory read error; skill packages load through the CLI skill flag. Design systems keep the existing prompt-path hint.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — pi argv construction for staged skill directories
- [ ] **None**

## Bug fix verification

- Test path: `apps/daemon/tests/runtimes/agent-args.test.ts`
- Red on the old `--append-system-prompt` assertion for skill dirs, green after the split (yes)

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/agent-args.test.ts` (53 passed)


Made with [Cursor](https://cursor.com)