### PR TITLE
test(desktop): give Electron probes a CI-sized timeout

### DIFF
--- a/apps/desktop/tests/main/base-href-precedence.test.ts
+++ b/apps/desktop/tests/main/base-href-precedence.test.ts
@@ -67,6 +67,18 @@ import { renderDeckSlides } from '../../src/main/deck-capture.js';
 
 const execFileP = promisify(execFile);
 const desktopRoot = fileURLToPath(new URL('../..', import.meta.url));
+
+/**
+ * Budget for one Electron probe process (`xvfb-run … electron <probeDir>` on
+ * Linux). The probes only need a second or two once Chromium is up, but a
+ * cold Electron start on a busy CI runner can take well over ten seconds,
+ * and `execFile` kills a timed-out child with a bare "Command failed" and no
+ * stderr — which is exactly what an otherwise green run shows when it flakes.
+ * Generous on purpose: a probe that really hangs still fails, just later.
+ */
+const ELECTRON_PROBE_TIMEOUT_MS = 60_000;
+/** Per-test budget for a test that runs one probe: the probe plus setup. */
+const ELECTRON_PROBE_TEST_TIMEOUT_MS = 90_000;
 const legacyBaseHref = 'https://external.invalid/legacy/';
 const scopedBaseHref = 'http://127.0.0.1:43123/preview/export-scope/';
 const sourceHtml = `<!doctype html>
@@ -106,7 +118,7 @@ describe('scoped renderer base precedence', () => {
     const resolution = await probeLoadedDocument(singleLoadedUrl());
     expect(result).toMatchObject({ errorCode: 'NO_SLIDES', ok: false });
     expect(resolution).toEqual(expectedResolution());
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   it('uses the scoped base for artifact-export CSS and images when HTML already has an external base', async () => {
     // Given: an artifact-export request whose source document already declares another base.
@@ -130,7 +142,7 @@ describe('scoped renderer base precedence', () => {
     } finally {
       if (result.path) await rm(dirname(result.path), { force: true, recursive: true });
     }
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 });
 
 function singleLoadedUrl(): string {
@@ -188,7 +200,7 @@ app.whenReady().then(async () => {
     const args = process.platform === 'linux' ? ['-a', electronPath, ...electronArgs] : electronArgs;
     const env: NodeJS.ProcessEnv = { ...process.env, OD_BASE_PROBE_URL_FILE: urlFile };
     delete env.ELECTRON_RUN_AS_NODE;
-    const { stdout } = await execFileP(command, args, { env, timeout: 20_000 });
+    const { stdout } = await execFileP(command, args, { env, timeout: ELECTRON_PROBE_TIMEOUT_MS });
     const marker = stdout.split(/\r?\n/).find((line) => line.startsWith('OD_BASE_PROBE:'));
     if (!marker) throw new Error(`Electron renderer probe returned no result: ${stdout}`);
     return parseBaseResolution(JSON.parse(marker.slice('OD_BASE_PROBE:'.length)));

--- a/apps/desktop/tests/main/pptx-layered-background.test.ts
+++ b/apps/desktop/tests/main/pptx-layered-background.test.ts
@@ -22,6 +22,18 @@ import {
 const execFileP = promisify(execFile);
 const desktopRoot = fileURLToPath(new URL('../..', import.meta.url));
 
+/**
+ * Budget for one Electron probe process (`xvfb-run … electron <probeDir>` on
+ * Linux). The probes only need a second or two once Chromium is up, but a
+ * cold Electron start on a busy CI runner can take well over ten seconds,
+ * and `execFile` kills a timed-out child with a bare "Command failed" and no
+ * stderr — which is exactly what an otherwise green run shows when it flakes.
+ * Generous on purpose: a probe that really hangs still fails, just later.
+ */
+const ELECTRON_PROBE_TIMEOUT_MS = 60_000;
+/** Per-test budget for a test that runs one probe: the probe plus setup. */
+const ELECTRON_PROBE_TEST_TIMEOUT_MS = 90_000;
+
 function bgraWithUniformAlpha(alpha: number): Buffer {
   const bitmap = Buffer.alloc(16);
   for (let pixel = 0; pixel < 4; pixel += 1) {
@@ -270,7 +282,7 @@ app.whenReady().then(() => {
       delete env.ELECTRON_RUN_AS_NODE;
       const command = process.platform === 'linux' ? 'xvfb-run' : electronPath;
       const args = process.platform === 'linux' ? ['-a', electronPath, probeDir] : [probeDir];
-      const { stdout, stderr } = await execFileP(command, args, { env, timeout: 10_000 });
+      const { stdout, stderr } = await execFileP(command, args, { env, timeout: ELECTRON_PROBE_TIMEOUT_MS });
       const marker = stdout.split(/\r?\n/).find((line) => line.startsWith('OD_PNG_PAINT:'));
       if (!marker) throw new Error(`Electron paint probe returned no result: ${stdout || stderr}`);
       expect(JSON.parse(marker.slice('OD_PNG_PAINT:'.length))).toEqual({
@@ -282,7 +294,7 @@ app.whenReady().then(() => {
     } finally {
       await rm(probeDir, { force: true, recursive: true });
     }
-  }, 15_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('retries a transparent capture then returns paint', async () => {
     const retries: number[] = [];
@@ -548,25 +560,25 @@ describe('editable PPTX layered backgrounds', () => {
       captures: 1,
       media: [expect.stringMatching(/\.png$/)],
     });
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('keeps layered-background captures at 2x CSS resolution on a dpr=2 renderer', async () => {
     const capture = await probeDpr2LayeredBackgroundCapture();
 
     expect(capture).toMatchObject({ devicePixelRatio: 2, height: 120, width: 240 });
-  }, 20_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('bounds clipped-backdrop hit testing independently of overlap area', async () => {
     const capture = await probeDpr2LayeredBackgroundCapture();
 
     expect(capture.largeAreaHitTests).toBeLessThanOrEqual(4_101);
-  }, 20_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('includes a 1px clipped backdrop nested in a layered blend compositor root', async () => {
     const capture = await probeDpr2LayeredBackgroundCapture();
 
     expect(capture.largeStripeExportedRgb).toEqual(capture.largeStripeChromiumRgb);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('captures standard and WebKit text-clipped layered gradients as Chromium-painted text', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -601,7 +613,7 @@ describe('editable PPTX layered backgrounds', () => {
       expect(fixture.comparison.maxChannelDelta, comparisonContext).toBeLessThanOrEqual(224);
       expect(fixture.nativeContent).toBe(-1);
     }
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('captures standard and WebKit text-clipped layered pseudos as Chromium-painted text', async () => {
     const captures = await probePseudoTextClipCaptures();
@@ -630,7 +642,7 @@ describe('editable PPTX layered backgrounds', () => {
       expect(fixture.result.paintedPixels, fixture.name).toBeGreaterThan(0);
       expect(fixture.result.transparentPixels, fixture.name).toBeGreaterThan(0);
     }
-  }, 20_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('keeps layered pseudo backgrounds behind native pseudo content', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -638,7 +650,7 @@ describe('editable PPTX layered backgrounds', () => {
     expect(media.pseudoLayerOrder.background, JSON.stringify(media.pseudoLayerOrder)).toBeGreaterThanOrEqual(0);
     expect(media.pseudoLayerOrder.content).toBeGreaterThanOrEqual(0);
     expect(media.pseudoLayerOrder.background).toBeLessThan(media.pseudoLayerOrder.content);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('keeps an opaque pseudo fallback in raster media without covering native content and border', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -648,7 +660,7 @@ describe('editable PPTX layered backgrounds', () => {
     expect(media.pseudoNativeStyle.content).toBeGreaterThanOrEqual(0);
     expect(media.pseudoNativeStyle.border).toBeGreaterThanOrEqual(0);
     expect(media.pseudoNativeStyle.fallbackFill).toBe(-1);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('preserves a layered pseudo box shadow in its exported raster media', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -660,7 +672,7 @@ describe('editable PPTX layered backgrounds', () => {
     });
     expect(image?.topLeftRgb, JSON.stringify(image)).toEqual([255, 0, 0]);
     expect(image?.centerRgb, JSON.stringify(image)).toEqual([0, 0, 255]);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('flattens a multiply-blended layered background against an authored pseudo backdrop', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -671,7 +683,7 @@ describe('editable PPTX layered backgrounds', () => {
       media: [expect.stringMatching(/\.png$/)],
     });
     expect(image?.centerRgb, JSON.stringify(image)).toEqual([64, 96, 64]);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('flattens a multiply-blended layered background against nested backdrop descendants', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -681,7 +693,7 @@ describe('editable PPTX layered backgrounds', () => {
       media: [expect.stringMatching(/\.png$/)],
     });
     expect(image?.centerRgb, JSON.stringify(image)).toEqual([64, 96, 64]);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('uses CSS paint order when selecting a blended background backdrop', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -691,7 +703,7 @@ describe('editable PPTX layered backgrounds', () => {
       media: [expect.stringMatching(/\.png$/)],
     });
     expect(image?.centerRgb, JSON.stringify(image)).toEqual([64, 96, 64]);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('includes a narrow clipped stripe in a layered blend target backdrop', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -709,7 +721,7 @@ describe('editable PPTX layered backgrounds', () => {
       .toBeLessThanOrEqual(1);
     expect(media.clippedStripeBackdropChromiumComparison.maxChannelDelta, comparisonContext)
       .toBeLessThanOrEqual(16);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('includes an explicit slide background behind a materialized layered pseudo', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -720,7 +732,7 @@ describe('editable PPTX layered backgrounds', () => {
       media: [expect.stringMatching(/\.png$/)],
     });
     expect(image?.centerRgb, JSON.stringify(image)).toEqual([64, 96, 64]);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('aligns a captured layered background with native content after export normalization', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -729,7 +741,7 @@ describe('editable PPTX layered backgrounds', () => {
       background: { height: 971550, width: 2171700, x: 1314450, y: 1028700 },
       content: { height: 971550, width: 2171700, x: 1314450, y: 1028700 },
     });
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('flattens a backdrop-filtered layered background against its authored backdrop', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -745,7 +757,7 @@ describe('editable PPTX layered backgrounds', () => {
       image?.centerRgb.every((channel, index) => Math.abs(channel - [96, 223, 223][index]!) <= 1),
       JSON.stringify(image),
     ).toBe(true);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('preserves background blending for standard and backdrop-dependent pseudos', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -754,7 +766,7 @@ describe('editable PPTX layered backgrounds', () => {
 
     expect(standard?.centerRgb, JSON.stringify(standard)).toEqual([64, 96, 64]);
     expect(materialized?.centerRgb, JSON.stringify(materialized)).toEqual([64, 96, 64]);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('captures non-empty backdrop-dependent pseudos with their Chromium-painted foregrounds', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -771,7 +783,7 @@ describe('editable PPTX layered backgrounds', () => {
     expect(comparison.meanChannelDelta, comparisonContext).toBeLessThanOrEqual(8);
     expect(comparison.maxChannelDelta, comparisonContext).toBeLessThanOrEqual(160);
     expect(media.compositedPseudoContentNativeContent).toBe(-1);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('captures a filtered layered pseudo with its generated content and border', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -790,7 +802,7 @@ describe('editable PPTX layered backgrounds', () => {
     expect(media.selfFilteredPseudoChromiumComparison.maxChannelDelta, comparisonContext)
       .toBeLessThanOrEqual(160);
     expect(media.selfFilteredPseudoNativeContent).toBe(-1);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('captures a real blended target with its Chromium-painted foreground', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -807,7 +819,7 @@ describe('editable PPTX layered backgrounds', () => {
     expect(media.realBlendChromiumComparison.meanChannelDelta, comparisonContext).toBeLessThanOrEqual(10);
     expect(media.realBlendChromiumComparison.maxChannelDelta, comparisonContext).toBeLessThanOrEqual(64);
     expect(media.realBlendNativeContent).toBe(-1);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('keeps a materialized pseudo fallback in its PNG without a duplicate native fill', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -822,7 +834,7 @@ describe('editable PPTX layered backgrounds', () => {
       JSON.stringify(image),
     ).toBe(true);
     expect(media.materializedOpaquePseudoNativeFill).toBe(-1);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('captures only the layered background pixels from a replaced element', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -837,7 +849,7 @@ describe('editable PPTX layered backgrounds', () => {
     expect(image?.translucentPixels, JSON.stringify(image)).toBeGreaterThan(0);
     expect(image?.opaquePixels, JSON.stringify(image)).toBe(0);
     expect(media.replacedForegroundMedia).toHaveLength(1);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('keeps a slide-root layered pseudo background above the opaque slide background', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -854,13 +866,13 @@ describe('editable PPTX layered backgrounds', () => {
     expect(media.rootPseudoLayerOrder.content).toBeGreaterThanOrEqual(0);
     expect(media.rootPseudoLayerOrder.slideBackground).toBeLessThan(media.rootPseudoLayerOrder.background);
     expect(media.rootPseudoLayerOrder.background).toBeLessThan(media.rootPseudoLayerOrder.content);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('skips hidden, zero-sized, and off-slide layered backgrounds without aborting export', async () => {
     const media = await probeLayeredBackgroundMedia();
 
     expect(media.skippedTargets).toBe(0);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('preserves clipping and effective opacity in the exported layered-background pixels', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -871,7 +883,7 @@ describe('editable PPTX layered backgrounds', () => {
     expect(image?.transparentPixels, JSON.stringify(image)).toBeGreaterThan(0);
     expect(image?.maxAlpha).toBeGreaterThanOrEqual(120);
     expect(image?.maxAlpha).toBeLessThanOrEqual(136);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('captures a layered target foreground with its own opacity applied once', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -899,7 +911,7 @@ describe('editable PPTX layered backgrounds', () => {
     expect(media.nestedOpacityNativeContent).toBe(-1);
     expect(media.nestedOpacityNativeShape).toBe(-1);
     expect(image?.topLeftRgb[0], JSON.stringify(image)).toBeGreaterThan(image?.topLeftRgb[1] ?? 0);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('keeps a whole-paint slide capture as the export root with full-slide geometry', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -915,7 +927,7 @@ describe('editable PPTX layered backgrounds', () => {
       y: 0,
     });
     expect(media.slideRootMaskNativeContent).toBe(-1);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('captures intermediate compositor paint with a partially transparent layered child', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -934,7 +946,7 @@ describe('editable PPTX layered backgrounds', () => {
     expect(image?.maxAlpha).toBeGreaterThanOrEqual(120);
     expect(image?.maxAlpha).toBeLessThanOrEqual(136);
     expect(media.nestedCompositorNativeFill).toBe(-1);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('captures a painted static wrapper inside an opacity group without re-emitting its fill', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -955,7 +967,7 @@ describe('editable PPTX layered backgrounds', () => {
     expect(media.paintedWrapperOrder.image).toBeGreaterThanOrEqual(0);
     expect(media.paintedWrapperOrder.nativeFill).toBe(-1);
     expect(media.paintedWrapperOrder.image).toBeLessThan(media.paintedWrapperOrder.nativeContent);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('captures a compositor root solid background below its native foreground', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -976,7 +988,7 @@ describe('editable PPTX layered backgrounds', () => {
     expect(media.solidCompositorOrder.image).toBeGreaterThanOrEqual(0);
     expect(media.solidCompositorOrder.nativeFill).toBe(-1);
     expect(media.solidCompositorOrder.image).toBeLessThan(media.solidCompositorOrder.nativeContent);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('propagates blended-child backdrop dependency to its opacity capture root', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -993,7 +1005,7 @@ describe('editable PPTX layered backgrounds', () => {
       JSON.stringify(image),
     ).toBe(true);
     expect(image?.minAlpha).toBe(255);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('captures an ancestor blend context with its layered child and backdrop', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -1005,7 +1017,7 @@ describe('editable PPTX layered backgrounds', () => {
     });
     expect(image?.centerRgb, JSON.stringify(image)).toEqual([64, 96, 64]);
     expect(image?.minAlpha).toBe(255);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('captures native foreground inside an unsupported ancestor filter context', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -1024,7 +1036,7 @@ describe('editable PPTX layered backgrounds', () => {
     expect(media.ancestorFilterForegroundChromiumComparison.maxChannelDelta, comparisonContext)
       .toBeLessThanOrEqual(160);
     expect(media.ancestorFilterForegroundNativeContent).toBe(-1);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('captures slide-root filter effects with layered backgrounds and native foreground', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -1043,7 +1055,7 @@ describe('editable PPTX layered backgrounds', () => {
     expect(media.slideFilterForegroundChromiumComparison.maxChannelDelta, comparisonContext)
       .toBeLessThanOrEqual(160);
     expect(media.slideFilterForegroundNativeContent).toBe(-1);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test.each([
     ['a layered element clip path', 'selfClipForeground'],
@@ -1066,7 +1078,7 @@ describe('editable PPTX layered backgrounds', () => {
     expect(probe.comparison.maxChannelDelta, comparisonContext).toBeLessThanOrEqual(160);
     expect(probe.nativeContent).toBe(-1);
     expect(probe.nativeBorder).toBe(-1);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('captures a real masked element complete instead of emitting unmasked native foreground', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -1079,7 +1091,7 @@ describe('editable PPTX layered backgrounds', () => {
     expect(image?.translucentPixels).toBeGreaterThan(0);
     expect(image?.maxAlpha).toBeGreaterThan(240);
     expect(media.maskedNativeContent).toBe(-1);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('preserves mask geometry on a normal layered pseudo background', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -1093,7 +1105,7 @@ describe('editable PPTX layered backgrounds', () => {
     expect(image?.minAlpha).toBe(0);
     expect(image?.maxAlpha).toBe(255);
     expect(image?.transparentPixels, JSON.stringify(image)).toBeGreaterThan(image?.opaquePixels ?? 0);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('preserves mask geometry on a background-blended layered pseudo', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -1107,7 +1119,7 @@ describe('editable PPTX layered backgrounds', () => {
     expect(image?.minAlpha).toBe(0);
     expect(image?.maxAlpha).toBe(255);
     expect(image?.transparentPixels, JSON.stringify(image)).toBeGreaterThan(image?.opaquePixels ?? 0);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 
   test('masks pseudo content and border in the captured layer without native duplicates', async () => {
     const media = await probeLayeredBackgroundMedia();
@@ -1124,7 +1136,7 @@ describe('editable PPTX layered backgrounds', () => {
     expect(media.maskedPseudoContentOrder.image).toBeGreaterThanOrEqual(0);
     expect(media.maskedPseudoContentOrder.nativeContent).toBe(-1);
     expect(media.maskedPseudoContentOrder.image).toBeLessThan(media.maskedPseudoContentOrder.sibling);
-  }, 30_000);
+  }, ELECTRON_PROBE_TEST_TIMEOUT_MS);
 });
 
 type LayeredBackgroundProbe = {
@@ -1425,7 +1437,7 @@ app.whenReady().then(async () => {
     let stderr: string;
     let stdout: string;
     try {
-      ({ stderr, stdout } = await execFileP(command, args, { env, timeout: 10_000 }));
+      ({ stderr, stdout } = await execFileP(command, args, { env, timeout: ELECTRON_PROBE_TIMEOUT_MS }));
     } catch (error) {
       const failure = error as Error & { stderr?: string; stdout?: string };
       throw new Error(
@@ -1589,7 +1601,7 @@ app.whenReady().then(async () => {
     let stderr: string;
     let stdout: string;
     try {
-      ({ stderr, stdout } = await execFileP(command, args, { env, timeout: 10_000 }));
+      ({ stderr, stdout } = await execFileP(command, args, { env, timeout: ELECTRON_PROBE_TIMEOUT_MS }));
     } catch (error) {
       const failure = error as Error & { stderr?: string; stdout?: string };
       throw new Error(
@@ -3075,7 +3087,7 @@ app.whenReady().then(async () => {
     let stderr: string;
     let stdout: string;
     try {
-      ({ stderr, stdout } = await execFileP(command, args, { env, timeout: 20_000 }));
+      ({ stderr, stdout } = await execFileP(command, args, { env, timeout: ELECTRON_PROBE_TIMEOUT_MS }));
     } catch (error) {
       const failure = error as Error & { stderr?: string; stdout?: string };
       throw new Error(

--- a/apps/desktop/tests/main/pptx-layered-background.test.ts
+++ b/apps/desktop/tests/main/pptx-layered-background.test.ts
@@ -280,9 +280,28 @@ app.whenReady().then(() => {
       const electronPath = join(desktopRoot, 'node_modules', 'electron', 'dist', electronRelativePath);
       const env: NodeJS.ProcessEnv = { ...process.env };
       delete env.ELECTRON_RUN_AS_NODE;
+      // Same flags as every other probe in this file: the CI runner has no
+      // usable Chromium sandbox or GPU, and a probe that asks for either can
+      // exit before `app.whenReady()` with nothing on stdout.
+      const electronArgs = [probeDir, '--no-sandbox', '--disable-gpu'];
       const command = process.platform === 'linux' ? 'xvfb-run' : electronPath;
-      const args = process.platform === 'linux' ? ['-a', electronPath, probeDir] : [probeDir];
-      const { stdout, stderr } = await execFileP(command, args, { env, timeout: ELECTRON_PROBE_TIMEOUT_MS });
+      const args = process.platform === 'linux' ? ['-a', electronPath, ...electronArgs] : electronArgs;
+      let stderr: string;
+      let stdout: string;
+      try {
+        ({ stderr, stdout } = await execFileP(command, args, { env, timeout: ELECTRON_PROBE_TIMEOUT_MS }));
+      } catch (error) {
+        // `execFile` reports a non-zero exit as a bare "Command failed"; the
+        // child's own output is what says why.
+        const failure = error as Error & { stderr?: string; stdout?: string };
+        throw new Error(
+          [
+            failure.message,
+            failure.stdout ? `stdout:\n${failure.stdout}` : '',
+            failure.stderr ? `stderr:\n${failure.stderr}` : '',
+          ].filter(Boolean).join('\n'),
+        );
+      }
       const marker = stdout.split(/\r?\n/).find((line) => line.startsWith('OD_PNG_PAINT:'));
       if (!marker) throw new Error(`Electron paint probe returned no result: ${stdout || stderr}`);
       expect(JSON.parse(marker.slice('OD_PNG_PAINT:'.length))).toEqual({


### PR DESCRIPTION
## Why

**Use case.** While landing OPEND-2553 PR-D (#7772, which touches nothing under `apps/desktop`), the `Workspace unit tests` job went red four runs in a row on one test: `tests/main/pptx-layered-background.test.ts › chromium empty-capture retry › treats real PNG buffers with any visible alpha as painted`. The first run also took down all 39 tests of the same file plus both `base-href-precedence` tests. #7768 (unrelated) fails on the identical case; #7771 / #7769 / #7766 passed the same job earlier in the day.

**Pain.** Two things, found in that order. (1) These tests spawn a throwaway Electron process (`xvfb-run -a electron <probeDir>` on Linux) through `execFile` with a 10 s (paint probe, DPR probes) or 20 s (layered-background / base-href probes) timeout. A cold Electron start on a busy runner exceeds that, and a timed-out `execFile` surfaces as a bare `Command failed: xvfb-run … electron …` with empty stdout/stderr — exactly the failure in the logs. The file passes locally on macOS (57/57) because the probe starts in well under a second there. (2) The first CI run of this PR still failed on the same test with the larger budget, in a 29 s run — so that probe is not timing out, it is exiting early. It was the only Electron spawn in the file without `--no-sandbox --disable-gpu`, and the only one that rethrew a failed spawn without the child's stdout/stderr, which is why every log so far shows a bare `Command failed`. The second commit aligns it with the other probes and attaches the child's output on failure.

Result before this PR: unrelated PRs go red on that probe, and the log never says why.

## What users will see

Nothing — test-only change. Contributors see fewer spurious `Workspace unit tests` failures on PRs that do not touch the desktop app.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — tests only (`apps/desktop/tests/main/pptx-layered-background.test.ts`, `apps/desktop/tests/main/base-href-precedence.test.ts`)

## Screenshots

Not applicable.

## Bug fix verification

Not a product bug; a CI timing budget. Evidence it is the timeout and not the probes:

- Failing runs on #7772: `33874996464` (39 + 2 failures, whole file), `33878351205` and its two reruns (the single paint-probe test each time), all with the bare `Command failed` message and no probe stdout/stderr.
- #7768 run `33870563966`, same single test, same message.
- #7774 run `33884230600` (first commit only, 60 s budget): same single test, same bare message, whole vitest run 29 s — an early exit, not a timeout.
- Locally on this branch: `apps/desktop` › `vitest run tests/main/pptx-layered-background.test.ts tests/main/base-href-precedence.test.ts` — **2 files, 57 passed** (and 55/55 for the layered-background file again after the second commit).

## Validation

- `pnpm guard` — exit 0
- `pnpm --filter @open-design/desktop typecheck` — exit 0
- `pnpm --filter @open-design/desktop build` — ok
- `apps/desktop`: `npx vitest run -c vitest.config.ts tests/main/pptx-layered-background.test.ts tests/main/base-href-precedence.test.ts` — 2 files passed, 57 passed (57)

## Adjacent issues

- `frame-capture.test.ts` already uses a 100 s budget for its real-Electron WebGL capture; the other Electron-spawning desktop tests were the only ones left on 10–20 s. No other timing constants were touched.
- If the sandbox-less paint probe still fails on a runner, the attached stderr from the second commit is the next lead; nothing else in the file changes behavior.
