### PR TITLE
fix(amr): restore the empty-wallet upgrade dialog for free accounts

### DIFF
--- a/apps/web/src/runtime/amr-balance-gate.ts
+++ b/apps/web/src/runtime/amr-balance-gate.ts
@@ -18,8 +18,7 @@ import type {
   WorkspaceBillingResponse,
 } from '@open-design/contracts';
 import { fetchAmrWalletSnapshot } from '../providers/daemon';
-import { resolveAmrPlan } from './amr-low-balance-plan';
-import { planUnlimitedTier } from './amr-unlimited-models';
+import { isFreeAmrPlan, resolveAmrPlan } from './amr-low-balance-plan';
 
 /**
  * Hard-block line (USD): at or below this the wallet cannot fund any part of
@@ -144,35 +143,6 @@ export function amrWalletBalanceInsufficient(
   return balance != null && balance <= AMR_HARD_BLOCK_BALANCE_USD;
 }
 
-/**
- * Whether a low-balance wallet may still start the selected model's run and
- * leave the authoritative billing / Model Limit call to Vela.
- *
- * ABOVE the hard-block line the wallet can fund at least the start, so the
- * client must not pre-judge a Model Limit it can no longer see: fail open.
- *
- * AT or BELOW the hard-block line the wallet can fund nothing, so failing open
- * only manufactures the mid-run AMR_INSUFFICIENT_BALANCE failure this pre-run
- * gate exists to prevent. The one account that may still proceed is one whose
- * plan funds runs without ever drawing the wallet — a Personal Coding Plan
- * tier, whose in-plan usage vela records through the `coding_plan` billing
- * mode. A free account (and every Team plan) has no such funding source, so an
- * empty wallet must stay a hard block for them.
- *
- * An unresolved plan counts as "no Coding Plan funding" and blocks. The block
- * is dismissible ("Not now") and re-checks the wallet, so a wrong block costs
- * one click, while a wrong allow costs a run that dies after the user has
- * already committed their task.
- */
-async function selectedModelMayRunOnThisBalance(
-  balance: number,
-  snapshot: AmrWalletSnapshot,
-): Promise<boolean> {
-  if (balance > AMR_HARD_BLOCK_BALANCE_USD) return true;
-  const plan = await resolveAmrPlan(snapshot).catch(() => null);
-  return planUnlimitedTier(plan) !== null;
-}
-
 /** Whether the user opted out of the low-balance soft warning ("don't remind
  * me again"). Hard blocks are never subject to this opt-out. */
 export function isAmrLowBalanceWarnOptedOut(): boolean {
@@ -191,6 +161,56 @@ export function setAmrLowBalanceWarnOptedOut(): void {
   } catch {
     // Persistence failure just means the warning shows again next time.
   }
+}
+
+/**
+ * Whether something OTHER than the wallet might fund this Personal run, so the
+ * wallet-balance preflight must stand down and let Vela decide at admission.
+ *
+ * This is the surviving half of a two-part question. The gate originally asked
+ * "is the caller on a Coding Plan, AND is this model unlimited on that plan";
+ * the model half was retired with the client-side entitlement catalog, so Vela
+ * is now the only authority on whether a GIVEN model is metered. The plan half
+ * is still readable, and it is the half that decides whether standing down can
+ * ever be right: a subscriber's $0 wallet is a NORMAL state (their day-to-day
+ * models are plan-funded and never touch it), while an account with no plan at
+ * all has nothing but the wallet — so its empty wallet is a real hard block,
+ * not a wallet the run might route around.
+ *
+ * Only a DEFINITIVE free answer lets the gate run. An unresolved plan fails
+ * open exactly like the retired catalog lookup did on an unavailable list, so a
+ * subscriber whose tier cannot be read is never blocked by a failed read.
+ */
+async function planMayFundRunOutsideWallet(
+  snapshot: AmrWalletSnapshot,
+): Promise<boolean> {
+  return !isFreeAmrPlan(await resolveAmrPlan(snapshot));
+}
+
+/**
+ * Whether the HARD tier — and ONLY the hard tier — must stand down for this
+ * run, because something other than the wallet may fund it.
+ *
+ * Scope note (OPEND-2600). This question must never be asked ahead of BOTH
+ * tiers and answered with a whole-gate `allow`: that deletes the soft reminder
+ * for every subscriber between $0 and the warning line, which is how a Pro
+ * account at $1.79 ended up getting no card at all. Standing down is only ever
+ * about NOT BLOCKING; a plan says nothing about whether a nearly-empty wallet
+ * is worth mentioning. Product ruling 2026-09-03 (T37/T39): warn at every tier,
+ * block at none that a plan may still fund. So this guards the hard branch
+ * alone and the soft branch is reached either way.
+ *
+ * Latency note (red line, T40). The plan read is a network roundtrip, and the
+ * soft tier must not add one to the send path. Call this ONLY once the balance
+ * is already at or below the hard-block line — the one case that was always
+ * going to block, and is therefore already allowed to wait.
+ */
+async function hardBlockMustStandDown(
+  snapshot: AmrWalletSnapshot,
+  modelId: string | null | undefined,
+): Promise<boolean> {
+  if (!modelId?.trim()) return false;
+  return planMayFundRunOutsideWallet(snapshot);
 }
 
 /**
@@ -291,22 +311,24 @@ async function checkWorkspaceBalanceGate(
   }
   const balance = amrWalletBalanceUsd(workspaceSnapshot);
   if (balance == null) return { kind: 'unavailable' };
-  if (
-    balance <= AMR_LOW_BALANCE_WARN_USD
-    && scope.workspaceType === 'personal'
-    && modelId?.trim()
-    && await selectedModelMayRunOnThisBalance(balance, workspaceSnapshot!)
-  ) {
-    // Per-model Coding Plan membership is no longer exposed to the client, so
-    // a fundable personal wallet defers the Model Limit decision to Vela.
-    return { kind: 'allow' };
-  }
   if (balance <= AMR_HARD_BLOCK_BALANCE_USD) {
-    return {
-      kind: 'hard',
-      reason: 'insufficient',
-      snapshot: workspaceSnapshot!,
-    };
+    // Coding Plan model membership is no longer exposed to the client, so Vela
+    // enforces the authoritative billing and Model Limit decision at admission
+    // time. The client still proves the caller HAS a plan first — without one
+    // there is nothing but the wallet, and failing open would delete this hard
+    // block for every empty personal wallet. Team wallets never stand down: a
+    // member's personal plan does not fund their team's runs.
+    const standsDown =
+      scope.workspaceType === 'personal'
+      && (await hardBlockMustStandDown(workspaceSnapshot!, modelId));
+    if (!standsDown) {
+      return {
+        kind: 'hard',
+        reason: 'insufficient',
+        snapshot: workspaceSnapshot!,
+      };
+    }
+    // Fall through: not blocked, but an empty wallet is still worth saying.
   }
   if (balance <= AMR_LOW_BALANCE_WARN_USD && !isAmrLowBalanceWarnOptedOut()) {
     return { kind: 'soft', snapshot: workspaceSnapshot! };
@@ -332,10 +354,11 @@ export async function checkAmrBalanceGate(
       if (cachedBalance > AMR_LOW_BALANCE_WARN_USD || isAmrLowBalanceWarnOptedOut()) {
         return { kind: 'allow' };
       }
+      // Above the hard line, so nothing here can block — and a plan never
+      // silences the reminder (OPEND-2600). Skipping the plan read also keeps
+      // the soft tier off the network, which is the latency red line (T40).
       // cached is non-null here: a definitive balance implies a snapshot.
-      return modelId?.trim()
-        ? { kind: 'allow' }
-        : { kind: 'soft', snapshot: cached! };
+      return { kind: 'soft', snapshot: cached! };
     }
     // Hard-block candidate (signed out or empty): confirm against the live
     // wallet before blocking — the cache may predate a sign-in or recharge.
@@ -355,13 +378,9 @@ export async function checkAmrBalanceGate(
     const freshBalance = amrWalletBalanceUsd(fresh);
     if (freshBalance == null) return { kind: 'allow' };
     if (
-      freshBalance <= AMR_LOW_BALANCE_WARN_USD
-      && modelId?.trim()
-      && await selectedModelMayRunOnThisBalance(freshBalance, fresh)
+      freshBalance <= AMR_HARD_BLOCK_BALANCE_USD
+      && !(await hardBlockMustStandDown(fresh, modelId))
     ) {
-      return { kind: 'allow' };
-    }
-    if (freshBalance <= AMR_HARD_BLOCK_BALANCE_USD) {
       return { kind: 'hard', reason: 'insufficient', snapshot: fresh };
     }
     if (freshBalance <= AMR_LOW_BALANCE_WARN_USD && !isAmrLowBalanceWarnOptedOut()) {

--- a/apps/web/src/runtime/amr-balance-gate.ts
+++ b/apps/web/src/runtime/amr-balance-gate.ts
@@ -18,6 +18,8 @@ import type {
   WorkspaceBillingResponse,
 } from '@open-design/contracts';
 import { fetchAmrWalletSnapshot } from '../providers/daemon';
+import { resolveAmrPlan } from './amr-low-balance-plan';
+import { planUnlimitedTier } from './amr-unlimited-models';
 
 /**
  * Hard-block line (USD): at or below this the wallet cannot fund any part of
@@ -142,6 +144,35 @@ export function amrWalletBalanceInsufficient(
   return balance != null && balance <= AMR_HARD_BLOCK_BALANCE_USD;
 }
 
+/**
+ * Whether a low-balance wallet may still start the selected model's run and
+ * leave the authoritative billing / Model Limit call to Vela.
+ *
+ * ABOVE the hard-block line the wallet can fund at least the start, so the
+ * client must not pre-judge a Model Limit it can no longer see: fail open.
+ *
+ * AT or BELOW the hard-block line the wallet can fund nothing, so failing open
+ * only manufactures the mid-run AMR_INSUFFICIENT_BALANCE failure this pre-run
+ * gate exists to prevent. The one account that may still proceed is one whose
+ * plan funds runs without ever drawing the wallet — a Personal Coding Plan
+ * tier, whose in-plan usage vela records through the `coding_plan` billing
+ * mode. A free account (and every Team plan) has no such funding source, so an
+ * empty wallet must stay a hard block for them.
+ *
+ * An unresolved plan counts as "no Coding Plan funding" and blocks. The block
+ * is dismissible ("Not now") and re-checks the wallet, so a wrong block costs
+ * one click, while a wrong allow costs a run that dies after the user has
+ * already committed their task.
+ */
+async function selectedModelMayRunOnThisBalance(
+  balance: number,
+  snapshot: AmrWalletSnapshot,
+): Promise<boolean> {
+  if (balance > AMR_HARD_BLOCK_BALANCE_USD) return true;
+  const plan = await resolveAmrPlan(snapshot).catch(() => null);
+  return planUnlimitedTier(plan) !== null;
+}
+
 /** Whether the user opted out of the low-balance soft warning ("don't remind
  * me again"). Hard blocks are never subject to this opt-out. */
 export function isAmrLowBalanceWarnOptedOut(): boolean {
@@ -264,10 +295,10 @@ async function checkWorkspaceBalanceGate(
     balance <= AMR_LOW_BALANCE_WARN_USD
     && scope.workspaceType === 'personal'
     && modelId?.trim()
+    && await selectedModelMayRunOnThisBalance(balance, workspaceSnapshot!)
   ) {
-    // Coding Plan membership is no longer exposed to the client. Personal
-    // requests therefore fail open here and let Vela enforce the authoritative
-    // billing and Model Limit decision at admission time.
+    // Per-model Coding Plan membership is no longer exposed to the client, so
+    // a fundable personal wallet defers the Model Limit decision to Vela.
     return { kind: 'allow' };
   }
   if (balance <= AMR_HARD_BLOCK_BALANCE_USD) {
@@ -323,7 +354,11 @@ export async function checkAmrBalanceGate(
     if (fresh.stale || fresh.error != null) return { kind: 'allow' };
     const freshBalance = amrWalletBalanceUsd(fresh);
     if (freshBalance == null) return { kind: 'allow' };
-    if (freshBalance <= AMR_LOW_BALANCE_WARN_USD && modelId?.trim()) {
+    if (
+      freshBalance <= AMR_LOW_BALANCE_WARN_USD
+      && modelId?.trim()
+      && await selectedModelMayRunOnThisBalance(freshBalance, fresh)
+    ) {
       return { kind: 'allow' };
     }
     if (freshBalance <= AMR_HARD_BLOCK_BALANCE_USD) {

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -1480,8 +1480,11 @@ describe('ProjectView conversation run isolation', () => {
     );
   });
 
-  it('lets Vela decide a selected Personal model when the wallet is empty', async () => {
+  it('hard-blocks the AMR send and shows the balance dialog when the wallet is empty', async () => {
     conversationAMessages = [];
+    // Both the cached read and the refresh confirmation report an empty
+    // wallet for an account with no Coding Plan tier, so the send must be
+    // hard-blocked before any run spawns (OPEND-2448).
     fetchAmrWalletSnapshot.mockResolvedValue({
       status: 'available',
       profile: 'prod',
@@ -1512,8 +1515,8 @@ describe('ProjectView conversation run isolation', () => {
 
     fireEvent.click(screen.getByTestId('send-message'));
 
-    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
-    expect(screen.queryByTestId('amr-balance-dialog')).toBeNull();
+    await waitFor(() => expect(screen.getByTestId('amr-balance-dialog')).toBeTruthy());
+    expect(streamViaDaemon).not.toHaveBeenCalled();
   });
 
   it('does not guess whether a selected Personal model is metered at low balance', async () => {

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -1482,13 +1482,19 @@ describe('ProjectView conversation run isolation', () => {
 
   it('hard-blocks the AMR send and shows the balance dialog when the wallet is empty', async () => {
     conversationAMessages = [];
-    // Both the cached read and the refresh confirmation report an empty
-    // wallet for an account with no Coding Plan tier, so the send must be
-    // hard-blocked before any run spawns (OPEND-2448).
+    // Both the cached read and the refresh confirmation report an empty wallet
+    // for a PROVABLY free account, so the send must be hard-blocked before any
+    // run spawns (OPEND-2448).
+    //
+    // `plan: 'free'` is load-bearing, not decoration. The gate blocks only a
+    // definitive free tier — an unresolved plan fails open (T39) — and this
+    // suite's `fetchVelaLoginStatus` returns `{ loggedIn: false }`, so with
+    // `user: null` the plan would resolve to null and this case would land in
+    // the fail-open cell without witnessing anything.
     fetchAmrWalletSnapshot.mockResolvedValue({
       status: 'available',
       profile: 'prod',
-      user: null,
+      user: { id: 'u-free', plan: 'free' },
       balanceUsd: '0',
       updatedAt: null,
       fetchedAt: '2026-07-02T00:00:00.000Z',
@@ -1551,8 +1557,15 @@ describe('ProjectView conversation run isolation', () => {
 
     fireEvent.click(screen.getByTestId('send-message'));
 
+    // A reminder is not a block (OPEND-2600 / T37): the plan check guards the
+    // hard tier only, so a subscriber between $0 and the warning line still
+    // reaches the soft tier and is told. The reminder holds THIS send.
+    await waitFor(() => expect(screen.getByTestId('amr-low-balance-dialog')).toBeTruthy());
+    expect(streamViaDaemon).not.toHaveBeenCalled();
+
+    // "Start anyway" resolves the pending send — the run starts without a re-submit.
+    fireEvent.click(screen.getByTestId('amr-low-balance-dialog-proceed'));
     await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
-    expect(screen.queryByTestId('amr-low-balance-dialog')).toBeNull();
     expect(streamViaDaemon).toHaveBeenCalledWith(
       expect.objectContaining({ agentId: 'amr' }),
     );

--- a/apps/web/tests/runtime/amr-balance-gate.test.ts
+++ b/apps/web/tests/runtime/amr-balance-gate.test.ts
@@ -186,7 +186,7 @@ describe('checkAmrBalanceGate', () => {
     await expect(checkAmrBalanceGate()).resolves.toEqual({ kind: 'allow' });
   });
 
-  it('allows a selected model without a client-side entitlement catalog', async () => {
+  it('does not block a selected model without a client-side entitlement catalog', async () => {
     const empty = snapshot({
       balanceUsd: '0',
       user: { id: 'u1', email: 'user@example.com', plan: 'go' },
@@ -195,16 +195,19 @@ describe('checkAmrBalanceGate', () => {
       .mockResolvedValueOnce({ ...empty, source: 'daemon_cache' })
       .mockResolvedValueOnce(empty);
 
+    // Not `hard` is the invariant. The reminder rides along (OPEND-2600): a
+    // plan means the run may still start, not that an empty wallet is unworthy
+    // of mention.
     await expect(
       checkAmrBalanceGate(undefined, 'new-coding-plan-model'),
-    ).resolves.toEqual({ kind: 'allow' });
+    ).resolves.toEqual({ kind: 'soft', snapshot: empty });
   });
 
   it.each([
     ['plus', 'kimi-k2.7-code'],
     ['pro', 'glm-5.2'],
     ['max', 'minimax-m2.7'],
-  ])('lets Vela decide a selected %s plan model at low balance', async (plan, modelId) => {
+  ])('warns without blocking a selected %s plan model at low balance', async (plan, modelId) => {
     const low = snapshot({
       balanceUsd: '1.20',
       user: { id: 'u1', email: 'user@example.com', plan },
@@ -212,7 +215,8 @@ describe('checkAmrBalanceGate', () => {
     mockedFetch.mockResolvedValueOnce(low);
 
     await expect(checkAmrBalanceGate(undefined, modelId)).resolves.toEqual({
-      kind: 'allow',
+      kind: 'soft',
+      snapshot: low,
     });
     expect(mockedFetch).toHaveBeenCalledTimes(1);
   });
@@ -224,9 +228,10 @@ describe('checkAmrBalanceGate', () => {
     });
     mockedFetch.mockResolvedValueOnce(low);
 
+    // Still no metering guess — the run is not blocked. It is only flagged.
     await expect(
       checkAmrBalanceGate(undefined, 'minimax-m2.7'),
-    ).resolves.toEqual({ kind: 'allow' });
+    ).resolves.toEqual({ kind: 'soft', snapshot: low });
   });
 
   it('skips the soft warning once the user opted out — but never the hard block', async () => {
@@ -263,7 +268,7 @@ describe('checkAmrBalanceGate', () => {
     ['plus', 'kimi-k2.7-code'],
     ['pro', 'glm-5.2'],
     ['max', 'glm-5.1'],
-  ])('lets Vela decide a selected %s model with a fresh zero-dollar wallet', async (plan, modelId) => {
+  ])('does not block a selected %s model with a fresh zero-dollar wallet', async (plan, modelId) => {
     const planAccount = snapshot({
       balanceUsd: '0',
       user: { id: 'u1', email: 'user@example.com', plan },
@@ -274,11 +279,11 @@ describe('checkAmrBalanceGate', () => {
 
     await expect(
       checkAmrBalanceGate(undefined, modelId),
-    ).resolves.toEqual({ kind: 'allow' });
+    ).resolves.toEqual({ kind: 'soft', snapshot: planAccount });
     expect(mockedFetch).toHaveBeenNthCalledWith(2, { refresh: true });
   });
 
-  it('allows a selected model when the fresh wallet omits the plan', async () => {
+  it('does not block a selected model when the fresh wallet omits the plan', async () => {
     const emptyWallet = snapshot({
       balanceUsd: '0',
     });
@@ -295,7 +300,7 @@ describe('checkAmrBalanceGate', () => {
 
     await expect(
       checkAmrBalanceGate(undefined, 'glm-5.2'),
-    ).resolves.toEqual({ kind: 'allow' });
+    ).resolves.toEqual({ kind: 'soft', snapshot: emptyWallet });
   });
 
   it('does not infer plan exclusion for a selected model', async () => {
@@ -309,20 +314,18 @@ describe('checkAmrBalanceGate', () => {
 
     await expect(
       checkAmrBalanceGate(undefined, 'glm-5.1'),
-    ).resolves.toEqual({ kind: 'allow' });
+    ).resolves.toEqual({ kind: 'soft', snapshot: plusAccount });
   });
 
-  // OPEND-2448. A free account has no plan that funds a run without the
-  // wallet, so an empty wallet means the run cannot start at all — selecting a
-  // model does not change that, and letting it through only manufactures the
-  // mid-run AMR_INSUFFICIENT_BALANCE failure this pre-run gate exists to
-  // prevent. Vela reports a free account either as plan 'free' or with no plan
-  // field at all (the daemon omits falsy plans), so both shapes must block.
-  it.each([
-    ['an explicit free plan', { id: 'u1', email: 'user@example.com', plan: 'free' }],
-    ['no plan field at all', { id: 'u1', email: 'user@example.com' }],
-  ])('hard-blocks a selected model on an empty wallet with %s', async (_label, user) => {
-    const freeAccount = snapshot({ balanceUsd: '0', user });
+  // OPEND-2448. An account that is PROVABLY free has nothing but the wallet
+  // behind it, so its empty wallet is a real hard block — selecting a model
+  // does not change that, and letting it through only manufactures the mid-run
+  // AMR_INSUFFICIENT_BALANCE failure this pre-run gate exists to prevent.
+  it('hard-blocks a selected model on an empty wallet for an explicitly free plan', async () => {
+    const freeAccount = snapshot({
+      balanceUsd: '0',
+      user: { id: 'u1', email: 'user@example.com', plan: 'free' },
+    });
     mockedFetch
       .mockResolvedValueOnce({ ...freeAccount, source: 'daemon_cache' })
       .mockResolvedValueOnce(freeAccount);
@@ -356,6 +359,28 @@ describe('checkAmrBalanceGate', () => {
       reason: 'insufficient',
       snapshot: freeAccount,
     });
+  });
+
+  // The counterpart to the two cases above, and the reason the gate asks the
+  // FREE question rather than the PAID one. `isFreeAmrPlan` and a paid-plan
+  // predicate are NOT complements: an unresolved plan is neither. Product
+  // ruling 2026-09-03 (T39) puts that third state on the allow side — a single
+  // failed read must never block someone who paid — so the block is scoped to
+  // a definitive `free`, and the real enforcement stays with Vela at admission.
+  // It is still `soft`, not `allow`: failing open means "not blocked", and an
+  // empty wallet is always worth mentioning (T37).
+  it('does not block a selected model on an empty wallet when the plan cannot be read', async () => {
+    const unknownPlan = snapshot({
+      balanceUsd: '0',
+      user: { id: 'u1', email: 'user@example.com' },
+    });
+    mockedFetch
+      .mockResolvedValueOnce({ ...unknownPlan, source: 'daemon_cache' })
+      .mockResolvedValueOnce(unknownPlan);
+
+    const result = await checkAmrBalanceGate(undefined, 'deepseek-v4-flash');
+    expect(result.kind).not.toBe('hard');
+    expect(result).toEqual({ kind: 'soft', snapshot: unknownPlan });
   });
 
   it('hard-blocks a signed-out account after refresh confirmation', async () => {
@@ -516,7 +541,7 @@ describe('checkAmrBalanceGate', () => {
     })).resolves.toEqual({ kind: 'allow' });
   });
 
-  it('lets Vela decide a selected model in a zero-dollar Personal workspace', async () => {
+  it('does not block a selected model in a zero-dollar Personal workspace', async () => {
     mockedFetch.mockResolvedValue(snapshot({
       balanceUsd: '0',
       user: { id: 'u1', email: 'user@example.com', plan: 'go' },
@@ -539,7 +564,39 @@ describe('checkAmrBalanceGate', () => {
         workspaceId: 'ws-personal-go',
         workspaceMemberId: 'wm-personal-go',
       }, 'deepseek-v4-pro'),
-    ).resolves.toEqual({ kind: 'allow' });
+    ).resolves.toEqual({
+      kind: 'soft',
+      snapshot: expect.objectContaining({ balanceUsd: '0' }),
+    });
+  });
+
+  // OPEND-2600 reverse control. The plan check must guard the HARD branch
+  // only. Asked ahead of both tiers it returns a whole-gate `allow`, which is
+  // how the reported Pro account at $1.79 got no card at all — the exact shape
+  // this file must never accept back.
+  it('still warns a subscriber between the hard-block and low-balance lines', async () => {
+    mockedFetch.mockResolvedValue(snapshot({
+      balanceUsd: '1.79',
+      user: { id: 'u1', email: 'user@example.com', plan: 'pro' },
+    }));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(
+        JSON.stringify(authoritativeWorkspaceBillingResponse(
+          'ws-personal-1379',
+          'wm-personal-1379',
+          '1.79',
+        )),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )),
+    );
+
+    const result = await checkAmrBalanceGate({
+      workspaceType: 'personal',
+      workspaceId: 'ws-personal-1379',
+      workspaceMemberId: 'wm-personal-1379',
+    }, 'glm-5.2');
+    expect(result.kind).toBe('soft');
   });
 
   // OPEND-2448, workspace-scoped half of the same invariant: the personal
@@ -574,7 +631,7 @@ describe('checkAmrBalanceGate', () => {
     });
   });
 
-  it('lets Vela decide a selected model in a low-balance Personal workspace', async () => {
+  it('warns without blocking a selected model in a low-balance Personal workspace', async () => {
     mockedFetch.mockResolvedValue(snapshot({
       balanceUsd: '1.50',
       user: { id: 'u1', email: 'user@example.com', plan: 'pro' },
@@ -597,7 +654,10 @@ describe('checkAmrBalanceGate', () => {
         workspaceId: 'ws-personal-pro',
         workspaceMemberId: 'wm-personal-pro',
       }, 'glm-5.2'),
-    ).resolves.toEqual({ kind: 'allow' });
+    ).resolves.toEqual({
+      kind: 'soft',
+      snapshot: expect.objectContaining({ balanceUsd: '1.50' }),
+    });
   });
 
   it('does not use a personal Go plan to bypass a team workspace zero balance', async () => {

--- a/apps/web/tests/runtime/amr-balance-gate.test.ts
+++ b/apps/web/tests/runtime/amr-balance-gate.test.ts
@@ -312,6 +312,52 @@ describe('checkAmrBalanceGate', () => {
     ).resolves.toEqual({ kind: 'allow' });
   });
 
+  // OPEND-2448. A free account has no plan that funds a run without the
+  // wallet, so an empty wallet means the run cannot start at all — selecting a
+  // model does not change that, and letting it through only manufactures the
+  // mid-run AMR_INSUFFICIENT_BALANCE failure this pre-run gate exists to
+  // prevent. Vela reports a free account either as plan 'free' or with no plan
+  // field at all (the daemon omits falsy plans), so both shapes must block.
+  it.each([
+    ['an explicit free plan', { id: 'u1', email: 'user@example.com', plan: 'free' }],
+    ['no plan field at all', { id: 'u1', email: 'user@example.com' }],
+  ])('hard-blocks a selected model on an empty wallet with %s', async (_label, user) => {
+    const freeAccount = snapshot({ balanceUsd: '0', user });
+    mockedFetch
+      .mockResolvedValueOnce({ ...freeAccount, source: 'daemon_cache' })
+      .mockResolvedValueOnce(freeAccount);
+
+    await expect(
+      checkAmrBalanceGate(undefined, 'deepseek-v4-flash'),
+    ).resolves.toEqual({
+      kind: 'hard',
+      reason: 'insufficient',
+      snapshot: freeAccount,
+    });
+  });
+
+  it('hard-blocks a selected model on an empty wallet for a signed-in free account', async () => {
+    const freeAccount = snapshot({ balanceUsd: '0', user: null });
+    mockedFetch
+      .mockResolvedValueOnce({ ...freeAccount, source: 'daemon_cache' })
+      .mockResolvedValueOnce(freeAccount);
+    mockedFetchStatus.mockResolvedValue({
+      loggedIn: true,
+      profile: 'prod',
+      user: null,
+      account: { plan: 'free', balanceUsd: '0' },
+      configPath: '/tmp/vela.json',
+    });
+
+    await expect(
+      checkAmrBalanceGate(undefined, 'glm-5.2'),
+    ).resolves.toEqual({
+      kind: 'hard',
+      reason: 'insufficient',
+      snapshot: freeAccount,
+    });
+  });
+
   it('hard-blocks a signed-out account after refresh confirmation', async () => {
     const signedOut = snapshot({ status: 'signed_out', balanceUsd: null, user: null });
     mockedFetch.mockResolvedValueOnce(signedOut).mockResolvedValueOnce(signedOut);
@@ -494,6 +540,38 @@ describe('checkAmrBalanceGate', () => {
         workspaceMemberId: 'wm-personal-go',
       }, 'deepseek-v4-pro'),
     ).resolves.toEqual({ kind: 'allow' });
+  });
+
+  // OPEND-2448, workspace-scoped half of the same invariant: the personal
+  // Coding Plan fail-open must not swallow the hard block for a free account.
+  it('hard-blocks a selected model in a zero-dollar free Personal workspace', async () => {
+    mockedFetch.mockResolvedValue(snapshot({
+      balanceUsd: '0',
+      user: { id: 'u1', email: 'user@example.com', plan: 'free' },
+    }));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(
+        JSON.stringify(authoritativeWorkspaceBillingResponse(
+          'ws-personal-free',
+          'wm-personal-free',
+          '0',
+        )),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )),
+    );
+
+    await expect(
+      checkAmrBalanceGate({
+        workspaceType: 'personal',
+        workspaceId: 'ws-personal-free',
+        workspaceMemberId: 'wm-personal-free',
+      }, 'deepseek-v4-flash'),
+    ).resolves.toEqual({
+      kind: 'hard',
+      reason: 'insufficient',
+      snapshot: expect.objectContaining({ balanceUsd: '0' }),
+    });
   });
 
   it('lets Vela decide a selected model in a low-balance Personal workspace', async () => {


### PR DESCRIPTION
Relates to OPEND-2448 — "新用户进来没有出现额度不足的弹窗，进来加载任务了才提示"
(https://plane.powerformer.net/open-design/browse/OPEND-2448/)

## Why

**Use case.** Picked up from dogfooding triage: a new user reported that the
"not enough allowance" dialog never appeared — they pressed Run, watched the
task start, and only then got told there was no money. I went looking for the
dialog assuming it had been deleted, and found it fully intact but unreachable.

**The pain.** The pre-run balance gate exists for exactly one reason: a wallet
at $0.00 cannot fund any part of a run, so starting one only manufactures a
mid-run `AMR_INSUFFICIENT_BALANCE` failure. Firing *before* the run is what lets
the dialog read as "one step from starting" at the moment of peak intent —
the user has just written their task and pressed send. Firing *after* turns the
same fact into a dead run and a failure card.

The gate stopped firing. #7544 ("retire unlimited model badges") removed the
Coding Plan model list from the client, and with it the membership check that
guarded the personal fail-open — replacing `codingPlanModelDecision(...) !== false`
with a bare `modelId?.trim()`. Two things make that unconditional:

- every real send carries a model id (`effectiveAgentModelId` falls back to the
  agent's default), so the predicate is always true; and
- the low-balance window is `<= $2` while the hard-block line is `$0`, so the
  window *contains* the hard-block zone.

Net effect: `checkAmrBalanceGate` returned `allow` for every low-balance user,
and the `hard` branch below it became dead code. The same commit also inverted
the test that covered this — `hard-blocks the AMR send and shows the balance
dialog when the wallet is empty` was rewritten into `lets Vela decide a selected
Personal model when the wallet is empty`, keeping the `user: null` / `$0`
fixture but flipping the assertion from "dialog shows, no run spawns" to "no
dialog, run spawns". That is why the regression shipped silently.

**Two corrections after the first revision of this PR.** Both came from
decisions this branch did not have, and both changed the fix:

1. **Which way the unknown case falls.** The first revision blocked whenever no
   Coding Plan tier could be read. That is wrong: an unresolved plan is not
   evidence of a free account, and blocking on it means one failed read can
   stop someone who paid. Ruling: let the unresolved case through and leave
   real enforcement to the remote. The gate therefore asks the **free**
   question, not the paid one — `isFreeAmrPlan` and a paid-plan predicate are
   *not* complements, and that third state belongs on the allow side.
2. **Where the check sits.** The first revision put it ahead of the merged
   low-balance condition, answering with a whole-gate `allow`. That is precisely
   the shape **OPEND-2600** was filed for — a Pro account at **$1.79** getting
   no card at all — because a plan that should only ever suppress the *block*
   was also suppressing the *reminder*. Product ruling **T37/T39**: a reminder
   is not a block. It now guards the **hard branch alone**, so subscribers
   between $0 and the warning line still reach the soft tier. Per **T40** the
   plan read happens only at or below zero, so the soft tier adds no await to
   the send path.

The implementation and its docblocks are ported from the equivalent fix on
`feat/chat-panel-next-impl` (`cf00c80bd1`, then `29fa59f7ba` for the OPEND-2600
placement) rather than reasoned out again here, so the two branches carry the
same semantics and the same explanation. The rulings live in that branch's
`specs/current/chat-panel-decisions-sheet.md` (T37–T40); that file does not
exist on `main`, hence the references by number.

Per-model membership stays server-side, exactly as #7544 intended — only the
**plan** half is restored, via `planUnlimitedTier`'s surviving sibling
`isFreeAmrPlan`.

## What users will see

A **free** user at $0.00 types a prompt and presses **Run** (Home composer or
project chat). Instead of the task appearing to start and then failing partway
through, the **"Upgrade to keep creating"** dialog opens immediately, before
anything runs. Their prompt is preserved: Home keeps the composer draft and
in-project sends stay parked, so "Not now" loses nothing and topping up
auto-resumes the same task without re-sending it.

**Subscribers are never newly blocked.** A $0.00 wallet is the *normal* state on
a plan whose models don't draw the wallet, and an account whose tier can't be
read is treated the same way. What they get instead is the **low-balance
reminder** they were previously missing between $0 and $2 — the OPEND-2600
symptom — which warns without blocking and has a "Start anyway" that resumes the
same send.

## Surface area

- [x] **UI** — the "Upgrade to keep creating" dialog (`AmrBalanceDialog`) becomes
      reachable again for free accounts, and the low-balance reminder
      (`AmrLowBalanceDialog`) becomes reachable for subscribers between $0 and
      the warning line. No markup, CSS, or copy changed; only the gate that
      decides whether they open.
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency**
- [x] **Default behavior change** — a provably free account at $0.00 is hard-blocked
      before the run again (restoring pre-#7544 behavior), and a low-balance
      subscriber now sees the soft reminder that the same fail-open was
      swallowing.

No i18n keys were added: every string these dialogs render already exists in all
19 locales — they were never removed, only made unreachable.

## Screenshots

Not attached — the author confirmed they are not needed for this change. No
markup, CSS, or copy is touched; the dialogs are the existing ones, and the
behavioral before/after is pinned by the specs below.

## Bug fix verification

- Test paths:
  - `apps/web/tests/runtime/amr-balance-gate.test.ts` — free at $0 blocks
    (explicit `plan: 'free'`, and via `fetchVelaLoginStatus`); unresolved plan
    at $0 does **not** block; workspace-scoped free at $0 blocks; plus an
    OPEND-2600 reverse control (`still warns a subscriber between the
    hard-block and low-balance lines`, the reported $1.79 Pro case).
  - `apps/web/tests/components/ProjectView.run-isolation.test.tsx` — the
    `hard-blocks the AMR send…` case #7544 inverted, restored **and** given the
    `plan: 'free'` its fixture was missing (see below), plus the soft-reminder
    flow (`reminder holds the send → Start anyway resumes it`) that the same
    commit deleted.
- Did they go red on `main` and green on this branch? **yes.**
- **Revert-the-implementation matrix** — each guard and each direction proved
  separately, so nothing in the patch is dead code:

  | reverted | red |
  |---|---|
  | workspace hard-branch guard only | 2 (`…zero-dollar free Personal workspace`, ProjectView `hard-blocks…`) |
  | account hard-branch guard only | 2 (`…explicitly free plan`, `…signed-in free account`) |
  | make the block unconditional (fail-open direction removed) | 9, incl. `does not block…when the plan cannot be read` and every subscriber-at-$0 case |
  | reintroduce the pre-OPEND-2600 shape (check ahead of both tiers) | 4, incl. the $1.79 reverse control and ProjectView `…at low balance` |
  | none | 131 passed, exit 0 |

- **A fixture that proved nothing, caught and fixed.** The restored ProjectView
  case used `user: null`, and that suite's `fetchVelaLoginStatus` returns
  `{ loggedIn: false }` — so the plan resolved to `null`, landing in the
  fail-open cell and witnessing nothing. It now carries `plan: 'free'`, with a
  comment saying why that field is load-bearing. The workspace-scoped red spec
  already carried it.
- **On flipped assertions.** Several existing cases move from `allow` to
  `soft`. That is the T37 ruling ("a reminder is not a block"), not the
  implementation being accommodated: the invariant those cases defend is
  *never `hard`*, and the strongest of them now assert `expect(result.kind)
  .not.toBe('hard')` explicitly alongside the exact value, so the thing they
  protect cannot be weakened by a future rename.
- No `as` casts were needed anywhere.

## Validation

- `pnpm guard` — exit 0
- `pnpm --filter @open-design/web typecheck` — exit 0
- `apps/web` targeted suites (via `./node_modules/.bin/vitest run <files>`):
  - `tests/runtime/amr-balance-gate.test.ts` + `tests/components/ProjectView.run-isolation.test.tsx` — 131 passed
  - all AMR runtime + component suites (`amr-artifact-upgrade`,
    `amr-auth-retry-continuation`, `amr-balance-gate`, `amr-guidance`,
    `amr-low-balance-plan`, `amr-unlimited-models.plan-tier`,
    `AmrBalanceDialog`, `AmrLowBalanceDialog`, `EntryShell.amr-workspace-race`,
    `App.amr-plan-tier`, `ProjectView.run-isolation`) — 231 passed
  - every other suite that touches the wallet snapshot
    (`providers/daemon-amr-models`, `EntryNavRail.credits-zero-balance`) — 19 passed
- Not run: Playwright UI. The two e2e cases that touch `amr-balance-dialog`
  (`e2e/ui/project-management-flows.test.ts`) are both **Team**-scope, and team
  wallets never stand down, so neither should move.

## Adjacent issues (not fixed here)

- **T38's render-side half is still open on `main`.** `EntryShell.tsx:1439` and
  `ProjectView.tsx:7111` both gate the reminder on `isPaidAmrPlan(plan)`, which
  matches exactly `{plus, pro, max}`. So a `go` subscriber, a free user, and an
  unreadable plan still get no card even though the gate now produces `soft` for
  them. Removing that filter is the other half of OPEND-2600 and belongs to that
  ticket — this PR deliberately does not touch the render side, and does not
  regress it (every tier that saw a card before still does).
- `AMR_LOW_BALANCE_WARN_USD` ($2) fully containing `AMR_HARD_BLOCK_BALANCE_USD`
  ($0) is the shape that let one predicate silently govern both tiers twice now.
  Worth expressing the two tiers as disjoint bands, but that is a refactor
  rather than this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSEeMMJ2rAigfmseU68yQR
