### PR TITLE
docs(i18n): refresh French core documentation

### DIFF
--- a/docs/i18n/CONTRIBUTING.fr.md
+++ b/docs/i18n/CONTRIBUTING.fr.md
@@ -22,7 +22,7 @@ une PR doit atteindre avant d’être mergée.
 | Faire parler à OD le langage visuel d'une nouvelle marque | un **Design System** | [`design-systems/<brand>/`](../../design-systems/) | un paquet : `manifest.json`, `DESIGN.md` et `tokens.css` |
 | Brancher une nouvelle CLI de coding agent | un **Agent adapter** | [`apps/daemon/src/runtimes/defs/`](../../apps/daemon/src/runtimes/defs/) | une définition et une entrée de registre |
 | Ajouter une feature, corriger un bug, reprendre un pattern UX de [`open-codesign`][ocod] | du code | `apps/web/src/`, `apps/daemon/` | PR classique |
-| Améliorer la doc, porter une section en Français / Deutsch / 中文, corriger une faute | documentation | `README.md`, `README.fr.md`, `README.de.md`, `README.zh-CN.md`, `docs/`, `QUICKSTART.md` | une PR |
+| Améliorer la doc, porter une section en Français / Deutsch / 中文, corriger une faute | documentation | `README.md`, `docs/i18n/README.fr.md`, `docs/i18n/README.de.md`, `docs/i18n/README.zh-CN.md`, `docs/`, `QUICKSTART.md` | une PR |
 
 Si vous ne savez pas dans quelle catégorie tombe votre idée, [ouvrez d'abord
 une discussion ou une issue](https://github.com/nexu-io/open-design/issues/new)
@@ -49,13 +49,70 @@ Node `~24` et pnpm `10.33.x` sont requis. `nvm` / `fnm` sont optionnels ;
 utilisez `nvm install 24 && nvm use 24` ou `fnm install 24 && fnm use 24` si
 vous gérez Node comme cela. macOS, Linux et WSL2 sont les environnements
 principaux pris en charge.
-Windows natif est supporté ; voir [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md)
+Windows natif est pris en charge au mieux ; voir [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md)
 pour les pièges de configuration les plus courants.
 
-Vous n'avez pas besoin d'une CLI d'agent dans votre `PATH` pour développer OD.
-Le daemon indiquera "no agents found" ; utilisez alors le mode API/BYOK
-(Anthropic, OpenAI, Azure OpenAI ou Google Gemini), qui est souvent la boucle
-de dev la plus rapide.
+## Configuration Docker
+
+Exécutez OpenDesign sans installer Node.js ou pnpm localement.
+
+### Prérequis
+
+Vérifiez que Docker Desktop et Compose v2 sont installés :
+
+```bash
+docker compose version
+```
+
+### Démarrer OpenDesign
+
+Depuis la racine du dépôt, préparez le fichier d'environnement :
+
+```bash
+cd deploy
+cp .env.example .env
+openssl rand -hex 32
+```
+
+Dans `.env`, renseignez `OD_API_TOKEN=` avec le token généré, puis démarrez le service :
+
+```bash
+docker compose up -d
+```
+
+Ouvrez `http://127.0.0.1:7456`. Si le navigateur demande des identifiants, utilisez `open-design` comme nom d'utilisateur et la valeur de `OD_API_TOKEN` comme mot de passe.
+
+### Commandes courantes
+
+```bash
+# View logs
+docker compose logs -f
+
+# Restart containers
+docker compose restart
+
+# Stop containers
+docker compose down
+
+# Pull latest image
+docker compose pull
+docker compose up -d
+```
+
+### Variables d'environnement optionnelles
+
+Ajustez ces valeurs dans `deploy/.env` en conservant votre `OD_API_TOKEN` :
+
+```env
+OPEN_DESIGN_PORT=7456
+OPEN_DESIGN_MEM_LIMIT=384m
+OPEN_DESIGN_ALLOWED_ORIGINS=https://yourdomain.com
+OPEN_DESIGN_IMAGE=ghcr.io/nexu-io/od:latest
+```
+
+Les projets et la base de données sont persistés dans des volumes Docker. Pour les règles de stockage du daemon, consultez la section **Daemon data directory contract** du fichier [`AGENTS.md`](../../AGENTS.md#daemon-data-directory-contract) à la racine.
+
+Le guide Docker complet et la configuration avancée se trouvent dans [`QUICKSTART.fr.md`](QUICKSTART.fr.md).
 
 ---
 
@@ -68,106 +125,17 @@ forme et les ressources de rendu d'un artifact affiché dans la galerie Template
 
 ### → Voir [`docs/skills-contributing.md`](../../docs/skills-contributing.md) pour le guide complet
 
-### Structure d'un dossier de template
+Ce guide détaille :
 
-```text
-design-templates/your-template/
-├── SKILL.md                    # requis
-├── assets/template.html        # optionnel mais recommandé — seed file
-├── references/                 # optionnel — fichiers de connaissance lus par l'agent
-│   ├── layouts.md
-│   ├── components.md
-│   └── checklist.md
-└── example.html                # fortement recommandé — vrai exemple construit à la main
-```
+- **Le démarrage rapide** — cloner le dépôt, copier le modèle existant le plus proche, lancer `pnpm tools-dev run web`, vérifier le sélecteur et ouvrir une PR.
+- **Ce qui constitue un modèle de design** — pour distinguer un modèle d'une fonctionnalité ou d'une intégration fournisseur.
+- **La structure d'un modèle** — arborescence minimale et aide-mémoire du frontmatter de `SKILL.md`.
+- **L'exécution locale** — les quatre commandes essentielles.
+- **Les critères de fusion** — une checklist prête à copier de tous les points vérifiés en revue.
+- **Le modèle de description de PR** — à copier et à remplir.
+- **Les motifs de refus fréquents** — avec des exemples concrets tirés de revues récentes.
 
-### Frontmatter de `SKILL.md`
-
-Les trois premières clés sont la spec Claude Code de base : `name`,
-`description`, `triggers`. Tout ce qui est sous `od:` est spécifique à OD et
-optionnel, mais **`od.mode`** décide dans quel groupe le template apparaît. La
-valeur est extensible ; les modes courants incluent Prototype, Deck, Image,
-Video, Audio, Design system et Utility.
-
-```yaml
----
-name: your-template
-description: |
-  One-paragraph elevator pitch. The agent reads this verbatim to decide
-  if the user's brief matches. Be concrete: surface, audience, what's in
-  the artifact, what's not.
-triggers:
-  - "your trigger phrase"
-  - "another phrase"
-  - "中文触发词"
-od:
-  mode: prototype           # prototype | deck | image | video | audio | design-system | utility
-  platform: desktop         # desktop | mobile
-  scenario: marketing       # free-form tag for grouping
-  featured: 1               # any positive integer surfaces it under "Showcase examples"
-  preview:
-    type: html              # html | jsx | pptx | markdown
-  design_system:
-    requires: true          # does the template read the active DESIGN.md?
-  craft:
-    requires: [typography, color, anti-ai-slop]
-  example_prompt: "A copy-pastable prompt that nicely shows what this template does."
----
-
-# Your Template
-
-Body is free-form Markdown describing the workflow the agent should follow…
-```
-
-La grammaire active complète (`od.mode`, `od.surface`, `od.craft.requires`,
-`od.critique.policy`, les indices de galerie, etc.) se trouve dans
-[`docs/skills-protocol.md`](../../docs/skills-protocol.md). D'anciens champs
-portables comme `od.inputs`, `od.parameters` et `od.capabilities_required`
-peuvent encore apparaître dans des bundles externes, mais le registre des
-skills/templates ne les consomme pas.
-
-### Critères de merge pour un nouveau template
-
-Nous sommes exigeants sur les templates parce qu'ils constituent une partie
-visible pour l'utilisateur. Un nouveau template doit :
-
-1. **Livrer un vrai `example.html`.** Construit à la main, ouvrable directement
-   depuis le disque, avec un niveau qu'un designer pourrait réellement livrer.
-   Pas de lorem ipsum, pas de hero placeholder en `<svg><rect/></svg>`. Si vous
-   ne pouvez pas construire l'exemple vous-même, le template n'est probablement
-   pas prêt.
-2. **Passer l'anti-AI-slop checklist** dans le body. Pas de gradients violets,
-   pas d'icônes emoji génériques, pas de carte arrondie avec accent en bord
-   gauche, pas d'Inter comme fonte *display*, pas de statistiques inventées.
-   Lisez la section **Anti-AI-slop machinery** du README pour la liste complète.
-3. **Utiliser des placeholders honnêtes.** Si l'agent n'a pas de vraie donnée,
-   écrivez `—` ou un bloc gris libellé, pas "10× faster".
-4. **Avoir un `references/checklist.md`** avec au moins les gates P0, c'est-à-dire
-   ce que l'agent doit vérifier avant d'émettre `<artifact>`. Reprenez le format
-   de [`design-templates/guizang-ppt/references/checklist.md`](../../design-templates/guizang-ppt/) ou
-   [`design-templates/dating-web/references/checklist.md`](../../design-templates/dating-web/).
-5. **Ajouter une capture** sous `docs/screenshots/skills/<skill>.png` si le template
-   est featured. PNG, environ 1024×640 retina, capturé depuis le vrai
-   `example.html` avec un zoom navigateur adapté.
-6. **Rester dans un dossier autonome.** Pas d'import CDN au-delà de ce que les
-   autres templates utilisent déjà ; pas de fonte sans licence ; pas d'image de
-   plus d'environ 250 KB.
-
-Si vous forkez un template existant (par exemple partir de `dating-web` pour en
-faire `recruiting-web`), conservez la LICENSE et l'attribution d'auteur dans
-`references/`, et mentionnez-le dans la description de la PR.
-
-### Templates existants à imiter
-
-- Prototype visuel single-screen : [`design-templates/dating-web/`](../../design-templates/dating-web/),
-  [`design-templates/digital-eguide/`](../../design-templates/digital-eguide/)
-- Flow mobile multi-frame : [`design-templates/mobile-onboarding/`](../../design-templates/mobile-onboarding/),
-  [`design-templates/gamified-app/`](../../design-templates/gamified-app/)
-- Document / template sans Design System requis : [`design-templates/pm-spec/`](../../design-templates/pm-spec/),
-  [`design-templates/weekly-update/`](../../design-templates/weekly-update/)
-- Deck mode : [`design-templates/guizang-ppt/`](../../design-templates/guizang-ppt/) (bundle repris tel
-  quel depuis [op7418/guizang-ppt-skill][guizang]) et
-  [`design-templates/simple-deck/`](../../design-templates/simple-deck/)
+La spécification du protocole — grammaire active du frontmatter, références aux règles de craft et primitives de test — se trouve dans [`docs/skills-protocol.md`](../../docs/skills-protocol.md). D'anciens champs portables comme `od.inputs`, `od.parameters` et `od.capabilities_required` peuvent encore apparaître dans des bundles externes, mais le registre des skills et des modèles ne les consomme pas.
 
 ---
 
@@ -226,7 +194,7 @@ et [`design-systems/_schema/AGENTS.md`](../../design-systems/_schema/AGENTS.md).
 
 Il n'existe pas de schéma fixe à neuf sections. Le guard de qualité exige au
 moins sept sections H2 substantielles, sans imposer leurs noms, leur ordre ou
-leur numérotation. Utilisez des titres adaptés au système réel.
+leur numérotation. Utilisez des titres adaptés au système réel ; un package utile couvre généralement le thème, les couleurs, la typographie, la mise en page, les composants, les animations, l’accessibilité et les pratiques à éviter.
 
 ### Critères de merge pour un nouveau Design System
 
@@ -239,8 +207,8 @@ leur numérotation. Utilisez des titres adaptés au système réel.
    décrits dans `DESIGN.md` doivent correspondre à `tokens.css`, qui doit passer
    les guards de tokens partagés.
 4. **Utiliser des preuves réelles et une provenance claire.** Échantillonnez le
-   produit ou site source et consignez la source dans le manifest ou les preuves
-   du package.
+   produit ou site source, sans vous fier à vos souvenirs ni aux suppositions d’une IA,
+   et consignez la source dans le manifeste ou les preuves du package.
 5. **Rédiger une copie catalogue utile.** `manifest.name`, `category` et
    `description` sont les métadonnées principales du picker ; évitez le fluff.
 
@@ -255,7 +223,7 @@ ajouts propres au projet qui ne rentrent pas upstream.
 ## Ajouter une nouvelle CLI de coding agent
 
 Brancher un nouvel agent (par exemple une CLI `foo-coder`) revient à ajouter
-une définition dans [`apps/daemon/src/runtimes/defs/`](../../apps/daemon/src/runtimes/defs/) et une entrée dans `runtimes/registry.ts` :
+une définition dans [`apps/daemon/src/runtimes/defs/`](../../apps/daemon/src/runtimes/defs/) et un import avec une entrée dans [`runtimes/registry.ts`](../../apps/daemon/src/runtimes/registry.ts) :
 
 ```ts
 import type { RuntimeAgentDef } from '../types.js';
@@ -317,7 +285,9 @@ qui motive cette mise à jour.
 
 La table `OVERRIDES` dans `maxTokens.ts` est réservée aux rares cas où LiteLLM
 est absent ou incorrect pour un model id réellement utilisé, par exemple
-`mimo-v2.5-pro`. Gardez-la petite ; tout ce que LiteLLM sait déjà correctement
+`mimo-v2.5-pro` : LiteLLM ne référence MiMo que sous les alias
+`openrouter/xiaomi/...` et `novita/xiaomimimo/...`, qui ne correspondent pas
+à l’identifiant canonique de l’API directe de Xiaomi. Gardez-la petite ; tout ce que LiteLLM sait déjà correctement
 doit rester upstream.
 
 [litellm]: https://github.com/BerriAI/litellm
@@ -326,17 +296,11 @@ doit rester upstream.
 
 ## Maintenance des localisations
 
-Les PR de locale doivent traduire le chrome UI, la documentation cœur et les
-métadonnées display-only de galerie dans `apps/web/src/i18n/content*.ts`, mais
-ne doivent pas traduire `skills/`, `design-systems/` ni les prompt bodies que
-les agents exécutent. Ces prompts source sont des entrées de workflow ; garder
-une langue source commune évite de multiplier la QA de prompts sur toutes les
-locales. Lorsqu'un Skill, un Design System ou un prompt template est ajouté ou
-renommé, mettez à jour les métadonnées display de la locale concernée et lancez
-`pnpm --filter @open-design/web test` ; `content.test.ts` échoue si la coverage
-couverture des métadonnées d'affichage d'une locale déclarée dérive. Les erreurs daemon, noms de fichiers
-d'export et textes d'artifact générés par agent restent des limites connues,
-sauf si une PR les inclut explicitement.
+L'allemand utilise le vouvoiement formel `Sie`, car OD s'adresse à des créateurs indépendants, des agences et des équipes d'ingénierie. Tant que les retours du projet ne justifient pas le tutoiement `du`, ce registre reste le choix par défaut le moins surprenant.
+
+Les PR de localisation doivent traduire les éléments d'interface, la documentation principale et les métadonnées de galerie destinées uniquement à l'affichage dans `apps/web/src/i18n/content.ts`. Elles ne doivent pas traduire `skills/`, `design-systems/` ni les corps de prompts exécutés par les agents. Ces prompts sont des entrées de workflow ; conserver une langue source commune évite de multiplier leur validation par langue.
+
+Lors de l'ajout ou du renommage d'un skill, d'un système de design ou d'un modèle de prompt, mettez à jour les métadonnées d'affichage allemandes et lancez `pnpm --filter @open-design/web test` : `content.test.ts` détecte les écarts de couverture en allemand. Les erreurs du daemon, les noms de fichiers exportés et les textes d'artefacts générés par les agents restent des limites connues, sauf si une PR les inclut explicitement.
 
 Pour les étapes détaillées d'ajout d'une locale (dictionnaire UI, README,
 language switcher, terminologie régionale), voir [`TRANSLATIONS.md`](../../TRANSLATIONS.md).
@@ -469,7 +433,7 @@ ressemble le chemin pour devenir Mainteneur, les règles se trouvent dans
   Core Team sur la qualité des contributions. Il n'y a pas de formulaire
   de candidature ; la Core Team identifie les candidats en interne et
   prend contact.
-- Il n'y a **aucun quota, aucun SLAs, et aucun mandat fixe.** Se retirer
+- Il n'y a **aucun quota, aucun SLA, et aucun mandat fixe.** Se retirer
   est facile et réversible (Emeritus → retour quand la vie se calme).
 - Tous les seuils, le flux de nomination, les règles de retrait et la
   dérogation pour les projets en phase initiale se trouvent dans
@@ -487,10 +451,7 @@ se fait tout seul.
 
 ## Licence
 
-En contribuant, vous acceptez que votre contribution soit licenciée sous la
-[licence Apache-2.0](../../LICENSE) de ce repo, à l'exception des fichiers dans
-[`design-templates/guizang-ppt/`](../../design-templates/guizang-ppt/), qui conservent leur licence MIT
-originale et l'attribution d'auteur à [op7418](https://github.com/op7418).
+En contribuant, vous acceptez que votre contribution soit placée sous la [licence Apache-2.0](../../LICENSE) de ce dépôt, sauf lorsqu'un skill ou un modèle intégré possède son propre fichier `LICENSE`. Les exceptions connues sous licence MIT comprennent [`design-templates/guizang-ppt/`](../../design-templates/guizang-ppt/), qui conserve l'attribution à [op7418](https://github.com/op7418), et [`skills/web-clone/`](../../skills/web-clone/), qui conserve l'attribution à [Jane Xiaoer](https://github.com/Jane-xiaoer).
 
 [skill]: https://docs.anthropic.com/en/docs/claude-code/skills
 [guizang]: https://github.com/op7418/guizang-ppt-skill

--- a/docs/i18n/QUICKSTART.fr.md
+++ b/docs/i18n/QUICKSTART.fr.md
@@ -8,10 +8,14 @@ Exécutez le produit complet localement.
 
 - **Node.js :** `~24` (Node 24.x). Le repo l’impose via `package.json#engines`.
 - **pnpm :** `10.33.x`. Le repo fixe `pnpm@10.33.2` via `packageManager` ; utilisez Corepack pour que la bonne version soit sélectionnée automatiquement.
-- **OS :** macOS, Linux et WSL2 sont les environnements principaux pris en charge. Windows natif devrait fonctionner pour la plupart des workflows, mais WSL2 reste l’option la plus fiable.
+- **OS :** macOS, Linux et WSL2 sont les environnements principaux pris en charge. Si vos CLI d’agents s’exécutent dans WSL2, suivez le [guide WSL2](../wsl-setup.md). Windows natif est pris en charge au mieux ; consultez le [guide de dépannage Windows](../windows-troubleshooting.md) pour sa configuration.
 - **CLI d’agent locale optionnelle :** OpenDesign prend en charge un registre de runtimes locaux, dont Claude Code, Codex, Devin for Terminal, OpenCode, Cursor Agent, Qwen, Qoder CLI, GitHub Copilot CLI et d’autres. La liste actuelle se trouve dans [`apps/daemon/src/runtimes/registry.ts`](../../apps/daemon/src/runtimes/registry.ts). Si aucun n’est installé, utilisez un runtime BYOK configuré dans Settings.
 
-`nvm` / `fnm` sont des outils de confort optionnels, pas une étape obligatoire de la configuration du projet. Si vous en utilisez un, installez/sélectionnez Node 24 avant de lancer pnpm :
+### CLI d'agent locale et PATH
+
+Le daemon détecte les CLI dans son `PATH` et dans les répertoires courants des outils utilisateur. Si une CLI installée avec `npm install -g` ou Homebrew n'apparaît pas, vérifiez le `PATH` du processus qui lance le daemon. Sur macOS, une application graphique peut recevoir un `PATH` minimal, différent de celui de votre shell de connexion. Ajoutez le répertoire `bin` contenant l'exécutable au `PATH` du daemon, puis cliquez sur **Rescan** dans **Models & providers → Local CLI**.
+
+[`nvm`](https://github.com/nvm-sh/nvm) / [`fnm`](https://github.com/Schniz/fnm) sont des outils de confort optionnels, pas une étape obligatoire de la configuration du projet. Si vous en utilisez un, installez/sélectionnez Node 24 avant de lancer pnpm :
 
 ```bash
 # nvm
@@ -29,48 +33,6 @@ Activez ensuite Corepack et laissez le repo sélectionner pnpm :
 corepack enable
 corepack pnpm --version   # doit afficher 10.33.2
 ```
-
-## Démarrage rapide (mode dev)
-
-```bash
-corepack enable
-pnpm install
-pnpm tools-dev run web # démarre daemon + web au premier plan
-# ouvrez l’URL web affichée par tools-dev
-```
-
-Pour le shell desktop et tous les sidecars gérés en arrière-plan :
-
-```bash
-pnpm tools-dev # démarre daemon + web + desktop en arrière-plan
-```
-
-Au premier chargement, l’app détecte les runtimes locaux disponibles et propose aussi les runtimes BYOK configurés dans Settings. Choisissez un runtime, une design template et un Design System, puis tapez un prompt et cliquez sur **Send**. Les runtimes locaux structurés écrivent les fichiers canoniques du projet et diffusent les événements de fichiers/outils ; l’espace de fichiers et la preview se mettent à jour depuis ces écritures. Les exécutions texte uniquement et BYOK renvoient à la place un bloc `<artifact>` complet que l’hôte parse. Avant de documenter ou de modifier un chemin de stockage d’artifact, vous DEVEZ lire `AGENTS.md` à la racine, section **Daemon data directory contract**.
-
-Le catalogue **Design Systems** est chargé directement depuis les paquets `DESIGN.md` de [`design-systems/`](../../design-systems/). Choisissez-en un pour appliquer le langage visuel de la marque à l’artifact.
-
-Le catalogue **Templates** vient de [`design-templates/`](../../design-templates/) et regroupe les formats d’artifact pour prototypes, decks, documents, images, vidéo et audio. [`skills/`](../../skills/) reste réservé aux capacités fonctionnelles que l’agent invoque pendant son travail. Associez une template à un Design System pour produire un artifact dans le langage visuel choisi.
-
-## Autres scripts
-
-```bash
-pnpm tools-dev                 # daemon + web + desktop en arrière-plan
-pnpm tools-dev start web       # daemon + web en arrière-plan
-pnpm tools-dev run web         # daemon + web au premier plan (e2e/dev server)
-pnpm tools-dev restart         # redémarre daemon + web + desktop
-pnpm tools-dev restart --daemon-port 7457 --web-port 5175
-pnpm tools-dev status          # inspecte les runtimes gérés
-pnpm tools-dev logs            # affiche les logs daemon/web/desktop
-pnpm tools-dev check           # statut + logs récents + diagnostics courants
-pnpm tools-dev stop            # arrête les runtimes gérés
-pnpm --filter @open-design/daemon build  # build apps/daemon/dist/cli.js pour `od`
-pnpm --filter @open-design/web build     # build du paquet web si nécessaire
-pnpm typecheck                 # typecheck du workspace
-```
-
-`pnpm tools-dev` est le seul point d’entrée du lifecycle local. N’utilisez pas les anciens alias root supprimés (`pnpm dev`, `pnpm dev:all`, `pnpm daemon`, `pnpm preview`, `pnpm start`).
-
-Pendant le développement local, `tools-dev` démarre d’abord le daemon, transmet son port à `apps/web`, puis `apps/web/next.config.ts` réécrit `/api/*`, `/artifacts/*` et `/frames/*` vers ce port daemon. L’app App Router peut ainsi parler au processus Express voisin sans configuration CORS.
 
 ## Configuration Docker
 
@@ -117,8 +79,10 @@ docker compose up -d
 Ouvrez l'application dans votre navigateur :
 
 ```text
-http://localhost:7456
+http://127.0.0.1:7456
 ```
+
+Si le navigateur demande des identifiants, utilisez `open-design` comme nom d'utilisateur et la valeur de `OD_API_TOKEN` dans `deploy/.env` comme mot de passe.
 
 Le premier démarrage peut prendre quelques secondes pendant que Docker télécharge la dernière image.
 
@@ -205,6 +169,50 @@ Ce Quickstart NE DOIT PAS répéter ce contrat ni définir de chemins de stockag
 
 ---
 
+## Démarrage rapide (mode dev)
+
+```bash
+corepack enable
+pnpm install
+pnpm tools-dev run web # démarre daemon + web au premier plan
+# ouvrez l’URL web affichée par tools-dev
+```
+
+Pour le shell desktop et tous les sidecars gérés en arrière-plan :
+
+```bash
+pnpm tools-dev # démarre daemon + web + desktop en arrière-plan
+```
+
+Au premier chargement, l’app détecte les runtimes locaux disponibles et propose aussi les runtimes BYOK configurés dans Settings. Choisissez un runtime, une design template et un Design System, puis tapez un prompt et cliquez sur **Send**. Les runtimes locaux structurés écrivent les fichiers canoniques du projet et diffusent les événements de fichiers/outils ; l’espace de fichiers et la preview se mettent à jour depuis ces écritures. Les exécutions texte uniquement et BYOK renvoient à la place un bloc `<artifact>` complet que l’hôte parse. Avant de documenter ou de modifier un chemin de stockage d’artifact, vous DEVEZ lire `AGENTS.md` à la racine, section **Daemon data directory contract**.
+
+Le catalogue **Design Systems** est chargé directement depuis les paquets `DESIGN.md` de [`design-systems/`](../../design-systems/). Choisissez-en un pour appliquer le langage visuel de la marque à l’artifact.
+
+Le catalogue **Templates** vient de [`design-templates/`](../../design-templates/) et regroupe les formats d’artifact pour prototypes, decks, documents, images, vidéo et audio. [`skills/`](../../skills/) reste réservé aux capacités fonctionnelles que l’agent invoque pendant son travail. Associez une template à un Design System pour produire un artifact dans le langage visuel choisi.
+
+## Autres scripts
+
+```bash
+pnpm tools-dev                 # daemon + web + desktop en arrière-plan
+pnpm tools-dev start web       # daemon + web en arrière-plan
+pnpm tools-dev run web         # daemon + web au premier plan (e2e/dev server)
+pnpm tools-dev restart         # redémarre daemon + web + desktop
+pnpm tools-dev restart --daemon-port 7457 --web-port 5175
+pnpm tools-dev status          # inspecte les runtimes gérés
+pnpm tools-dev logs            # affiche les logs daemon/web/desktop
+pnpm tools-dev check           # statut + logs récents + diagnostics courants
+pnpm tools-dev stop            # arrête les runtimes gérés
+pnpm --filter @open-design/daemon build  # build apps/daemon/dist/cli.js pour `od`
+pnpm --filter @open-design/web build     # build du paquet web si nécessaire
+pnpm typecheck                 # typecheck du workspace
+```
+
+`tools-dev` charge automatiquement les fichiers d'environnement du workspace avant de résoudre les ports, les namespaces et l'environnement des processus. L'ordre de priorité est `.env.development.local`, `.env.local`, `.env.development`, puis `.env` ; leurs valeurs priment sur les variables déjà exportées par le shell. Utilisez `--no-env-file` pour désactiver ce chargement, ou répétez `--env-file <path>` pour choisir explicitement les fichiers.
+
+`pnpm tools-dev` est le seul point d’entrée du lifecycle local. N’utilisez pas les anciens alias root supprimés (`pnpm dev`, `pnpm dev:all`, `pnpm daemon`, `pnpm preview`, `pnpm start`).
+
+Pendant le développement local, `tools-dev` démarre d’abord le daemon, transmet son port à `apps/web`, puis `apps/web/next.config.ts` réécrit `/api/*`, `/artifacts/*` et `/frames/*` vers ce port daemon. L’app App Router peut ainsi parler au processus Express voisin sans configuration CORS.
+
 ## Checks de génération média / agent dispatcher
 
 Les Skills image, vidéo, audio et HyperFrames appellent la CLI locale `od` via des variables d’environnement injectées par le daemon lorsqu’il lance un agent :
@@ -235,7 +243,7 @@ ls -la "$OD_BIN"
 
 `OD_DAEMON_URL` doit être un vrai port daemon comme `http://127.0.0.1:7457`, pas `http://127.0.0.1:0`. La valeur `:0` est seulement une indication interne "choisir un port libre" au lancement et ne doit pas se retrouver dans les sessions agent.
 
-En mode production daemon-only, le daemon sert lui-même l’export static Next.js à `http://localhost:7456`; aucun reverse proxy n’est impliqué.
+En mode production daemon-only, le daemon sert lui-même l’export static Next.js à `http://127.0.0.1:7456`; aucun reverse proxy n’est impliqué.
 
 Si vous placez nginx devant le daemon, gardez les routes SSE non bufferisées et non compressées. Un échec courant : la console navigateur affiche `net::ERR_INCOMPLETE_CHUNKED_ENCODING 200 (OK)` après 80-90 secondes, parce que `gzip on` dans nginx bufferise les réponses SSE chunked même quand le daemon envoie `X-Accel-Buffering: no`.
 
@@ -265,11 +273,11 @@ location /api/ {
 | **Local CLI** (par défaut quand le daemon détecte un agent) | "Local CLI" | Frontend → daemon `/api/chat` → `spawn(<agent>, ...)` → événements structurés outils/fichiers sur SSE → fichiers du projet → preview. Les CLI plain-stream utilisent le chemin text-artifact. |
 | **Mode API** (fallback / aucune CLI) | "Anthropic API" / "OpenAI API" / "Atlas Cloud" / "Azure OpenAI" / "Google Gemini" | Frontend → daemon `/api/proxy/{provider}/stream` → SSE provider normalisé en `delta/end/error` → parser `<artifact>` → preview |
 
-Les deux modes aboutissent au même espace de fichiers et à la même preview sandboxée, mais leur contrat de remise diffère. Les runtimes avec système de fichiers écrivent les fichiers canoniques et ne doivent pas recopier leur source dans `<artifact>`. Les exécutions plain/texte uniquement et BYOK n’ont pas d’outils de fichiers : leur livrable canonique est le HTML complet dans `<artifact>`. Le profil d’exécution découle du transport du runtime.
+Les deux modes aboutissent au même espace de fichiers et à la même preview sandboxée, mais leur contrat de remise diffère. Les runtimes avec système de fichiers écrivent les fichiers canoniques et ne doivent pas recopier leur source dans `<artifact>`. Les exécutions plain/texte uniquement et BYOK n’ont pas d’outils de fichiers : leur livrable canonique est le HTML complet dans `<artifact>`. Le profil d’exécution découle du transport du runtime. Les CLI locales reçoivent le prompt composé selon le format d’invocation déclaré dans leur définition de runtime.
 
 ## Composition du prompt
 
-À chaque envoi, l’app construit un system prompt à partir de trois couches et l’envoie au provider :
+Dans le chemin de composition historique, l’app assemble notamment ces trois couches pour construire le prompt système envoyé au fournisseur :
 
 ```
 BASE_SYSTEM_PROMPT   (remise fichier ou <artifact> selon le profil d’exécution)
@@ -277,7 +285,7 @@ BASE_SYSTEM_PROMPT   (remise fichier ou <artifact> selon le profil d’exécutio
    + active skill body          (SKILL.md — workflow and output rules)
 ```
 
-Changez le Skill ou le Design System dans la barre supérieure : le prochain envoi utilise le nouveau stack. Les contenus sont mis en cache en mémoire par session, donc un choix ne coûte qu’un fetch daemon.
+Changer le skill ou le système de design modifie la composition du prochain envoi. Le chemin **OD Next**, activable dans **Settings → Labs → Design Harness** et soumis à des conditions d'éligibilité par exécution, utilise une composition indépendante. Pour comprendre les deux chemins et leurs contrats, consultez [`docs/prompt-composition.md`](../prompt-composition.md).
 
 ## File map
 
@@ -326,17 +334,27 @@ open-design/
 
 ## Dépannage
 
-- **"no agents found on PATH"** — installez l’un des runtimes locaux enregistrés dans [`apps/daemon/src/runtimes/registry.ts`](../../apps/daemon/src/runtimes/registry.ts), vérifiez que son exécutable est visible par le daemon, puis utilisez **Rescan** dans **Settings → Execution mode**. Ou configurez un runtime BYOK dans Settings.
+- **Échec du chargement de `better-sqlite3` / incompatibilité ABI après un changement de version de Node.js** — `pnpm install` relance automatiquement `postinstall` pour recompiler le module natif avec la version active de Node.js. Pour le recompiler et vérifier son chargement manuellement : `pnpm --filter @open-design/daemon rebuild better-sqlite3`, puis `pnpm --filter @open-design/daemon exec node -e "require('better-sqlite3')"`. Les outils `python3`, `make` et `g++` (ou `clang++`) sont nécessaires. Si votre `.npmrc` contient `ignore-scripts=true` — fréquent avec les paquets AUR — lancez `pnpm bootstrap` après `pnpm install`.
+- **Claude Code se termine avec le code 1** — OpenDesign a pu lancer `claude`, mais l'exécution non interactive a échoué avant de produire une réponse. Dans le même shell ou environnement d'application que celui qui lance OpenDesign, vérifiez :
+  ```bash
+  claude --version
+  claude auth status --text
+  printf 'hello' | claude -p --output-format stream-json --verbose --permission-mode bypassPermissions
+  ```
+  Si ce test signale `401`, `apiKeySource: "none"` ou une autre erreur d'authentification sans point de terminaison personnalisé, lancez `claude`, utilisez `/login`, quittez Claude et réessayez dans OpenDesign. Si vous utilisez plusieurs profils Claude, indiquez leur chemin, par exemple `~/.claude-2`, dans **Models & providers → Local CLI → Claude Code config directory**. Si `ANTHROPIC_BASE_URL` ou un proxy est configuré, vérifiez l'URL, les identifiants du proxy, les variables d'authentification du point de terminaison et l'accès au modèle. Ne retirez ce point de terminaison personnalisé que si vous souhaitez réessayer avec l'authentification standard de Claude Code. Sous Windows, PowerShell natif et WSL utilisent des installations et des magasins d'identifiants distincts : reconnectez-vous dans l'environnement utilisé par OpenDesign et vérifiez le Gestionnaire d'informations d'identification Windows si `/login` ne répare pas les identifiants natifs.
+- **"no agents found on PATH"** — installez l’un des runtimes locaux enregistrés dans [`apps/daemon/src/runtimes/registry.ts`](../../apps/daemon/src/runtimes/registry.ts), vérifiez que son exécutable est visible par le daemon, puis utilisez **Rescan** dans **Models & providers → Local CLI**. Ou configurez un runtime BYOK dans Settings.
 - **daemon 500 sur /api/chat** — vérifiez la fin de stderr dans le terminal daemon ; la CLI a généralement rejeté ses args. Les CLIs n’acceptent pas toutes la même forme d’argv ; consultez la définition correspondante sous `apps/daemon/src/runtimes/defs/` si vous devez l’ajuster.
 - **la génération média dit que `OD_BIN` manque ou que l’URL daemon vaut `:0`** — exécutez les checks du dispatcher média ci-dessus. Ne reprenez pas l’ancienne session CLI ; rouvrez le projet depuis l’app OpenDesign pour que le daemon injecte des variables `OD_*` fraîches.
 - **Codex charge trop de contexte plugin** — démarrez OpenDesign avec `OD_CODEX_DISABLE_PLUGINS=1 pnpm tools-dev` pour que les processus Codex lancés par le daemon tournent avec `--disable plugins`.
 - **l’artifact ne rend jamais** — identifiez d’abord le profil de remise. Avec un runtime local doté d’un système de fichiers, vérifiez qu’un fichier de projet prévisualisable a été créé et que ses événements ont atteint le daemon ; sa source ne doit pas être dans `<artifact>`. Pour une exécution plain/texte uniquement ou BYOK, vérifiez la présence d’un unique bloc `<artifact>` complet, puis repérez dans les logs du daemon la première frontière en échec.
 
+- **Le navigateur demande une authentification sur macOS** — conservez le réseau bridge par défaut de Docker Desktop. Utilisez `open-design` comme nom d'utilisateur et la valeur de `OD_API_TOKEN` dans `deploy/.env` comme mot de passe. Le réseau hôte n'est pas nécessaire. Voir [`deploy/README.md` — Docker Desktop sur macOS](../../deploy/README.md#docker-desktop-on-macos).
+
 ## Retour à la vision
 
-Ce Quickstart est la graine exécutable de la spec dans [`docs/`](../../docs/). La spec décrit vers quoi le projet grandit (voir [`docs/roadmap.md`](../../docs/roadmap.md)). Points clés :
+Ce guide accompagne la documentation dans [`docs/`](../../docs/). La [spécification](../spec.md) et la [feuille de route](../roadmap.md) historiques sont archivées ; les documents ci-dessous décrivent les contrats actuels. Points clés :
 
 - `docs/architecture.md` décrit le stack livré : Next.js 16 App Router devant, daemon local derrière, et rewrites `apps/web/next.config.ts` en dev pour que le navigateur parle toujours à la même surface `/api`.
-- `docs/skills-protocol.md` décrit le schéma `od:` complet. Le daemon lit les métadonnées runtime utiles depuis `SKILL.md` pour router les Skills, composer le prompt, afficher les exemples et configurer les surfaces web / image / vidéo / audio ; le protocole reste la référence pour les champs avancés.
+- `docs/skills-protocol.md` décrit le frontmatter actuel de `SKILL.md` / `od:` et la séparation entre skills fonctionnels et modèles de rendu. Le parseur et la normalisation de référence se trouvent dans `apps/daemon/src/skills.ts`.
 - `docs/agent-adapters.md` décrit le contrat d’adapter. Les paramètres de lancement, d’arguments, de modèles et de stream propres à chaque runtime se trouvent sous `apps/daemon/src/runtimes/defs/`, avec leur enregistrement dans `apps/daemon/src/runtimes/registry.ts` ; `apps/daemon/src/agents.ts` reste une surface d’export de compatibilité.
 - `docs/modes.md` distingue les six onglets New Project des sept modes normalisés du registre (`prototype`, `deck`, `template`, `design-system`, `image`, `video`, `audio`).

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -7,13 +7,13 @@
 > 🧩 **[DeepSeek Harness est maintenant pris en charge.](https://open-design.ai/zh/agents/deepseek-harness-design/)** Connectez l'Agent Harness officiel `dsh` de DeepSeek à OpenDesign en tant que runtime natif, avec raisonnement structuré, appels d'outils, découverte des modèles, annulation et reprise de session. Les fichiers générés restent dans le workflow OpenDesign pour la prévisualisation en direct et la livraison.
 
 <p align="center">
-  <img src="https://repo-assets.open-design.ai/resources/images/hero.png" alt="OpenDesign hero banner" width="100%" />
+  <img src="https://repo-assets.open-design.ai/resources/images/hero.png" alt="Bannière OpenDesign — le titre &quot;L’alternative open source à Claude Design&quot; sur une scène de colonnes et de personnages drapés devant un fond de code, avec des cartes présentant les systèmes de design, les plugins, les agents de code et les fournisseurs média" width="100%" />
 </p>
 
 <p align="center">
-  <a href="https://open-design.ai/">Site web</a> ·
-  <a href="https://open-design.ai/">Télécharger</a> ·
-  <a href="https://open-design.ai/cloud/">OpenDesign Cloud</a> ·
+  <a href="https://open-design.ai/?utm_source=github&utm_medium=referral&utm_content=readme_website">Site web</a> ·
+  <a href="https://open-design.ai/?utm_source=github&utm_medium=referral&utm_content=readme_download">Télécharger</a> ·
+  <a href="https://open-design.ai/cloud/?utm_source=github&utm_medium=referral&utm_content=readme_cloud">OpenDesign Cloud</a> ·
   <a href="https://discord.gg/mHAjSMV6gz">Discord</a> ·
   <a href="https://x.com/OpenDesignHQ">Suivre @OpenDesignHQ</a>
 </p>
@@ -31,9 +31,9 @@
 
 ## Qu'est-ce qu'OpenDesign
 
-🎨 **L'alternative open source et local-first à Claude Design.** &nbsp;🖥️ **Application de bureau native pour macOS et Windows.** &nbsp;⚡ **Plus de 100 skills fonctionnels + catalogue séparé de modèles de rendu** · ✨ **151 packages de systèmes de design** · 📦 **277 plugins prêts à l'emploi.** &nbsp;🖼️ Génère des **prototypes web · bureau · mobile**, des **tableaux de bord / artefacts en direct**, des **présentations**, des **images**, de la **vidéo**, ainsi que des motion graphics **HyperFrames**. 🔒 Aperçu en iframe sandboxée · export HTML / PDF / PPTX / MP4. &nbsp;🤖 **Fonctionne avec Claude Code · OpenClaw · Codex · Cursor · OpenCode · Qwen · Copilot · Hermes · Kimi · Antigravity et 25 exécutables CLI locaux distincts**, ou tout point de terminaison compatible OpenAI via BYOK.
+🎨 **L'alternative open source à Claude Design.** &nbsp;🖥️ **Application de bureau native et local-first pour macOS et Windows.** &nbsp;⚡ **Skills composables, systèmes de design `DESIGN.md` fidèles à votre marque et plugins prêts à l'emploi.** &nbsp;🖼️ Génère des **prototypes web · bureau · mobile**, des **tableaux de bord / artefacts en direct**, des **présentations**, des **images**, de la **vidéo**, ainsi que des motion graphics **HyperFrames**. 🔒 Aperçu en iframe sandboxée · export HTML / PDF / PPTX / MP4. &nbsp;🤖 **Fonctionne avec DeepSeek Harness (`dsh`) · Claude Code · OpenClaw · Codex · Cursor · OpenCode · Qwen · Copilot · Amp · Hermes · Kimi · Antigravity et 26 exécutables CLI locaux distincts**, ou tout point de terminaison compatible OpenAI via BYOK.
 
-OpenDesign transforme cette boucle en un **système de fichiers de skills fonctionnels, de modèles de rendu, de systèmes de design et de plugins** que vos agents peuvent lire, écrire et remixer.
+OpenDesign ouvre la boucle **agent-native** proposée par Anthropic avec Claude Design — comprendre le brief, fixer la direction, générer l'artefact en continu, le critiquer et le livrer — en la transformant en un **système de fichiers de skills fonctionnels, de modèles de rendu, de systèmes de design et de plugins**. Les agents de code déjà installés sur votre ordinateur peuvent les lire, les écrire et les remixer. Votre CLI devient le moteur de design, votre ordinateur le studio et le `DESIGN.md` de votre équipe le contrat de marque.
 
 C'est aussi l'**alternative à Figma pour l'ère des agents** — au lieu de déplacer des pixels sur un canevas, il livre des artefacts d'une seule page en CSS réel, en polices réelles, en composants réels, exportés directement en HTML / PDF / PPTX / MP4 — déjà façonnés par votre système de design, déjà exécutables au sein de l'agent que vous utilisez chaque jour.
 
@@ -49,7 +49,7 @@ Un aperçu rapide du workflow principal d'OpenDesign. Commencez sur **Home** ave
 <table>
 <tr>
 <td valign="top">
-<img src="../../docs/screenshots/product-tour/home.png" alt="Home" /><br/>
+<img src="../../docs/screenshots/product-tour/home.png" alt="Page d’accueil OpenDesign avec types d’artefacts, champ de brief, sélecteur de modèle et exemples" /><br/>
 <sub><b>Home</b> — Choisissez un type d'artefact, saisissez un brief, puis définissez le système de design, le répertoire de travail et le modèle avant de commencer.</sub>
 </td>
 </tr>
@@ -58,11 +58,11 @@ Un aperçu rapide du workflow principal d'OpenDesign. Commencez sur **Home** ave
 <table>
 <tr>
 <td width="50%" valign="top">
-<img src="../../docs/screenshots/product-tour/plugins.png" alt="Plugins" /><br/>
+<img src="../../docs/screenshots/product-tour/plugins.png" alt="Page Plugins d’OpenDesign présentant le catalogue de skills officiels" /><br/>
 <sub><b>Plugins</b> — Parcourez les skills officiels par catégorie, recherchez dans le catalogue et lancez un workflow avec <code>Try it</code>.</sub>
 </td>
 <td width="50%" valign="top">
-<img src="../../docs/screenshots/product-tour/design-system.png" alt="Design System" /><br/>
+<img src="../../docs/screenshots/product-tour/design-system.png" alt="Aperçu du système de design Shopify dans le Studio OpenDesign" /><br/>
 <sub><b>Design System</b> — Extrayez et affinez le langage visuel d'une marque, prévisualisez le résultat et continuez à créer avec lui dans le même espace de travail.</sub>
 </td>
 </tr>
@@ -75,31 +75,31 @@ Dans le Studio d'un projet, la conversation, les fichiers générés et la prév
 <table>
 <tr>
 <td width="50%" valign="top">
-<img src="../../docs/screenshots/product-tour/studio-prototype.png" alt="Prototype" /><br/>
+<img src="../../docs/screenshots/product-tour/studio-prototype.png" alt="Aperçu d’un prototype web dans le Studio OpenDesign" /><br/>
 <sub><b>Prototype</b> — Générez ou reconstruisez des expériences web, inspectez la page rendue et itérez sur place avec l'agent.</sub>
 </td>
 <td width="50%" valign="top">
-<img src="../../docs/screenshots/product-tour/studio-deck.png" alt="Présentation" /><br/>
+<img src="../../docs/screenshots/product-tour/studio-deck.png" alt="Aperçu d’une présentation de plusieurs diapositives dans le Studio OpenDesign" /><br/>
 <sub><b>Présentation</b> — Créez des présentations de plusieurs diapositives, examinez les miniatures et les notes du présentateur, puis exportez lorsqu'elles sont prêtes.</sub>
 </td>
 </tr>
 <tr>
 <td width="50%" valign="top">
-<img src="../../docs/screenshots/product-tour/studio-mobile-app.png" alt="Application mobile" /><br/>
+<img src="../../docs/screenshots/product-tour/studio-mobile-app.png" alt="Aperçu d’un artefact d’application mobile dans le Studio OpenDesign" /><br/>
 <sub><b>Application mobile</b> — Générez et peaufinez des interfaces mobiles dans un aperçu d'appareil, avec la conversation, les fichiers de sortie et les prochaines étapes à côté.</sub>
 </td>
 <td width="50%" valign="top">
-<img src="../../docs/screenshots/product-tour/studio-image.png" alt="Image" /><br/>
+<img src="../../docs/screenshots/product-tour/studio-image.png" alt="Aperçu d’une image générée dans le Studio OpenDesign" /><br/>
 <sub><b>Image</b> — Générez des ressources visuelles depuis la conversation du projet, prévisualisez le résultat en taille réelle, puis téléchargez-le ou ouvrez-le.</sub>
 </td>
 </tr>
 <tr>
 <td width="50%" valign="top">
-<img src="../../docs/screenshots/product-tour/studio-document.png" alt="Document" /><br/>
+<img src="../../docs/screenshots/product-tour/studio-document.png" alt="Aperçu d’un document multipage dans le Studio OpenDesign" /><br/>
 <sub><b>Document</b> — Créez des guides multipages et des documents éditoriaux soignés, vérifiez la mise en page rendue, puis exportez ou partagez.</sub>
 </td>
 <td width="50%" valign="top">
-<img src="../../docs/screenshots/product-tour/studio-hyperframe.png" alt="HyperFrame" /><br/>
+<img src="../../docs/screenshots/product-tour/studio-hyperframe.png" alt="Aperçu d’une animation HyperFrame dans le Studio OpenDesign" /><br/>
 <sub><b>HyperFrame</b> — Créez des motion graphics pilotés par le code, prévisualisez l'animation dans Studio et exportez la vidéo finale.</sub>
 </td>
 </tr>
@@ -108,13 +108,15 @@ Dans le Studio d'un projet, la conversation, les fichiers générés et la prév
 
 ## Compatibilité des plateformes
 
-> OpenDesign se présente sous forme de **skills, d'un CLI et d'un serveur MCP** que les principaux agents de code consomment nativement. Une fois OD installé, une seule commande `od mcp install <agent>` câble le serveur MCP dans la configuration de cet agent, et vous appelez les mêmes outils depuis n'importe quel agent.
+> OpenDesign se connecte aux principaux agents de code de deux façons : par des **skills, un CLI et un serveur MCP** pour les agents qui utilisent OD, et par des **adaptateurs de runtime natifs** pour les agents qu'OD lance directement. DeepSeek Harness est un runtime natif à part entière via la CLI officielle `dsh`, avec streaming structuré, découverte des modèles, annulation et reprise de session.
 
-| Agent de code / plateforme &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Statut &nbsp;&nbsp; | Installation du serveur MCP en une ligne &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; |
+| Agent de code / plateforme &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Statut &nbsp;&nbsp; | Configuration rapide &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; |
 |---|:---:|---|
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | ✅ Pris en charge | `od mcp install claude` |
+| [Claude Desktop](https://claude.ai/download) | ✅ Pris en charge¹ | `od mcp install claude-desktop` |
 | [Codex CLI](https://github.com/openai/codex) | ✅ Pris en charge | `od mcp install codex` |
 | [DeepSeek Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | ✅ Pris en charge | `od mcp install reasonix` |
+| [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) | ✅ Runtime natif | `od agent setup deepseek-harness` |
 | [Raven](https://github.com/EverMind-AI/Raven) | ✅ Pris en charge | `od mcp install raven` |
 | [Cursor](https://www.cursor.com/cli) | ✅ Pris en charge | `od mcp install cursor` |
 | [VS Code + GitHub Copilot](https://github.com/features/copilot) | ✅ Pris en charge | `od mcp install copilot` |
@@ -130,15 +132,17 @@ Dans le Studio d'un projet, la conversation, les fichiers générés et la prév
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | ✅ Pris en charge | `od mcp install vibe` |
 | [Hermes Agent](https://github.com/nousresearch/hermes-agent) | ✅ Pris en charge | `od mcp install hermes` |
 
-`od mcp install <agent> --print` pour un aperçu à blanc · `--uninstall` pour supprimer · liste complète avec `od mcp install --help`.
+Pour DeepSeek Harness, installez d'abord la CLI officielle `dsh`, puis sélectionnez-la dans OpenDesign ou lancez `od agent setup deepseek-harness` pour installer ou réparer le composant de connexion d'OD. Pour les intégrations MCP : `od mcp install <agent> --print` affiche un aperçu sans modification · `--uninstall` supprime l'intégration · `od mcp install --help` donne la liste complète.
+
+¹ La configuration automatique du serveur MCP pour Claude Desktop est actuellement prise en charge uniquement sur macOS et Windows.
 
 <p align="center">
-  <img src="https://repo-assets.open-design.ai/resources/images/coding-agents.png" alt="Les 25 CLI d'agents de code pris en charge par OpenDesign — Claude Code · Codex · OpenCode · Hermes · Antigravity · Vela · Grok Build · Kimi · Cursor Agent · Qwen · Qoder · GitHub Copilot · Pi · Kiro · Kilo · Mistral Vibe · DeepSeek · Reasonix · Aider · Amp · CodeBuddy · Mimo · AtomCode · Devin · Trae" width="100%" />
+  <img src="https://repo-assets.open-design.ai/resources/images/coding-agents.png" alt="Les 26 CLI d'agents de code pris en charge par OpenDesign — DeepSeek Harness · Claude Code · Codex · OpenCode · Hermes · Antigravity · Vela · Grok Build · Kimi · Cursor Agent · Qwen · Qoder · GitHub Copilot · Pi · Kiro · Kilo · Mistral Vibe · DeepSeek · Reasonix · Aider · Amp · CodeBuddy · Mimo · AtomCode · Devin · Trae" width="100%" />
 </p>
 
-**Aucun CLI installé ?** Le proxy BYOK à `POST /api/proxy/{anthropic,openai,azure,google,ollama,senseaudio}/stream` vous offre la même boucle (sans spawn de processus) — collez `baseUrl` + `apiKey` + `model`, avec prise en charge d'OpenAI, Anthropic, Azure OpenAI, Google Gemini, Ollama, LM Studio, vLLM ou tout point de terminaison compatible OpenAI. Une protection SSRF par cible bloque les IP internes / link-local / CGNAT à la périphérie du daemon.
+**Aucun CLI installé ?** Le proxy BYOK à `POST /api/proxy/{anthropic,openai,azure,google,ollama,senseaudio}/stream` vous offre la même boucle (sans spawn de processus) — collez `baseUrl` + `apiKey` + `model`, avec des préréglages pour OpenAI, Atlas Cloud, Anthropic, Azure OpenAI, Google Gemini, Ollama, LM Studio, vLLM ou tout point de terminaison compatible OpenAI. Atlas Cloud utilise `https://api.atlascloud.ai/v1` avec votre propre clé et des identifiants de modèles compatibles OpenAI comme `qwen/qwen3.5-flash`. Une protection SSRF par cible bloque les IP internes / link-local / CGNAT à la périphérie du daemon.
 
-Les définitions de runtime se trouvent dans [`apps/daemon/src/runtimes/defs/`](../../apps/daemon/src/runtimes/defs/) et sont enregistrées dans `runtimes/registry.ts`. Un nouveau parseur n'est requis que pour un nouveau format de flux — voir [`docs/agent-adapters.md`](../../docs/agent-adapters.md).
+Les définitions de runtime se trouvent dans [`apps/daemon/src/runtimes/defs/`](../../apps/daemon/src/runtimes/defs/), avec leur enregistrement et le traitement partagé des flux dans [`apps/daemon/src/runtimes/`](../../apps/daemon/src/runtimes/). Le contrat des adaptateurs est décrit dans [`docs/agent-adapters.md`](../../docs/agent-adapters.md).
 
 ---
 
@@ -254,8 +258,8 @@ OpenDesign (OD) est l'alternative open source. La même boucle, le même modèle
 
 - 🤖 **Agent-native, agnostique au modèle.** Nous ne livrons pas d'agent. Les `claude` / `codex` / `cursor-agent` / `copilot` / `hermes` / `kimi` déjà présents dans votre `PATH` sont le moteur de design. Changez-en d'un seul clic.
 - 🧠 **Qualité professionnelle par défaut.** Chaque rendu lit le `DESIGN.md` du package actif comme contrat de marque central. Le dépôt fournit 151 packages de systèmes de design ; les packages historiques peuvent ne contenir que `DESIGN.md`, tandis que les plus récents peuvent ajouter `manifest.json`, `tokens.css`, des composants, des assets et leur provenance. Déposez un dossier, le sélecteur le trouve.
-- 🖥️ **Local-first, BYOK à chaque couche.** Les applications de bureau natives restent local-first, sans aller-retour vers le cloud. Avant de décrire des chemins de données du daemon, vous DEVEZ lire `AGENTS.md` à la racine, section **Daemon data directory contract**.
-- 🌍 **Composable sur quatre plans.** Les **plugins** portent les workflows · les **skills fonctionnels** le comportement de l'agent · les **modèles de design** les plans de rendu · les **systèmes de design** la marque.
+- 🖥️ **Local-first, BYOK à chaque couche.** Applications de bureau natives pour macOS (Apple Silicon et Intel) et Windows (x64), avec une AppImage Linux dans la voie de publication optionnelle. L'analyse d'usage et la relecture de session nécessitent un consentement ; la télémétrie de sécurité et de fiabilité, expurgée des données sensibles, reste active. Avant de décrire des chemins de données du daemon, les contributeurs et opérateurs DOIVENT lire [`AGENTS.md` → **Daemon data directory contract**](../../AGENTS.md#daemon-data-directory-contract). Ce README NE DOIT PAS répéter ce contrat.
+- 🌍 **Composable sur quatre plans.** Les **plugins** portent les workflows · les **skills fonctionnels** le comportement de l'agent · les **modèles de design** les plans de rendu · les **systèmes de design** la marque. Ces quatre éléments sont des répertoires portables et versionnables que chacun peut créer et publier.
 - 🔁 **Rafraîchissez une base de code existante.** Confiez un dépôt `git` + un `DESIGN.md` à l'agent et il refactorise vos vrais composants selon les spécifications de la marque. Des plugins dédiés migrent les workflows Figma / Pencil vers du code React / Next.js / Vue.
 - 🔒 **Confidentialité par conviction.** Tout s'exécute là où vivent vos données — votre ordinateur, le serveur de votre équipe, votre projet Vercel. Lorsque le réseau est nécessaire, le proxy BYOK est protégé contre la SSRF.
 
@@ -265,7 +269,7 @@ OpenDesign (OD) est l'alternative open source. La même boucle, le même modèle
 |---|---|---|---|---|
 | Open source | ❌ | ❌ | ❌ | **✅ Apache-2.0** |
 | Auto-hébergement / bureau | ❌ | ❌ | ❌ | **✅ macOS + Windows + Docker** |
-| Agent-native (s'exécute dans votre CLI) | Anthropic uniquement | ❌ | Agent cloud uniquement | **✅ 25 CLI + BYOK** |
+| Agent-native (s'exécute dans votre CLI) | Anthropic uniquement | ❌ | Agent cloud uniquement | **✅ 26 CLI + BYOK** |
 | `DESIGN.md` de qualité professionnelle | Propriétaire | Theme JSON | Tokens limités | **✅ 151 systèmes fournis** |
 | Skills / plugins / modèles | Fermé | Boutique de plugins | Fermé | **✅ Plus de 100 skills fonctionnels · catalogue séparé de modèles de rendu · 277 plugins** |
 | HyperFrames (HTML→MP4) | ❌ | ❌ | ❌ | **✅ Première classe** |
@@ -280,8 +284,8 @@ OpenDesign (OD) est l'alternative open source. La même boucle, le même modèle
 
 Le moyen le plus rapide d'utiliser OpenDesign. Pas de Node, pas de pnpm, pas de clone.
 
-- **macOS** (Apple Silicon · Intel x64) → [**open-design.ai**](https://open-design.ai/) ou [GitHub Releases](https://github.com/nexu-io/open-design/releases)
-- **Windows** (x64) → [**open-design.ai**](https://open-design.ai/) ou [GitHub Releases](https://github.com/nexu-io/open-design/releases)
+- **macOS** (Apple Silicon · Intel x64) → [**open-design.ai**](https://open-design.ai/?utm_source=github&utm_medium=referral&utm_content=readme_download_macos) ou [GitHub Releases](https://github.com/nexu-io/open-design/releases)
+- **Windows** (x64) → [**open-design.ai**](https://open-design.ai/?utm_source=github&utm_medium=referral&utm_content=readme_download_windows) ou [GitHub Releases](https://github.com/nexu-io/open-design/releases)
 - **Linux** (AppImage, voie optionnelle) → [GitHub Releases](https://github.com/nexu-io/open-design/releases)
 
 Après l'installation : l'application détecte automatiquement chaque CLI d'agent de code présent dans votre `PATH`, charge plus de 100 skills fonctionnels, le catalogue séparé de modèles de rendu et 151 packages de systèmes de design, et vous permet de saisir un brief dans la vue d'entrée.
@@ -290,12 +294,22 @@ Après l'installation : l'application détecte automatiquement chaque CLI d'agen
 
 Vous pouvez utiliser OpenDesign sans jamais ouvrir l'interface graphique — appelez-le en tant que skill, plugin ou serveur MCP à l'intérieur de Claude Code, Codex, Cursor, Copilot, OpenClaw, Antigravity, Hermes, Kimi, et bien d'autres.
 
+Si vous avez installé l'application macOS via le DMG ou le cask Homebrew, votre shell peut encore associer `od` à l'utilitaire système de représentation octale `/usr/bin/od`. Dans ce cas, ouvrez **Settings → MCP server** dans l'application et copiez l'extrait correspondant à votre client : il utilise des chemins absolus et ne dépend pas de la commande `od` seule.
+
 ```bash
 # One-line install into the agent you're using:
 od mcp install <agent>
-# <agent> = claude | codex | reasonix | raven | cursor | copilot | openclaw | antigravity
-#         | pi | vibe | hermes | cline | kimi | kiro | trae | opencode
+# <agent> = claude | codex | reasonix | raven | cursor | copilot | openclaw
+#         | antigravity | pi | vibe | hermes | cline | kimi | kiro
+#         | trae | opencode
+
+# Hosted equivalent for curl-based setup:
+curl -fsSL https://open-design.ai/install.sh | sh -s <agent>
 ```
+
+`install.sh` est un simple script d'enveloppe pour `od mcp install` : l'URL hébergée renvoie ainsi un script shell plutôt que la page d'accueil HTML. Le script s'arrête immédiatement si le shell trouve un exécutable `od` qui n'appartient pas à OpenDesign.
+
+> **Utilisateurs de macOS / WSL2 :** la commande système `/usr/bin/od` peut masquer celle d'OpenDesign. Dans l'application de bureau, privilégiez l'extrait de **Settings → MCP server** ; sous WSL2, commencez par le [guide de configuration WSL2](../wsl-setup.md).
 
 Ensuite, à l'intérieur de l'agent :
 
@@ -313,8 +327,10 @@ cd open-design/deploy
 cp .env.example .env
 echo "OD_API_TOKEN=$(openssl rand -hex 32)" >> .env
 docker compose up -d
-# open http://localhost:7456
+# open http://127.0.0.1:7456
 ```
+
+Si le navigateur demande des identifiants, utilisez `open-design` comme nom d'utilisateur et la valeur de `OD_API_TOKEN` dans `deploy/.env` comme mot de passe. Le trafic du réseau bridge Docker reste ainsi authentifié, sans exiger le réseau hôte. Les clients API peuvent continuer à utiliser `Authorization: Bearer <OD_API_TOKEN>`.
 
 ### 🚀 Déployer sur Sealos
 
@@ -333,7 +349,7 @@ pnpm tools-dev run web
 
 Ouvrez l'URL affichée par `tools-dev` ; les ports de développement sont attribués dynamiquement sans flags explicites.
 
-Node `~24`, pnpm `10.33.x`. Utilisateurs de Windows, consultez [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md). Démarrage rapide complet, variables d'environnement et flux de build packagé → [`QUICKSTART.fr.md`](QUICKSTART.fr.md).
+Node `~24`, pnpm `10.33.x`. Sous WSL2, consultez le [guide WSL2](../wsl-setup.md) ; sous Windows natif, consultez [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md). Démarrage rapide complet, variables d'environnement et flux de build packagé → [`QUICKSTART.fr.md`](QUICKSTART.fr.md).
 
 ### Un workflow complet — du brief à l'artefact
 
@@ -341,7 +357,7 @@ Node `~24`, pnpm `10.33.x`. Utilisateurs de Windows, consultez [`docs/windows-tr
 
 1. **Un PM soumet un brief.** Le sélecteur de plugins propose landing page · pitch deck · tableau de bord · publication sociale · spec PM · tableau de scores OKR…
 2. **Un designer (ou l'agent) verrouille la direction.** Pas de marque ? Choisissez parmi 5 directions sélectionnées. Vous avez une marque ? Déposez une capture d'écran / une URL → l'agent se connecte à GitHub, importe Figma, et codifie un `DESIGN.md` réutilisable.
-3. **L'agent crée le premier livrable.** Les exécutions CLI avec filesystem écrivent les fichiers canoniques ; les exécutions BYOK/API sans outils de fichiers renvoient un bloc `<artifact>` complet.
+3. **L'agent crée le premier livrable.** Le plugin, le skill fonctionnel ou le modèle de design et le `DESIGN.md` sont associés. Les exécutions CLI avec système de fichiers écrivent les fichiers canoniques du projet et l'aperçu suit leurs modifications ; les exécutions BYOK/API sans outils de fichiers renvoient un bloc `<artifact>` complet.
 4. **Transmettez à l'ingénierie.** L'artefact est du véritable HTML/CSS — déposez-le dans Cursor, Codex ou Claude Code pour continuer à construire en code. Ou exportez en PPTX / PDF / MP4 directement vers le marketing.
 5. **OpenDesign devient plus intelligent à mesure que vous l'utilisez.** Vos captures d'écran, polices, palettes et artefacts confirmés s'accumulent comme valeurs par défaut pour la session suivante. Moins de retouches, moins de dérive.
 
@@ -365,17 +381,21 @@ od skills list --json
 
 **Pourquoi MCP ?** Exporter et rattacher un zip à chaque itération casse le flux. MCP expose directement la source de design — l'agent voit toujours le fichier en direct.
 
-**Pour un agent partant de zéro,** l'installeur place `~/.config/<agent>/open-design.json` (ou l'équivalent de la plateforme) plus un extrait MCP à copier-coller. Cursor obtient un deeplink en un clic ; Claude Code obtient une ligne `claude mcp add-json` ; chaque autre agent obtient du JSON dans le schéma attendu par sa configuration. Flux complet par agent → **Settings → MCP server** dans l'application de bureau, ou [`docs/agent-adapters.md`](../../docs/agent-adapters.md).
+**Pour un agent partant de zéro,** l'installeur place `~/.config/<agent>/open-design.json` (ou l'équivalent de la plateforme) plus un extrait MCP à copier-coller. Cursor obtient un deeplink en un clic ; Claude Code obtient une ligne `claude mcp add-json` ; chaque autre agent obtient du JSON dans le schéma attendu par sa configuration. Sur une installation macOS de bureau, privilégiez cet extrait dans Settings plutôt que la commande `od mcp install <agent>` seule dans le terminal : `/usr/bin/od` peut être prioritaire dans le `PATH`. Flux complet par agent → **Settings → MCP server** dans l'application de bureau, ou [`docs/agent-adapters.md`](../../docs/agent-adapters.md).
 
 **Modèle de sécurité.** En lecture seule par défaut, le daemon se lie à `127.0.0.1`, et la SSRF est bloquée à la périphérie du proxy. L'exposition au réseau local nécessite un `OD_BIND_HOST` explicite plus `OD_ALLOWED_ORIGINS`. Les identifiants de connecteurs et les routes d'aperçu d'artefacts en direct restent en loopback uniquement, quoi qu'il en soit.
+
+**Points de terminaison de modèles hébergés en interne.** Pour prévenir les attaques SSRF, le daemon bloque par défaut les URL de base de fournisseurs qui se résolvent vers des adresses privées ou internes (RFC1918, link-local, CGNAT et adresses de métadonnées cloud), avec l'erreur `Internal IPs blocked`. Si vous hébergez une passerelle interne, par exemple LiteLLM ou Ollama sur une adresse `10.x` / `192.168.x` accessible uniquement par VPN, autorisez explicitement cet hôte avec `OD_ALLOWED_INTERNAL_HOSTS=<host1>,<host2>,...`. Cette liste accepte des noms d'hôtes ou des IP séparés par des virgules ou des espaces (`10.0.0.5`, `litellm.internal.corp`) ; une valeur `host:port` ou une URL complète est ramenée à son nom d'hôte. Les adresses IPv6 doivent être entre crochets, par exemple `[fd00::1]`.
+
+La liste est vide par défaut et ne reconnaît que des hôtes exacts, sans correspondance par sous-domaine ni sous-chaîne. Elle s'applique **uniquement aux points de terminaison de fournisseurs que vous configurez** : test de connexion, découverte des modèles et chat BYOK. Elle **n'assouplit pas** la protection des URL de téléchargement renvoyées dans les réponses des fournisseurs. Une entrée mal formée ou une notation CIDR, non prise en charge, est ignorée avec un avertissement : une faute de frappe ne modifie jamais silencieusement la protection. Autoriser un nom d'hôte revient à faire confiance à toutes les adresses vers lesquelles il se résout, comme pour `OD_ALLOWED_ORIGINS`. Autorisez plutôt l'IP résolue si vous voulez que l'adresse issue de la résolution DNS soit revérifiée.
 
 ---
 
 ## Skills et modèles de design
 
-**Plus de 100 skills fonctionnels vivent dans [`skills/`](../../skills/)** et fournissent comportement, références ou outils réutilisables. Les starters rendables vivent séparément dans [`design-templates/`](../../design-templates/) et alimentent le catalogue de modèles, pas le registre des skills fonctionnels.
+**Plus de 100 skills fonctionnels sont fournis dans [`skills/`](../../skills/)**. Chacun suit la convention Agent Skills [`SKILL.md`][skill] et fournit des comportements, des références ou des outils réutilisables. Les modèles de rendu se trouvent séparément dans [`design-templates/`](../../design-templates/) ; ils peuvent eux aussi utiliser `SKILL.md`, mais alimentent le catalogue de modèles plutôt que le registre des skills fonctionnels.
 
-Deux **modes** ancrent le catalogue de modèles : `prototype` et `deck` ; d'autres modèles couvrent `image`, `video`, `audio` et les surfaces utility.
+Deux **modes** structurent le catalogue : `prototype` (artefacts monopages web, mobile ou bureau) et `deck` (présentations à défilement horizontal). D'autres modèles couvrent `image`, `video`, `audio` et les surfaces utilitaires. Le champ **`scenario`** regroupe les modèles par public : `design` · `marketing` · `operation` · `engineering` · `product` · `finance` · `hr` · `sale` · `personal`.
 
 | Modèle de design | Mode | Scénario | Ce qu'il produit |
 |---|---|---|---|
@@ -406,7 +426,7 @@ Protocole et séparation des répertoires → [`docs/skills-protocol.md`](../../
 
 ## Systèmes de design
 
-**151 packages de systèmes de design centrés sur `DESIGN.md`** sont fournis. Les packages historiques peuvent ne contenir que ce contrat Markdown ; les plus récents peuvent aussi inclure `manifest.json`, `tokens.css` compilé, fixtures, assets et preuves de provenance. Le catalogue mêle sources upstream et ajouts propres au projet ; [`design-systems/README.md`](../../design-systems/README.md) documente forme et provenance.
+**151 packages de systèmes de design centrés sur `DESIGN.md`** sont fournis. Les packages historiques peuvent ne contenir que ce contrat Markdown ; les plus récents peuvent aussi inclure `manifest.json`, `tokens.css` compilé, fixtures, assets et preuves de provenance. Le catalogue mêle sources upstream et ajouts propres au projet ; [`design-systems/README.md`](../../design-systems/README.md) documente forme et provenance. Changez de système : le prochain rendu utilise les nouveaux tokens.
 
 <details>
 <summary><b>Catalogue complet (cliquez pour déplier)</b></summary>
@@ -492,7 +512,7 @@ my-plugin/
 └── examples/           ← optional: concrete use cases
 ```
 
-Champs principaux : `specVersion`, `name`, `version`, le `compat.agentSkills[].path` optionnel lorsqu'un Agent Skill est exposé, puis `od.kind`, `od.taskKind`, `od.mode`, `od.capabilities[]` et `od.inputs[]`.
+Champs principaux de `open-design.json` : `specVersion` (actuellement `1.0.0`), `name` (identifiant stable), `version` (version sémantique), `compat.agentSkills[].path` (optionnel, pointe vers `./SKILL.md` lorsqu'un Agent Skill est exposé), `od.kind` (`skill` / `scenario` / `atom` / `bundle`), `od.taskKind` (`new-generation` / `figma-migration` / `code-migration` / `tune-collab`), `od.mode` (surface de sortie, par exemple `prototype` / `deck` / `live-artifact` / `image` / `video` / `hyperframes` / `audio` / `design-system` / `scenario`), `od.capabilities[]` (**déclarez le minimum** : une installation restreinte n'accorde que `prompt:inject` par défaut) et `od.inputs[]` (paramètres fournis lors de l'application).
 
 Échafaudez + validez localement :
 
@@ -537,10 +557,11 @@ Point de terminaison du registre des plugins : `GET /api/plugins`. Vue d'ensembl
              │ spawn(cli, [...], { cwd: managed project cwd })
              ▼
    ┌──────────────────────────────────────────────────────────────────┐
-   │  Base registry: 26 runtime definitions (including byok-opencode),       │
-   │  backed by 25 distinct local CLI executables because byok-opencode      │
-   │  shares the OpenCode executable.                                        │
-   │  Composes a functional skill or design template + DESIGN.md; writes files │
+   │  Local runtime definitions come from runtimes/registry.ts;                 │
+   │  the base registry has 27 definitions (including byok-opencode),           │
+   │  backed by 26 distinct local CLI executables because byok-opencode shares │
+   │  the OpenCode executable. See docs/agent-adapters.md.                     │
+   │  composes a functional skill or design template + DESIGN.md; writes files │
    └──────────────────────────────────────────────────────────────────┘
 ```
 
@@ -560,16 +581,20 @@ Architecture complète → [`docs/architecture.md`](../../docs/architecture.md).
 
 ## Feuille de route
 
-- [x] Daemon + 26 définitions runtime sur 25 exécutables CLI distincts + registres skills/modèles + catalogue de systèmes
+- [x] Daemon + 27 définitions de runtime sur 26 exécutables CLI distincts + registres skills/modèles + catalogue de systèmes
 - [x] Application web + chat + formulaire de questions + sélecteur à 5 directions + progression todo + aperçu sandboxé
 - [x] Plus de 100 skills fonctionnels · catalogue séparé de modèles · 151 packages de systèmes · 5 directions visuelles · 5 cadres d'appareils
 - [x] Projets · conversations · messages · onglets · modèles adossés à SQLite
-- [x] Proxy BYOK multi-fournisseurs (`/api/proxy/{anthropic,openai,azure,google,ollama,senseaudio}/stream`) + protection SSRF
+- [x] Proxy BYOK multi-fournisseurs (`/api/proxy/{anthropic,openai,azure,google,ollama,senseaudio}/stream`) avec des préréglages compatibles OpenAI, dont Atlas Cloud, et une protection SSRF
 - [x] Import de ZIP Claude Design (`/api/import/claude-design`)
 - [x] Protocole sidecar + bureau Electron + automatisation IPC
 - [x] API de lint d'artefacts + portail d'auto-critique en 5 dimensions avant émission
 - [x] **0.8.0** — infrastructure de marketplace de plugins (261 plugins officiels, spec de manifeste, scripts d'installation par agent)
-- [x] **0.9.0** — OpenDesign Cloud (Model Router officiel intégré à l'application : zéro configuration, connexion en un clic)
+- [x] **0.9.0** — OpenDesign Cloud (service de modèles officiel intégré à l'application : zéro configuration, connexion en un clic)
+- [x] **0.10.0** — le workspace de design tout-en-un : toute la boucle créative dans une fenêtre (références → matière → édition interactive → animation → transmission)
+- [x] **0.11.0** — _The Bazaar_ : une marketplace communautaire ouverte de plugins et de systèmes de design que chacun peut utiliser et enrichir
+- [x] **0.12.0** — _Brand-backed Design System_ : transformez votre marque existante en un système `DESIGN.md` réutilisable et portable
+- [x] **0.13.0** — _Stay in Flow_ : reprise native des sessions, sélection des modèles plus rapide et export direct en PPTX / PDF à partir de captures d'écran
 - [x] Builds Electron packagés — macOS (Apple Silicon + Intel) + Windows (x64) + AppImage Linux (voie optionnelle)
 - [ ] Éditions chirurgicales en mode commentaire — partiellement livré ; patching ciblé fiable en cours
 - [ ] UX du panneau de réglages émis par l'IA — pas encore implémenté
@@ -578,7 +603,7 @@ Architecture complète → [`docs/architecture.md`](../../docs/architecture.md).
 - [ ] Plugins de migration Figma / Pencil → React / Next / Vue (alpha)
 - [ ] Plugin de rafraîchissement de base de code existante (pointer vers un dépôt git + un `DESIGN.md`)
 
-Livraison par phases → [`docs/roadmap.md`](../../docs/roadmap.md).
+Historique de la livraison par phases (document archivé) → [`docs/roadmap.md`](../../docs/roadmap.md).
 
 ---
 
@@ -603,7 +628,8 @@ OpenDesign continue d'avancer parce que des contributeurs — designers, ingéni
 
 | Vous voulez livrer… | Comment | Où |
 |---|---|---|
-| Un nouveau **skill** | Déposez un dossier avec `SKILL.md` + `assets/` + `references/` | [`skills/`](../../skills/) · spec dans [`docs/skills-protocol.md`](../../docs/skills-protocol.md) |
+| Un nouveau **skill fonctionnel** | Déposez un dossier avec `SKILL.md` et, si nécessaire, `assets/` + `references/` | [`skills/`](../../skills/) · spec dans [`docs/skills-protocol.md`](../../docs/skills-protocol.md) |
+| Un nouveau **modèle de rendu** | Ajoutez un bundle `SKILL.md` avec ses ressources de rendu | [`design-templates/`](../../design-templates/) |
 | Un nouveau **système de design** | Déposez un package centré sur `DESIGN.md` ; ajoutez `manifest.json`, `tokens.css`, composants, assets ou provenance selon les besoins | [`design-systems/<brand>/`](../../design-systems/) |
 | Un nouveau **plugin** | Déposez `open-design.json` + le payload propre à son type sous un dossier de catégorie | [`plugins/community/`](../../plugins/community/) · spec dans [`plugins/spec/SPEC.md`](../../plugins/spec/SPEC.md) · guide de dev agent dans [`plugins/spec/AGENT-DEVELOPMENT.md`](../../plugins/spec/AGENT-DEVELOPMENT.md) |
 | Prendre en charge un nouveau **CLI d'agent de code** | Définition de runtime + entrée de registre ; parseur seulement pour un nouveau format | [`apps/daemon/src/runtimes/defs/`](../../apps/daemon/src/runtimes/defs/) |
@@ -632,7 +658,7 @@ pnpm --filter @open-design/<package> test
 gh pr create --fill
 ```
 
-Flux complet de contribution adapté aux agents, style de code et exigences pour les PR → [English](../../CONTRIBUTING.md) ([Deutsch](CONTRIBUTING.de.md) · [Français](CONTRIBUTING.fr.md) · [简体中文](CONTRIBUTING.zh-CN.md) · [日本語](CONTRIBUTING.ja-JP.md) · [Português](CONTRIBUTING.pt-BR.md)).
+Flux complet de contribution adapté aux agents, style de code et exigences pour les PR → [English](../../CONTRIBUTING.md) ([Deutsch](CONTRIBUTING.de.md) · [Français](CONTRIBUTING.fr.md) · [简体中文](CONTRIBUTING.zh-CN.md) · [日本語](CONTRIBUTING.ja-JP.md) · [한국어](CONTRIBUTING.ko.md) · [Português](CONTRIBUTING.pt-BR.md) · [ภาษาไทย](CONTRIBUTING.th.md)).
 
 ### 🏅 Programme OpenDesign Fellow
 
@@ -660,10 +686,17 @@ Ils portent une grande partie de la charge — maintenance quotidienne, revue et
       </a><br/>
       <sub>Mainteneur</sub>
     </td>
+    <td align="center" valign="top" width="200">
+      <a href="https://github.com/YOMXXX">
+        <img src="https://github.com/YOMXXX.png" width="96" alt="@YOMXXX" /><br/>
+        <sub><b>@YOMXXX</b></sub>
+      </a><br/>
+      <sub>Mainteneur</sub>
+    </td>
   </tr>
 </table>
 
-Règles des mainteneurs, critères de promotion et protocole de départ → [`MAINTAINERS.md`](../../MAINTAINERS.md) (aussi [Deutsch](MAINTAINERS.de.md) · [Français](MAINTAINERS.fr.md) · [简体中文](MAINTAINERS.zh-CN.md) · [日本語](MAINTAINERS.ja-JP.md) · [Português](MAINTAINERS.pt-BR.md)).
+Règles des mainteneurs, critères de promotion et protocole de départ → [`MAINTAINERS.md`](../../MAINTAINERS.md) (aussi [Deutsch](MAINTAINERS.de.md) · [Français](MAINTAINERS.fr.md) · [简体中文](MAINTAINERS.zh-CN.md) · [日本語](MAINTAINERS.ja-JP.md) · [한국어](MAINTAINERS.ko.md) · [Português](MAINTAINERS.pt-BR.md) · [ภาษาไทย](MAINTAINERS.th.md)).
 
 ## Contributeurs
 
@@ -724,4 +757,4 @@ Provenance détaillée → [`docs/references.md`](../../docs/references.md).
 
 ## Licence
 
-Apache-2.0. Le `design-templates/guizang-ppt/` intégré conserve sa [LICENSE](../../design-templates/guizang-ppt/LICENSE) d'origine (MIT, [@op7418](https://github.com/op7418)). Le `design-templates/html-ppt/` intégré conserve sa [LICENSE](../../design-templates/html-ppt/LICENSE) d'origine (MIT, [@lewislulu](https://github.com/lewislulu)).
+Apache-2.0. Les skills et modèles intégrés possédant leur propre fichier `LICENSE` conservent leur licence, notamment `design-templates/guizang-ppt/` (MIT, [@op7418](https://github.com/op7418)), `design-templates/html-ppt/` (MIT, [@lewislulu](https://github.com/lewislulu)) et `skills/web-clone/` (MIT, [@Jane-xiaoer](https://github.com/Jane-xiaoer)).


### PR DESCRIPTION
## Why

While refreshing the French UI, I also compared the French onboarding and contribution docs with the current English sources. French readers were missing recent agent integrations, Docker authentication instructions, CLI troubleshooting, and the current template contribution guidance.

This refresh updates the three French core documents against main at `9bb4a7d66d31a4bb7a678a93c6940d3677774e51`. It is independent of the French UI translation PR #7753 and does not include that branch's changes.

## What users will see

French readers get the DeepSeek Harness and Claude Desktop setup instructions, Atlas Cloud and internal provider endpoint guidance, Docker browser authentication, macOS/WSL PATH troubleshooting, Claude Code authentication diagnostics, and the current links and requirements for contributing templates and skills. Existing French prose is retained where it still matches the source.

The translation also follows the authoritative repository guidance where the English quickstart is older: native Windows remains best-effort, archived planning documents are identified as historical, and legacy prompt composition is distinguished from OD Next. The Docker contribution example includes the token setup already required by the README and Quickstart.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: documentation translation only; no application UI changes.

## Bug fix verification

Not applicable: documentation synchronization; no runtime behavior changes or regression test additions.

## Validation

- `pnpm guard` — passed.
- `pnpm typecheck` — passed.
- `pnpm i18n:check` — passed.
- Markdown parsed successfully; 209 local link targets resolve, and linked local heading anchors were checked.
- README and Quickstart executable code blocks match the English source after excluding comments. CONTRIBUTING's Docker example adds the existing required token setup before starting Compose.
- `git diff --check` — passed.
- Application test suites and builds were not rerun because this PR changes only Markdown documentation.
- Independent review completed; two minor source-sync omissions were fixed and re-reviewed, with no remaining actionable findings.
