### PR TITLE
fix(mcp): accept workflow id when confirming briefs

### DIFF
--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -1269,6 +1269,12 @@ export class McpObservabilitySession {
           pluginWorkflowId: inherited.pluginWorkflowId,
         };
       }
+      if (args.pluginWorkflowId !== undefined) {
+        validatePluginWorkflowId(args.pluginWorkflowId);
+        throw pluginContractError(
+          'pluginWorkflowId requires an attributed brief draft',
+        );
+      }
     }
 
     if (args.pluginWorkflowId !== undefined) {

--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -1251,6 +1251,15 @@ export class McpObservabilitySession {
     if (name === 'confirm_brief') {
       const inherited = briefStore.attributionForDraft(args.briefDraftId);
       if (inherited) {
+        if (
+          args.pluginWorkflowId !== undefined
+          && validatePluginWorkflowId(args.pluginWorkflowId)
+            !== inherited.pluginWorkflowId
+        ) {
+          throw pluginContractError(
+            'pluginWorkflowId does not match the brief draft',
+          );
+        }
         this.workflows.set(
           inherited.pluginWorkflowId,
           inherited.externalPluginContext,

--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -431,6 +431,7 @@ export const TOOL_DEFS = [
           description:
             'BCP-47 Host locale used only when collect_brief had no request or tool-call locale.',
         },
+        pluginWorkflowId: PLUGIN_WORKFLOW_ID_ARG,
       },
       required: ['briefDraftId', 'nonce', 'answers'],
       additionalProperties: false,

--- a/apps/daemon/tests/mcp-observability.test.ts
+++ b/apps/daemon/tests/mcp-observability.test.ts
@@ -223,6 +223,38 @@ describe('local MCP plugin observability contract', () => {
     ).toBe('skipped');
   });
 
+  it('rejects confirmation workflow ids that do not match the brief draft', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      enabled: false,
+      deviceId: null,
+      locale: 'en',
+    }), { status: 200 })));
+    const session = await McpObservabilitySession.create(
+      'http://127.0.0.1:17456',
+      { name: 'codex', version: '1.0.0' },
+    );
+    const store = createLocalMcpBriefStore();
+    const pluginWorkflowId = '018f6f2e-2222-7222-8222-222222222222';
+    const collected = store.collect({
+      artifactType: 'website',
+      skip: true,
+      pluginWorkflowId,
+      externalPluginContext: pluginContext,
+    });
+
+    await expect(session.resolveAttribution('confirm_brief', {
+      briefDraftId: collected.briefDraftId,
+      pluginWorkflowId: '018f6f2e-9999-7999-8999-999999999999',
+    }, store)).rejects.toThrow(/pluginWorkflowId does not match the brief draft/u);
+    await expect(session.resolveAttribution('confirm_brief', {
+      briefDraftId: collected.briefDraftId,
+      pluginWorkflowId,
+    }, store)).resolves.toEqual({
+      context: pluginContext,
+      pluginWorkflowId,
+    });
+  });
+
   it('records a confirmed brief state without retaining answers in analytics', () => {
     const store = createLocalMcpBriefStore();
     const collected = store.collect({

--- a/apps/daemon/tests/mcp-observability.test.ts
+++ b/apps/daemon/tests/mcp-observability.test.ts
@@ -255,6 +255,36 @@ describe('local MCP plugin observability contract', () => {
     });
   });
 
+  it('rejects plugin workflow ids on ordinary brief confirmations', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      enabled: false,
+      deviceId: null,
+      locale: 'en',
+    }), { status: 200 })));
+    const session = await McpObservabilitySession.create(
+      'http://127.0.0.1:17456',
+      { name: 'codex', version: '1.0.0' },
+    );
+    const store = createLocalMcpBriefStore();
+    const pluginArgs = {
+      artifactType: 'website',
+      externalPluginContext: pluginContext,
+    };
+    const attribution = await session.resolveAttribution(
+      'collect_brief',
+      pluginArgs,
+      store,
+    );
+    const ordinary = store.collect({ artifactType: 'website', skip: true });
+
+    await expect(session.resolveAttribution('confirm_brief', {
+      briefDraftId: ordinary.briefDraftId,
+      pluginWorkflowId: attribution?.pluginWorkflowId,
+    }, store)).rejects.toThrow(
+      /pluginWorkflowId requires an attributed brief draft/u,
+    );
+  });
+
   it('records a confirmed brief state without retaining answers in analytics', () => {
     const store = createLocalMcpBriefStore();
     const collected = store.collect({

--- a/apps/daemon/tests/mcp-observability.test.ts
+++ b/apps/daemon/tests/mcp-observability.test.ts
@@ -71,6 +71,13 @@ describe('local MCP plugin observability contract', () => {
       externalPluginContext: pluginContext,
     })).not.toThrow();
 
+    expect(() => validateMcpToolArgs('confirm_brief', {
+      briefDraftId: 'brief-draft',
+      nonce: 'brief-nonce',
+      answers: {},
+      pluginWorkflowId: '018f6f2e-4444-7444-8444-444444444444',
+    })).not.toThrow();
+
     expect(() => validateMcpToolArgs('start_run', {
       project: 'Demo',
       prompt: 'Create a launch page',


### PR DESCRIPTION
Fixes #7778

## Why

I picked up the reported official Codex plugin integration failure because it blocks the confirmed brief from reaching the next OpenDesign step. `collect_brief` issues a `pluginWorkflowId` that the plugin is required to preserve, but `confirm_brief` had `additionalProperties: false` without declaring that field, so the local MCP rejected a valid follow-up call before confirmation could run.

The confirmation path also keeps that opaque correlation fail-closed: when a caller supplies the workflow id, it must be canonical and match the attribution stored with the brief draft instead of being silently replaced by a different inherited id. An ordinary brief without plugin attribution cannot be attached to an unrelated known workflow during confirmation.

## What users will see

Confirming a brief through the official Codex plugin can now preserve the server-issued workflow context and continue normally instead of failing with `PLUGIN_CONTRACT_REJECTED: confirm_brief.pluginWorkflowId is unsupported`. Stale, cross-wired, or ordinary-draft workflow ids fail explicitly rather than confirming under another workflow.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — the local MCP `confirm_brief` input contract now accepts the existing opaque workflow-id field
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this changes the local MCP tool schema and has no UI surface.

## Bug fix verification

- Test path: `apps/daemon/tests/mcp-observability.test.ts`
- Red on `main`: yes — the new regression failed with `confirm_brief.pluginWorkflowId is unsupported`.
- Review regression: a different canonical workflow id initially resolved under the draft's stored id; it now fails with `pluginWorkflowId does not match the brief draft`, while the matching id succeeds.
- Review regression: a known plugin workflow id attached to an ordinary brief initially acquired unrelated attribution; it now fails with `pluginWorkflowId requires an attributed brief draft`.
- Green on this branch: yes — 15/15 focused observability tests and 32/32 related MCP brief/observability tests pass.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/mcp-observability.test.ts` — 15 passed
- `pnpm exec vitest run -c vitest.config.ts tests/mcp-brief-app.test.ts tests/mcp-observability.test.ts` — 32 passed
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm typecheck`
- Initial full daemon suite before the two focused review follow-ups: 9,833 passed and 20 skipped. The unrelated membership test failure passed 4/4 when rerun alone; the non-loopback export hook timeout reproduced unchanged on clean `origin/main`, where its 12 tests were skipped. Final-head focused/related tests and all typecheck/guard checks above were rerun after both follow-ups.
- `git diff --check`
- Publication leak scan: no new secret, token, cookie, personal email, or local-path finding in the two changed files or this PR body; whole-tree findings are existing repository fixtures and generated/source baselines.

## AI assistance

OpenAI Codex assisted with source navigation, implementation, and validation. I reviewed and verified the final change.
