### PR TITLE
fix(packaged): stop MCP from reopening stale mac app

### DIFF
--- a/apps/packaged/src/headless-runtime.ts
+++ b/apps/packaged/src/headless-runtime.ts
@@ -1,4 +1,6 @@
-import { mkdir } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { lstat, mkdir, readlink, rename, rm, symlink } from "node:fs/promises";
+import { basename, join, resolve, sep } from "node:path";
 
 import {
   APP_KEYS,
@@ -125,11 +127,49 @@ export function parsePackagedHeadlessRequest(
   return { headless: true, mcpInstallAgent: agent };
 }
 
-export function resolvePackagedMcpBootstrapLaunch(options: {
+function macAppBundleForExecutable(executablePath: string): string | null {
+  const marker = `${sep}Contents${sep}MacOS${sep}`;
+  const markerIndex = executablePath.lastIndexOf(marker);
+  if (markerIndex === -1) return null;
+  const bundlePath = executablePath.slice(0, markerIndex);
+  return bundlePath.endsWith(".app") ? bundlePath : null;
+}
+
+async function publishActiveMacAppAlias(
+  launcherNamespaceRoot: string,
+  appBundlePath: string,
+): Promise<string | null> {
+  const bundle = await lstat(appBundlePath).catch(() => null);
+  if (bundle == null || !bundle.isDirectory()) return null;
+
+  const activeRoot = join(launcherNamespaceRoot, "active");
+  const aliasPath = join(activeRoot, basename(appBundlePath));
+  const existing = await lstat(aliasPath).catch(() => null);
+  if (existing != null && !existing.isSymbolicLink()) return null;
+  if (existing?.isSymbolicLink()) {
+    const currentTarget = await readlink(aliasPath).catch(() => null);
+    if (currentTarget != null && resolve(activeRoot, currentTarget) === resolve(appBundlePath)) {
+      return aliasPath;
+    }
+  }
+
+  await mkdir(activeRoot, { recursive: true });
+  const pendingAliasPath = join(activeRoot, `.${basename(appBundlePath)}.${randomUUID()}`);
+  try {
+    await symlink(appBundlePath, pendingAliasPath, "dir");
+    await rename(pendingAliasPath, aliasPath);
+  } finally {
+    await rm(pendingAliasPath, { force: true });
+  }
+  return aliasPath;
+}
+
+export async function resolvePackagedMcpBootstrapLaunch(options: {
   currentExecutablePath?: string;
   installedLaunchPath: string | null;
+  launcherNamespaceRoot?: string;
   platform?: NodeJS.Platform;
-}): PackagedMcpBootstrapLaunch {
+}): Promise<PackagedMcpBootstrapLaunch> {
   const platform = options.platform ?? process.platform;
   const currentExecutablePath =
     options.currentExecutablePath ?? process.execPath;
@@ -137,12 +177,17 @@ export function resolvePackagedMcpBootstrapLaunch(options: {
     platform === "darwin"
     && options.installedLaunchPath?.endsWith(".app")
   ) {
+    const activeAppBundle = macAppBundleForExecutable(currentExecutablePath);
+    const launchPath = activeAppBundle != null && options.launcherNamespaceRoot != null
+      ? await publishActiveMacAppAlias(options.launcherNamespaceRoot, activeAppBundle)
+        .catch(() => null)
+      : null;
     return {
       command: "/usr/bin/open",
       args: [
         "-g",
         "-j",
-        options.installedLaunchPath,
+        launchPath ?? options.installedLaunchPath,
         "--args",
         "--headless",
       ],
@@ -184,8 +229,9 @@ export async function runPackagedHeadless(
   };
   const mcpBootstrap =
     options.mcpBootstrapLaunch
-    ?? resolvePackagedMcpBootstrapLaunch({
+    ?? await resolvePackagedMcpBootstrapLaunch({
       installedLaunchPath: launcherRuntime.installedLaunchPath,
+      launcherNamespaceRoot: launcherRuntime.launcherPaths.namespaceRoot,
     });
 
   await mkdir(paths.runtimeRoot, { recursive: true });

--- a/apps/packaged/src/index.ts
+++ b/apps/packaged/src/index.ts
@@ -202,8 +202,9 @@ async function main(): Promise<void> {
   }
   const activeConfig = launcherRuntime.config;
   const paths = launcherRuntime.paths;
-  const mcpBootstrap = resolvePackagedMcpBootstrapLaunch({
+  const mcpBootstrap = await resolvePackagedMcpBootstrapLaunch({
     installedLaunchPath: launcherRuntime.installedLaunchPath,
+    launcherNamespaceRoot: launcherRuntime.launcherPaths.namespaceRoot,
   });
 
   // Arm fatal-exit telemetry now that we know the channel key/version. The

--- a/apps/packaged/tests/headless-runtime.test.ts
+++ b/apps/packaged/tests/headless-runtime.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
+import { mkdtemp, mkdir, readlink, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   acquirePackagedHeadlessStartup,
@@ -30,30 +33,47 @@ describe("parsePackagedHeadlessRequest", () => {
 });
 
 describe("resolvePackagedMcpBootstrapLaunch", () => {
-  it("uses macOS open against the stable signed app bundle", () => {
-    expect(resolvePackagedMcpBootstrapLaunch({
-      currentExecutablePath:
-        "/private/payload/Open Design.app/Contents/MacOS/Open Design",
-      installedLaunchPath: "/Applications/Open Design.app",
-      platform: "darwin",
-    })).toEqual({
-      command: "/usr/bin/open",
-      args: [
-        "-g",
-        "-j",
-        "/Applications/Open Design.app",
-        "--args",
-        "--headless",
-      ],
-    });
+  it("keeps one stable macOS bootstrap alias pointed at the active payload", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-mcp-bootstrap-alias-"));
+    try {
+      const namespaceRoot = join(root, "launcher", "channels", "stable", "namespaces", "release-stable");
+      const firstBundle = join(namespaceRoot, "versions", "0.21.0", "payload", "Open Design.app");
+      const secondBundle = join(namespaceRoot, "versions", "0.21.1", "payload", "Open Design.app");
+      await mkdir(join(firstBundle, "Contents", "MacOS"), { recursive: true });
+      await mkdir(join(secondBundle, "Contents", "MacOS"), { recursive: true });
+
+      const first = await resolvePackagedMcpBootstrapLaunch({
+        currentExecutablePath: join(firstBundle, "Contents", "MacOS", "Open Design"),
+        installedLaunchPath: "/Applications/Open Design.app",
+        launcherNamespaceRoot: namespaceRoot,
+        platform: "darwin",
+      });
+      const stableBundle = join(namespaceRoot, "active", "Open Design.app");
+      expect(first).toEqual({
+        command: "/usr/bin/open",
+        args: ["-g", "-j", stableBundle, "--args", "--headless"],
+      });
+      expect(await readlink(stableBundle)).toBe(firstBundle);
+
+      const second = await resolvePackagedMcpBootstrapLaunch({
+        currentExecutablePath: join(secondBundle, "Contents", "MacOS", "Open Design"),
+        installedLaunchPath: "/Applications/Open Design.app",
+        launcherNamespaceRoot: namespaceRoot,
+        platform: "darwin",
+      });
+      expect(second.args[2]).toBe(stableBundle);
+      expect(await readlink(stableBundle)).toBe(secondBundle);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
   });
 
-  it("invokes a non-macOS installed launcher directly", () => {
-    expect(resolvePackagedMcpBootstrapLaunch({
+  it("invokes a non-macOS installed launcher directly", async () => {
+    await expect(resolvePackagedMcpBootstrapLaunch({
       currentExecutablePath: "/tmp/payload/open-design",
       installedLaunchPath: "/opt/open-design/open-design",
       platform: "linux",
-    })).toEqual({
+    })).resolves.toEqual({
       command: "/opt/open-design/open-design",
       args: ["--headless"],
     });


### PR DESCRIPTION
Related to #7264

## Why

A macOS user can close Open Design and have an MCP client reopen a visible, obsolete app minutes later. In-app updates advance the active payload while the canonical Applications bundle remains old, but MCP bootstrap configuration keeps targeting that old bundle.

## What users will see

MCP starts the current Open Design runtime in the background without reopening the stale Applications copy or showing a desktop window. Future payload updates keep one stable bootstrap path and atomically repoint it to the active signed app.

## Surface area

- [ ] UI
- [ ] Keyboard shortcut
- [x] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [x] Default behavior change
- [ ] None

## Screenshots

Not applicable. The corrected behavior is intentionally windowless.

## Bug fix verification

- Test path: `apps/packaged/tests/headless-runtime.test.ts`
- Red on main: yes. The bootstrap resolved to `/Applications/Open Design.app` instead of an active-payload alias.
- Green on branch: yes. The same stable alias follows a simulated update from 0.21.0 to 0.21.1.

## Validation

- `pnpm --filter @open-design/packaged test` (22 files, 317 tests)
- `pnpm guard`
- `pnpm typecheck`
- Live macOS proof with the 0.21.1 signed payload: MCP initialize succeeded, daemon socket became ready, local web returned HTTP 200, and the desktop process remained `--headless` with no attachable window.
