### PR TITLE
fix(daemon): publish public artifact dependencies

### DIFF
--- a/apps/daemon/src/artifacts/relative-refs.ts
+++ b/apps/daemon/src/artifacts/relative-refs.ts
@@ -1,0 +1,142 @@
+// Shared project-local dependency reference extraction.
+//
+// Used by both MCP artifact bundling and public-file publishing so the two
+// surfaces agree on which local files belong to an HTML/CSS/JS artifact.
+//
+// This intentionally returns project-relative logical paths only. External,
+// data, fragment and project-root-escaping references are not returned.
+
+// Patterns common to HTML and CSS.
+const HTML_REF_PATTERNS = [
+  /<script\b[^>]*\bsrc=["']([^"']+)["']/gi,
+  /<link\b[^>]*\bhref=["']([^"']+)["']/gi,
+  /<img\b[^>]*\bsrc=["']([^"']+)["']/gi,
+  /<source\b[^>]*\bsrc=["']([^"']+)["']/gi,
+  /<video\b[^>]*\bsrc=["']([^"']+)["']/gi,
+  /<audio\b[^>]*\bsrc=["']([^"']+)["']/gi,
+  /<iframe\b[^>]*\bsrc=["']([^"']+)["']/gi,
+];
+
+const CSS_REF_PATTERNS = [
+  /\burl\(\s*["']?([^"')]+)["']?\s*\)/gi,
+  /@import\s+(?:url\()?\s*["']([^"')]+)["']/gi,
+];
+
+// JS/TS only - running these on prose creates false positives on words
+// like "imported from 'X'".
+const JS_REF_PATTERNS = [
+  /\bimport\s+[^'"]*?['"]([^'"]+)['"]/g,
+  /\bfrom\s+['"]([^'"]+)['"]/g,
+  /\bimport\(\s*['"]([^'"]+)['"]\s*\)/g,
+  /\brequire\(\s*['"]([^'"]+)['"]\s*\)/g,
+];
+
+// `srcset` can list multiple comma-separated candidates.
+const SRCSET_PATTERN = /\bsrcset=["']([^"']+)["']/gi;
+
+function isJsLike(mime: string | undefined, fromPath: string): boolean {
+  if (mime && /javascript|typescript/i.test(mime)) return true;
+  return /\.(?:m?jsx?|tsx?|cjs)$/i.test(fromPath);
+}
+
+function isCssLike(mime: string | undefined, fromPath: string): boolean {
+  if (mime && /^text\/css\b/i.test(mime)) return true;
+  return /\.css$/i.test(fromPath);
+}
+
+function isHtmlLike(mime: string | undefined, fromPath: string): boolean {
+  if (mime && /^text\/html\b/i.test(mime)) return true;
+  return /\.html?$/i.test(fromPath);
+}
+
+export function referenceMimeForPath(filePath: string): string | null {
+  if (/\.html?$/i.test(filePath)) return 'text/html';
+  if (/\.css$/i.test(filePath)) return 'text/css';
+  if (/\.tsx?$/i.test(filePath)) {
+    return 'application/typescript';
+  }
+  if (/\.(?:m?jsx?|cjs)$/i.test(filePath)) return 'application/javascript';
+  if (/\.svg$/i.test(filePath)) return 'image/svg+xml';
+  return null;
+}
+
+export function extractRelativeRefs(
+  text: string,
+  fromPath: string,
+  fromMime: string,
+): string[] {
+  if (!text) return [];
+
+  const refs = new Set<string>();
+  const runPatterns: RegExp[] = [];
+
+  if (isHtmlLike(fromMime, fromPath)) {
+    runPatterns.push(...HTML_REF_PATTERNS, ...CSS_REF_PATTERNS);
+  }
+  if (isCssLike(fromMime, fromPath)) {
+    runPatterns.push(...CSS_REF_PATTERNS);
+  }
+  if (isJsLike(fromMime, fromPath)) {
+    runPatterns.push(...JS_REF_PATTERNS);
+  }
+
+  // Fallback for unknown textual files: only the safest pattern,
+  // url() in case it's CSS-in-something we don't recognize.
+  if (runPatterns.length === 0) {
+    runPatterns.push(...CSS_REF_PATTERNS);
+  }
+
+  const candidates: string[] = [];
+
+  for (const re of runPatterns) {
+    for (const match of text.matchAll(re)) {
+      const ref = (match[1] || '').trim();
+      if (ref) candidates.push(ref);
+    }
+  }
+
+  if (isHtmlLike(fromMime, fromPath)) {
+    for (const match of text.matchAll(SRCSET_PATTERN)) {
+      const list = match[1] || '';
+      for (const part of list.split(',')) {
+        const url = part.trim().split(/\s+/)[0];
+        if (url) candidates.push(url);
+      }
+    }
+  }
+
+  for (const raw of candidates) {
+    if (/^(?:https?:|\/\/|data:|mailto:|tel:|#)/i.test(raw)) continue;
+
+    const dir = fromPath.includes('/')
+      ? fromPath.slice(0, fromPath.lastIndexOf('/') + 1)
+      : '';
+
+    const resolved = raw.startsWith('/') ? raw.slice(1) : dir + raw;
+    const stripped = resolved.replace(/[?#].*$/, '');
+    const segments = stripped.split('/').filter(Boolean);
+
+    const out: string[] = [];
+    let escaped = false;
+
+    for (const segment of segments) {
+      if (segment === '.') continue;
+
+      if (segment === '..') {
+        if (out.length === 0) {
+          escaped = true;
+          break;
+        }
+        out.pop();
+        continue;
+      }
+
+      out.push(segment);
+    }
+
+    if (escaped || out.length === 0) continue;
+    refs.add(out.join('/'));
+  }
+
+  return [...refs];
+}

--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -39,6 +39,7 @@ import {
 import { randomUUID } from 'node:crypto';
 
 import { postCreateArtifactRequest } from './artifacts/create.js';
+import { extractRelativeRefs } from './artifacts/relative-refs.js';
 import { resolveMcpWorkspaceContext } from './mcp-workspace-context.js';
 import {
   createLocalMcpBriefStore as createBriefStore,
@@ -3323,111 +3324,6 @@ async function fetchProjectFile(
     );
   }
   return { name: relPath, mime, size: size ?? contentBytes, content, binary: false };
-}
-
-// Patterns common to HTML and CSS (also fine to run on plain markdown).
-const HTML_REF_PATTERNS = [
-  /<script\b[^>]*\bsrc=["']([^"']+)["']/gi,
-  /<link\b[^>]*\bhref=["']([^"']+)["']/gi,
-  /<img\b[^>]*\bsrc=["']([^"']+)["']/gi,
-  /<source\b[^>]*\bsrc=["']([^"']+)["']/gi,
-  /<video\b[^>]*\bsrc=["']([^"']+)["']/gi,
-  /<audio\b[^>]*\bsrc=["']([^"']+)["']/gi,
-  /<iframe\b[^>]*\bsrc=["']([^"']+)["']/gi,
-];
-
-const CSS_REF_PATTERNS = [
-  /\burl\(\s*["']?([^"')]+)["']?\s*\)/gi,
-  /@import\s+(?:url\()?\s*["']([^"')]+)["']/gi,
-];
-
-// JS/TS only - running these on prose creates false positives on words
-// like "imported from 'X'".
-const JS_REF_PATTERNS = [
-  /\bimport\s+[^'"]*?['"]([^'"]+)['"]/g,
-  /\bfrom\s+['"]([^'"]+)['"]/g,
-  /\bimport\(\s*['"]([^'"]+)['"]\s*\)/g,
-  /\brequire\(\s*['"]([^'"]+)['"]\s*\)/g,
-];
-
-// `srcset` can list multiple comma-separated candidates.
-const SRCSET_PATTERN = /\bsrcset=["']([^"']+)["']/gi;
-
-function isJsLike(mime: string | undefined, fromPath: string): boolean {
-  if (mime && /javascript|typescript/i.test(mime)) return true;
-  return /\.(?:m?jsx?|tsx?|cjs)$/i.test(fromPath);
-}
-
-function isCssLike(mime: string | undefined, fromPath: string): boolean {
-  if (mime && /^text\/css\b/i.test(mime)) return true;
-  return /\.css$/i.test(fromPath);
-}
-
-function isHtmlLike(mime: string | undefined, fromPath: string): boolean {
-  if (mime && /^text\/html\b/i.test(mime)) return true;
-  return /\.html?$/i.test(fromPath);
-}
-
-function extractRelativeRefs(text: string, fromPath: string, fromMime: string): string[] {
-  if (!text) return [];
-  const refs = new Set<string>();
-  const runPatterns: RegExp[] = [];
-  if (isHtmlLike(fromMime, fromPath)) {
-    runPatterns.push(...HTML_REF_PATTERNS, ...CSS_REF_PATTERNS);
-  }
-  if (isCssLike(fromMime, fromPath)) {
-    runPatterns.push(...CSS_REF_PATTERNS);
-  }
-  if (isJsLike(fromMime, fromPath)) {
-    runPatterns.push(...JS_REF_PATTERNS);
-  }
-  // Fallback for unknown textual files: only the safest pattern,
-  // url() in case it's a CSS-in-something we don't recognize.
-  if (runPatterns.length === 0) {
-    runPatterns.push(...CSS_REF_PATTERNS);
-  }
-
-  const candidates: string[] = [];
-  for (const re of runPatterns) {
-    for (const m of text.matchAll(re)) {
-      const ref = (m[1] || '').trim();
-      if (ref) candidates.push(ref);
-    }
-  }
-  // Pull every candidate URL out of any srcset attributes in HTML.
-  if (isHtmlLike(fromMime, fromPath)) {
-    for (const m of text.matchAll(SRCSET_PATTERN)) {
-      const list = m[1] || '';
-      for (const part of list.split(',')) {
-        const url = part.trim().split(/\s+/)[0];
-        if (url) candidates.push(url);
-      }
-    }
-  }
-
-  for (const raw of candidates) {
-    if (/^(?:https?:|\/\/|data:|mailto:|tel:|#)/i.test(raw)) continue;
-    const dir = fromPath.includes('/')
-      ? fromPath.slice(0, fromPath.lastIndexOf('/') + 1)
-      : '';
-    const resolved = raw.startsWith('/') ? raw.slice(1) : dir + raw;
-    const stripped = resolved.replace(/[?#].*$/, '');
-    const segs = stripped.split('/').filter(Boolean);
-    const out: string[] = [];
-    let escaped = false;
-    for (const s of segs) {
-      if (s === '.') continue;
-      if (s === '..') {
-        if (out.length === 0) { escaped = true; break; }
-        out.pop();
-        continue;
-      }
-      out.push(s);
-    }
-    if (escaped || out.length === 0) continue;
-    refs.add(out.join('/'));
-  }
-  return [...refs];
 }
 
 function okBundle(bundle: BundleInput) {

--- a/apps/daemon/src/routes/collab-sync.ts
+++ b/apps/daemon/src/routes/collab-sync.ts
@@ -58,6 +58,7 @@ import {
 import { readVelaControlApiContext } from '../integrations/vela.js';
 import { isAbortedOperationError } from '../integrations/aborted-error.js';
 import { readProjectManifest } from '../project-locations.js';
+import { extractRelativeRefs, referenceMimeForPath } from '../artifacts/relative-refs.js';
 import { redactSecrets } from '../redact.js';
 import { findRealElementRange, HTML_TAG_PATTERNS } from '@open-design/contracts/runtime/html-injection-points';
 
@@ -383,6 +384,8 @@ const SYNC_INTENT_EVENTS: ReadonlySet<ProjectSyncIntentEvent> = new Set([
 const PULLED_PROJECT_PLACEHOLDER_NAME = '共享项目';
 const PUBLIC_FILE_RESOURCE_KIND = 'project';
 const PUBLIC_FILE_REF = 'published';
+const PUBLIC_FILE_BUNDLE_MAX_DEPTH = 3;
+const PUBLIC_FILE_BUNDLE_MAX_FILES = 200;
 
 const MAX_ERROR_LOG_FIELD_LENGTH = 2_048;
 
@@ -533,6 +536,82 @@ async function resolvePublicSourceFile(projectDir: string, filePath: string): Pr
   const error = new Error('public file path escapes project root') as NodeJS.ErrnoException;
   error.code = 'EACCES';
   throw error;
+}
+
+async function writePublicBundleFile(
+  tempDir: string,
+  filePath: string,
+  data: Buffer,
+): Promise<void> {
+  const targetFile = path.join(tempDir, filePath);
+  await mkdir(path.dirname(targetFile), { recursive: true });
+  await writeFile(targetFile, data);
+}
+
+/**
+ * Stage the requested public entry plus its transitive project-local runtime
+ * dependencies. Unrelated project files remain private.
+ *
+ * Every dependency is passed through resolvePublicSourceFile(), so symlinks
+ * cannot escape the project root. Missing/broken dependencies are skipped just
+ * as a browser would fail those individual resource requests; the entry file
+ * itself has already been validated by the route.
+ */
+async function stagePublicFileBundle(
+  projectDir: string,
+  entryPath: string,
+  entryData: Buffer,
+  tempDir: string,
+): Promise<void> {
+  await writePublicBundleFile(tempDir, entryPath, entryData);
+
+  const entryMime = referenceMimeForPath(entryPath);
+  if (!entryMime) return;
+
+  const visited = new Set<string>([entryPath]);
+  let frontier = extractRelativeRefs(
+    entryData.toString('utf8'),
+    entryPath,
+    entryMime,
+  ).filter((ref) => !visited.has(ref));
+
+  for (
+    let depth = 1;
+    depth < PUBLIC_FILE_BUNDLE_MAX_DEPTH && frontier.length > 0;
+    depth += 1
+  ) {
+    const next: string[] = [];
+
+    for (const refPath of frontier) {
+      if (visited.has(refPath)) continue;
+      if (visited.size >= PUBLIC_FILE_BUNDLE_MAX_FILES) return;
+
+      visited.add(refPath);
+
+      let data: Buffer;
+      try {
+        const sourceFile = await resolvePublicSourceFile(projectDir, refPath);
+        data = await readFile(sourceFile);
+      } catch {
+        // A missing, unreadable or escaping dependency must never widen the
+        // publication. Keep the entry publishable and leave that reference
+        // unresolved in the public snapshot.
+        continue;
+      }
+
+      await writePublicBundleFile(tempDir, refPath, data);
+
+      const mime = referenceMimeForPath(refPath);
+      if (!mime) continue;
+
+      const refs = extractRelativeRefs(data.toString('utf8'), refPath, mime);
+      for (const ref of refs) {
+        if (!visited.has(ref)) next.push(ref);
+      }
+    }
+
+    frontier = next;
+  }
 }
 
 function publicFileResourceIdFor(
@@ -1289,9 +1368,7 @@ export function registerCollabSyncRoutes(
     const resourceId = publicFileResourceIdFor(projectId, filePath, principal);
     const tempDir = await mkdtemp(path.join(os.tmpdir(), 'od-public-file-'));
     try {
-      const targetFile = path.join(tempDir, filePath);
-      await mkdir(path.dirname(targetFile), { recursive: true });
-      await writeFile(targetFile, data);
+      await stagePublicFileBundle(projectDir, filePath, data, tempDir);
       const metadata = {
         source: 'open-design',
         projectId,

--- a/apps/daemon/tests/collab-sync-routes.test.ts
+++ b/apps/daemon/tests/collab-sync-routes.test.ts
@@ -1877,6 +1877,98 @@ describe('collab sync routes', () => {
     expect(unpublish.status).toBe(200);
   });
 
+  it('publishes project-local HTML dependencies without exposing unrelated project files', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'od-public-file-assets-'));
+    tempDirs.push(dir);
+
+    await mkdir(path.join(dir, 'css'), { recursive: true });
+    await mkdir(path.join(dir, 'fonts'), { recursive: true });
+
+    const heroBytes = Buffer.from([0xff, 0xd8, 0xff, 0xd9]);
+    const fontBytes = Buffer.from([0x77, 0x4f, 0x46, 0x32]);
+
+    await writeFile(
+      path.join(dir, 'index.html'),
+      '<link rel="stylesheet" href="css/app.css"><img src="hero.jpg">',
+    );
+    await writeFile(path.join(dir, 'hero.jpg'), heroBytes);
+    await writeFile(
+      path.join(dir, 'css/app.css'),
+      '@font-face { font-family: Club; src: url("../fonts/club.woff2"); }',
+    );
+    await writeFile(path.join(dir, 'fonts/club.woff2'), fontBytes);
+    await writeFile(path.join(dir, 'private-notes.md'), 'must stay private');
+
+    vi.mocked(readVelaControlApiContext).mockReturnValue({
+      profile: 'test',
+      apiUrl: 'https://hub.example.test',
+      controlKey: 'ctrl-test',
+      user: null,
+      configMtimeMs: null,
+    });
+
+    let pushedHtml: string | null = null;
+    let pushedCss: string | null = null;
+    let pushedHero: Buffer | null = null;
+    let pushedFont: Buffer | null = null;
+    let privateIncluded = false;
+
+    vi.mocked(runVelaResourceCommand).mockImplementation(async (args) => {
+      if (args[0] === 'push') {
+        const pushedDir = String(args[3]);
+
+        pushedHtml = await readFile(path.join(pushedDir, 'index.html'), 'utf8');
+        pushedCss = await readFile(path.join(pushedDir, 'css/app.css'), 'utf8');
+        pushedHero = await readFile(path.join(pushedDir, 'hero.jpg'));
+        pushedFont = await readFile(path.join(pushedDir, 'fonts/club.woff2'));
+
+        try {
+          await readFile(path.join(pushedDir, 'private-notes.md'));
+          privateIncluded = true;
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+        }
+
+        return JSON.stringify({ version: 1 });
+      }
+
+      if (args[0] === 'snapshot') {
+        return JSON.stringify({
+          slug: 'asset-slug',
+          name: 'index.html',
+          kind: 'project',
+          versionId: 'v1',
+          createdAt: new Date(1).toISOString(),
+        });
+      }
+
+      return JSON.stringify({ version: 1 });
+    });
+
+    const api = await startSyncServer(personalContextProvider(), {
+      resolveProjectDir: () => dir,
+      resolveSharedProject: async () => null,
+    });
+
+    const publish = await api.json('/api/projects/p1/files/index.html/publish-public', {
+      method: 'POST',
+    });
+
+    expect(publish.status).toBe(200);
+    expect(publish.body).toEqual({
+      url: 'https://hub.example.test/api/v1/public/snapshots/asset-slug/files/index.html',
+      slug: 'asset-slug',
+      fileName: 'index.html',
+    });
+
+    expect(pushedHtml).toContain('hero.jpg');
+    expect(pushedHtml).toContain('css/app.css');
+    expect(pushedCss).toContain('../fonts/club.woff2');
+    expect(pushedHero).toEqual(heroBytes);
+    expect(pushedFont).toEqual(fontBytes);
+    expect(privateIncluded).toBe(false);
+  });
+
   it('keeps public file ownership reads on request workspace A while ambient workspace B is active', async () => {
     const workspaceA = teamContext('workspace-a', 'member-a');
     const dir = await mkdtemp(path.join(tmpdir(), 'od-public-file-'));


### PR DESCRIPTION
Fixes #7812

Why

I hit this while sharing a multi-file HTML artifact from OpenDesign.

The artifact rendered correctly inside OpenDesign, but the public Share → Publish online URL contained only the selected HTML file. Project-local files referenced by that HTML, such as images, were absent from the public snapshot and returned HTTP 404.

The issue is not specific to images: the same publishing behavior can affect relative CSS, JavaScript, fonts, video, and other runtime dependencies.

The public-file publisher currently stages only the selected entry file before vela resource push, even when that entry depends on other project-local files.

This PR makes a public artifact snapshot include the selected entry plus its bounded transitive project-local dependency graph, while deliberately not publishing unrelated project files.

What users will see

Multi-file HTML artifacts shared through a public URL now keep working when they reference project-local assets.

For example, given:

index.html
hero.jpg
logo.png

and:

<img src="hero.jpg">
<img src="logo.png">

the referenced images are included in the public snapshot instead of returning 404.

Relative paths are preserved, so HTML does not need to be rewritten.

Unrelated sibling files remain unpublished.

Surface area

UI — new page / dialog / panel / menu item / setting / empty state in apps/web or apps/desktop (including Electron menu bar)

Keyboard shortcut — new or changed

CLI / env var — new od subcommand or flag, new tools-dev / tools-pack flag, or new OD_* env var

API / contract — new /api/* endpoint, new SSE event, or changed shape in packages/contracts

Extension point — new entry under skills/, design-systems/, design-templates/, or craft/, or change to the skills protocol

i18n keys — added new translation keys (see TRANSLATIONS.md for the locale workflow)

New top-level dependency — adding any new entry to the root package.json (dependencies or devDependencies); workspace-package package.json files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see CONTRIBUTING.md → Code style)

Default behavior change — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)

None — internal refactor, docs, tests, or translation update only

Screenshots

N/A — no UI changes.

The change affects the contents of public artifact snapshots.

Bug fix verification

Test path that reproduces the bug:
apps/daemon/tests/collab-sync-routes.test.ts

Regression:
publishes project-local HTML dependencies without exposing unrelated project files

Did the test go red on main and green on this branch? No — the regression test was added together with the fix rather than being run as a separate red/green commit.

The pre-fix behavior was independently reproduced against a real public snapshot: the HTML returned HTTP 200 while referenced project-local JPG and PNG files returned HTTP 404.

After the fix, a newly-created public snapshot returned HTTP 200 for the HTML and both referenced assets, while an unrelated sibling project file continued to return HTTP 404.

The regression test inspects the temporary directory passed to the mocked vela resource push and verifies that:

the entry HTML is included,

a directly referenced image is included,

referenced CSS is included,

a transitively referenced font is included,

an unrelated project file is not included.

Validation

Validated against current upstream main.

pnpm typecheck
PASS

Targeted tests:

tests/collab-sync-routes.test.ts
110 passed

tests/mcp-extract-refs.test.ts
tests/mcp-get-artifact.test.ts
20 passed

Also passed:

@open-design/daemon build
@open-design/contracts build
@open-design/registry-protocol build
git diff --check

pnpm guard was run. It currently exits non-zero in the cross-app-import check because the checkout expects:

apps/landing-page/package.json

but that manifest is absent.

Neither the upstream base commit nor this PR branch contains that manifest, and this PR does not modify the guard or app-registration code. The other guard checks shown during the run passed.

End-to-end validation with a newly-created public snapshot:

entry HTML                 HTTP 200
referenced JPG             HTTP 200
referenced PNG             HTTP 200
unrelated sibling file     HTTP 404

Implementation notes

Extracted the existing relative-reference discovery logic from apps/daemon/src/mcp.ts into a reusable daemon helper:
apps/daemon/src/artifacts/relative-refs.ts

Reused that helper from MCP artifact bundling, preserving existing behavior.

Added bounded dependency traversal to the public-file publishing path.

Preserved the existing resolvePublicSourceFile() realpath/project-root boundary for every discovered dependency.

Missing, unreadable, or escaping dependencies are skipped rather than widening the public publication.

Public URL/API behavior is unchanged.

The implementation intentionally does not copy the complete project directory.

The public bundle traversal is currently bounded to:

max depth: 3
max files: 200