### PR TITLE
fix(platform): search Home Manager per-user profile for CLI discovery (#7790)

### DIFF
--- a/packages/platform/src/toolchain.ts
+++ b/packages/platform/src/toolchain.ts
@@ -9,7 +9,7 @@
  * concerns.
  */
 import { existsSync, readdirSync } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, userInfo } from "node:os";
 import { isAbsolute, join } from "node:path";
 
 export type WellKnownUserToolchainOptions = {
@@ -185,6 +185,10 @@ export function wellKnownUserToolchainBins(
     dirs.push("/run/current-system/sw/bin");
     // `/nix/var/nix/profiles/default/bin` — default system profile
     dirs.push("/nix/var/nix/profiles/default/bin");
+    // Home Manager as a nix-darwin / NixOS module (`home.packages`) lands
+    // binaries here — not in ~/.nix-profile. Prefer os.userInfo().username
+    // over $USER: launchd GUI processes often have USER unset (#7790).
+    dirs.push(`/etc/profiles/per-user/${userInfo().username}/bin`);
   }
   // Per-version Node toolchains: scan the install root and surface every
   // version directory's bin folder. Best-effort — missing roots simply

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { tmpdir, userInfo } from "node:os";
 import { join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
@@ -1131,6 +1131,7 @@ describe("wellKnownUserToolchainBins", () => {
       // System-wide Nix paths must NOT appear when includeSystemBins is false
       expect(dirs).not.toContain("/run/current-system/sw/bin");
       expect(dirs).not.toContain("/nix/var/nix/profiles/default/bin");
+      expect(dirs).not.toContain(`/etc/profiles/per-user/${userInfo().username}/bin`);
     } finally {
       rmSync(home, { recursive: true, force: true });
     }
@@ -1143,6 +1144,17 @@ describe("wellKnownUserToolchainBins", () => {
       expect(dirs).toContain("/run/current-system/sw/bin");
       expect(dirs).toContain("/nix/var/nix/profiles/default/bin");
       expect(dirs).toContain(join(home, ".nix-profile", "bin"));
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("includes Home Manager per-user profile bin when includeSystemBins is true (issue #7790)", () => {
+    const home = mkdtempSync(join(tmpdir(), "wkutb-nix-hm-"));
+    try {
+      const dirs = wellKnownUserToolchainBins({ home, env: {}, includeSystemBins: true });
+      // Prefer os.userInfo().username — launchd GUI may leave $USER unset
+      expect(dirs).toContain(`/etc/profiles/per-user/${userInfo().username}/bin`);
     } finally {
       rmSync(home, { recursive: true, force: true });
     }


### PR DESCRIPTION
Fixes #7790.

## User-facing impact
On Nix + Home Manager, GUI / Finder / launchd-launched apps can miss CLIs that live only in the per-user profile. This adds that profile's `bin` to discovery so those tools resolve the same way they do from a login shell.

## Affected surface
`wellKnownUserToolchainBins` when `includeSystemBins` is true: also search `/etc/profiles/per-user/<username>/bin` (`os.userInfo().username`). Sandboxed / user-profile-only calls keep the existing behavior.

## Regression / validation
- Added a focused regression test for the Home Manager per-user path
- Re-ran the platform test suite (89 tests) for both resolver consumers
