### PR TITLE
fix(daemon): collapse identical ternary arms in normalizeComparableValue

### DIFF
--- a/apps/daemon/src/project-design-token-suggestions.ts
+++ b/apps/daemon/src/project-design-token-suggestions.ts
@@ -291,7 +291,7 @@ function normalizeComparableValue(value: string): string {
   const hex = clean.match(/#[0-9a-f]{3,8}\b/u)?.[0];
   if (hex) return expandShortHex(hex);
   const num = clean.match(/-?\d+(?:\.\d+)?(?:px|rem|em|%)?/u)?.[0];
-  if (num) return num.endsWith('px') ? num : num;
+  if (num) return num;
   return clean.replace(/\s+/gu, ' ');
 }
 


### PR DESCRIPTION
`apps/daemon/src/project-design-token-suggestions.ts:294`:

`if (num) return num.endsWith('px') ? num : num;`

Both arms return `num`, so the conditional is dead code. This PR collapses it to `if (num) return num;` — behavior-preserving.

For context: the `endsWith('px')` check looks like the stub of an unfinished unit normalization (rem/em values can never exactly match a px query under the exact-match comparison at line ~315). Implementing the conversion would change suggestion behavior, so this PR only removes the dead branch and leaves that as a possible follow-up.