### PR TITLE
fix: make Home working directory writable

### DIFF
--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -312,14 +312,37 @@ export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps
 
       const entryFile = await detectEntryFile(normalizedPath);
       const existingMeta = existing.metadata ?? {};
-      const { orchestratorWorkspace: _existingOrchestratorWorkspace, ...preservedMeta } =
-        existingMeta;
+      const {
+        orchestratorWorkspace: _existingOrchestratorWorkspace,
+        linkedDirs: existingLinkedDirs,
+        userWorkingDir: _pendingUserWorkingDir,
+        ...preservedMeta
+      } = existingMeta;
+      const nextLinkedDirs: string[] = [];
+      if (Array.isArray(existingLinkedDirs)) {
+        for (const dir of existingLinkedDirs) {
+          let canonicalDir = dir;
+          try {
+            canonicalDir = await fs.promises.realpath(dir);
+          } catch {
+            // Preserve an existing reference that became unavailable; only
+            // remove the folder when it resolves to the new writable root.
+          }
+          if (
+            canonicalDir !== normalizedPath
+            && !nextLinkedDirs.includes(canonicalDir)
+          ) {
+            nextLinkedDirs.push(canonicalDir);
+          }
+        }
+      }
       const nextMeta = {
         ...preservedMeta,
         kind: existingMeta.kind ?? 'prototype',
         baseDir: normalizedPath,
         importedFrom: 'folder' as const,
         entryFile,
+        ...(nextLinkedDirs.length > 0 ? { linkedDirs: nextLinkedDirs } : {}),
         ...(normalizedOrchestratorWorkspace
           ? { orchestratorWorkspace: normalizedOrchestratorWorkspace }
           : {}),

--- a/apps/daemon/tests/folder-import-route.test.ts
+++ b/apps/daemon/tests/folder-import-route.test.ts
@@ -586,6 +586,93 @@ describe('POST /api/import/folder', () => {
     });
   });
 
