### PR TITLE
fix(packaged): keep a busy sidecar peer from restarting the desktop

### DIFF
--- a/apps/packaged/src/launcher-after-quit.ts
+++ b/apps/packaged/src/launcher-after-quit.ts
@@ -14,6 +14,7 @@ import {
 import {
   getSidecarStatus,
   invokeSidecar,
+  isJsonIpcTimeoutError,
   stopSidecar,
   type SidecarStamp,
 } from "@open-design/sidecar";
@@ -26,6 +27,28 @@ const PACKAGED_SIDECAR_SOURCES = [SIDECAR_SOURCES.TOOLS_PACK, SIDECAR_SOURCES.PA
 
 function packagedSidecarSourcesFor(stamp: SidecarStamp): readonly SidecarStamp["source"][] {
   return [stamp.source, ...PACKAGED_SIDECAR_SOURCES.filter((source) => source !== stamp.source)];
+}
+
+const PEER_PROBE_TIMEOUT_MS = 350;
+const BUSY_PEER_PROBE_TIMEOUT_MS = 1500;
+
+type PeerProbeResult = "busy" | "healthy" | "stale";
+
+/**
+ * A peer whose endpoint is gone is stale; a peer that accepts the connection
+ * but cannot answer inside the probe budget is merely busy (for example the
+ * daemon serving an agent run) and must not cost the user their desktop.
+ */
+async function probeSidecarPeer(peer: SidecarStamp, getStatus: typeof getSidecarStatus): Promise<PeerProbeResult> {
+  for (const timeoutMs of [PEER_PROBE_TIMEOUT_MS, BUSY_PEER_PROBE_TIMEOUT_MS]) {
+    try {
+      const status = await getStatus<{ url?: unknown }>(peer, { timeoutMs });
+      return typeof status?.url === "string" && status.url.length > 0 ? "healthy" : "stale";
+    } catch (error) {
+      if (!isJsonIpcTimeoutError(error)) return "stale";
+    }
+  }
+  return "busy";
 }
 
 export type LauncherExistingDesktopGateResult =
@@ -244,14 +267,11 @@ export async function inspectExistingDesktopForLauncher(
   const { stamp: inspectedStamp, status } = ownerInspection.running;
 
   const staleSidecars: AppKey[] = [];
+  const busySidecars: AppKey[] = [];
   for (const app of [APP_KEYS.DAEMON, APP_KEYS.WEB]) {
-    const sidecarStatus = await getStatus<{ url?: unknown }>(
-      { ...inspectedStamp, app, mode: inspectedStamp.mode },
-      { timeoutMs: 350 },
-    ).catch(() => null);
-    if (typeof sidecarStatus?.url !== "string" || sidecarStatus.url.length === 0) {
-      staleSidecars.push(app);
-    }
+    const probe = await probeSidecarPeer({ ...inspectedStamp, app, mode: inspectedStamp.mode }, getStatus);
+    if (probe === "stale") staleSidecars.push(app);
+    else if (probe === "busy") busySidecars.push(app);
   }
 
   if (staleSidecars.length > 0) {
@@ -271,6 +291,13 @@ export async function inspectExistingDesktopForLauncher(
     });
     if (!restarted) return { action: "exit", reason: "existing-focus-failed" };
     return { action: "continue", reason: "stale-sidecar" };
+  }
+
+  if (busySidecars.length > 0) {
+    await writeLauncherAfterQuitLog(
+      options.paths,
+      `inspect-found-existing namespace=${namespace} peer=busy apps=${busySidecars.join(",")} pid=${typeof status.pid === "number" ? status.pid : "unknown"}`,
+    );
   }
 
   const existingVersion = status.update?.currentVersion;

--- a/apps/packaged/tests/launcher-after-quit.test.ts
+++ b/apps/packaged/tests/launcher-after-quit.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import type { SidecarStamp, SidecarStopResult } from "@open-design/sidecar";
+import { JsonIpcTimeoutError, type SidecarStamp, type SidecarStopResult } from "@open-design/sidecar";
 import { APP_KEYS, SIDECAR_SOURCES } from "@open-design/sidecar-proto";
 import type { StopProcessesResult, stopProcesses, waitForProcessExit } from "@open-design/platform";
 import { describe, expect, it, vi } from "vitest";
@@ -103,6 +103,52 @@ describe("inspectExistingDesktopForLauncher", () => {
         paths: fakePaths(root), stopSidecar: stop,
       })).resolves.toEqual({ action: "continue", reason: "stale-sidecar" });
       expect(stop).toHaveBeenCalledWith(stamp());
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("focuses a desktop whose daemon peer is busy instead of restarting it", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-launcher-busy-peer-"));
+    const stop = vi.fn(async () => sidecarStop());
+    const invoke = vi.fn(async () => ({ accepted: true }));
+    const getStatus = vi.fn(async (target: SidecarStamp) => {
+      if (target.app === APP_KEYS.DAEMON) throw new JsonIpcTimeoutError("od-daemon-ipc", 350);
+      return target.app === APP_KEYS.DESKTOP
+        ? { pid: 1234, state: "running", updatedAt: new Date().toISOString(), windowVisible: true }
+        : { state: "running", url: "http://127.0.0.1:1234" };
+    });
+    try {
+      await expect(inspectExistingDesktopForLauncher(stamp(), {
+        getStatus: getStatus as never, invoke: invoke as never, paths: fakePaths(root), stopSidecar: stop,
+      })).resolves.toEqual({ action: "exit", reason: "existing-focused" });
+      expect(stop).not.toHaveBeenCalled();
+      expect(invoke).toHaveBeenCalledWith(stamp(), "show", {}, { timeoutMs: 800 });
+      expect(getStatus).toHaveBeenCalledWith({ ...stamp(), app: APP_KEYS.DAEMON }, { timeoutMs: 350 });
+      expect(getStatus).toHaveBeenCalledWith({ ...stamp(), app: APP_KEYS.DAEMON }, { timeoutMs: 1500 });
+      expect(await readFile(join(root, "logs", "launcher", "after-quit.log"), "utf8")).toContain("peer=busy apps=daemon pid=1234");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("accepts a daemon peer that answers on the slower retry probe", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-launcher-retry-peer-"));
+    const stop = vi.fn(async () => sidecarStop());
+    let daemonProbes = 0;
+    const getStatus = vi.fn(async (target: SidecarStamp) => {
+      if (target.app === APP_KEYS.DAEMON && daemonProbes++ === 0) throw new JsonIpcTimeoutError("od-daemon-ipc", 350);
+      return target.app === APP_KEYS.DESKTOP
+        ? { pid: 1234, state: "running", updatedAt: new Date().toISOString(), windowVisible: true }
+        : { state: "running", url: "http://127.0.0.1:1234" };
+    });
+    try {
+      await expect(inspectExistingDesktopForLauncher(stamp(), {
+        getStatus: getStatus as never, invoke: vi.fn(async () => ({ accepted: true })) as never, paths: fakePaths(root), stopSidecar: stop,
+      })).resolves.toEqual({ action: "exit", reason: "existing-focused" });
+      expect(stop).not.toHaveBeenCalled();
+      expect(daemonProbes).toBe(2);
+      expect(await readFile(join(root, "logs", "launcher", "after-quit.log"), "utf8")).not.toContain("peer=busy");
     } finally {
       await rm(root, { force: true, recursive: true });
     }

--- a/packages/sidecar/src/index.ts
+++ b/packages/sidecar/src/index.ts
@@ -46,6 +46,7 @@ export type {
 export { handoffCurrentSidecarGeneration, SidecarClient, SidecarFactory } from "./client.js";
 export type { SidecarLifecycleLockOptions } from "./lifecycle-lock.js";
 export { withSidecarLifecycleLock } from "./lifecycle-lock.js";
+export { isJsonIpcTimeoutError, JsonIpcTimeoutError } from "./json-ipc.js";
 export type { SidecarStamp, SidecarStampField } from "./stamp.js";
 export {
   normalizeSidecarStamp,

--- a/packages/sidecar/src/json-ipc.ts
+++ b/packages/sidecar/src/json-ipc.ts
@@ -289,6 +289,24 @@ export async function createJsonIpcServer({
   };
 }
 
+export class JsonIpcTimeoutError extends Error {
+  readonly code = "IPC_REQUEST_TIMEOUT";
+  readonly socketPath: string;
+  readonly timeoutMs: number;
+
+  constructor(socketPath: string, timeoutMs: number) {
+    super(`IPC request timed out: ${socketPath}`);
+    this.name = "JsonIpcTimeoutError";
+    this.socketPath = socketPath;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export function isJsonIpcTimeoutError(error: unknown): error is JsonIpcTimeoutError {
+  if (error instanceof JsonIpcTimeoutError) return true;
+  return error instanceof Error && (error as { code?: unknown }).code === "IPC_REQUEST_TIMEOUT";
+}
+
 /**
  * Send one newline-delimited JSON request over a unix socket / named pipe and
  * resolve with the server's `result`, rejecting on error response or timeout.
@@ -325,7 +343,7 @@ export async function requestJsonIpc<T = any>(
         traceId,
       });
       socket.destroy();
-      settle(() => rejectRequest(new Error(`IPC request timed out: ${socketPath}`)));
+      settle(() => rejectRequest(new JsonIpcTimeoutError(socketPath, timeoutMs)));
     }, timeoutMs);
 
     socket.on("connect", () => {

--- a/packages/sidecar/tests/index.test.ts
+++ b/packages/sidecar/tests/index.test.ts
@@ -4,7 +4,7 @@ import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 
 import { bootstrapSidecarRuntime, createSidecarLaunchEnv } from "../src/bootstrap.js";
-import { createJsonIpcServer, requestJsonIpc } from "../src/json-ipc.js";
+import { createJsonIpcServer, isJsonIpcTimeoutError, JsonIpcTimeoutError, requestJsonIpc } from "../src/json-ipc.js";
 import { resolveAppIpcPath } from "../src/paths.js";
 import {
   resolveAppRuntimePath,
@@ -317,5 +317,33 @@ describe("resolveRuntimeNamespaceRoot", () => {
     expect(
       resolveNamespaceRoot({ base: runtime.base, contract: fakeContract, namespace: runtime.namespace }),
     ).toBe(join(resolve("/data/ns/alpha/runtime"), "alpha"));
+  });
+});
+
+describe("generic sidecar JSON IPC timeouts", () => {
+  it("rejects a request the server never answers with a typed timeout error", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-sidecar-ipc-timeout-"));
+    const socketPath = testIpcPath(root);
+    let release!: () => void;
+    const hold = new Promise<void>((resolve) => { release = resolve; });
+    const server = await createJsonIpcServer({
+      socketPath,
+      handler: async () => {
+        await hold;
+        return { answered: true };
+      },
+    });
+    try {
+      const request = requestJsonIpc(socketPath, { type: "status" }, { timeoutMs: 50 });
+      await expect(request).rejects.toBeInstanceOf(JsonIpcTimeoutError);
+      await expect(request).rejects.toMatchObject({ code: "IPC_REQUEST_TIMEOUT", socketPath, timeoutMs: 50 });
+      await expect(request).rejects.toSatisfy((error: unknown) => isJsonIpcTimeoutError(error));
+      expect(isJsonIpcTimeoutError(new Error("IPC request timed out: elsewhere"))).toBe(false);
+      expect(isJsonIpcTimeoutError(Object.assign(new Error("copy"), { code: "IPC_REQUEST_TIMEOUT" }))).toBe(true);
+    } finally {
+      release();
+      await server.close();
+      await rm(root, { force: true, recursive: true });
+    }
   });
 });


### PR DESCRIPTION
Fixes #7787

## Why

I hit this on Windows 0.21.1 while running Codex tasks inside the desktop app: a second `Open Design.exe` started while the daemon was busy serving my run (on this build the agent's `& $env:OD_NODE_BIN ...` calls launch the GUI, see #7148, but a double-click or an `od://` link takes the same path). The launcher gate in `apps/packaged/src/launcher-after-quit.ts` probed the daemon peer with a 350 ms status request, the busy daemon did not answer in time, and `.catch(() => null)` turned that timeout into `reason=stale-sidecar`. The gate then shut down the live desktop, force-stopped it after 5 s, and the run died with `DAEMON_RESTARTED`. Two seconds earlier the same desktop had accepted a focus request, so the endpoint was alive, only slow.

`after-quit.log` from the machine:

```text
2026-09-05T12:20:31.425Z inspect-found-existing namespace=release-stable-win focus=accepted
2026-09-05T12:20:33.611Z inspect-found-existing namespace=release-stable-win action=restart reason=stale-sidecar apps=daemon pid=170056
2026-09-05T12:20:38.651Z inspect-found-existing namespace=release-stable-win shutdown=timed-out reason=stale-sidecar pid=170056
2026-09-05T12:20:38.711Z force-stop stale-sidecar pid=170056 outcome=sigterm
```

The pain: any second launch of the app during a heavy run costs the user the desktop, the sidecars and the run. This is the `stale-sidecar` branch of the gate; the `headless-owner` branch is #7154 / #7388, and #7621 removes the most common Windows trigger. This PR is independent of both and keeps the diff to the probe classification.

## What users will see

- Launching Open Design a second time while a run keeps the daemon busy now focuses the existing window instead of restarting the app. The run keeps going.
- `logs/launcher/after-quit.log` records the case as `inspect-found-existing namespace=<ns> peer=busy apps=daemon pid=<pid>`.
- A sidecar whose endpoint is actually gone (connect error) still takes the existing `stale-sidecar` restart path. Nothing changes for `superseded-version` or `headless-owner`.

## How

- `packages/sidecar`: `requestJsonIpc` rejects a timeout with a typed `JsonIpcTimeoutError` (`code: "IPC_REQUEST_TIMEOUT"`, same message as before) and exports `isJsonIpcTimeoutError`, so callers can tell "no answer in time" from "endpoint gone" without matching on message text.
- `apps/packaged`: the peer probe distinguishes three outcomes. A status answer with a URL is healthy; a non-timeout error or an answer without a URL is stale (unchanged); a timeout is retried once with a 1500 ms budget and, if it times out again, the peer is treated as busy: logged, not restarted. The worst-case added latency for a launcher start is ~1.5 s and only in the busy case.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — a second launch during a busy daemon focuses the running desktop instead of restarting it.
- [ ] **None**

## Screenshots

Not applicable (no UI change).

## Bug fix verification

- Test path: `apps/packaged/tests/launcher-after-quit.test.ts` → `focuses a desktop whose daemon peer is busy instead of restarting it` and `accepts a daemon peer that answers on the slower retry probe`. Typed error coverage in `packages/sidecar/tests/index.test.ts` → `rejects a request the server never answers with a typed timeout error`.
- Red on `main`, green on this branch: **yes**. With the two specs added and the launcher untouched, both fail with `{ action: "continue", reason: "stale-sidecar" }`; after the source change the file passes 12/12. The pre-existing `terminally stops a stale peer set before continuing` spec still passes, which pins the unreachable-endpoint restart path.
- Also run locally (Windows 11, Node 24.16, pnpm 10.33.2): `pnpm --filter @open-design/sidecar typecheck`, `pnpm --filter @open-design/sidecar exec vitest run tests/index.test.ts` (11/11), `pnpm --filter @open-design/packaged typecheck`, `pnpm guard`. The full `@open-design/packaged` suite has 7 failures in `prewarm.test.ts` and `launcher-runtime.test.ts` (symlink/FUSE cases) that fail identically with this change reverted, so they are Windows-environment issues unrelated to this PR.

## Validation

**Unit / typecheck (Windows 11, Node 24.16, pnpm 10.33.2)**

| Check | Result |
|---|---|
| `pnpm --filter @open-design/packaged exec vitest run tests/launcher-after-quit.test.ts` on `main` with the two new specs | 2 failed (`{ action: "continue", reason: "stale-sidecar" }`), 10 passed |
| same command on this branch | 12 passed |
| `pnpm --filter @open-design/sidecar exec vitest run tests/index.test.ts` | 11 passed (includes the typed timeout spec) |
| `pnpm --filter @open-design/sidecar typecheck` | pass |
| `pnpm --filter @open-design/packaged typecheck` | pass |
| `pnpm guard` | pass |

**Manual pass, packaged Windows app, deterministic busy daemon**

Method: with the desktop up and its IPC server listening, suspend the daemon sidecar process for 8 s (`psutil.Process.suspend()`), launch a second `Open Design.exe` for the same namespace 0.2 s later, resume the daemon. The suspended daemon accepts the pipe connection but never answers, which is exactly the "timeout, not ENOENT" case; no agent run or LLM call is involved.

Before, installed 0.21.1 (`release-stable-win`), reproduced twice:

```text
2026-09-05T14:06:51.035Z inspect-found-existing namespace=release-stable-win action=restart reason=stale-sidecar apps=daemon pid=143952
2026-09-05T14:06:56.077Z inspect-found-existing namespace=release-stable-win shutdown=timed-out reason=stale-sidecar pid=143952
2026-09-05T14:06:56.091Z force-stop stale-sidecar pid=143952 outcome=sigterm
```

Desktop log at the same moment: `desktop IPC request start {"type":"shutdown"}`; next session opens with `prior session(s) ended abnormally (no clean shutdown)`. `Open Design.exe` processes: 8 before, 0 after. The window is gone.

After, `tools-pack win build --to dir --namespace fx` from this branch:

| Check | Result |
|---|---|
| daemon supervisor + child suspended 8 s, second `Open Design.exe` launched 0.02 s later | `after-quit.log`: `inspect-found-existing namespace=fx peer=busy apps=daemon pid=71984` then `inspect-found-existing namespace=fx focus=accepted` |
| desktop log at the same moment | `sidecar action start {"type":"show"}` and `sidecar action end`; no `shutdown`, no `ended abnormally` |
| `Open Design.exe` processes | 11 before, 11 after; window still up |
| `tools-pack win inspect --namespace fx` after the test | daemon `state: "running"`, same pid 27752, same url |
| timing | busy line logged 1.99 s after the second launch, consistent with the 350 ms probe plus the 1500 ms retry |

Control on the same build, daemon supervisor + child killed for real before the second launch (the endpoint is gone, so the stale path must still fire):

```text
2026-09-05T14:23:14.557Z inspect-found-existing namespace=fx action=restart reason=stale-sidecar apps=daemon pid=71984
2026-09-05T14:23:22.907Z inspect-found-existing namespace=fx shutdown=exited reason=stale-sidecar pid=71984
2026-09-05T14:23:23.418Z inspect-unavailable namespace=fx action=continue error=connect ENOENT \\.\pipe\open-design-sidecar-...
```

The old desktop exited on the graceful request and the launcher continued into a fresh desktop, which is the existing recovery behavior, unchanged.

Note for reproducing: the packaged Windows build needed `%LOCALAPPDATA%\electron-builder\Cache\winCodeSign\winCodeSign-2.6.0` pre-extracted by hand, because electron-builder's own extraction fails on this machine without symlink privilege; unrelated to this PR.


