### PR TITLE
fix(daemon): complete project-scoped run lists from durable history after restart

### DIFF
--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -707,6 +707,28 @@ export function createChatRunService({
   const runs = new Map();
   const runIdsByClientRequestId = new Map();
   const runIdsByPluginWorkflowId = new Map();
+  // Every run id ever persisted or created for a project, whether or not the
+  // run object is currently in `runs`. This is the index a project-scoped
+  // `list()` completes itself from; see `hydrateProjectRuns`.
+  const runIdsByProjectId = new Map();
+
+  const indexRunProject = (projectId, runId) => {
+    if (typeof projectId !== 'string' || !projectId) return;
+    if (typeof runId !== 'string' || !runId) return;
+    let ids = runIdsByProjectId.get(projectId);
+    if (!ids) {
+      ids = new Set();
+      runIdsByProjectId.set(projectId, ids);
+    }
+    ids.add(runId);
+  };
+
+  const unindexRunProject = (projectId, runId) => {
+    const ids = runIdsByProjectId.get(projectId);
+    if (!ids) return;
+    ids.delete(runId);
+    if (ids.size === 0) runIdsByProjectId.delete(projectId);
+  };
 
   const finalizeTerminalLocally = (run, status, terminalAt) => {
     if (!onTerminal) return;
@@ -733,6 +755,7 @@ export function createChatRunService({
         const statePath = path.join(runsLogDir, entry.name, 'state.json');
         const state = readDurableRunState(statePath);
         if (!state) continue;
+        indexRunProject(state.projectId, state.id);
         if (
           typeof state.clientRequestId === 'string'
           && state.clientRequestId
@@ -834,6 +857,31 @@ export function createChatRunService({
     };
     runs.set(id, run);
     return run;
+  };
+
+  /**
+   * Bring every persisted run of `projectId` into `runs`.
+   *
+   * Invariant: a project-scoped run list is complete with respect to persisted
+   * history. The in-memory map only ever holds what this process created or
+   * happened to hydrate by id, so after a daemon restart (or after the terminal
+   * TTL evicted a run) a project's newest terminal run can be missing while an
+   * older one is present, and every consumer that folds the list into one
+   * status per project — `GET /api/runs?projectId`, the Home entry rail, the
+   * `od run list` CLI — then reports the wrong outcome. Hydration is scoped to
+   * the one project being listed so listing never loads the whole run history.
+   *
+   * A run whose durable state can no longer be read (dropped, or the journal
+   * is gone) is forgotten from the index so it is not re-read on every call.
+   */
+  const hydrateProjectRuns = (projectId) => {
+    if (!runsLogDir) return;
+    const ids = runIdsByProjectId.get(projectId);
+    if (!ids) return;
+    for (const id of [...ids]) {
+      if (runs.has(id)) continue;
+      if (!hydrateDurableRun(id)) unindexRunProject(projectId, id);
+    }
   };
 
   const create = (meta = {}) => {
@@ -987,6 +1035,7 @@ export function createChatRunService({
       run.workspaceScope = meta.workspaceScope ?? null;
     }
     runs.set(run.id, run);
+    indexRunProject(run.projectId, run.id);
     if (run.clientRequestId) runIdsByClientRequestId.set(run.clientRequestId, run.id);
     if (
       run.externalPluginAnalytics?.externalPluginId === OPEN_DESIGN_PLUGIN_ID
@@ -1580,13 +1629,16 @@ export function createChatRunService({
     });
   };
 
-  const list = ({ projectId, conversationId, status } = {}) => Array.from(runs.values()).filter((run) => {
-    if (typeof projectId === 'string' && projectId && run.projectId !== projectId) return false;
-    if (typeof conversationId === 'string' && conversationId && run.conversationId !== conversationId) return false;
-    if (status === 'active') return !TERMINAL_RUN_STATUSES.has(run.status);
-    if (typeof status === 'string' && status) return run.status === status;
-    return true;
-  });
+  const list = ({ projectId, conversationId, status } = {}) => {
+    if (typeof projectId === 'string' && projectId) hydrateProjectRuns(projectId);
+    return Array.from(runs.values()).filter((run) => {
+      if (typeof projectId === 'string' && projectId && run.projectId !== projectId) return false;
+      if (typeof conversationId === 'string' && conversationId && run.conversationId !== conversationId) return false;
+      if (status === 'active') return !TERMINAL_RUN_STATUSES.has(run.status);
+      if (typeof status === 'string' && status) return run.status === status;
+      return true;
+    });
+  };
 
   const childHasExited = (child) => !child || child.exitCode !== null || child.signalCode !== null;
 
@@ -2014,6 +2066,7 @@ export function createChatRunService({
       try { finalize(); } catch { /* best-effort */ }
     }
     runs.delete(run.id);
+    unindexRunProject(run.projectId, run.id);
     if (
       run.clientRequestId
       && runIdsByClientRequestId.get(run.clientRequestId) === run.id

--- a/apps/daemon/tests/runtimes/runs.test.ts
+++ b/apps/daemon/tests/runtimes/runs.test.ts
@@ -1780,6 +1780,122 @@ describe('run event log persistence', () => {
     });
   });
 
+  // OPEND-2629: `GET /api/runs?projectId` is what the Home entry rail folds
+  // into one status per project. After a restart nothing is in memory, so the
+  // project-scoped list has to be rebuilt from durable history — every
+  // persisted run of the queried project, and only that project's runs.
+  describe('project-scoped list after restart', () => {
+    it('lists every persisted run of the project without loading other projects', () => {
+      const before = createRunsWithLog(tmpDir);
+      const failed = before.create({ projectId: 'p1', conversationId: 'c1' });
+      before.finish(failed, 'failed', 1, null);
+      const succeeded = before.create({ projectId: 'p1', conversationId: 'c1' });
+      before.finish(succeeded, 'succeeded', 0, null);
+      const other = before.create({ projectId: 'p2', conversationId: 'c2' });
+      before.finish(other, 'succeeded', 0, null);
+
+      const restarted = createRunsWithLog(tmpDir);
+      const listed = restarted.list({ projectId: 'p1' });
+      expect(listed.map((run) => run.id).sort()).toEqual([failed.id, succeeded.id].sort());
+      expect(listed.map((run) => run.status).sort()).toEqual(['failed', 'succeeded']);
+      expect(listed.every((run) => run.projectId === 'p1')).toBe(true);
+
+      // Hydration is scoped to the queried project: p2 stays on disk until
+      // something asks for it, so a project-scoped list never loads the
+      // whole run history.
+      expect(restarted.list().map((run) => run.id)).not.toContain(other.id);
+      expect(restarted.get(other.id)).toMatchObject({ id: other.id, projectId: 'p2' });
+    });
+
+    it('applies conversation and status filters on top of the hydrated project history', () => {
+      const before = createRunsWithLog(tmpDir);
+      const failed = before.create({ projectId: 'p1', conversationId: 'c1' });
+      before.finish(failed, 'failed', 1, null);
+      const succeeded = before.create({ projectId: 'p1', conversationId: 'c2' });
+      before.finish(succeeded, 'succeeded', 0, null);
+
+      const restarted = createRunsWithLog(tmpDir);
+      expect(
+        restarted.list({ projectId: 'p1', status: 'succeeded' }).map((run) => run.id),
+      ).toEqual([succeeded.id]);
+      expect(
+        restarted.list({ projectId: 'p1', conversationId: 'c1' }).map((run) => run.id),
+      ).toEqual([failed.id]);
+      expect(restarted.list({ projectId: 'p1', status: 'active' })).toEqual([]);
+    });
+
+    it('keeps the persisted workspace scope and runtime on hydrated project runs', () => {
+      const workspaceScope = {
+        schemaVersion: 1,
+        projectId: 'p-team',
+        workspaceId: 'workspace-a',
+        source: 'persisted_project_binding',
+      };
+      const before = createRunsWithLog(tmpDir);
+      const teamRun = before.create({
+        projectId: 'p-team',
+        conversationId: 'c-team',
+        agentId: 'amr',
+        workspaceScope,
+      });
+      before.finish(teamRun, 'succeeded', 0, null);
+      const localRun = before.create({
+        projectId: 'p-team',
+        conversationId: 'c-team',
+        agentId: 'claude',
+        workspaceScope: null,
+      });
+      before.finish(localRun, 'succeeded', 0, null);
+
+      const restarted = createRunsWithLog(tmpDir);
+      const listed = restarted.list({ projectId: 'p-team' });
+      expect(listed).toHaveLength(2);
+      // The route's visibility filters key off these two fields, so they must
+      // come back exactly as persisted for the same authorization decision.
+      expect(listed.find((run) => run.id === teamRun.id)).toMatchObject({
+        agentId: 'amr',
+        workspaceScope,
+      });
+      expect(listed.find((run) => run.id === localRun.id)).toMatchObject({
+        agentId: 'claude',
+        workspaceScope: null,
+      });
+      expect(restarted.list({ projectId: 'p-other' })).toEqual([]);
+    });
+
+    it('lists runs created after the restart alongside hydrated history and forgets dropped runs', () => {
+      const before = createRunsWithLog(tmpDir);
+      const persisted = before.create({ projectId: 'p1', conversationId: 'c1' });
+      before.finish(persisted, 'succeeded', 0, null);
+
+      const restarted = createRunsWithLog(tmpDir);
+      const fresh = restarted.create({ projectId: 'p1', conversationId: 'c1' });
+      restarted.finish(fresh, 'succeeded', 0, null);
+      const dropped = restarted.create({ projectId: 'p1', conversationId: 'c1' });
+      restarted.drop(dropped);
+
+      expect(restarted.list({ projectId: 'p1' }).map((run) => run.id).sort()).toEqual(
+        [persisted.id, fresh.id].sort(),
+      );
+    });
+
+    it('re-lists a terminal run the in-memory TTL already evicted', () => {
+      vi.useFakeTimers();
+      try {
+        const runs = createRunsWithLog(tmpDir);
+        const run = runs.create({ projectId: 'p1', conversationId: 'c1' });
+        runs.finish(run, 'succeeded', 0, null);
+        vi.advanceTimersByTime(60_001);
+        // The unscoped list is a view of what is in memory and still forgets
+        // the run after the TTL; the project-scoped list is the durable one.
+        expect(runs.list().map((entry) => entry.id)).not.toContain(run.id);
+        expect(runs.list({ projectId: 'p1' }).map((entry) => entry.id)).toEqual([run.id]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   it('retains the cancellation cause when hydrating durable status after restart', async () => {
     const beforeRestart = createRunsWithLog(tmpDir);
     const canceled = beforeRestart.create({ projectId: 'p1' });

--- a/e2e/tests/dialog/run-list-survives-restart.test.ts
+++ b/e2e/tests/dialog/run-list-survives-restart.test.ts
@@ -1,0 +1,264 @@
+// @vitest-environment node
+
+// OPEND-2629 — the per-project run list must survive a full daemon restart.
+//
+// Symptom from the work item: after fully quitting and relaunching the daemon
+// over the same data directory, `GET /api/runs?projectId=<id>` returned only
+// the subset of that project's persisted runs that happened to be hydrated
+// into memory (or none at all). The Home entry rail (PR #7730) folds that feed
+// into one status per project, so an older `failed` run outranked a newer
+// `succeeded` one, and a project blocked on an unanswered `<question-form>`
+// lost its `awaiting_input` flag because `awaitingInputProjectIds` is
+// intersected with the projects the returned runs reveal.
+//
+// This spec exercises the daemon HTTP contract across the restart boundary:
+// every persisted run of the queried project comes back, and the awaiting set
+// still names the project, so the same fold gives the same answer before and
+// after the restart.
+
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+import { createFakeAgentRuntimes } from '@/fake-agents';
+import { requestJson } from '@/vitest/http';
+import { saveMessage } from '@/vitest/messages';
+import { startRun, waitForRunTerminal, type ChatRunStatusBody } from '@/vitest/runs';
+import { createSmokeSuite } from '@/vitest/suite';
+
+type ProjectResponse = {
+  conversationId: string;
+  project: { id: string; name: string };
+};
+
+type RunsListResponse = {
+  runs: ChatRunStatusBody[];
+  awaitingInputProjectIds: string[];
+};
+
+/** Same shape the daemon's own awaiting-input detector accepts as renderable. */
+const RENDERABLE_FORM =
+  'Which direction? <question-form>{"questions":[{"id":"dir","label":"Direction?"}]}</question-form>';
+
+const TERMINAL_STATUSES = new Set(['succeeded', 'failed', 'canceled']);
+
+describe('project run list survives daemon restart', () => {
+  test('failed→succeeded history and an unanswered question-form fold the same before and after restart', async () => {
+    const externalRoot = await mkdtemp(join(tmpdir(), 'od-run-list-restart-e2e-'));
+    const sharedDataDir = join(externalRoot, 'daemon-data');
+    // The fake agent binaries live outside either suite's scratch dir: a
+    // successful suite removes its scratch dir, and the restarted daemon still
+    // reads the persisted agent env that points at them.
+    const fakeAgents = await createFakeAgentRuntimes({
+      root: join(externalRoot, 'fake-agents'),
+      runtimeIds: ['codex'],
+    });
+
+    let retriedProjectId = '';
+    let failedRunId = '';
+    let succeededRunId = '';
+    let askingProjectId = '';
+    let askingRunId = '';
+
+    try {
+      const first = await createSmokeSuite('run-list-restart-first', { dataDir: sharedDataDir });
+      await first.with.toolsDev(async ({ webUrl }) => {
+        await requestJson<{ config: Record<string, unknown> }>(webUrl, '/api/app-config', {
+          body: {
+            agentCliEnv: { codex: fakeAgents.codex.env },
+            agentId: 'codex',
+            agentModels: { codex: { model: 'default', reasoning: 'default' } },
+            designSystemId: null,
+            onboardingCompleted: true,
+            skillId: null,
+            telemetry: { artifactManifest: true, content: false, metrics: false },
+          },
+          method: 'PUT',
+        });
+
+        // Project 1: an older failed run, then a newer succeeded run.
+        const retried = await createProject(webUrl, 'Run list restart: retried');
+        retriedProjectId = retried.project.id;
+        const failedRun = await runToTerminal(
+          webUrl,
+          retried,
+          'Return an intentional daemon smoke failure',
+        );
+        expect(failedRun.status).toBe('failed');
+        failedRunId = failedRun.id;
+        const succeededRun = await runToTerminal(
+          webUrl,
+          retried,
+          'Create a deterministic smoke artifact',
+        );
+        expect(succeededRun.status).toBe('succeeded');
+        succeededRunId = succeededRun.id;
+        expect(succeededRun.updatedAt).toBeGreaterThan(failedRun.updatedAt);
+
+        // Project 2: a succeeded run whose conversation ends on an unanswered
+        // renderable question form.
+        const asking = await createProject(webUrl, 'Run list restart: asking');
+        askingProjectId = asking.project.id;
+        const askingRun = await runToTerminal(
+          webUrl,
+          asking,
+          'Create a deterministic smoke artifact',
+        );
+        expect(askingRun.status).toBe('succeeded');
+        askingRunId = askingRun.id;
+        await saveMessage(webUrl, asking.project.id, asking.conversationId, {
+          agentId: 'codex',
+          agentName: 'Codex',
+          content: RENDERABLE_FORM,
+          createdAt: Date.now(),
+          id: `assistant-ask-${Date.now()}`,
+          role: 'assistant',
+          runStatus: 'succeeded',
+        });
+
+        // Baseline: the live daemon already answers correctly.
+        await expectProjectRunList(webUrl, {
+          askingProjectId,
+          askingRunId,
+          failedRunId,
+          retriedProjectId,
+          succeededRunId,
+        });
+      });
+
+      // Full restart over the same persisted data. Nothing in memory survives
+      // this boundary, so the project-scoped list must be rebuilt from the
+      // durable run history instead of from whatever happened to be loaded.
+      const restarted = await createSmokeSuite('run-list-restart-restarted', {
+        dataDir: sharedDataDir,
+      });
+      await restarted.with.toolsDev(async ({ webUrl }) => {
+        await expectProjectRunList(webUrl, {
+          askingProjectId,
+          askingRunId,
+          failedRunId,
+          retriedProjectId,
+          succeededRunId,
+        });
+      });
+    } finally {
+      await rm(externalRoot, { force: true, recursive: true });
+    }
+  }, 300_000);
+});
+
+async function createProject(webUrl: string, name: string): Promise<ProjectResponse> {
+  return await requestJson<ProjectResponse>(webUrl, '/api/projects', {
+    body: {
+      designSystemId: null,
+      id: randomUUID(),
+      metadata: { kind: 'prototype' },
+      name,
+      pendingPrompt: null,
+      skillId: null,
+    },
+  });
+}
+
+/** Drive one chat turn through the production run API until it terminates. */
+async function runToTerminal(
+  webUrl: string,
+  project: ProjectResponse,
+  prompt: string,
+): Promise<ChatRunStatusBody> {
+  const startedAt = Date.now();
+  const userMessageId = `user-${startedAt}-${randomUUID().slice(0, 8)}`;
+  const assistantMessageId = `assistant-${startedAt}-${randomUUID().slice(0, 8)}`;
+  const projectId = project.project.id;
+  const conversationId = project.conversationId;
+  await saveMessage(webUrl, projectId, conversationId, {
+    content: prompt,
+    createdAt: startedAt,
+    id: userMessageId,
+    role: 'user',
+  });
+  await saveMessage(webUrl, projectId, conversationId, {
+    agentId: 'codex',
+    agentName: 'Codex',
+    content: '',
+    createdAt: startedAt,
+    events: [],
+    id: assistantMessageId,
+    role: 'assistant',
+    runStatus: 'running',
+    startedAt,
+  });
+  const run = await startRun(webUrl, {
+    agentId: 'codex',
+    assistantMessageId,
+    clientRequestId: `req-${startedAt}-${randomUUID().slice(0, 8)}`,
+    conversationId,
+    designSystemId: null,
+    message: prompt,
+    model: 'default',
+    projectId,
+    reasoning: 'default',
+    skillId: null,
+  });
+  const terminal = await waitForRunTerminal(webUrl, run.runId, { timeoutMs: 30_000 });
+  // Keep terminal timestamps strictly ordered between consecutive turns so
+  // the newest-terminal fold below is unambiguous.
+  await delay(20);
+  return terminal;
+}
+
+/**
+ * The newest terminal run wins, exactly as the web fold does
+ * (`foldRunsToProjectRunSummaries` in `apps/web/src/state/projectRunStatus.ts`).
+ */
+function newestTerminalRun(runs: ChatRunStatusBody[]): ChatRunStatusBody | null {
+  let newest: ChatRunStatusBody | null = null;
+  for (const run of runs) {
+    if (!TERMINAL_STATUSES.has(run.status)) continue;
+    if (!newest || run.updatedAt > newest.updatedAt) newest = run;
+  }
+  return newest;
+}
+
+async function expectProjectRunList(
+  webUrl: string,
+  ids: {
+    askingProjectId: string;
+    askingRunId: string;
+    failedRunId: string;
+    retriedProjectId: string;
+    succeededRunId: string;
+  },
+): Promise<void> {
+  const retried = await requestJson<RunsListResponse>(
+    webUrl,
+    `/api/runs?projectId=${encodeURIComponent(ids.retriedProjectId)}`,
+  );
+  expect(retried.runs.map((run) => run.id).sort()).toEqual(
+    [ids.failedRunId, ids.succeededRunId].sort(),
+  );
+  expect(retried.runs.every((run) => run.projectId === ids.retriedProjectId)).toBe(true);
+  expect(newestTerminalRun(retried.runs)).toMatchObject({
+    id: ids.succeededRunId,
+    status: 'succeeded',
+  });
+  expect(retried.awaitingInputProjectIds).not.toContain(ids.retriedProjectId);
+
+  const asking = await requestJson<RunsListResponse>(
+    webUrl,
+    `/api/runs?projectId=${encodeURIComponent(ids.askingProjectId)}`,
+  );
+  expect(asking.runs.map((run) => run.id)).toEqual([ids.askingRunId]);
+  expect(newestTerminalRun(asking.runs)).toMatchObject({
+    id: ids.askingRunId,
+    status: 'succeeded',
+  });
+  expect(asking.awaitingInputProjectIds).toEqual([ids.askingProjectId]);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Plane: OPEND-2629 — "[P1][PR #7730][最近项目] 完整重启后运行状态错误，awaiting 可显示为失败". Follow-up to #7730 (recent projects and run status in the entry rail). No GitHub issue to close.

## Why

**Use case.** Verifying #7730 + #7731 on a real data directory: quit the daemon and Electron completely, relaunch over the same `OD_DATA_DIR`, and look at the "Recently viewed" rail on Home. A project whose history is an older `failed` run followed by a newer `succeeded` run stayed red, and a project blocked on an unanswered `<question-form>` showed no awaiting-input state at all. Requesting `GET /api/runs?projectId=<id>` directly returned either the older run only or `{ runs: [], awaitingInputProjectIds: [] }`, while `runs/<runId>/state.json` on disk held the full history.

**Pain.** The startup scan in `createChatRunService` (`apps/daemon/src/runtimes/runs.ts`) only rebuilds the `clientRequestId` / `pluginWorkflowId` indexes; it never puts persisted runs back into the in-memory `runs` map, and `hydrateDurableRun` is only reached through `get(id)` / `createOrReuse`. `list()` is a plain scan of that map, so after a restart a project-scoped list is whatever subset happened to be hydrated. The same map also forgets terminal runs after the 30-minute TTL, so a long-running daemon drifts into the same partial view without any restart. `GET /api/runs` then intersects `listProjectsAwaitingInput(db)` with the project ids of the returned runs, so an unhydrated project loses its awaiting flag too, and the web fold (`foldRunsToProjectRunSummaries`) only upgrades `succeeded` to `awaiting_input`, which lets a stale `failed` win. Every consumer of that feed — the Home rail, the finished-run notifications, `od run list --json` — is fed the wrong answer.

## What users will see

- After fully quitting and relaunching OpenDesign, the run-status dot on a project in the Home "Recently viewed" rail matches the project's newest run: a project that failed once and then succeeded shows as succeeded, and a project waiting on an unanswered question shows the yellow awaiting-input state. Before this change the rail could stay red or show nothing until the project was opened.
- The same holds for a daemon that has been running for more than 30 minutes: a project's status no longer flips once its finished runs age out of memory.
- `od run list --project <id> --json` returns the project's complete persisted run history instead of whatever the daemon still had in memory. Both surfaces read the same `GET /api/runs?projectId` endpoint, so UI and CLI stay consistent.
- Workspace-bound projects keep the existing visibility rules: the route still applies its authorization and headerless-caller filters after the list is complete, and the awaiting set is still intersected with the projects the caller may see.

## Surface area

- [ ] **UI** — no UI code changed; the Home rail and its notifications are consumers of the fixed endpoint
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — no new subcommand or flag; `od run list` already reads this endpoint and is fixed by the same change
- [ ] **API / contract** — no endpoint, SSE event, or contract shape changed; `GET /api/runs?projectId` now returns the complete persisted set
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — none
- [x] **Default behavior change** — `GET /api/runs?projectId=<id>` (and therefore the Home rail and `od run list`) now reflects the project's full persisted run history after a restart or TTL eviction, without opting in
- [ ] **None**

## Screenshots

No UI code changed. The user-visible effect is the Home rail status dot after a restart; the behaviour is pinned by the e2e spec below at the HTTP boundary the rail reads from.

## Bug fix verification

- Red spec that reproduces the bug at the daemon HTTP boundary through a real restart: `e2e/tests/dialog/run-list-survives-restart.test.ts`. It seeds a failed then a succeeded run on one project and a succeeded run plus an unanswered `<question-form>` on another through the production APIs (`/api/app-config`, `/api/projects`, messages PUT, `POST /api/runs`), asserts the baseline on the first daemon, then starts a second tools-dev daemon over the same `OD_DATA_DIR` and asserts `GET /api/runs?projectId` and `awaitingInputProjectIds` again.
- Daemon unit coverage for the new index and hydration path, in `apps/daemon/tests/runtimes/runs.test.ts` → `run event log persistence › project-scoped list after restart` (5 cases: complete list without loading other projects; conversation/status filters on top of hydrated history; persisted `workspaceScope` + `agentId` preserved for the route's visibility filters; runs created after restart and dropped runs; re-listing a run the TTL evicted).
- Red on `main` (branch tip `d4138ea818` with only the tests applied) and green on this branch: **yes**.

Red, e2e (before the fix — the first daemon's baseline assertions pass, the restarted daemon returns `runs: []`):

```
 ❯ tests/dialog/run-list-survives-restart.test.ts (1 test | 1 failed) 15515ms
     × failed→succeeded history and an unanswered question-form fold the same before and after restart 15513ms
AssertionError: expected [] to deeply equal [ …(2) ]
 ❯ expectProjectRunList tests/dialog/run-list-survives-restart.test.ts:240:52
 ❯ tests/dialog/run-list-survives-restart.test.ts:139:9
 Test Files  1 failed (1)
      Tests  1 failed (1)
```

Red, daemon unit (before the fix):

```
 Test Files  1 failed (1)
      Tests  5 failed | 65 skipped (70)
```

Green, e2e (after the fix):

```
 Test Files  1 passed (1)
      Tests  1 passed (1)
   Duration  20.76s
```

Green, daemon unit (`tests/runtimes/runs.test.ts`, after the fix):

```
 Test Files  1 passed (1)
      Tests  70 passed (70)
```

## Validation

- `pnpm install` — done
- `pnpm guard` — exit 0
- `pnpm typecheck` — exit 0 (covers `apps/daemon`, `e2e`, and the rest of the workspace)
- `pnpm --filter @open-design/daemon exec vitest run tests/runtimes/runs.test.ts` — 70 passed (70)
- `pnpm --filter @open-design/daemon test` (full) — `Test Files 11 failed | 731 passed | 2 skipped (744)`, `Tests 88 failed | 9421 passed | 350 skipped (9859)` on the first full parallel run on this machine. Breakdown of the 11 failing files:
  - `chat-route`, `connection-test`, `od-next-automatic-simple-server` — known env/flaky failures on this machine, unrelated to this change (they fail the same way on `main`).
  - `connectors-routes`, `deploy-routes`, `integrations/vela.routes`, `project-file-range`, `proxy-routes`, `routes/projects`, `routes/workspace-projects`, `run-retry-runtime` — every failure was `Hook timed out in 10000ms` / `Test timed out in 20000ms` under full-suite load. Re-run in isolation on this branch: `Test Files 7 passed`, `Tests 428 passed` for seven of them, and `connectors-routes` alone `45 passed (45)` on a second isolated run (its single leftover failure was again a `beforeEach` hook timeout; the same test also passes with `main`'s `runs.ts` swapped in). None of them exercise the run registry's hydration path.
- `cd e2e && pnpm exec vitest run -c vitest.config.ts tests/dialog/run-list-survives-restart.test.ts` — 1 passed (1), real tools-dev daemon restarted over a shared data dir
- `packages/contracts` untouched, its tests were not run

## Adjacent issues

- **Unscoped `list()` is still a view of memory.** `GET /api/runs` without `projectId` and `design.runs.list()` in `routes/project/index.ts` still see only what is in the map. Hydrating every persisted run on an unscoped call would load the whole history on each request, which the work item explicitly asks to avoid, so this PR keeps the unscoped behaviour unchanged. If an unscoped consumer needs completeness it should get its own index-backed path.
- **Hydrated runs are never evicted.** `hydrateDurableRun` (pre-existing, also reached via `get(id)`) never calls `scheduleCleanup`, so runs loaded on demand stay in memory for the daemon's lifetime. Bounded by the number of runs actually listed, and unchanged by this PR, but worth a follow-up if memory on long-lived daemons with large histories becomes a concern.
- **Web fold precedence.** `foldRunsToProjectRunSummaries` only upgrades `succeeded` to `awaiting_input`; with the complete list that rule is correct, so it is left alone.