+  it('promotes a linked folder to baseDir without leaving it read-only', async () => {
+    const originalFolder = makeFolder();
+    await writeFile(path.join(originalFolder, 'index.html'), '<!doctype html>');
+    const importResp = await importFolder({ baseDir: originalFolder });
+    expect(importResp.status).toBe(200);
+    const { project } = (await importResp.json()) as {
+      project: { id: string; metadata: Record<string, unknown> };
+    };
+
+    const workspaceFolder = makeFolder();
+    const referenceFolder = makeFolder();
+    const aliasParent = makeFolder();
+    const workspaceAlias = path.join(aliasParent, 'workspace-alias');
+    symlinkSync(workspaceFolder, workspaceAlias, 'dir');
+    await writeFile(path.join(workspaceFolder, 'index.html'), '<!doctype html>');
+
+    const secret = randomBytes(32);
+    setDesktopAuthSecret(secret);
+    const initialToken = signDesktopImportToken(secret, originalFolder, {
+      nonce: `initial-${Date.now()}`,
+      exp: new Date(Date.now() + 30_000).toISOString(),
+    });
+    const trustedResp = await fetch(`${baseUrl}/api/projects/${project.id}/working-dir`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-od-desktop-import-token': initialToken,
+      },
+      body: JSON.stringify({ baseDir: originalFolder }),
+    });
+    expect(trustedResp.status).toBe(200);
+    const trustedProject = ((await trustedResp.json()) as {
+      project: { metadata: Record<string, unknown> };
+    }).project;
+
+    const patchResp = await fetch(`${baseUrl}/api/projects/${project.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        metadata: {
+          ...trustedProject.metadata,
+          userWorkingDir: workspaceFolder,
+          linkedDirs: [workspaceAlias, referenceFolder],
+        },
+      }),
+    });
+    expect(patchResp.status).toBe(200);
+
+    const promotionToken = signDesktopImportToken(secret, workspaceFolder, {
+      nonce: `promotion-${Date.now()}`,
+      exp: new Date(Date.now() + 30_000).toISOString(),
+    });
+    const replaceResp = await fetch(`${baseUrl}/api/projects/${project.id}/working-dir`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-od-desktop-import-token': promotionToken,
+      },
+      body: JSON.stringify({ baseDir: workspaceFolder }),
+    });
+    expect(replaceResp.status).toBe(200);
+    const replaceBody = (await replaceResp.json()) as {
+      project: {
+        metadata?: {
+          baseDir?: string;
+          fromTrustedPicker?: boolean;
+          linkedDirs?: string[];
+          userWorkingDir?: string;
+        };
+      };
+    };
+    expect(replaceBody.project.metadata?.baseDir).toBe(await realpath(workspaceFolder));
+    expect(replaceBody.project.metadata?.fromTrustedPicker).toBe(true);
+    expect(replaceBody.project.metadata?.linkedDirs).toEqual([await realpath(referenceFolder)]);
+    expect(replaceBody.project.metadata?.userWorkingDir).toBeUndefined();
+
+    const replayResp = await fetch(`${baseUrl}/api/projects/${project.id}/working-dir`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-od-desktop-import-token': promotionToken,
+      },
+      body: JSON.stringify({ baseDir: workspaceFolder }),
+    });
+    expect(replayResp.status).toBe(403);
+  });
+
   it('fails result-package when a folder-backed workspace cannot be enumerated', async () => {
     const folder = makeFolder();
     await writeFile(path.join(folder, 'index.html'), '<!doctype html>');

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -1469,16 +1469,20 @@ export function EntryShell({
       payload.pluginTitle && payload.pluginTitle.trim().length > 0
         ? payload.pluginTitle.trim()
         : fallbackName;
+    const workingDir = payload.workingDir?.trim() ?? '';
+    const metadataLinkedDirs = payload.projectMetadata?.linkedDirs ?? [];
     const linkedDirs = Array.from(
       new Set(
         [
-          ...(payload.workingDir ? [payload.workingDir] : []),
+          ...metadataLinkedDirs,
           ...(payload.linkedDirs ?? []),
-        ].map((dir) => dir.trim()).filter(Boolean),
+        ].map((dir) => dir.trim()).filter((dir) => Boolean(dir) && dir !== workingDir),
       ),
     );
+    const projectMetadata = { ...(payload.projectMetadata ?? {}) };
+    delete projectMetadata.linkedDirs;
     const metadata: ProjectMetadata = {
-      ...(payload.projectMetadata ?? {}),
+      ...projectMetadata,
       kind: payload.projectKind ?? payload.projectMetadata?.kind ?? 'prototype',
       nameSource: 'prompt',
       ...(payload.contextPlugins && payload.contextPlugins.length > 0
@@ -1490,12 +1494,12 @@ export function EntryShell({
       ...(payload.contextConnectors && payload.contextConnectors.length > 0
         ? { contextConnectors: payload.contextConnectors }
         : {}),
-      // The Home working-directory picker grants the agent read-only
-      // awareness of a local folder (via `--add-dir`), it does NOT import
-      // that folder into Design Files. So the picked path becomes the new
-      // project's `linkedDirs` rather than its `baseDir`/`userWorkingDir`:
-      // Design Files stays the managed `.od/projects/<id>` artifact store,
-      // independent of the user's local files.
+      // The trusted Home picker selects the project's writable workspace.
+      // App.tsx creates the project first, then spends the host-minted token
+      // on POST /api/projects/:id/working-dir before upload or auto-send.
+      ...(workingDir ? { userWorkingDir: workingDir } : {}),
+      // Context folders remain read-only. If the chosen workspace was already
+      // linked, promoting it removes the conflicting read-only classification.
       ...(linkedDirs.length > 0 ? { linkedDirs } : {}),
       ...(payload.examplePromptContext ? {
         examplePrompt: true,
@@ -1533,10 +1537,9 @@ export function EntryShell({
       ...(payload.attachments && payload.attachments.length > 0
         ? { pendingFiles: payload.attachments }
         : {}),
-      // No `userWorkingDirToken`: linkedDirs grant read-only `--add-dir`
-      // access and are validated by the daemon at create time, so they do
-      // not need the desktop main-process trust token that baseDir imports
-      // require for write access.
+      ...(workingDir && payload.workingDirToken
+        ? { userWorkingDirToken: payload.workingDirToken }
+        : {}),
       autoSendFirstMessage: true,
       ...(amrGatePrecheckWitness ? { amrGatePrecheckWitness } : {}),
     };

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -3196,9 +3196,13 @@ export function HomeView({
         onPickWorkingDir={handlePickWorkingDir}
         onPickLocalCodeDir={handlePickLocalCodeDir}
         onSelectRecentWorkingDir={(dir) => {
+          if (isOpenDesignHostAvailable()) {
+            // A remembered path is not an authorization grant. Re-open the
+            // native picker so the selected workspace receives a fresh token.
+            void handlePickWorkingDir();
+            return;
+          }
           setWorkingDir(dir);
-          // Recents come from the browser-side picker only; they carry no
-          // desktop trust token (and linkedDirs don't need one).
           setWorkingDirToken(null);
           void rememberRecentDir(dir);
         }}

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { useState } from 'react';
+import { useState, type ComponentProps } from 'react';
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -17,6 +17,7 @@ import { I18nProvider } from '../../src/i18n';
 import { fetchProjectFiles } from '../../src/providers/registry';
 import type { AgentInfo, AppConfig } from '../../src/types';
 import { setHomeHeroPrompt } from '../helpers/home-hero-lexical';
+import { isOpenDesignHostAvailable, pickHostWorkingDir } from '@open-design/host';
 
 const analyticsMocks = vi.hoisted(() => ({
   track: vi.fn(),
@@ -36,6 +37,18 @@ vi.mock('../../src/analytics/provider', async (importOriginal) => {
     useAppVersion: () => null,
   };
 });
+
+vi.mock('@open-design/host', async () => {
+  const actual = await vi.importActual<typeof import('@open-design/host')>('@open-design/host');
+  return {
+    ...actual,
+    isOpenDesignHostAvailable: vi.fn(() => false),
+    pickHostWorkingDir: vi.fn(),
+  };
+});
+
+const mockedIsOpenDesignHostAvailable = vi.mocked(isOpenDesignHostAvailable);
+const mockedPickHostWorkingDir = vi.mocked(pickHostWorkingDir);
 
 const originalFetch = globalThis.fetch;
 const originalResizeObserver = globalThis.ResizeObserver;
@@ -323,6 +336,8 @@ beforeEach(() => {
   globalThis.fetch = originalFetch;
   globalThis.ResizeObserver = ResizeObserverMock as typeof ResizeObserver;
   analyticsMocks.track.mockReset();
+  mockedIsOpenDesignHostAvailable.mockReturnValue(false);
+  mockedPickHostWorkingDir.mockReset();
 });
 
 describe('EntryShell settings menu', () => {
@@ -695,6 +710,44 @@ describe('EntryShell new project rail', () => {
 });
 
 describe('EntryShell Home submit handoff', () => {
+  it('promotes the Home working directory instead of classifying it as linked', async () => {
+    globalThis.fetch = vi.fn(async (input: Parameters<typeof fetch>[0]) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      if (url.endsWith('/api/app-config')) return jsonResponse({ recentLinkedDirs: [] });
+      if (url.endsWith('/api/plugins')) return jsonResponse({ plugins: [] });
+      if (url.endsWith('/api/mcp/servers')) return jsonResponse({ servers: [] });
+      if (url.endsWith('/api/community/discord')) return jsonResponse({ stale: true });
+      if (url.endsWith('/api/github/open-design')) return jsonResponse({ stale: true });
+      return jsonResponse({});
+    }) as typeof fetch;
+    mockedIsOpenDesignHostAvailable.mockReturnValue(true);
+    mockedPickHostWorkingDir.mockResolvedValue({
+      ok: true,
+      baseDir: '/Users/me/workspace',
+      token: 'trusted-working-dir-token',
+    });
+    const onCreateProject = vi.fn((
+      _input: Parameters<ComponentProps<typeof EntryShell>['onCreateProject']>[0],
+    ) => true);
+    renderHome({ onCreateProject });
+
+    fireEvent.click(await screen.findByTestId('working-dir-trigger'));
+    fireEvent.click(screen.getByTestId('working-dir-pick'));
+    await waitFor(() => expect(mockedPickHostWorkingDir).toHaveBeenCalledTimes(1));
+
+    setHomeHeroPrompt('Build in my repository');
+    fireEvent.click(await screen.findByTestId('home-hero-submit'));
+
+    await waitFor(() => expect(onCreateProject).toHaveBeenCalledTimes(1));
+    expect(onCreateProject).toHaveBeenCalledWith(expect.objectContaining({
+      metadata: expect.objectContaining({
+        userWorkingDir: '/Users/me/workspace',
+      }),
+      userWorkingDirToken: 'trusted-working-dir-token',
+    }));
+    expect(onCreateProject.mock.calls[0]?.[0]?.metadata?.linkedDirs).toBeUndefined();
+  });
+
   it('keeps the Home run button in sending state until project creation resolves', async () => {
     globalThis.fetch = vi.fn(async (input: Parameters<typeof fetch>[0]) => {
       const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);

--- a/apps/web/tests/components/HomeView.working-dir.test.tsx
+++ b/apps/web/tests/components/HomeView.working-dir.test.tsx
@@ -9,7 +9,7 @@ vi.mock('../../src/components/home-hero/PlaceholderCarousel', () => ({
 
 import { HomeView } from '../../src/components/HomeView';
 import { isOpenDesignHostAvailable, pickHostWorkingDir } from '@open-design/host';
-import { openFolderDialog } from '../../src/providers/registry';
+import { fetchRecentLinkedDirs, openFolderDialog } from '../../src/providers/registry';
 
 vi.mock('@open-design/host', async () => {
   const actual = await vi.importActual<typeof import('@open-design/host')>('@open-design/host');
@@ -27,12 +27,14 @@ vi.mock('../../src/providers/registry', async () => {
   return {
     ...actual,
     openFolderDialog: vi.fn(),
+    fetchRecentLinkedDirs: vi.fn(),
     fetchProjectFiles: vi.fn().mockResolvedValue([]),
   };
 });
 
 const mockedIsHostAvailable = vi.mocked(isOpenDesignHostAvailable);
 const mockedPickHostWorkingDir = vi.mocked(pickHostWorkingDir);
+const mockedFetchRecentLinkedDirs = vi.mocked(fetchRecentLinkedDirs);
 const mockedOpenFolderDialog = vi.mocked(openFolderDialog);
 
 function renderHome() {
@@ -49,6 +51,7 @@ function renderHome() {
 describe('HomeView working-dir picker host fallback', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockedFetchRecentLinkedDirs.mockResolvedValue([]);
     mockedOpenFolderDialog.mockResolvedValue(null);
   });
 
@@ -106,6 +109,27 @@ describe('HomeView working-dir picker host fallback', () => {
 
     fireEvent.click(screen.getByTestId('working-dir-trigger'));
     fireEvent.click(screen.getByTestId('working-dir-pick'));
+
+    await waitFor(() => {
+      expect(mockedPickHostWorkingDir).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedOpenFolderDialog).not.toHaveBeenCalled();
+  });
+
+  it('re-authorizes a recent desktop folder through the native picker', async () => {
+    mockedIsHostAvailable.mockReturnValue(true);
+    mockedFetchRecentLinkedDirs.mockResolvedValue(['/Users/me/recent-folder']);
+    mockedPickHostWorkingDir.mockResolvedValue({
+      ok: true,
+      baseDir: '/Users/me/recent-folder',
+      token: 'fresh-token',
+    });
+
+    renderHome();
+
+    fireEvent.click(screen.getByTestId('working-dir-trigger'));
+    fireEvent.click(screen.getByTestId('working-dir-recent'));
+    fireEvent.click(await screen.findByTitle('/Users/me/recent-folder'));
 
     await waitFor(() => {
       expect(mockedPickHostWorkingDir).toHaveBeenCalledTimes(1);

--- a/e2e/ui/entry-chrome-flows.test.ts
+++ b/e2e/ui/entry-chrome-flows.test.ts
@@ -1171,7 +1171,7 @@ test('[P0] @critical home composer delegates the default prototype scenario to d
   expect(body.metadata?.kind).toBe('prototype');
 });
 
-test('[P0] @critical home working directory creates the project with linked dirs instead of importing files', async ({ page }) => {
+test('[P0] @critical home working directory creates the project with a writable workspace', async ({ page }) => {
   const workingDir = '/Users/mac/Projects/Dashboard-UI-Liquid-Glass';
   await page.route('**/api/recent-dirs', async (route) => {
     await route.fulfill({ json: { dirs: [workingDir] } });
@@ -1213,9 +1213,9 @@ test('[P0] @critical home working directory creates the project with linked dirs
   };
   expect(body.pendingPrompt).toBe('Create a premium dashboard for operations review.');
   expect(body.conversationMode).toBe('design');
-  expect(body.metadata?.linkedDirs).toEqual([workingDir]);
+  expect(body.metadata?.linkedDirs).toBeUndefined();
   expect(body.metadata?.baseDir).toBeUndefined();
-  expect(body.metadata?.userWorkingDir).toBeUndefined();
+  expect(body.metadata?.userWorkingDir).toBe(workingDir);
 });
 
 test('[P0] @critical clearing the home working directory removes linked dirs from project creation', async ({ page }) => {

--- a/packages/contracts/src/api/projects.ts
+++ b/packages/contracts/src/api/projects.ts
@@ -259,9 +259,8 @@ export interface ProjectMetadata {
   // Externally prepared scratch workspace provenance. OD may read/write
   // metadata.baseDir, but source authority and writeback stay outside OD.
   orchestratorWorkspace?: OrchestratorWorkspace;
-  // Hint stamped by the Home composer working-directory chip. It records
-  // where the user wanted the project to live without granting write access
-  // to that path; actual filesystem roots still use baseDir/import flows.
+  // Transient hint stamped by project-creation surfaces before the trusted
+  // working-directory route promotes the selected folder to baseDir.
   userWorkingDir?: string;
   imageModel?: string;
   imageAspect?: MediaAspect;


### PR DESCRIPTION
Addresses #7643

## Why

I hit this on macOS with OpenDesign 0.21.1 while trying to use an existing repository as the working directory for a new project.

The Home “Working directory” control opened the trusted native folder picker correctly, but project creation then treated the chosen folder as linked reference code. That made it read-only and started the agent in OpenDesign's generated project folder instead.

The picker already returns a short-lived authorization token, and the app already has a safe working-directory update flow. The missing piece was passing the chosen folder and token into that flow instead of converting the folder to linkedDirs.

Issue #7643 also contains broader project-discovery concerns. This PR addresses the working-directory/cwd part without claiming to close the entire issue.

## What users will see

Selecting a Working directory on Home now makes that folder the writable workspace for the new project.

- New sessions start in the selected folder.
- The folder is stored as metadata.baseDir and becomes the writable project root.
- Folders added as reference context remain in metadata.linkedDirs and remain read-only.
- If a folder was previously linked and is then promoted to the workspace, the conflicting read-only classification is removed, including filesystem aliases.
- Choosing a recent folder in the desktop app reopens the trusted native picker to obtain a fresh authorization token.
- Picker/token failures continue to stop uploads and auto-send and show the existing clear error instead of silently continuing in the generated folder.

## Surface area

- [x] **UI** — corrects the behavior of the existing Home working-directory control
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new od subcommand or flag, new tools-dev / tools-pack flag, or new OD_* env var
- [ ] **API / contract** — no endpoint or response-shape change
- [ ] **Extension point** — new entry under skills/, design-systems/, design-templates/, or craft/, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root package.json
- [x] **Default behavior change** — the existing control now applies the selected folder as its writable workspace
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No visual layout or copy changes. This corrects what happens after using the existing Home → Working directory picker.

Manual macOS verification used the existing control and confirmed a new session started in /Users/hendrik/coding/startupseeker_v2, could create and remove a probe file there, and persisted the repository as baseDir rather than linkedDirs.

## Bug fix verification

- Red specs:
  - apps/web/tests/components/EntryShell.onboarding.test.tsx
  - apps/web/tests/components/HomeView.working-dir.test.tsx
  - apps/daemon/tests/folder-import-route.test.ts
- The new tests were run against an untouched main worktree and failed in the expected places: Home converted the workspace to linkedDirs, recent desktop selection did not re-authorize it, and promotion left the workspace alias in linkedDirs.
- The same tests pass on this branch.
- The daemon regression uses signed desktop picker tokens, verifies replay is rejected, verifies filesystem aliases are removed from linkedDirs, preserves an unrelated linked folder, and confirms the temporary handoff marker is cleared.

## Validation

- pnpm guard — passed
- pnpm typecheck — passed across the workspace
- Focused web tests — 126 passed:
  - EntryShell.onboarding.test.tsx
  - HomeView.working-dir.test.tsx
  - App.project-create-race.test.tsx
- Folder import/working-directory daemon suite — 39 passed
- Full web suite — 676 files passed; 7,177 tests passed, 1 expected failure, 11 skipped
- git diff --check — passed
- Independent OpenCode Muse Spark 1.3 review — no blocking findings after canonical-path and transient-metadata hardening
- Manual packaged-flow verification on macOS:
  - new session cwd matched the selected repository
  - repository was writable and accepted a create/read/delete probe
  - metadata.baseDir matched the repository
  - the repository was absent from linkedDirs

For transparency, I also started the full daemon suite. Four unrelated tests in od-next-automatic-simple-server.test.ts timed out amid their existing closed-database watcher noise, so I stopped that long sweep after the failures. The complete touched daemon test file passes, and none of the timeout failures exercise working-directory or import behavior.
