### PR TITLE
fix(web): close the Home hero/composer acceptance issues against #7731 (OPEND-2553 PR-B2)

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -62,6 +62,12 @@ import type {
 } from '@open-design/contracts';
 import { buildVisualAnnotationAttachment, commentTargetDisplayName } from '../comments';
 import { Icon, type IconName } from "./Icon";
+import {
+  FileTypeIcon,
+  fileTypePreviewKind,
+  previewFallbackIcon,
+  resolveFileTypeIcon,
+} from "./FileTypeIcon";
 import { ComposerPlusMenu, PLUS_SUBMENU_RESOURCE_KIND, type PlusMenuSubmenu } from './ComposerPlusMenu';
 import { LibraryPicker } from './LibraryPicker';
 import { FigmaImportModal } from './FigmaImportModal';
@@ -3935,7 +3941,11 @@ function StagedRunContexts({
         </div>
       ))}
       {attachments.map((a, index) => {
-        const canPreview = a.kind === 'image' && Boolean(projectId);
+        // Rasters, vectors and videos lead with a thumbnail; every other type
+        // leads with its own mark (per product). `a.kind` cannot decide it —
+        // the daemon only splits image/file, so a video arrives as 'file'.
+        const previewKind = fileTypePreviewKind(a.name || a.path);
+        const canPreview = previewKind !== null && Boolean(projectId);
         const imageUrl = canPreview
           ? projectRawUrl(projectId!, a.path, workspaceContext)
           : null;
@@ -3957,12 +3967,26 @@ function StagedRunContexts({
                 title={a.name}
                 aria-label={`Preview ${a.name}`}
               >
-                <img src={imageUrl} alt="" aria-hidden />
+                {previewKind === 'video' ? (
+                  <video src={imageUrl} muted playsInline preload="metadata" aria-hidden />
+                ) : (
+                  <img src={imageUrl} alt="" aria-hidden />
+                )}
               </button>
             ) : (
               <>
                 <span className="staged-icon" aria-hidden>
-                  <Icon name="file" size={13} />
+                  {/* The type's own mark, from the same table the home
+                      composer's chips read — one answer per file type across
+                      both composers. */}
+                  <FileTypeIcon
+                    name={
+                      previewKind
+                        ? previewFallbackIcon(previewKind, a.name || a.path)
+                        : resolveFileTypeIcon(a.name || a.path)
+                    }
+                    size={16}
+                  />
                 </span>
                 <span className="staged-name" title={a.path}>
                   {a.name}
@@ -4007,7 +4031,11 @@ function StagedRunContexts({
               <Icon name="close" size={14} />
             </button>
           </div>
-          <img src={previewUrl} alt={preview.name} />
+          {fileTypePreviewKind(preview.name || preview.path) === 'video' ? (
+            <video src={previewUrl} controls playsInline />
+          ) : (
+            <img src={previewUrl} alt={preview.name} />
+          )}
         </div>
       </div>,
       document.body

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -3738,6 +3738,13 @@ function workspaceContextKindLabel(kind: WorkspaceContextItem['kind']): string {
   }
 }
 
+/** Human labels may omit the filename; retain image-only staging metadata as a fallback. */
+function attachmentPreviewKind(attachment: ChatAttachment) {
+  return fileTypePreviewKind(attachment.name)
+    ?? fileTypePreviewKind(attachment.path)
+    ?? (attachment.kind === 'image' ? 'image' : null);
+}
+
 function StagedRunContexts({
   designSystemPicker,
   workspaceItems,
@@ -3942,9 +3949,9 @@ function StagedRunContexts({
       ))}
       {attachments.map((a, index) => {
         // Rasters, vectors and videos lead with a thumbnail; every other type
-        // leads with its own mark (per product). `a.kind` cannot decide it —
-        // the daemon only splits image/file, so a video arrives as 'file'.
-        const previewKind = fileTypePreviewKind(a.name || a.path);
+        // leads with its own mark (per product). The daemon's image/file
+        // kind is a fallback: videos arrive as 'file'.
+        const previewKind = attachmentPreviewKind(a);
         const canPreview = previewKind !== null && Boolean(projectId);
         const imageUrl = canPreview
           ? projectRawUrl(projectId!, a.path, workspaceContext)
@@ -4031,7 +4038,7 @@ function StagedRunContexts({
               <Icon name="close" size={14} />
             </button>
           </div>
-          {fileTypePreviewKind(preview.name || preview.path) === 'video' ? (
+          {attachmentPreviewKind(preview) === 'video' ? (
             <video src={previewUrl} controls playsInline />
           ) : (
             <img src={previewUrl} alt={preview.name} />

--- a/apps/web/src/components/DesignSystemPicker.tsx
+++ b/apps/web/src/components/DesignSystemPicker.tsx
@@ -519,15 +519,20 @@ export function DesignSystemPicker({
         <button
           ref={triggerRef}
           type="button"
-          className={`home-hero__ds-row-trigger${selected ? ' is-selected' : ' is-icon-only'}`}
+          className={`home-hero__ds-row-trigger${selected ? ' is-selected' : ' is-icon-only od-tooltip'}`}
           data-testid="home-hero-design-system-trigger"
           aria-haspopup="listbox"
           aria-expanded={open}
           disabled={triggerDisabled}
-          title={triggerLabel}
           /* Unselected the control is the palette glyph alone (per product:
              不选择不显示文案), so the field name lives on the tooltip + this
-             label rather than in the pill. */
+             label rather than in the pill. The tooltip is the app's own
+             `od-tooltip` bubble, the same one the "+" trigger beside it uses,
+             not the browser's native `title` — the two sat in one row and
+             showed two different styles. Once a system is picked its name is
+             on the pill, so the bubble would only repeat it (the "+" trigger
+             drops its bubble for the same reason once it carries a label). */
+          {...(selected ? {} : { 'data-tooltip': triggerLabel })}
           aria-label={triggerLabel}
           onClick={() => setOpen((v) => !v)}
         >

--- a/apps/web/src/components/FigmaImportModal.module.css
+++ b/apps/web/src/components/FigmaImportModal.module.css
@@ -6,7 +6,7 @@
   align-items: center;
   justify-content: center;
   padding: 32px;
-  background: rgba(17, 24, 39, 0.55);
+  background: var(--scrim-tint);
   -webkit-backdrop-filter: var(--scrim-backdrop);
   backdrop-filter: var(--scrim-backdrop);
 }
@@ -49,8 +49,15 @@
   justify-content: center;
   width: 34px;
   height: 34px;
+  /* The global `button` rule in styles/primitives.css sets `padding: 0 16px`,
+     which on a 34px border-box square leaves 2px of content width — the ×
+     (a shrinkable flex item) collapsed to 0 and the button rendered as an
+     empty box. */
+  padding: 0;
   border: 1px solid var(--border);
-  border-radius: var(--radius-large, 8px);
+  /* Pill (per product: every button in this modal is fully rounded) — on a
+     34px square that reads as a circle. */
+  border-radius: var(--radius-pill);
   background: var(--bg-elevated);
   color: var(--text);
   cursor: pointer;
@@ -72,13 +79,15 @@
   margin: 14px 16px 0;
   padding: 4px;
   background: var(--bg-subtle);
-  border-radius: 12px;
+  /* The track follows its options' pill so the selected thumb doesn't sit in
+     a rounded-rect groove. */
+  border-radius: var(--radius-pill);
 }
 .tab {
   flex: 1 1 0;
   padding: 7px 12px;
   border: none;
-  border-radius: var(--radius-large, 8px);
+  border-radius: var(--radius-pill);
   background: transparent;
   color: var(--text-muted);
   font-size: 13px;
@@ -165,6 +174,12 @@
 /* --- notes -------------------------------------------------------------- */
 .notes {
   margin: 0 16px;
+  /* The global `input, textarea` rule in styles/primitives.css sets
+     `width: 100%`; with the 16px side margins that is 32px wider than the
+     modal, and `.modal { overflow: hidden }` clipped the right edge. As a
+     stretched flex item the field already fills the column, so hand the width
+     back to the layout. */
+  width: auto;
   padding: 10px 12px;
   border: 1px solid var(--border);
   border-radius: var(--radius-large, 8px);
@@ -193,6 +208,13 @@
   gap: 10px;
   padding: 16px;
   flex: 0 0 auto;
+}
+/* Cancel / Import & build are the shared `Button` primitive, whose radius is
+   owned by packages/components. Reach it through the element rather than
+   editing the primitive: the pill is this modal's call (per product), not a
+   change every button in the app should inherit. */
+.foot button {
+  border-radius: var(--radius-pill);
 }
 .spin {
   animation: figmaImportSpin 700ms linear infinite;

--- a/apps/web/src/components/FileTypeIcon.tsx
+++ b/apps/web/src/components/FileTypeIcon.tsx
@@ -1,0 +1,279 @@
+// The one place an uploaded file's type becomes a glyph.
+//
+// Supplied artwork (per product), inlined for the same reason the rail's marks
+// are: every one of these is MULTI-COLOUR — brand fills, two of them
+// gradients — and the shared `Icon` / `RemixIcon` components emit a single
+// `currentColor` path, which would flatten a Figma logo into a grey blob.
+//
+// What does NOT live here, deliberately: raster images, vectors and videos.
+// Those three families lead with a real thumbnail the user can click to open
+// (per product: 视频类、图像类位图、矢量图 默认展示可打开预览), so a chip only
+// falls back to `previewFallbackIcon()` for them when no thumbnail can be made
+// (an unreadable file, a codec the browser won't decode). `fileTypePreviewKind`
+// is what a surface asks to decide between the two paths.
+import { useId } from 'react';
+
+export type FileTypeIconName =
+  | 'audio'
+  | 'code'
+  | 'ebook'
+  | 'excel'
+  | 'figma'
+  | 'font'
+  | 'gif'
+  | 'markdown'
+  | 'model3d'
+  | 'pdf'
+  | 'ppt'
+  | 'unknown'
+  | 'word'
+  | 'zip';
+
+/** The families that show a thumbnail instead of a glyph. */
+export type FilePreviewKind = 'image' | 'vector' | 'video';
+
+function extensionOf(name: string): string {
+  return /\.([a-z0-9_]{1,10})$/i.exec(name)?.[1]?.toLowerCase() ?? '';
+}
+
+const VIDEO_EXTENSIONS = new Set([
+  '3gp', 'avi', 'flv', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'mpg', 'ogv', 'webm', 'wmv',
+]);
+
+/** Raster only — `svg` is a vector and answers `'vector'` below. */
+const IMAGE_EXTENSIONS = new Set([
+  'avif', 'bmp', 'gif', 'heic', 'heif', 'ico', 'jpeg', 'jpg', 'png', 'tif', 'tiff', 'webp',
+]);
+
+/** Browser-renderable vectors. `.ai` / `.eps` are vectors too, but nothing can
+ *  draw them here, so they take a glyph like any other opaque document. */
+const VECTOR_EXTENSIONS = new Set(['svg']);
+
+const ICON_BY_EXTENSION = new Map<string, FileTypeIconName>([
+  // Figma (per product: Figma 使用 figma 的 icon)
+  ...(['fig', 'figma', 'jam'] as const).map((ext) => [ext, 'figma'] as const),
+  // 3D / CAD / 工程 (per product: 使用 3d 的 icon)
+  ...([
+    '3dm', '3ds', '3mf', 'blend', 'catpart', 'dae', 'dwg', 'dxf', 'fbx', 'glb', 'gltf',
+    'iam', 'iges', 'igs', 'ipt', 'obj', 'ply', 'prt', 'skp', 'sldasm', 'sldprt', 'step',
+    'stl', 'stp', 'usd', 'usda', 'usdc', 'usdz', 'x_t',
+  ] as const).map((ext) => [ext, 'model3d'] as const),
+  ...(['csv', 'numbers', 'tsv', 'xls', 'xlsm', 'xlsx'] as const)
+    .map((ext) => [ext, 'excel'] as const),
+  ...(['doc', 'docx', 'odt', 'pages', 'rtf'] as const).map((ext) => [ext, 'word'] as const),
+  ...(['key', 'odp', 'ppt', 'pptx'] as const).map((ext) => [ext, 'ppt'] as const),
+  ...(['pdf'] as const).map((ext) => [ext, 'pdf'] as const),
+  ...(['markdown', 'md', 'mdx'] as const).map((ext) => [ext, 'markdown'] as const),
+  ...([
+    'astro', 'bash', 'c', 'cc', 'cjs', 'cpp', 'cs', 'css', 'dart', 'fish', 'go', 'gradle',
+    'h', 'hpp', 'htm', 'html', 'ini', 'ipynb', 'java', 'js', 'json', 'json5', 'jsx', 'kt',
+    'kts', 'less', 'lua', 'mjs', 'php', 'pl', 'ps1', 'py', 'r', 'rb', 'rs', 'sass', 'scala',
+    'scss', 'sh', 'sql', 'svelte', 'swift', 'toml', 'ts', 'tsx', 'vue', 'xml', 'yaml', 'yml',
+    'zsh',
+  ] as const).map((ext) => [ext, 'code'] as const),
+  ...(['7z', 'bz2', 'gz', 'rar', 'tar', 'tgz', 'xz', 'zip', 'zst'] as const)
+    .map((ext) => [ext, 'zip'] as const),
+  ...([
+    'aac', 'aif', 'aiff', 'flac', 'm4a', 'mid', 'midi', 'mp3', 'oga', 'ogg', 'opus', 'wav',
+    'wma',
+  ] as const).map((ext) => [ext, 'audio'] as const),
+  ...(['eot', 'otf', 'ttc', 'ttf', 'woff', 'woff2'] as const)
+    .map((ext) => [ext, 'font'] as const),
+  ...(['azw', 'azw3', 'djvu', 'epub', 'fb2', 'mobi'] as const)
+    .map((ext) => [ext, 'ebook'] as const),
+  ...(['gif'] as const).map((ext) => [ext, 'gif'] as const),
+]);
+
+/**
+ * Which of the three thumbnail families this file belongs to, or `null` when it
+ * is a document that leads with a glyph.
+ *
+ * The name decides it; the MIME type is only consulted when there is no usable
+ * extension (a pasted screenshot, a drag from an app that names its payload
+ * `image`), because a browser's guess at a type is far less reliable than the
+ * name the user is looking at.
+ */
+export function fileTypePreviewKind(name: string, mime?: string): FilePreviewKind | null {
+  const ext = extensionOf(name);
+  if (ext) {
+    if (VECTOR_EXTENSIONS.has(ext)) return 'vector';
+    if (IMAGE_EXTENSIONS.has(ext)) return 'image';
+    if (VIDEO_EXTENSIONS.has(ext)) return 'video';
+    // A known document extension is the answer even if the MIME disagrees.
+    if (ICON_BY_EXTENSION.has(ext)) return null;
+  }
+  const type = (mime ?? '').toLowerCase();
+  if (type === 'image/svg+xml') return 'vector';
+  if (type.startsWith('image/')) return 'image';
+  if (type.startsWith('video/')) return 'video';
+  return null;
+}
+
+/** The glyph a chip leads with when it is NOT showing a thumbnail. */
+export function resolveFileTypeIcon(name: string, mime?: string): FileTypeIconName {
+  const ext = extensionOf(name);
+  const byExtension = ext ? ICON_BY_EXTENSION.get(ext) : undefined;
+  if (byExtension) return byExtension;
+
+  const type = (mime ?? '').toLowerCase();
+  if (type.startsWith('audio/')) return 'audio';
+  if (type === 'application/pdf') return 'pdf';
+  if (type === 'text/markdown') return 'markdown';
+  if (type.startsWith('font/')) return 'font';
+  if (type === 'application/zip' || type === 'application/x-tar' || type === 'application/gzip') {
+    return 'zip';
+  }
+  if (type === 'application/json' || type === 'application/xml' || type.startsWith('text/x-')) {
+    return 'code';
+  }
+  return 'unknown';
+}
+
+/**
+ * The glyph a thumbnail family falls back to when its thumbnail cannot be
+ * produced — a GIF whose object URL failed, a video the browser won't decode.
+ * Raster and vector have no artwork of their own in the supplied set (they are
+ * never meant to be seen as a glyph), so they take the neutral one.
+ */
+export function previewFallbackIcon(kind: FilePreviewKind, name: string): FileTypeIconName {
+  if (kind === 'image' && extensionOf(name) === 'gif') return 'gif';
+  return 'unknown';
+}
+
+interface Props {
+  name: FileTypeIconName;
+  /** Rendered edge length in px. The artwork is drawn on a 24 grid. */
+  size?: number;
+}
+
+export function FileTypeIcon({ name, size = 16 }: Props) {
+  // Both gradient marks below need document-unique ids: two chips showing the
+  // same type would otherwise emit the same `<linearGradient id>` twice, and a
+  // `url(#…)` reference resolves to whichever one is still in the DOM — so
+  // removing the first chip blanked the second one's fill.
+  const gradientId = useId();
+  const common = {
+    width: size,
+    height: size,
+    viewBox: '0 0 24 24',
+    fill: 'none' as const,
+    xmlns: 'http://www.w3.org/2000/svg',
+    'aria-hidden': true,
+    focusable: 'false' as const,
+  };
+
+  switch (name) {
+    case 'figma':
+      // The export's mask + clipPath are dropped: both crop to the artwork's
+      // own bounds, so they change nothing visually and would have been two
+      // more ids to keep unique.
+      return (
+        <svg {...common}>
+          <path d="M8.65803 21.9987C10.4978 21.9987 11.9911 20.5056 11.9911 18.6658V15.333H8.65803C6.81826 15.333 5.3252 16.8261 5.3252 18.6658C5.3252 20.5056 6.81826 21.9987 8.65803 21.9987Z" fill="#0ACF83" />
+          <path d="M5.3252 11.9998C5.3252 10.1601 6.81826 8.66699 8.65803 8.66699H11.9911V15.3327H8.65803C6.81826 15.3327 5.3252 13.8396 5.3252 11.9998Z" fill="#A259FF" />
+          <path d="M5.3252 5.33381C5.3252 3.49404 6.81826 2.00098 8.65803 2.00098H11.9911V8.66689H8.65803C6.81826 8.66689 5.3252 7.17358 5.3252 5.33381Z" fill="#F24E1E" />
+          <path d="M11.991 2.00098H15.3238C17.1636 2.00098 18.6566 3.49404 18.6566 5.33381C18.6566 7.17358 17.1636 8.66689 15.3238 8.66689H11.991V2.00098Z" fill="#FF7262" />
+          <path d="M18.6566 11.9998C18.6566 13.8396 17.1636 15.3327 15.3238 15.3327C13.484 15.3327 11.991 13.8396 11.991 11.9998C11.991 10.1601 13.484 8.66699 15.3238 8.66699C17.1636 8.66699 18.6566 10.1601 18.6566 11.9998Z" fill="#1ABCFE" />
+        </svg>
+      );
+    case 'model3d':
+      return (
+        <svg {...common}>
+          <path d="M19.0073 6.78768C19.6726 6.40251 19.6726 5.44199 19.0073 5.05682L12.501 1.29007C12.1911 1.11064 11.8089 1.11064 11.499 1.29007L4.99276 5.05682C4.32747 5.44199 4.32747 6.40251 4.99276 6.78768L11.499 10.5544C11.8089 10.7339 12.1911 10.7339 12.501 10.5544L19.0073 6.78768ZM4.00103 8.52451C3.33437 8.13855 2.5 8.61961 2.5 9.38994V16.9235C2.5 17.2803 2.69015 17.6101 2.99896 17.7889L9.49896 21.5521C10.1656 21.938 11 21.457 11 20.6866V13.1531C11 12.7962 10.8099 12.4664 10.501 12.2876L4.00103 8.52451ZM13 20.6866C13 21.457 13.8344 21.938 14.501 21.5521L21.001 17.7889C21.3099 17.6101 21.5 17.2803 21.5 16.9235V9.38994C21.5 8.61961 20.6656 8.13855 19.999 8.52451L13.499 12.2876C13.1901 12.4664 13 12.7962 13 13.1531V20.6866Z" fill="#00E3AE" />
+        </svg>
+      );
+    case 'excel':
+      return (
+        <svg {...common}>
+          <path d="M2.85858 2.87708L15.4293 1.08126C15.7027 1.04221 15.9559 1.23216 15.995 1.50553C15.9983 1.52895 16 1.55258 16 1.57624V22.4233C16 22.6994 15.7761 22.9233 15.5 22.9233C15.4763 22.9233 15.4527 22.9216 15.4293 22.9182L2.85858 21.1224C2.36593 21.052 2 20.6301 2 20.1325V3.86703C2 3.36938 2.36593 2.94746 2.85858 2.87708ZM17 2.99973H21C21.5523 2.99973 22 3.44745 22 3.99973V19.9998C22 20.5521 21.5523 20.9998 21 20.9998H17V2.99973ZM10.2 11.9998L13 7.99973H10.6L9 10.2855L7.39999 7.99973H5L7.8 11.9998L5 15.9998H7.39999L9 13.7141L10.6 15.9998H13L10.2 11.9998Z" fill="#F34801" />
+        </svg>
+      );
+    case 'word':
+      return (
+        <svg {...common}>
+          <path d="M17 2.99973H21C21.5523 2.99973 22 3.44745 22 3.99973V19.9998C22 20.5521 21.5523 20.9998 21 20.9998H17V2.99973ZM2.85858 2.87708L15.4293 1.08126C15.7027 1.04221 15.9559 1.23216 15.995 1.50553C15.9983 1.52895 16 1.55258 16 1.57624V22.4233C16 22.6994 15.7761 22.9233 15.5 22.9233C15.4763 22.9233 15.4527 22.9216 15.4293 22.9182L2.85858 21.1224C2.36593 21.052 2 20.6301 2 20.1325V3.86703C2 3.36938 2.36593 2.94746 2.85858 2.87708ZM11 7.99973V12.9888L9 10.9998L7.01083 12.9998L7 7.99973H5V15.9998H7L9 13.9998L11 15.9998H13V7.99973H11Z" fill="#00A365" />
+        </svg>
+      );
+    case 'ppt':
+      return (
+        <svg {...common}>
+          <path d="M17 2.99973H21C21.5523 2.99973 22 3.44745 22 3.99973V19.9998C22 20.5521 21.5523 20.9998 21 20.9998H17V2.99973ZM2.85858 2.87708L15.4293 1.08126C15.7027 1.04221 15.9559 1.23216 15.995 1.50553C15.9983 1.52895 16 1.55258 16 1.57624V22.4233C16 22.6994 15.7761 22.9233 15.5 22.9233C15.4763 22.9233 15.4527 22.9216 15.4293 22.9182L2.85858 21.1224C2.36593 21.052 2 20.6301 2 20.1325V3.86703C2 3.36938 2.36593 2.94746 2.85858 2.87708ZM5 7.99973V15.9998H7V13.9998H13V7.99973H5ZM7 9.99974H11V11.9998H7V9.99974Z" fill="#1F68FE" />
+        </svg>
+      );
+    case 'pdf':
+      return (
+        <svg {...common}>
+          <path d="M3.9985 2C3.44749 2 3 2.44405 3 2.9918V21.0082C3 21.5447 3.44476 22 3.9934 22H20.0066C20.5551 22 21 21.5489 21 20.9925L20.9997 7L16 2H3.9985ZM10.5 7.5H12.5C12.5 9.98994 14.6436 12.6604 17.3162 13.5513L16.8586 15.49C13.7234 15.0421 10.4821 16.3804 7.5547 18.3321L6.3753 16.7191C7.46149 15.8502 8.50293 14.3757 9.27499 12.6534C10.0443 10.9373 10.5 9.07749 10.5 7.5ZM11.1 13.4716C11.3673 12.8752 11.6043 12.2563 11.8037 11.6285C12.2754 12.3531 12.8553 13.0182 13.5102 13.5953C12.5284 13.7711 11.5666 14.0596 10.6353 14.4276C10.8 14.1143 10.9551 13.7948 11.1 13.4716Z" fill="#FF0044" />
+        </svg>
+      );
+    case 'markdown':
+      return (
+        <svg {...common}>
+          <path d="M3 3H21C21.5523 3 22 3.44772 22 4V20C22 20.5523 21.5523 21 21 21H3C2.44772 21 2 20.5523 2 20V4C2 3.44772 2.44772 3 3 3ZM7 15.5V11.5L9 13.5L11 11.5V15.5H13V8.5H11L9 10.5L7 8.5H5V15.5H7ZM18 12.5V8.5H16V12.5H14L17 15.5L20 12.5H18Z" fill="black" />
+        </svg>
+      );
+    case 'code':
+      return (
+        <svg {...common}>
+          <path d="M3 3H21C21.5523 3 22 3.44772 22 4V20C22 20.5523 21.5523 21 21 21H3C2.44772 21 2 20.5523 2 20V4C2 3.44772 2.44772 3 3 3ZM16.4645 15.5355L20 12L16.4645 8.46447L15.0503 9.87868L17.1716 12L15.0503 14.1213L16.4645 15.5355ZM6.82843 12L8.94975 9.87868L7.53553 8.46447L4 12L7.53553 15.5355L8.94975 14.1213L6.82843 12ZM11.2443 17L14.884 7H12.7557L9.11597 17H11.2443Z" fill="#00CCFF" />
+        </svg>
+      );
+    case 'zip':
+      return (
+        <svg {...common}>
+          <path d="M10 2V4H12V2H20.0066C20.5551 2 21 2.44405 21 2.9918V21.0082C21 21.5447 20.5552 22 20.0066 22H3.9934C3.44495 22 3 21.556 3 21.0082V2.9918C3 2.45531 3.44476 2 3.9934 2H10ZM12 4V6H14V4H12ZM10 6V8H12V6H10ZM12 8V10H14V8H12ZM10 10V12H12V10H10ZM12 12V14H10V17H14V12H12Z" fill="#0B06FE" />
+        </svg>
+      );
+    case 'gif':
+      return (
+        <svg {...common}>
+          <path d="M16 2L20.9997 7L21 20.9925C21 21.5489 20.5551 22 20.0066 22H3.9934C3.44476 22 3 21.5447 3 21.0082V2.9918C3 2.44405 3.44749 2 3.9985 2H16ZM13 10H12V15H13V10ZM11 10H9C7.89543 10 7 10.8954 7 12V13C7 14.1046 7.89543 15 9 15H10C10.5523 15 11 14.5523 11 14V12H9V13H10V14H9C8.44772 14 8 13.5523 8 13V12C8 11.4477 8.44772 11 9 11H11V10ZM17 10H14V15H15V13H17V12H15V11H17V10Z" fill="#F49624" />
+        </svg>
+      );
+    case 'audio':
+      return (
+        <svg {...common}>
+          <path d="M2 3.9934C2 3.44476 2.45531 3 2.9918 3H21.0082C21.556 3 22 3.44495 22 3.9934V20.0066C22 20.5552 21.5447 21 21.0082 21H2.9918C2.44405 21 2 20.5551 2 20.0066V3.9934ZM12 12.1707C11.6872 12.0602 11.3506 12 11 12C9.34315 12 8 13.3431 8 15C8 16.6569 9.34315 18 11 18C12.6569 18 14 16.6569 14 15V8H17V6H12V12.1707Z" fill="#9500FF" />
+        </svg>
+      );
+    case 'ebook':
+      return (
+        <svg {...common}>
+          <path d="M20 22H6.5C4.567 22 3 20.433 3 18.5V5C3 3.34315 4.34315 2 6 2H20C20.5523 2 21 2.44772 21 3V21C21 21.5523 20.5523 22 20 22ZM19 20V17H6.5C5.67157 17 5 17.6716 5 18.5C5 19.3284 5.67157 20 6.5 20H19Z" fill="#006FE5" />
+        </svg>
+      );
+    case 'font':
+      return (
+        <svg {...common}>
+          <path d="M17 8H7V10H11V17H13V10H17V8ZM4 3H20C20.5523 3 21 3.44772 21 4V20C21 20.5523 20.5523 21 20 21H4C3.44772 21 3 20.5523 3 20V4C3 3.44772 3.44772 3 4 3Z" fill={`url(#${gradientId})`} />
+          <defs>
+            <linearGradient id={gradientId} x1="12" y1="3" x2="12" y2="21" gradientUnits="userSpaceOnUse">
+              <stop />
+              <stop offset="1" stopColor="#029F27" />
+            </linearGradient>
+          </defs>
+        </svg>
+      );
+    case 'unknown':
+    default:
+      return (
+        <svg {...common}>
+          <path d="M16 2L21 7V21.0082C21 21.556 20.5551 22 20.0066 22H3.9934C3.44476 22 3 21.5447 3 21.0082V2.9918C3 2.44405 3.44495 2 3.9934 2H16ZM11 15V17H13V15H11ZM13 13.3551C14.4457 12.9248 15.5 11.5855 15.5 10C15.5 8.067 13.933 6.5 12 6.5C10.302 6.5 8.88637 7.70919 8.56731 9.31346L10.5288 9.70577C10.6656 9.01823 11.2723 8.5 12 8.5C12.8284 8.5 13.5 9.17157 13.5 10C13.5 10.8284 12.8284 11.5 12 11.5C11.4477 11.5 11 11.9477 11 12.5V14H13V13.3551Z" fill={`url(#${gradientId})`} />
+          <defs>
+            <radialGradient
+              id={gradientId}
+              cx="0"
+              cy="0"
+              r="1"
+              gradientUnits="userSpaceOnUse"
+              gradientTransform="translate(4.5 3.5) rotate(50.1944) scale(19.5256 17.5731)"
+            >
+              <stop stopColor="#00FF08" />
+              <stop offset="0.509615" stopColor="#00FFEA" />
+              <stop offset="1" stopColor="#121212" />
+            </radialGradient>
+          </defs>
+        </svg>
+      );
+  }
+}

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -35,6 +35,12 @@ import type {
 import { DesignSystemPicker } from './DesignSystemPicker';
 import type { SkillSummary } from '../types';
 import { Icon, type IconName } from './Icon';
+import {
+  FileTypeIcon,
+  fileTypePreviewKind,
+  previewFallbackIcon,
+  resolveFileTypeIcon,
+} from './FileTypeIcon';
 import { useAnalytics } from '../analytics/provider';
 import {
   trackContextLinkResult,
@@ -979,7 +985,12 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
     const urls = new Map<string, string>();
     if (typeof URL !== 'undefined' && typeof URL.createObjectURL === 'function') {
       stagedFiles.forEach((file, index) => {
-        if (isImageFile(file)) urls.set(homeFileKey(file, index), URL.createObjectURL(file));
+        // Rasters, vectors AND videos all lead with a thumbnail now (per
+        // product: 视频类、图像类位图、矢量图 默认展示可打开预览), so each of
+        // them needs an object URL to draw from.
+        if (fileTypePreviewKind(file.name, file.type)) {
+          urls.set(homeFileKey(file, index), URL.createObjectURL(file));
+        }
       });
     }
     setStagedFilePreviewUrls(urls);
@@ -1672,9 +1683,23 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
                 {stagedFiles.map((file, index) => {
                   const key = homeFileKey(file, index);
                   const previewUrl = stagedFilePreviewUrls.get(key) ?? null;
+                  const previewKind = fileTypePreviewKind(file.name, file.type);
                   const fileBody = (
                     <>
-                      {previewUrl ? (
+                      {previewUrl && previewKind === 'video' ? (
+                        // Its own first frame is the thumbnail: `preload
+                        // metadata` is enough to paint one, and the element
+                        // stays inert (no controls, muted) — the chip is a
+                        // label, the click opens the real player.
+                        <video
+                          className="home-hero__active-thumb"
+                          src={previewUrl}
+                          muted
+                          playsInline
+                          preload="metadata"
+                          aria-hidden
+                        />
+                      ) : previewUrl && previewKind ? (
                         <img
                           className="home-hero__active-thumb"
                           src={previewUrl}
@@ -1684,7 +1709,17 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
                         />
                       ) : (
                         <span className="home-hero__active-icon" aria-hidden>
-                          <Icon name={isImageFile(file) ? 'image' : 'file'} size={12} />
+                          {/* The type's own mark (per product). A previewable
+                              file only lands here when its thumbnail could not
+                              be made at all. */}
+                          <FileTypeIcon
+                            name={
+                              previewKind
+                                ? previewFallbackIcon(previewKind, file.name)
+                                : resolveFileTypeIcon(file.name, file.type)
+                            }
+                            size={20}
+                          />
                         </span>
                       )}
                       {/* Name over type · size (per product): two lines inside the
@@ -2550,7 +2585,14 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
                 <Icon name="close" size={14} />
               </button>
             </div>
-            <img src={previewHomeFileUrl} alt={previewHomeFile.name} />
+            {/* A video opens as a player, everything else as a still — the
+                same card either way, so the chip's click always lands on the
+                file itself rather than on a download. */}
+            {fileTypePreviewKind(previewHomeFile.name, previewHomeFile.type) === 'video' ? (
+              <video src={previewHomeFileUrl} controls autoPlay={false} playsInline />
+            ) : (
+              <img src={previewHomeFileUrl} alt={previewHomeFile.name} />
+            )}
           </div>
         </div>,
         document.body,

--- a/apps/web/src/components/WorkingDirPicker.module.css
+++ b/apps/web/src/components/WorkingDirPicker.module.css
@@ -359,10 +359,3 @@
   white-space: nowrap;
 }
 
-.empty {
-  padding: 8px 10px;
-  font-size: 12px;
-  color: var(--text-muted, var(--text));
-  opacity: 0.7;
-  white-space: nowrap;
-}

--- a/apps/web/src/components/WorkingDirPicker.tsx
+++ b/apps/web/src/components/WorkingDirPicker.tsx
@@ -195,34 +195,36 @@ export function WorkingDirPicker({
             <span>{workingDir ? t('homeWorkingDir.replace') : t('homeWorkingDir.pick')}</span>
           </button>
 
-          <div
-            className={styles.submenuRow}
-            onMouseEnter={() => setRecentOpen(true)}
-            onMouseLeave={() => setRecentOpen(false)}
-          >
-            <button
-              type="button"
-              role="menuitem"
-              className={styles.item}
-              aria-haspopup="menu"
-              aria-expanded={recentOpen}
-              data-testid="working-dir-recent"
-              onClick={() => setRecentOpen((v) => !v)}
+          {/* The submenu only exists when there is something to list: with no
+              recent folders it opened onto a faint empty-state line, which
+              read as a broken row rather than a menu (per product: 没有最近
+              使用的目录时不显示该项). */}
+          {recentDirs.length > 0 ? (
+            <div
+              className={styles.submenuRow}
+              onMouseEnter={() => setRecentOpen(true)}
+              onMouseLeave={() => setRecentOpen(false)}
             >
-              <Icon name="history" size={14} className={styles.itemIcon} />
-              <span>{t('homeWorkingDir.recent')}</span>
-              <Icon name="chevron-right" size={14} className={styles.itemChevron} />
-            </button>
-            {recentOpen ? (
-              <div
-                className={`${styles.flyout}${placement === 'up' ? ` ${styles.flyoutUp}` : ''}`}
-                role="menu"
-                data-testid="working-dir-recent-list"
+              <button
+                type="button"
+                role="menuitem"
+                className={styles.item}
+                aria-haspopup="menu"
+                aria-expanded={recentOpen}
+                data-testid="working-dir-recent"
+                onClick={() => setRecentOpen((v) => !v)}
               >
-                {recentDirs.length === 0 ? (
-                  <div className={styles.empty}>{t('homeWorkingDir.recentEmpty')}</div>
-                ) : (
-                  recentDirs.map((dir) => (
+                <Icon name="history" size={14} className={styles.itemIcon} />
+                <span>{t('homeWorkingDir.recent')}</span>
+                <Icon name="chevron-right" size={14} className={styles.itemChevron} />
+              </button>
+              {recentOpen ? (
+                <div
+                  className={`${styles.flyout}${placement === 'up' ? ` ${styles.flyoutUp}` : ''}`}
+                  role="menu"
+                  data-testid="working-dir-recent-list"
+                >
+                  {recentDirs.map((dir) => (
                     <button
                       key={dir}
                       type="button"
@@ -238,11 +240,11 @@ export function WorkingDirPicker({
                       <span className={styles.recentName}>{basename(dir)}</span>
                       <span className={styles.recentPath}>{dir}</span>
                     </button>
-                  ))
-                )}
-              </div>
-            ) : null}
-          </div>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
 
           {onReferenceProject || onLinkLocalCode ? (
             <div className={styles.divider} role="separator" />

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1000,7 +1000,6 @@ export const ar: Dict = {
   'homeWorkingDir.pick': 'Choose folder',
   'homeWorkingDir.replace': 'Change working directory',
   'homeWorkingDir.recent': 'Recent folders',
-  'homeWorkingDir.recentEmpty': 'No recent folders',
   'homeWorkingDir.clear': 'Remove working directory',
   'homeWorkingDir.hint': 'Let the agent read this local folder (not imported into Design Files)',
   'homeWorkingDir.missing': 'This working folder no longer exists — pick another',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -1000,7 +1000,6 @@ export const de: Dict = {
   'homeWorkingDir.pick': 'Choose folder',
   'homeWorkingDir.replace': 'Change working directory',
   'homeWorkingDir.recent': 'Recent folders',
-  'homeWorkingDir.recentEmpty': 'No recent folders',
   'homeWorkingDir.clear': 'Remove working directory',
   'homeWorkingDir.hint': 'Let the agent read this local folder (not imported into Design Files)',
   'homeWorkingDir.missing': 'This working folder no longer exists — pick another',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1000,7 +1000,6 @@ export const en: Dict = {
   'homeWorkingDir.pick': 'Choose folder',
   'homeWorkingDir.replace': 'Change working directory',
   'homeWorkingDir.recent': 'Recent folders',
-  'homeWorkingDir.recentEmpty': 'No recent folders',
   'homeWorkingDir.clear': 'Remove working directory',
   'homeWorkingDir.hint': 'Let the agent read this local folder (not imported into Design Files)',
   'homeWorkingDir.missing': 'This working folder no longer exists — pick another',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -1000,7 +1000,6 @@ export const esES: Dict = {
   'homeWorkingDir.pick': 'Choose folder',
   'homeWorkingDir.replace': 'Change working directory',
   'homeWorkingDir.recent': 'Recent folders',
-  'homeWorkingDir.recentEmpty': 'No recent folders',
   'homeWorkingDir.clear': 'Remove working directory',
   'homeWorkingDir.hint': 'Let the agent read this local folder (not imported into Design Files)',
   'homeWorkingDir.missing': 'This working folder no longer exists — pick another',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1000,7 +1000,6 @@ export const fa: Dict = {
   'homeWorkingDir.pick': 'Choose folder',
   'homeWorkingDir.replace': 'Change working directory',
   'homeWorkingDir.recent': 'Recent folders',
-  'homeWorkingDir.recentEmpty': 'No recent folders',
   'homeWorkingDir.clear': 'Remove working directory',
   'homeWorkingDir.hint': 'Let the agent read this local folder (not imported into Design Files)',
   'homeWorkingDir.missing': 'This working folder no longer exists — pick another',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -1000,7 +1000,6 @@ export const fr: Dict = {
   'homeWorkingDir.pick': 'Choisir un dossier',
   'homeWorkingDir.replace': 'Changer de dossier de travail',
   'homeWorkingDir.recent': 'Dossiers récents',
-  'homeWorkingDir.recentEmpty': 'Aucun dossier récent',
   'homeWorkingDir.clear': 'Retirer le dossier de travail',
   'homeWorkingDir.hint': 'Autoriser l’agent à lire ce dossier local (sans l’importer dans les fichiers de design)',
   'homeWorkingDir.missing': 'Ce dossier de travail n’existe plus — choisissez-en un autre',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1000,7 +1000,6 @@ export const hu: Dict = {
   'homeWorkingDir.pick': 'Choose folder',
   'homeWorkingDir.replace': 'Change working directory',
   'homeWorkingDir.recent': 'Recent folders',
-  'homeWorkingDir.recentEmpty': 'No recent folders',
   'homeWorkingDir.clear': 'Remove working directory',
   'homeWorkingDir.hint': 'Let the agent read this local folder (not imported into Design Files)',
   'homeWorkingDir.missing': 'This working folder no longer exists — pick another',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1000,7 +1000,6 @@ export const id: Dict = {
   'homeWorkingDir.pick': 'Choose folder',
   'homeWorkingDir.replace': 'Change working directory',
   'homeWorkingDir.recent': 'Recent folders',
-  'homeWorkingDir.recentEmpty': 'No recent folders',
   'homeWorkingDir.clear': 'Remove working directory',
   'homeWorkingDir.hint': 'Let the agent read this local folder (not imported into Design Files)',
   'homeWorkingDir.missing': 'This working folder no longer exists — pick another',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -1000,7 +1000,6 @@ export const it: Dict = {
   'homeWorkingDir.pick': 'Choose folder',
   'homeWorkingDir.replace': 'Change working directory',
   'homeWorkingDir.recent': 'Recent folders',
-  'homeWorkingDir.recentEmpty': 'No recent folders',
   'homeWorkingDir.clear': 'Remove working directory',
   'homeWorkingDir.hint': 'Let the agent read this local folder (not imported into Design Files)',
   'homeWorkingDir.missing': 'This working folder no longer exists — pick another',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -1000,7 +1000,6 @@ export const ja: Dict = {
   'homeWorkingDir.pick': 'Choose folder',
   'homeWorkingDir.replace': 'Change working directory',
   'homeWorkingDir.recent': 'Recent folders',
-  'homeWorkingDir.recentEmpty': 'No recent folders',
   'homeWorkingDir.clear': 'Remove working directory',
   'homeWorkingDir.hint': 'Let the agent read this local folder (not imported into Design Files)',
   'homeWorkingDir.missing': 'This working folder no longer exists — pick another',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1000,7 +1000,6 @@ export const ko: Dict = {
   'homeWorkingDir.pick': 'Choose folder',
   'homeWorkingDir.replace': 'Change working directory',
   'homeWorkingDir.recent': 'Recent folders',
-  'homeWorkingDir.recentEmpty': 'No recent folders',
   'homeWorkingDir.clear': 'Remove working directory',
   'homeWorkingDir.hint': 'Let the agent read this local folder (not imported into Design Files)',
   'homeWorkingDir.missing': 'This working folder no longer exists — pick another',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1000,7 +1000,6 @@ export const pl: Dict = {
   'homeWorkingDir.pick': 'Choose folder',
   'homeWorkingDir.replace': 'Change working directory',
   'homeWorkingDir.recent': 'Recent folders',
-  'homeWorkingDir.recentEmpty': 'No recent folders',
   'homeWorkingDir.clear': 'Remove working directory',
   'homeWorkingDir.hint': 'Let the agent read this local folder (not imported into Design Files)',
   'homeWorkingDir.missing': 'This working folder no longer exists — pick another',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1000,7 +1000,6 @@ export const ptBR: Dict = {
   'homeWorkingDir.pick': 'Choose folder',
   'homeWorkingDir.replace': 'Change working directory',
   'homeWorkingDir.recent': 'Recent folders',
-  'homeWorkingDir.recentEmpty': 'No recent folders',
   'homeWorkingDir.clear': 'Remove working directory',
   'homeWorkingDir.hint': 'Let the agent read this local folder (not imported into Design Files)',
   'homeWorkingDir.missing': 'This working folder no longer exists — pick another',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1000,7 +1000,6 @@ export const ru: Dict = {
   'homeWorkingDir.pick': 'Выбрать папку',
   'homeWorkingDir.replace': 'Сменить рабочую папку',
   'homeWorkingDir.recent': 'Недавние папки',
-  'homeWorkingDir.recentEmpty': 'Недавних папок нет',
   'homeWorkingDir.clear': 'Убрать рабочую папку',
   'homeWorkingDir.hint': 'Разрешите агенту читать эту локальную папку (она не импортируется в Design Files)',
   'homeWorkingDir.missing': 'Эта рабочая папка больше не существует — выберите другую',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -1000,7 +1000,6 @@ export const th: Dict = {
   'homeWorkingDir.pick': 'Choose folder',
   'homeWorkingDir.replace': 'Change working directory',
   'homeWorkingDir.recent': 'Recent folders',
-  'homeWorkingDir.recentEmpty': 'No recent folders',
   'homeWorkingDir.clear': 'Remove working directory',
   'homeWorkingDir.hint': 'Let the agent read this local folder (not imported into Design Files)',
   'homeWorkingDir.missing': 'This working folder no longer exists — pick another',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1000,7 +1000,6 @@ export const tr: Dict = {
   'homeWorkingDir.pick': 'Choose folder',
   'homeWorkingDir.replace': 'Change working directory',
   'homeWorkingDir.recent': 'Recent folders',
-  'homeWorkingDir.recentEmpty': 'No recent folders',
   'homeWorkingDir.clear': 'Remove working directory',
   'homeWorkingDir.hint': 'Let the agent read this local folder (not imported into Design Files)',
   'homeWorkingDir.missing': 'This working folder no longer exists — pick another',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1000,7 +1000,6 @@ export const uk: Dict = {
   'homeWorkingDir.pick': 'Choose folder',
   'homeWorkingDir.replace': 'Change working directory',
   'homeWorkingDir.recent': 'Recent folders',
-  'homeWorkingDir.recentEmpty': 'No recent folders',
   'homeWorkingDir.clear': 'Remove working directory',
   'homeWorkingDir.hint': 'Let the agent read this local folder (not imported into Design Files)',
   'homeWorkingDir.missing': 'This working folder no longer exists — pick another',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1011,7 +1011,6 @@ export const zhCN: Dict = {
   "homeWorkingDir.pick": "选择目录",
   "homeWorkingDir.replace": "修改工作目录",
   "homeWorkingDir.recent": "最近使用的目录",
-  "homeWorkingDir.recentEmpty": "暂无最近使用的目录",
   "homeWorkingDir.clear": "移除工作目录",
   "homeWorkingDir.hint": "让 Agent 可读取该本地目录（不会导入到 Design Files）",
   "homeWorkingDir.missing": "该工作目录已不存在，请重新选择",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1013,7 +1013,6 @@ export const zhTW: Dict = {
   "homeWorkingDir.pick": "選擇目錄",
   "homeWorkingDir.replace": "修改工作目錄",
   "homeWorkingDir.recent": "最近使用的目錄",
-  "homeWorkingDir.recentEmpty": "尚無最近使用的目錄",
   "homeWorkingDir.clear": "移除工作目錄",
   "homeWorkingDir.hint": "讓 Agent 可讀取該本機目錄（不會匯入 Design Files）",
   "homeWorkingDir.missing": "該工作目錄已不存在，請重新選擇",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -1393,7 +1393,6 @@ export interface Dict {
   'homeWorkingDir.pick': string;
   'homeWorkingDir.replace': string;
   'homeWorkingDir.recent': string;
-  'homeWorkingDir.recentEmpty': string;
   'homeWorkingDir.clear': string;
   'homeWorkingDir.hint': string;
   'homeWorkingDir.missing': string;

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -2735,11 +2735,15 @@
   background: transparent;
   border-color: transparent;
 }
-.staged-preview-trigger img {
+/* Videos ride the same thumbnail box as stills — a staged .mp4 shows its own
+   first frame here (per product: 视频类默认展示可打开预览). */
+.staged-preview-trigger img,
+.staged-preview-trigger video {
   flex: 0 0 12px;
   width: 12px;
   height: 12px;
   border-radius: 3px;
+  object-fit: cover;
 }
 /* Image attachments mirror the home composer's chips: a 36px thumbnail with
    no filename text (the name lives in the tooltip / preview modal). */
@@ -2753,7 +2757,8 @@
 .staged-chip--image-file .staged-preview-trigger {
   flex: 0 0 auto;
 }
-.staged-chip--image-file .staged-preview-trigger img {
+.staged-chip--image-file .staged-preview-trigger img,
+.staged-chip--image-file .staged-preview-trigger video {
   flex: 0 0 var(--spacing-36, 36px);
   width: var(--spacing-36, 36px);
   height: var(--spacing-36, 36px);
@@ -2807,7 +2812,24 @@
   font-size: 13px;
   font-weight: 600;
 }
-.staged-preview-card > img {
+/* The close control is a circle (per product: 换成纯圆角). Left to the button
+   primitive it was a wide rounded rectangle — 36px tall, `0 16px` of padding
+   around a 14px glyph, and the small square radius. Pinning the width to the
+   height and dropping the padding is what turns the pill into a true circle;
+   `flex: 0 0 auto` keeps the long filename beside it from squashing it back
+   into an oval. */
+.staged-preview-head .icon-only {
+  flex: 0 0 auto;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border-radius: var(--radius-pill, 999px);
+}
+/* One box for both: a staged video opens in this same card as a player (the
+   home composer previews video now, not only stills), and it has to be bound
+   by the card exactly the way an image is. */
+.staged-preview-card > img,
+.staged-preview-card > video {
   display: block;
   max-width: 100%;
   max-height: min(70vh, 640px);

--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -633,15 +633,16 @@
    so the SECOND line would still be pushed right — so `.is-chip-inline` takes
    the row out of flow and indents just the first line past it, using the two
    custom props HomeHero measures (`--home-hero-chip-w`, and
-   `--home-hero-chip-text-left`, the chip's border+padding). Also owns the
-   prompt's scroll (moved off `.composer-input-editor`) so the out-of-flow chip
-   scrolls together with the text it leads. */
+   `--home-hero-chip-text-left`, the chip's border+padding).
+   It does NOT scroll: the attachment band above the prompt is its child, and a
+   scroller here carried that band away with the text — an attachment the user
+   staged has to stay in sight while they write about it. The scroll sits on
+   `.home-hero__prompt-surface` below, which holds the prompt and the lead chip
+   and nothing else. */
 .home-hero__prompt-flow {
   position: relative;
   display: block;
   min-width: 0;
-  max-height: var(--home-hero-prompt-max-height, 180px);
-  overflow-y: auto;
 }
 .home-hero__active {
   display: flex;
@@ -666,7 +667,9 @@
   display: none;
 }
 /* Staged files + the remaining context chips keep their own band above the
-   prompt; only the template chip below leads the text. */
+   prompt; only the template chip below leads the text. The band sits OUTSIDE
+   the prompt's scroller (see `.home-hero__prompt-surface`), so a long prompt
+   scrolls underneath it and what the user attached stays on screen. */
 .home-hero__prompt-flow > .home-hero__active-band {
   margin-bottom: var(--spacing-8);
 }
@@ -740,8 +743,14 @@
 /* The template chip's own line, anchored to the prompt surface (NOT the flow —
    the attachment row above must be able to push it down). Stays in flow when
    the inline treatment is off, so it simply sits above the text. */
+/* The prompt's own scroller. `position: relative` is load-bearing twice: it is
+   the containing block for the out-of-flow lead chip, and because that
+   containing block IS this scroller, the chip scrolls with the text it leads
+   instead of pinning itself to the top of the box. */
 .home-hero__prompt-surface {
   position: relative;
+  max-height: var(--home-hero-prompt-max-height, 180px);
+  overflow-y: auto;
 }
 .home-hero__lead-chip {
   display: flex;
@@ -809,8 +818,8 @@
   display: block;
   min-width: 0;
 }
-/* Scroll moved to .home-hero__prompt-flow (above) — keeping it here would fence
-   the text off from the float in its own formatting context. */
+/* Scroll moved up to `.home-hero__prompt-surface` — keeping it here would fence
+   the text off from the out-of-flow chip in its own formatting context. */
 .home-hero__prompt-flow .composer-input-editor {
   max-height: none;
   overflow: visible;

--- a/apps/web/src/styles/home/plus-menu.css
+++ b/apps/web/src/styles/home/plus-menu.css
@@ -11,6 +11,19 @@
   position: relative;
   display: inline-flex;
 }
+/* Typography ladder stand-in for the popup — same reason as the block at the
+   top of home/home-hero.css: the app-wide `body` / `button { font-weight: 600 }`
+   default ships with the rest of the entry refresh, and until then each entry
+   surface inherits it locally. The popup is portaled to document.body, so the
+   hero's and the composer's scoped ladders never reach it and its rows fell
+   back to the 400/500 the app still defaults to. `:where()` keeps the button
+   rule at element specificity, exactly where primitives.css's own sits, so a
+   control that names its weight still wins. Drop this block when the global
+   ladder lands. */
+.plus-menu__popup,
+:where(.plus-menu__popup) button {
+  font-weight: 600;
+}
 .plus-menu__trigger {
   position: relative;
   /* The base `button.icon-btn` only sets padding/font-size, so the inline SVG

--- a/apps/web/tests/components/ChatComposer.search.test.tsx
+++ b/apps/web/tests/components/ChatComposer.search.test.tsx
@@ -3,7 +3,7 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { ChatComposer } from '../../src/components/ChatComposer';
+import { ChatComposer, STAGE_ATTACHMENT_EVENT } from '../../src/components/ChatComposer';
 import { ANNOTATION_EVENT } from '../../src/components/PreviewDrawOverlay';
 import { uploadProjectFiles } from '../../src/providers/registry';
 import { readExpandedIndexCss } from '../helpers/read-expanded-css';
@@ -525,6 +525,42 @@ describe('ChatComposer /search command', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Close' }));
     expect(screen.queryByRole('dialog', { name: longName })).toBeNull();
+  });
+
+  it.each([
+    { name: 'Company logo', path: 'uploads/chat-image.png', kind: 'image', element: 'img' },
+    { name: 'Pasted screenshot', path: 'uploads/capture', kind: 'image', element: 'img' },
+    { name: 'Brand vector', path: 'uploads/logo.svg', kind: 'file', element: 'img' },
+    { name: 'Walkthrough', path: 'uploads/demo.mp4', kind: 'file', element: 'video' },
+    { name: 'original.mp4', path: 'uploads/opaque', kind: 'file', element: 'video' },
+  ] as const)('previews $name using attachment metadata in both chip and card', ({ element, ...attachment }) => {
+    render(
+      <ChatComposer
+        projectId="project-1"
+        projectFiles={[]}
+        streaming={false}
+        onEnsureProject={async () => 'project-1'}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+      />,
+    );
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(STAGE_ATTACHMENT_EVENT, {
+        detail: { attachments: [attachment] },
+      }));
+    });
+
+    const trigger = screen.getByRole('button', { name: `Preview ${attachment.name}` });
+    const url = `/api/projects/project-1/raw/${attachment.path}`;
+    expect(trigger.querySelector(element)?.getAttribute('src')).toContain(url);
+    fireEvent.click(trigger);
+    const dialog = screen.getByRole('dialog', { name: attachment.name });
+    const media = dialog.querySelector(`.staged-preview-card > ${element}`);
+    expect(media?.getAttribute('src')).toContain(url);
+    if (element === 'video') expect(media?.hasAttribute('controls')).toBe(true);
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(screen.queryByRole('dialog', { name: attachment.name })).toBeNull();
   });
 
   it('keeps staged image preview modal styling available', () => {

--- a/apps/web/tests/components/DesignSystemPicker.test.tsx
+++ b/apps/web/tests/components/DesignSystemPicker.test.tsx
@@ -172,6 +172,31 @@ describe('DesignSystemPicker', () => {
     expect(screen.queryByTestId('project-ds-picker-popover')).toBeNull();
   });
 
+  // The palette trigger and the "+" trigger share one row on Home. The "+"
+  // shows the app's own `od-tooltip` bubble; the palette used to show the
+  // browser's native `title`, so the two controls hovered in two styles.
+  it('names the unselected home trigger through the app tooltip, not a native title', () => {
+    renderPicker({ variant: 'home', selectedId: null }, 'en');
+
+    const trigger = screen.getByTestId('home-hero-design-system-trigger');
+    expect(trigger.className).toContain('is-icon-only');
+    expect(trigger.className).toContain('od-tooltip');
+    expect(trigger.getAttribute('data-tooltip')).toBe('Design system');
+    expect(trigger.getAttribute('aria-label')).toBe('Design system');
+    expect(trigger.hasAttribute('title')).toBe(false);
+  });
+
+  it('drops the tooltip once the picked system is named on the pill', () => {
+    renderPicker({ variant: 'home' }, 'en');
+
+    const trigger = screen.getByTestId('home-hero-design-system-trigger');
+    expect(trigger.className).toContain('is-selected');
+    expect(trigger.className).not.toContain('od-tooltip');
+    expect(trigger.hasAttribute('data-tooltip')).toBe(false);
+    expect(trigger.hasAttribute('title')).toBe(false);
+    expect(trigger.textContent).toContain('Editorial Noir');
+  });
+
   it('uses localized picker copy', async () => {
     renderPicker({}, 'fr');
 

--- a/apps/web/tests/components/FileTypeIcon.test.tsx
+++ b/apps/web/tests/components/FileTypeIcon.test.tsx
@@ -1,0 +1,87 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import {
+  FileTypeIcon,
+  fileTypePreviewKind,
+  previewFallbackIcon,
+  resolveFileTypeIcon,
+} from '../../src/components/FileTypeIcon';
+
+/**
+ * One table answers "what does a staged file lead with?" for both composers.
+ * The daemon only splits attachments into image/file, so a video arrives as
+ * 'file' — the name has to decide, with the MIME type as a fallback only.
+ */
+describe('fileTypePreviewKind', () => {
+  it('routes rasters, vectors and videos to a thumbnail and documents to a glyph', () => {
+    expect(fileTypePreviewKind('hero.png')).toBe('image');
+    expect(fileTypePreviewKind('logo.svg')).toBe('vector');
+    expect(fileTypePreviewKind('walkthrough.mp4')).toBe('video');
+    expect(fileTypePreviewKind('design.fig')).toBeNull();
+    expect(fileTypePreviewKind('index.html')).toBeNull();
+  });
+
+  it('is case-insensitive on the extension', () => {
+    expect(fileTypePreviewKind('HERO.PNG')).toBe('image');
+    expect(fileTypePreviewKind('Clip.MOV')).toBe('video');
+  });
+
+  it('falls back to the MIME type only when the name has no usable extension', () => {
+    expect(fileTypePreviewKind('image', 'image/png')).toBe('image');
+    expect(fileTypePreviewKind('image', 'image/svg+xml')).toBe('vector');
+    expect(fileTypePreviewKind('clip', 'video/webm')).toBe('video');
+    // A known document extension wins even when the browser guesses otherwise.
+    expect(fileTypePreviewKind('index.html', 'image/png')).toBeNull();
+  });
+});
+
+describe('resolveFileTypeIcon', () => {
+  it('maps the product-named types to their own mark', () => {
+    expect(resolveFileTypeIcon('design.fig')).toBe('figma');
+    expect(resolveFileTypeIcon('index.html')).toBe('code');
+    expect(resolveFileTypeIcon('brief.pdf')).toBe('pdf');
+    expect(resolveFileTypeIcon('sheet.xlsx')).toBe('excel');
+    expect(resolveFileTypeIcon('scene.glb')).toBe('model3d');
+    expect(resolveFileTypeIcon('notes.md')).toBe('markdown');
+  });
+
+  it('consults the MIME type when the extension is unknown', () => {
+    expect(resolveFileTypeIcon('track', 'audio/mpeg')).toBe('audio');
+    expect(resolveFileTypeIcon('archive', 'application/zip')).toBe('zip');
+    expect(resolveFileTypeIcon('mystery.bin')).toBe('unknown');
+  });
+});
+
+describe('previewFallbackIcon', () => {
+  it('keeps the GIF mark for a raster GIF whose thumbnail could not be made', () => {
+    expect(previewFallbackIcon('image', 'loop.gif')).toBe('gif');
+    expect(previewFallbackIcon('image', 'hero.png')).toBe('unknown');
+    expect(previewFallbackIcon('video', 'clip.mp4')).toBe('unknown');
+    expect(previewFallbackIcon('vector', 'logo.svg')).toBe('unknown');
+  });
+});
+
+describe('FileTypeIcon', () => {
+  it('renders the Figma mark with its brand fills at the requested size', () => {
+    const markup = renderToStaticMarkup(<FileTypeIcon name="figma" size={20} />);
+    expect(markup).toMatch(/^<svg\b/);
+    expect(markup).toContain('width="20"');
+    expect(markup).toContain('height="20"');
+    expect(markup).toContain('fill="#0ACF83"');
+    expect(markup).toContain('aria-hidden="true"');
+  });
+
+  it('gives every gradient mark its own gradient id so two chips do not share one', () => {
+    const markup = renderToStaticMarkup(
+      <>
+        <FileTypeIcon name="font" />
+        <FileTypeIcon name="font" />
+      </>,
+    );
+    const ids = [...markup.matchAll(/<linearGradient id="([^"]+)"/g)].map((m) => m[1]);
+    expect(ids).toHaveLength(2);
+    expect(new Set(ids).size).toBe(2);
+    for (const id of ids) expect(markup).toContain(`fill="url(#${id})"`);
+  });
+});

--- a/apps/web/tests/components/WorkingDirPicker.test.tsx
+++ b/apps/web/tests/components/WorkingDirPicker.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { WorkingDirPicker } from '../../src/components/WorkingDirPicker';
+import { I18nProvider, type Locale } from '../../src/i18n';
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderPicker(overrides: Partial<ComponentProps<typeof WorkingDirPicker>> = {}) {
+  const props: ComponentProps<typeof WorkingDirPicker> = {
+    workingDir: null,
+    recentDirs: [],
+    onPickDirectory: vi.fn(),
+    onSelectRecent: vi.fn(),
+    ...overrides,
+  };
+  render(
+    <I18nProvider initial={'en' as Locale}>
+      <WorkingDirPicker {...props} />
+    </I18nProvider>,
+  );
+  return props;
+}
+
+describe('WorkingDirPicker recent folders submenu', () => {
+  // With nothing to list, the submenu row used to render anyway and open onto
+  // a faint "No recent folders" line — a menu whose only content was that it
+  // was empty.
+  it('does not render the submenu row when there are no recent folders', () => {
+    renderPicker();
+
+    fireEvent.click(screen.getByTestId('working-dir-trigger'));
+    expect(screen.getByTestId('working-dir-panel')).toBeTruthy();
+    expect(screen.getByTestId('working-dir-pick')).toBeTruthy();
+    expect(screen.queryByTestId('working-dir-recent')).toBeNull();
+    expect(screen.queryByTestId('working-dir-recent-list')).toBeNull();
+  });
+
+  it('lists the recent folders in the submenu once there are some', () => {
+    const props = renderPicker({ recentDirs: ['/Users/me/work/site', '/Users/me/work/deck'] });
+
+    fireEvent.click(screen.getByTestId('working-dir-trigger'));
+    const row = screen.getByTestId('working-dir-recent');
+    expect(row.textContent).toContain('Recent folders');
+
+    fireEvent.click(row);
+    const list = screen.getByTestId('working-dir-recent-list');
+    const items = list.querySelectorAll('[role="menuitem"]');
+    expect(items).toHaveLength(2);
+    expect(items[0]?.textContent).toContain('site');
+    expect(items[1]?.textContent).toContain('deck');
+
+    fireEvent.click(items[1]!);
+    expect(props.onSelectRecent).toHaveBeenCalledWith('/Users/me/work/deck');
+    expect(screen.queryByTestId('working-dir-panel')).toBeNull();
+  });
+});

--- a/apps/web/tests/styles/figma-import-modal.test.ts
+++ b/apps/web/tests/styles/figma-import-modal.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const modalCss = readFileSync(
+  new URL('../../src/components/FigmaImportModal.module.css', import.meta.url),
+  'utf8',
+);
+
+function cssDeclarations(selector: string): string {
+  const blocks: string[] = [];
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  const cssWithoutComments = modalCss.replace(/\/\*[\s\S]*?\*\//g, '');
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  if (blocks.length === 0) throw new Error(`Missing CSS block for ${selector}`);
+  return blocks.join('\n');
+}
+
+const declaration = (property: string, value: string) =>
+  new RegExp(`(?:^|[;\\n])\\s*${property}:\\s*${value}\\s*;`);
+
+/**
+ * The modal's chrome is styled through a CSS Module, but the global element
+ * rules in styles/primitives.css still reach every `button` and `textarea`
+ * inside it. Two of those defaults broke the modal: `button { padding: 0 16px }`
+ * left a 34px close button with no room for its glyph (the × rendered as an
+ * empty box), and `textarea { width: 100% }` plus the notes field's own side
+ * margins pushed the field past the modal's clipped edge.
+ */
+describe('FigmaImportModal chrome', () => {
+  it('gives the close control room for its glyph and rounds it into a circle', () => {
+    const close = cssDeclarations('.closeBtn');
+    expect(close).toMatch(declaration('padding', '0'));
+    expect(close).toMatch(declaration('width', '34px'));
+    expect(close).toMatch(declaration('height', '34px'));
+    expect(close).toMatch(declaration('border-radius', 'var\\(--radius-pill\\)'));
+  });
+
+  it('renders the mode tabs and footer actions as pills', () => {
+    expect(cssDeclarations('.tabs')).toMatch(declaration('border-radius', 'var\\(--radius-pill\\)'));
+    expect(cssDeclarations('.tab')).toMatch(declaration('border-radius', 'var\\(--radius-pill\\)'));
+    expect(cssDeclarations('.foot button')).toMatch(
+      declaration('border-radius', 'var\\(--radius-pill\\)'),
+    );
+  });
+
+  it('keeps the notes field inside the modal content width', () => {
+    const notes = cssDeclarations('.notes');
+    expect(notes).toMatch(declaration('margin', '0 16px'));
+    expect(notes).toMatch(declaration('width', 'auto'));
+  });
+
+  it('tints the backdrop with the shared scrim token', () => {
+    expect(cssDeclarations('.backdrop')).toMatch(
+      declaration('background', 'var\\(--scrim-tint\\)'),
+    );
+  });
+});

--- a/apps/web/tests/styles/home-hero-attachment-band.test.ts
+++ b/apps/web/tests/styles/home-hero-attachment-band.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const homeHeroCss = readFileSync(
+  new URL('../../src/styles/home/home-hero.css', import.meta.url),
+  'utf8',
+);
+
+function cssDeclarations(selector: string): string {
+  const blocks: string[] = [];
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  const cssWithoutComments = homeHeroCss.replace(/\/\*[\s\S]*?\*\//g, '');
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  if (blocks.length === 0) throw new Error(`Missing CSS block for ${selector}`);
+  return blocks.join('\n');
+}
+
+/**
+ * The staged-attachment band and the prompt sit in the same block
+ * (`.home-hero__prompt-flow`), and only ONE of them may scroll. When the flow
+ * owned the scroll, a prompt long enough to overflow carried the band up and
+ * out of the card with it — the user lost sight of the file they had just
+ * attached exactly while they were writing about it.
+ */
+describe('HomeHero staged attachment band', () => {
+  it('scrolls the prompt, never the band above it', () => {
+    const flow = cssDeclarations('.home-hero__prompt-flow');
+    expect(flow).not.toMatch(/overflow-y:\s*(auto|scroll)/);
+    expect(flow).not.toMatch(/max-height:/);
+
+    const surface = cssDeclarations('.home-hero__prompt-surface');
+    expect(surface).toMatch(/(?:^|[;\n])\s*overflow-y:\s*auto\s*;/);
+    expect(surface).toMatch(/max-height:\s*var\(--home-hero-prompt-max-height/);
+  });
+
+  // The lead chip is taken out of flow to sit beside the prompt's first line.
+  // Its containing block has to BE the scroller, or it would pin itself to the
+  // top of the box while the line it leads scrolled away underneath.
+  it('keeps the out-of-flow lead chip inside the prompt scroller', () => {
+    expect(cssDeclarations('.home-hero__prompt-surface')).toMatch(
+      /(?:^|[;\n])\s*position:\s*relative\s*;/,
+    );
+    expect(cssDeclarations('.home-hero__prompt-flow.is-chip-inline .home-hero__lead-chip')).toMatch(
+      /(?:^|[;\n])\s*position:\s*absolute\s*;/,
+    );
+  });
+});

--- a/apps/web/tests/styles/plus-menu-typography.test.ts
+++ b/apps/web/tests/styles/plus-menu-typography.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const plusMenuCss = readFileSync(
+  new URL('../../src/styles/home/plus-menu.css', import.meta.url),
+  'utf8',
+);
+
+function cssDeclarations(selector: string): string {
+  const blocks: string[] = [];
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  const cssWithoutComments = plusMenuCss.replace(/\/\*[\s\S]*?\*\//g, '');
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  if (blocks.length === 0) throw new Error(`Missing CSS block for ${selector}`);
+  return blocks.join('\n');
+}
+
+/**
+ * The entry surfaces were designed on an app-wide 600 text weight that has
+ * not shipped yet; until it does, `.home-hero` and `.composer` each carry the
+ * ladder locally. The "+" menu popup renders through a portal on
+ * document.body, outside both of those scopes, so it needs the same stand-in
+ * or its rows read lighter than the trigger that opened them.
+ */
+describe('ComposerPlusMenu popup typography', () => {
+  it('carries the 600 ladder on the portaled popup', () => {
+    expect(cssDeclarations('.plus-menu__popup')).toMatch(
+      /(?:^|[;\n])\s*font-weight:\s*600\s*;/,
+    );
+  });
+
+  it('keeps the button rule at element specificity so named weights still win', () => {
+    expect(cssDeclarations(':where(.plus-menu__popup) button')).toMatch(
+      /(?:^|[;\n])\s*font-weight:\s*600\s*;/,
+    );
+  });
+
+  it('lets the rows inherit that weight instead of naming a lighter one', () => {
+    expect(cssDeclarations('.plus-menu__item')).toMatch(/(?:^|[;\n])\s*font:\s*inherit\s*;/);
+    expect(cssDeclarations('.plus-menu__item')).not.toMatch(/font-weight:/);
+  });
+});


### PR DESCRIPTION
## Why

Acceptance of the merged Home hero / composer refresh (#7731, Plane OPEND-2553 PR-B) against the Demo branch (#7635) turned up a set of visible gaps that the product team logged in 飞书 and Plane. This PR closes the ones that are already verified in code and by reproduction, so the entry surface matches what was accepted on the Demo:

- OPEND-2638 (飞书#5): the staged attachment band scrolls out of the card with a long prompt.
- OPEND-2635 (飞书#2) / OPEND-2637 (飞书#4): staged files show a generic chip instead of a per-type thumbnail or mark; the preview card's close control is an oval pill rather than a circle.
- OPEND-2636 (飞书#3, also closes OPEND-2616): the Figma import modal's close × is invisible, the notes field is wider than the modal, and the tabs / buttons are not pills.
- OPEND-2634 (飞书#1): the composer "+" menu text reads lighter than on the Demo.
- OPEND-2618: the design-system trigger shows a native browser tooltip while the "+" trigger beside it shows the app bubble.
- OPEND-2620: the "Recent folders" submenu renders even when there are no recent folders.

Two of the items port Demo commits from #7635 (`2981a2025`, `d3b251de0`); the Figma modal item ports the Demo's `FigmaImportModal.module.css` and additionally fixes the notes width, which is broken on the Demo too. The remaining three are acceptance follow-ups the Demo does not carry.

Root causes worth knowing: the global `button { padding: 0 16px }` and `input, textarea { width: 100% }` rules in `styles/primitives.css` reach into the CSS-Module modal and collapse the 34px close button's content width to 0 (so the 18px glyph rendered at 0px wide) and push the notes textarea 32px past the modal edge. The "+" menu popup is portaled to `document.body`, so the interim `font-weight: 600` ladder that PR-B scoped to `.home-hero` and `.composer` never reached it.

## What users will see

- With one or more files attached, a long prompt scrolls underneath the attachment band; the files stay in view while you write about them.
- Staged `.fig`, `.html`, `.pdf`, `.xlsx`, `.glb` … files lead with their own mark (Figma, code, PDF, spreadsheet, 3D …); `.svg` and `.mp4` now show a real thumbnail (rendered vector / first frame) and open in the same preview card as images, where video plays with controls.
- The preview card's close control is a 36px circle.
- Import from Figma: the close × is visible in a round button; "Upload .fig / Figma URL" tabs and "Cancel / Import & build" are pills; the notes field fits inside the modal; the backdrop uses the shared scrim tint.
- The "+" menu rows read at the same weight as the composer (600) instead of lighter.
- Hovering the palette (design system) button on Home shows the same tooltip bubble as the "+" button. Once a system is picked, its name is on the pill and no bubble repeats it.
- The working-directory menu only shows "Recent folders" when there is at least one recent folder.

## Surface area

- [x] **UI** — Home hero composer (staged chips, preview card, "+" menu, design-system trigger, working-directory menu) and the Figma import modal in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — not applicable: no `/api/*` endpoint or payload changes; every item is presentation-only inside the web composer, so there is no capability for `od` to mirror
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — removed the now-unreferenced `homeWorkingDir.recentEmpty` key from `types.ts` and all 19 locales (no keys added)
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Each image is Before (`main` @ d4138ea8) | After (this branch) | Demo (`upstream/pr-7635-new` @ 7c9b4dbf), captured from three namespaced `tools-dev` runtimes with the same Playwright driver.

Plus menu weight (OPEND-2634) — main 400 → this PR 600, Demo 600:

![plus menu](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-b2/01-plus-menu.png)

Figma import modal (OPEND-2636 / 2616) — close glyph 0px → 18px wide, radii 8px/12px/4px → pill, notes 538px (clipped) → 506px inside a 540px modal. Note the Demo still clips the notes field on the right:

![figma modal](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-b2/02-figma-modal.png)

Staged file thumbnails (OPEND-2635) — `.fig` / `.html` lead with their own mark, `.svg` / `.mp4` / `.png` with a thumbnail that opens the preview:

![staged files](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-b2/03-staged-files.png)

Preview card close control (OPEND-2637) — 48×36 pill → 36×36 circle:

![preview card](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-b2/04-preview-card.png)

Long prompt with attachments (OPEND-2638) — on main the band's top edge measured at −207px (scrolled out of the card); after, it stays at the top of the card while `.home-hero__prompt-surface` scrolls:

![long prompt](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-b2/05-long-prompt.png)

Design-system trigger tooltip (OPEND-2618) — native `title` → `od-tooltip` bubble (the Demo still uses the native title here):

![ds tooltip](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-b2/06-ds-tooltip.png)

Working-directory menu without recents (OPEND-2620) — the "Recent folders" row and its "No recent folders" flyout are gone (the Demo still shows them):

![working dir](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-b2/07-working-dir-menu.png)

## Bug fix verification

Every item carries a spec that is red on `main` and green on this branch (all confirmed by running the spec against the `main` version of the file):

- OPEND-2638: `apps/web/tests/styles/home-hero-attachment-band.test.ts` — red on main (1 failed / 1 passed), green here.
- OPEND-2635 / 2637: `apps/web/tests/components/FileTypeIcon.test.tsx` — new module, 8 specs covering `.fig` / `.html` / `.svg` / `.mp4` / `.png` resolution, MIME fallbacks and unique gradient ids. The close-control geometry is pinned live above (36×36, radius 999px).
- OPEND-2636 / 2616: `apps/web/tests/styles/figma-import-modal.test.ts` — red on main (4 failed), green here.
- OPEND-2634: `apps/web/tests/styles/plus-menu-typography.test.ts` — red on main (missing block), green here; live measurement main 400 → 600 (Demo 600).
- OPEND-2618: `apps/web/tests/components/DesignSystemPicker.test.tsx` — two new specs for the home trigger's `od-tooltip` / `data-tooltip` / no `title`.
- OPEND-2620: `apps/web/tests/components/WorkingDirPicker.test.tsx` — red on main (1 failed / 1 passed), green here.

## Validation

- `pnpm install`, `pnpm guard`, `pnpm typecheck`, `pnpm --filter @open-design/web typecheck`, `pnpm --filter @open-design/e2e typecheck`, `pnpm i18n:check` — all pass.
- `pnpm --filter @open-design/web test` (full): `Test Files 685 passed (685)` · `Tests 7248 passed | 1 expected fail | 11 skipped (7260)`. Baseline on `main` (d4138ea8): `Test Files 680 passed (680)` · `Tests 7227 passed | 1 expected fail | 11 skipped (7239)` — +5 files / +21 specs, no regressions.
- Playwright: after the CI prebuild (`daemon build`, `desktop build`, `web build:sidecar`), run through `pnpm --filter @open-design/e2e exec playwright test` with `OD_PLAYWRIGHT_WORKERS=1`:
  - `ui/home-hero-rail.test.ts` + `ui/entry-chrome-flows.test.ts`: `52 passed, 7 failed`. The same 7 fail identically on `main` (d4138ea8) with the same prebuild (`entry-chrome-flows` 754 / 843 / 933 / 1464, `home-hero-rail` 747 / 1137 / 1533: Settings About updater, BYOK analytics code, rail collapse, real-project URL after auto-send, create-failure alert), so they are pre-existing and untouched by this PR.
  - `playwright.visual.config.ts` (`visual-entry`, `visual-navigation`, `visual-settings`, `visual-workspace`): `41 passed`.
- 1:1 live comparison against the Demo (three `tools-dev` namespaces `main-b2` / `work-b2` / `demo-b2`, Playwright driver): plus-menu item weight, Figma close glyph box, tab / footer radii, notes width vs modal, staged chip lead element per type, preview close bounding box, attachment band position after scrolling a 30-line prompt, tooltip attributes and the `.od-tooltip-layer` state, working-dir menu rows. This branch matches the Demo on every ported item and differs only where intended (notes width fixed, DS tooltip, empty recent-folders row).

## Adjacent issues

Out of scope here, tracked separately: OPEND-2617 (send pending state, waiting on product), OPEND-2639 (example-row font size, not in the Demo), OPEND-2619 (phase 2), and the app-wide `body` / `button { font-weight: 600 }` ladder itself (PR-C); the scoped `:where()` stand-ins in `home-hero.css`, `chat.css` and now `plus-menu.css` are removed when that lands.
