### PR TITLE
fix(tools-pack): unbreak linux --containerized build on a populated tree

### DIFF
--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -174,8 +174,14 @@ export function buildDockerArgs(
     `mv ${CONTAINER_PNPM_PATH}.tmp ${CONTAINER_PNPM_PATH} && ` +
     `chmod +x ${CONTAINER_PNPM_PATH} && ` +
     `PNPM_HOME=${CONTAINER_PNPM_HOME} PATH=${CONTAINER_PNPM_HOME}:$PATH ${CONTAINER_PNPM_PATH} env use --global ${CONTAINER_NODE_VERSION} && ` +
-    `export PNPM_HOME=${CONTAINER_PNPM_HOME} PATH=${CONTAINER_PNPM_HOME}:$PATH && ` +
-    `command -v node >/dev/null`;
+    // Put the pnpm-managed Node bin (node/npm/npx/corepack) on PATH and expose the
+    // standalone pnpm as a bare `pnpm`. electron-builder's node-module-collector
+    // spawns the detected package manager directly (pnpm here — the assembled app
+    // has a node_modules/.pnpm dir); builder:base ships none of these on PATH,
+    // which surfaced as "Node module collector process exited with code 127".
+    `export PNPM_HOME=${CONTAINER_PNPM_HOME} PATH=${CONTAINER_PNPM_HOME}/nodejs/${CONTAINER_NODE_VERSION}/bin:${CONTAINER_PNPM_HOME}:$PATH && ` +
+    `ln -sf ${CONTAINER_PNPM_PATH} ${CONTAINER_PNPM_HOME}/pnpm && ` +
+    `command -v node >/dev/null && command -v npm >/dev/null && command -v pnpm >/dev/null`;
   const pnpmCmd = CONTAINER_PNPM_PATH;
   const innerArgs = [
     `node ${CONTAINER_TOOLS_PACK_CLI_PATH} linux build`,
@@ -211,12 +217,41 @@ export function buildDockerArgs(
     `${electronBuilderCache}:/home/builder/.cache/electron-builder`,
     "-e",
     "HOME=/home/builder",
+    // Match the CI environment the containerized build models. The inner
+    // `pnpm install --frozen-lockfile` runs against the mounted /project, which
+    // on a developer machine already contains a host-installed node_modules with
+    // a different store/config. pnpm decides that modules directory must be
+    // purged and rebuilt; without a TTY and without CI it refuses the
+    // destructive purge and aborts with ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY.
+    // A fresh CI checkout has no node_modules so this never triggers there.
+    // Setting CI=true makes pnpm proceed non-interactively, exactly as it does in
+    // CI. Note: this reinstalls node_modules inside the mounted workspace, so a
+    // local containerized build leaves the host tree with container-built native
+    // modules; re-run host `pnpm install` afterward if you switch back to host dev.
+    "-e",
+    "CI=true",
     "-e",
     "ELECTRON_CACHE=/home/builder/.cache/electron",
     "-e",
     "ELECTRON_BUILDER_CACHE=/home/builder/.cache/electron-builder",
+    // Production install of the assembled app uses npm (resolveProductionInstallCommand's
+    // default), NOT the standalone pnpm. npm is available because the PATH export below
+    // includes the pnpm-managed Node bin, which bundles npm. We deliberately do not set
+    // OD_TOOLS_PACK_PNPM_BIN: a pnpm `--prod --no-lockfile` install over the file: tarballs
+    // failed to materialize transitive deps (jszip's `setimmediate` went missing), yielding
+    // a package that built but crashed on boot. npm's flat hoist matches the working host
+    // build and installs the full tree.
+    // Nested `runPnpm` calls (buildWorkspaceArtifacts, collectWorkspaceTarballs)
+    // route through createPackageManagerInvocation, which prefers `npm_execpath`
+    // and otherwise falls back to `corepack pnpm …`. The inner build is launched
+    // as `node tools-pack.mjs` (not via pnpm), so npm_execpath is unset, and the
+    // builder:base image has no corepack on PATH (pnpm's managed Node only
+    // symlinks `node` into PNPM_HOME) — the fallback dies with `spawn corepack
+    // ENOENT`. Point npm_execpath at the standalone pnpm we bootstrapped so every
+    // nested invocation runs `${CONTAINER_PNPM_PATH} …` directly, bypassing
+    // corepack entirely.
     "-e",
-    `${PRODUCTION_INSTALL_PNPM_BIN_ENV}=${CONTAINER_PNPM_PATH}`,
+    `npm_execpath=${CONTAINER_PNPM_PATH}`,
   ];
   if (config.telemetryRelayUrl != null) {
     dockerArgs.push("-e", `OPEN_DESIGN_TELEMETRY_RELAY_URL=${config.telemetryRelayUrl}`);
@@ -423,14 +458,14 @@ async function runPnpm(
 export type ProductionInstallCommand = { command: string; args: string[] };
 
 // Picks the package manager used to materialize the assembled-app node_modules
-// during writeAssembledApp. The default (`npm`) preserves host behavior for
-// developer-machine builds. When the build runs inside
-// `electronuserland/builder:base` (which strips npm, npx, and corepack),
-// buildDockerArgs sets OD_TOOLS_PACK_PNPM_BIN to the standalone pnpm binary it
-// bootstrapped, and this resolver routes the install through that binary.
-// `--config.node-linker=hoisted` keeps the resulting layout flat so
-// electron-builder packs node_modules the same way it does for npm-installed
-// trees.
+// during writeAssembledApp. Both the host and (now) the containerized build use
+// npm: it hoists the file: internal deps flat and installs the full transitive
+// tree, which is what actually boots. The containerized build exposes npm by
+// putting the pnpm-managed Node bin on PATH (see buildDockerArgs), so it no longer
+// sets OD_TOOLS_PACK_PNPM_BIN. The OD_TOOLS_PACK_PNPM_BIN branch is retained as an
+// opt-in escape hatch, but it is not the container default anymore: a pnpm
+// `--prod --no-lockfile` install over the file: tarballs dropped transitive deps
+// (jszip's `setimmediate`), yielding a package that built but crashed on boot.
 export function resolveProductionInstallCommand(env: NodeJS.ProcessEnv): ProductionInstallCommand {
   const pnpmBin = env[PRODUCTION_INSTALL_PNPM_BIN_ENV];
   if (pnpmBin != null && pnpmBin.length > 0) {

--- a/tools/pack/tests/linux.test.ts
+++ b/tools/pack/tests/linux.test.ts
@@ -140,6 +140,22 @@ describe("buildDockerArgs", () => {
     expect(args).toContain("ELECTRON_BUILDER_CACHE=/home/builder/.cache/electron-builder");
   });
 
+  it("sets CI=true so the inner pnpm install does not abort the modules-dir purge on a populated host tree", () => {
+    // Regression guard for ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY: a local
+    // developer tree mounts an existing node_modules the container pnpm wants to
+    // rebuild; without CI it refuses the purge with no TTY and the build fails.
+    const args = buildDockerArgs(makeConfig(), { uid: 1000, gid: 1000 });
+    expect(args).toContain("CI=true");
+  });
+
+  it("points npm_execpath at the standalone container pnpm so nested runPnpm calls avoid corepack", () => {
+    // Regression guard for `spawn corepack ENOENT`: the builder:base image has no
+    // corepack, so createPackageManagerInvocation must resolve to the bootstrapped
+    // pnpm instead of the corepack fallback.
+    const args = buildDockerArgs(makeConfig(), { uid: 1000, gid: 1000 });
+    expect(args).toContain("npm_execpath=/tmp/pnpm");
+  });
+
   it("passes the telemetry relay URL into containerized builds when configured", () => {
     const args = buildDockerArgs(
       {
@@ -315,12 +331,16 @@ describe("buildDockerArgs", () => {
     expect(last).toContain("--app-version '0.5.0-beta.1'\\''quoted'");
   });
 
-  it("exports OD_TOOLS_PACK_PNPM_BIN=/tmp/pnpm so the inner build's production install skips npm", () => {
+  it("does not export OD_TOOLS_PACK_PNPM_BIN so the assembled-app production install uses npm", () => {
+    // The container now exposes npm (pnpm-managed Node bin on PATH). A pnpm
+    // `--prod --no-lockfile` install over the file: tarballs dropped transitive
+    // deps (jszip's `setimmediate`) and the package crashed on boot, so the
+    // production install falls back to npm's full flat hoist.
     const args = buildDockerArgs(makeConfig(), { uid: 1000, gid: 1000 });
     const envFlagIndex = args.findIndex(
-      (arg, i) => arg === "-e" && args[i + 1] === "OD_TOOLS_PACK_PNPM_BIN=/tmp/pnpm",
+      (arg, i) => arg === "-e" && args[i + 1]?.startsWith("OD_TOOLS_PACK_PNPM_BIN="),
     );
-    expect(envFlagIndex).toBeGreaterThan(-1);
+    expect(envFlagIndex).toBe(-1);
   });
 });
 
@@ -641,21 +661,23 @@ describe("resolveProductionInstallCommand", () => {
     });
   });
 
-  it("chains end-to-end with buildDockerArgs: docker exports OD_TOOLS_PACK_PNPM_BIN and the resolver returns the standalone pnpm install for that value", () => {
+  it("chains end-to-end with buildDockerArgs: the container omits OD_TOOLS_PACK_PNPM_BIN so the resolver returns the npm install", () => {
+    // The containerized build exposes npm on PATH and relies on it for the
+    // assembled-app production install (pnpm dropped transitive deps like
+    // jszip's `setimmediate`, crashing the packaged app on boot). So docker must
+    // NOT export OD_TOOLS_PACK_PNPM_BIN, and the resolver — reading the same
+    // (absent) env — must return npm.
     const dockerArgs = buildDockerArgs(makeConfig(), { uid: 1000, gid: 1000 });
     const envFlagIndex = dockerArgs.findIndex(
       (arg, i) => arg === "-e" && dockerArgs[i + 1]?.startsWith("OD_TOOLS_PACK_PNPM_BIN="),
     );
-    expect(envFlagIndex).toBeGreaterThan(-1);
-    const envValue = dockerArgs[envFlagIndex + 1]?.split("=")[1];
-    expect(envValue).toBe("/tmp/pnpm");
+    expect(envFlagIndex).toBe(-1);
 
-    const resolved = resolveProductionInstallCommand({ OD_TOOLS_PACK_PNPM_BIN: envValue });
+    const resolved = resolveProductionInstallCommand({});
     expect(resolved).toEqual({
-      command: "/tmp/pnpm",
-      args: ["install", "--prod", "--no-lockfile", "--config.node-linker=hoisted"],
+      command: "npm",
+      args: ["install", "--omit=dev", "--no-package-lock"],
     });
-    expect(resolved.command).not.toBe("npm");
   });
 });
 


### PR DESCRIPTION
> Supersedes #6009, which was auto-closed for inactivity and cannot be reopened by the author. Same head commit (`d72f8ad7a`), already approved by @PerishCode there, still cleanly mergeable against `main`. No code change.

Fixes #5983

## Why

I hit this while adding native `.deb` packaging (#5982): the feature's acceptance
criterion is a build through the **sanctioned** `--containerized` path
(`electronuserland/builder`, per `tools/pack/AGENTS.md`), and that path is **broken
on any developer machine** — it only works on a fresh CI checkout.

The failures are all triggered by state a developer tree has and a clean checkout
does not (a populated `node_modules`, no interactive TTY, a corepack-stripped image).
They surface as a *chain* of five pre-existing root causes — full detail in #5983.
Failures 1, 2 and 4 also block the **AppImage** `--containerized` build, so this fix
has value independent of `.deb`.

## What users will see

No product-facing change. For anyone building packaged Linux artifacts locally,
`pnpm tools-pack linux build --containerized` now builds end-to-end on a normal
working tree instead of aborting at the inner `pnpm install` (and the produced
package actually boots).

The five fixes, all scoped to the Docker environment/setup in `buildDockerArgs` +
`resolveProductionInstallCommand`:
- `CI=true` — pnpm runs the modules-dir purge non-interactively, as it does in CI.
- `npm_execpath` → the bootstrapped standalone pnpm — nested `runPnpm` calls stop
  falling back to the absent `corepack`.
- pnpm-managed Node bin on PATH + a bare `pnpm` symlink — electron-builder's
  node-module-collector finds a package manager (no more exit code 127).
- Production install via **npm** (drop `OD_TOOLS_PACK_PNPM_BIN`) — npm's flat hoist
  installs the full transitive tree, fixing both the `@open-design/*` registry 404s
  and the missing `setimmediate` that crashed the packaged app on boot.

## Surface area

- [x] **CLI / env var** — behavior of `tools-pack linux build --containerized` (no new flag; drops the internal `OD_TOOLS_PACK_PNPM_BIN` container env in favor of npm)

## Bug fix verification

- Test path: `tools/pack/tests/linux.test.ts` — `buildDockerArgs` regression guards
  (`CI=true`, `npm_execpath=/tmp/pnpm`, `OD_TOOLS_PACK_PNPM_BIN` absent) and the
  `resolveProductionInstallCommand` end-to-end chain asserting the container now
  resolves to npm.
- The full failure chain needs Docker + a populated tree, so these are unit guards
  on the generated docker args rather than a single red e2e. End-to-end, the
  containerized `--to deb` build was run to completion and the resulting package was
  extracted and booted (0 fatal errors) to confirm all five fixes.

## Validation

- `pnpm guard`
- `pnpm --filter @open-design/tools-pack typecheck`
- `pnpm --filter @open-design/tools-pack test`
- `pnpm tools-pack linux build --to deb --containerized` (end-to-end) + extract & boot smoke

