### PR TITLE
chore(release): bump main to 0.21.2

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/daemon",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "type": "module",
   "main": "./dist/cli.js",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/desktop",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "type": "module",
   "main": "./dist/main/index.js",

--- a/apps/packaged/package.json
+++ b/apps/packaged/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/packaged",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/web",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/e2e",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-design",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/contracts",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "type": "module",
   "description": "Shared pure TypeScript contracts for the OpenDesign web/daemon boundary.",

--- a/packages/download/package.json
+++ b/packages/download/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/download",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/host",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "type": "module",
   "description": "OpenDesign renderer host bridge protocol.",

--- a/packages/launcher-proto/package.json
+++ b/packages/launcher-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/launcher-proto",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/platform",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/release/package.json
+++ b/packages/release/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/release",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "type": "module",
   "description": "Open Design release domain primitives.",

--- a/packages/sidecar-proto/package.json
+++ b/packages/sidecar-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar-proto",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/tools/dev/package.json
+++ b/tools/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-dev",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "type": "module",
   "bin": {

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-pack",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "type": "module",
   "bin": {

--- a/tools/release/package.json
+++ b/tools/release/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-release",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Why

The daily Beta build from `main` failed in GitHub Actions run 33704161806. Stable `0.21.1` had already shipped, but the automated post-release bump PR #7666 was closed without merging, leaving the packaged base version equal to stable. The release guard correctly blocks Beta publication unless the packaged base version is strictly newer.

This restores the required version ordering without bypassing the release safety check.

## What users will see

Once merged, the next Beta build from `main` will prepare `0.21.2-beta.1` instead of failing before platform builds start.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — release metadata version maintenance only

## Screenshots

Not applicable; there is no UI change.

## Bug fix verification

- Existing behavior seam: `tools/release/tests/channel-prepare.test.ts`
- Red evidence on `main`: GitHub Actions run 33704161806 failed with `packaged base version 0.21.1 must be strictly greater than latest stable 0.21.1`.
- No new red spec was added because this is the expected release guard catching an operationally missed post-stable version bump, not a defect in the guard.
- After the bump, a direct `tools-release prepare beta` probe against the public release metadata succeeded and produced `0.21.2-beta.1` with latest stable `0.21.1`.

## Validation

- `pnpm install`
- Direct public-feed probe: `pnpm exec tools-release prepare beta` → `0.21.2-beta.1`
- `pnpm --filter @open-design/tools-release test -- tests/channel-prepare.test.ts` (82 tests passed)
- `pnpm --filter @open-design/tools-release typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
