### PR TITLE
docs: fix dead Regional terminology anchor in TRANSLATIONS.md

### DIFF
--- a/TRANSLATIONS.md
+++ b/TRANSLATIONS.md
@@ -257,7 +257,7 @@ The `LOCALES` array in [`apps/web/src/i18n/types.ts`](apps/web/src/i18n/types.ts
   OpenDesign è un'alternativa open-source (codice aperto) a Claude Design.
   ```
 - For regional variants (zh-CN vs zh-TW, pt-BR vs pt-PT), choose the most widely understood variant for your target audience
-- See [Regional terminology](#regional-terminology) section for specific glossaries
+- See [Regional terminology](#-regional-terminology) section for specific glossaries
 
 ### Badge Translation
 


### PR DESCRIPTION
The Translation Guide's cross-reference to `## 🌍 Regional Terminology` used the plain `#regional-terminology` slug; GitHub's slugger strips the emoji but keeps the following space as a separator, producing `#-regional-terminology`. Updated the link to the real anchor. Same class as the plugins-spec anchor fixes in 77a7342e.