### PR TITLE
fix: remove duplicate web-clone chip in HOME_HERO_CHIPS

### DIFF
--- a/apps/web/src/components/home-hero/chips.ts
+++ b/apps/web/src/components/home-hero/chips.ts
@@ -287,29 +287,6 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
     },
   },
   {
-    id: 'web-clone',
-    label: 'Website clone',
-    icon: 'globe',
-    group: 'create',
-    description: 'Source-first site reproduction',
-    hint: 'Paste a target URL, then reconstruct the site and audit the clone.',
-    // Website reproduction binds the bundled `example-web-clone` plugin.
-    // Stored as a prototype so the artifact keeps prototype preview
-    // behavior; `intent: 'web-clone'` is what routes the scenario plugin
-    // (see `defaultScenarioPluginIdForProjectMetadata`) and splits these
-    // projects into their own `web_clone` analytics kind.
-    action: {
-      kind: 'apply-scenario',
-      pluginId: 'example-web-clone',
-      projectKind: 'prototype',
-      projectMetadata: {
-        kind: 'prototype',
-        intent: 'web-clone',
-        fidelity: 'high-fidelity',
-      },
-    },
-  },
-  {
     id: 'image',
     label: 'Image',
     icon: 'image',

--- a/apps/web/tests/components/chips.automatic-default.test.ts
+++ b/apps/web/tests/components/chips.automatic-default.test.ts
@@ -45,3 +45,19 @@ describe('create rail chips claim the automatic default', () => {
     }
   });
 });
+
+// A duplicate chip id collides as a React key and makes findChip and the
+// group-filtered lookups ambiguous: they observe only the first match, so a
+// second entry sharing an id (as `web-clone` did) is silently shadowed and can
+// drift from the entry that is actually used — e.g. quietly losing
+// `automaticDefault`. Existing findChip / rail tests passed with the duplicate
+// present because they only ever see the first match, so keep an explicit
+// catalog-wide invariant that fails the moment an id is reused.
+describe('HOME_HERO_CHIPS catalog', () => {
+  it('has a unique id for every chip', () => {
+    const ids = HOME_HERO_CHIPS.map((chip) => chip.id);
+    const duplicates = [...new Set(ids.filter((id, index) => ids.indexOf(id) !== index))];
+    expect(duplicates).toEqual([]);
+    expect(new Set(ids).size).toBe(HOME_HERO_CHIPS.length);
+  });
+});


### PR DESCRIPTION
Fixes #7775.

## Why
`HOME_HERO_CHIPS` defined two objects with `id: 'web-clone'`. They were identical except the second lacked `automaticDefault: true`. A duplicate `id` collides as a React key and makes `findChip` / `orderedCreateChips` lookups ambiguous, and because those lookups observe only the first match, the second copy silently opted out of automatic-default binding without any test failing.

## What users will see
No visible change to the Home hero rail: the single retained `web-clone` chip is the canonical one that already carried `automaticDefault: true`, so its create behavior is unchanged. The fix removes a hidden second definition that was never the one used, and eliminates the duplicate-React-key risk.

## Surface area
- `apps/web/src/components/home-hero/chips.ts` — removed the duplicate `web-clone` entry (the copy without `automaticDefault`), keeping the canonical one.
- `apps/web/tests/components/chips.automatic-default.test.ts` — added a catalog-wide id-uniqueness invariant.

## Validation
- New test `HOME_HERO_CHIPS catalog › has a unique id for every chip` compares `new Set(ids).size` with `HOME_HERO_CHIPS.length` (and reports offending ids). It **fails on `main`** (duplicate `web-clone`) and **passes with this deletion**.
- `grep -n "id: 'web-clone'" apps/web/src/components/home-hero/chips.ts` now returns a single match.