### PR TITLE
fix(tools-pack): keep the manual trigger in the update cache lifecycle snapshot

### DIFF
--- a/tools/pack/src/updates/cache-lifecycle-snapshot.ts
+++ b/tools/pack/src/updates/cache-lifecycle-snapshot.ts
@@ -1,9 +1,25 @@
 import { readdir, readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
 
-import type { DesktopUpdateCacheLifecycleSummary } from "@open-design/sidecar-proto";
+import type {
+  DesktopUpdateCacheLifecycleSummary,
+  DesktopUpdateCacheLifecycleTrigger,
+} from "@open-design/sidecar-proto";
 
 import type { ToolPackConfig } from "../config/index.js";
+
+// Keyed by the whole trigger union so adding a member fails the build here
+// instead of silently dropping `lastTrigger` from the snapshot.
+const CACHE_LIFECYCLE_TRIGGERS: Record<DesktopUpdateCacheLifecycleTrigger, true> = {
+  "cold-start": true,
+  manual: true,
+  "next-version-ready": true,
+};
+
+function toCacheLifecycleTrigger(value: unknown): DesktopUpdateCacheLifecycleTrigger | null {
+  if (typeof value !== "string") return null;
+  return Object.hasOwn(CACHE_LIFECYCLE_TRIGGERS, value) ? (value as DesktopUpdateCacheLifecycleTrigger) : null;
+}
 
 const UPDATE_STATE_DIR = "state";
 const UPDATE_CLEANUP_FILE = "cleanup.json";
@@ -47,7 +63,8 @@ function summarizeDescriptor(raw: ReleaseLifecycleDescriptor): DesktopUpdateCach
   const platform = typeof raw.platform === "string" ? raw.platform : "unknown";
   const summary = emptySummary(platform);
   if (raw.updatedAt != null && typeof raw.updatedAt === "string") summary.lastRunAt = raw.updatedAt;
-  if (raw.trigger === "cold-start" || raw.trigger === "next-version-ready") summary.lastTrigger = raw.trigger;
+  const trigger = toCacheLifecycleTrigger(raw.trigger);
+  if (trigger != null) summary.lastTrigger = trigger;
   summary.releases.total = raw.releases.length;
   for (const entry of raw.releases) {
     if (entry == null || typeof entry !== "object") continue;

--- a/tools/pack/tests/updates/cache-lifecycle-snapshot.test.ts
+++ b/tools/pack/tests/updates/cache-lifecycle-snapshot.test.ts
@@ -80,4 +80,28 @@ describe("tools-pack updater cache lifecycle snapshot", () => {
       await rm(root, { force: true, recursive: true });
     }
   });
+
+  it("keeps the manual trigger a desktop cache clear writes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-tools-pack-update-cache-manual-"));
+    try {
+      const config = makeConfig(root);
+      const updateRoot = join(config.roots.runtime.namespaceRoot, "updates");
+      await mkdir(join(updateRoot, "state"), { recursive: true });
+      await writeFile(join(updateRoot, "state", "cleanup.json"), `${JSON.stringify({
+        platform: "win32",
+        releases: [],
+        trigger: "manual",
+        updatedAt: "2026-06-08T00:00:00.000Z",
+        version: 1,
+      }, null, 2)}\n`, "utf8");
+
+      const snapshot = await readToolPackUpdateCacheLifecycleSnapshot(config);
+
+      expect(snapshot.descriptorExists).toBe(true);
+      expect(snapshot.summary?.lastTrigger).toBe("manual");
+      expect(snapshot.summary?.lastRunAt).toBe("2026-06-08T00:00:00.000Z");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
 });


### PR DESCRIPTION
### Problem

`tools/pack`'s lifecycle reader accepted only two of the three trigger values:

```ts
if (raw.trigger === "cold-start" || raw.trigger === "next-version-ready") summary.lastTrigger = raw.trigger;
```

`manual` is a full member of the union and is genuinely written to disk:

| | |
| --- | --- |
| `packages/sidecar-proto/src/index.ts:464` | `type DesktopUpdateCacheLifecycleTrigger = "cold-start" \| "manual" \| "next-version-ready"` |
| `apps/desktop/src/main/updater.ts:1316` | the manual cache clear writes `trigger: "manual"` |
| `apps/desktop/src/main/updater/release-lifecycle.ts` | the sibling summarizer copies `descriptor.trigger` straight through |

So two summarizers read the same `cleanup.json` and disagree on exactly one value. After a user runs "Clear update cache", `tools-pack mac inspect` / `win inspect` report the last lifecycle run with no trigger at all, while the desktop summary reports `manual`.

History confirms drift rather than intent: the reader landed in `2ce9d09f4` (#3960, Jun 9), and `manual` was added to the union later in `a2ba3ee2a` (#6032, Jul 24) without updating it.

### Fix

The accepted set is now keyed off the union itself, so a fourth trigger fails the build here instead of silently vanishing from the snapshot:

```ts
const CACHE_LIFECYCLE_TRIGGERS: Record<DesktopUpdateCacheLifecycleTrigger, true> = { ... }
```

Removing a key from that record makes `tsc` fail with `TS2741: Property 'manual' is missing…`, so the guard is real rather than an `any` in disguise.

### Testing

```
pnpm exec vitest run tests/updates/cache-lifecycle-snapshot.test.ts
  Tests  2 passed (2)
```

Red/green — restoring the old two-value condition fails exactly the new case and nothing else:

```
× keeps the manual trigger a desktop cache clear writes
  AssertionError: expected undefined to be 'manual'
  Tests  1 failed | 1 passed (2)
```

`tools/pack` typecheck output is byte-identical to baseline, and the package's full suite shows the same pre-existing failures on `origin/main` with this change stashed.