### PR TITLE
fix(web): clarify local-only MCP setup for remote Docker users

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -8637,6 +8637,16 @@ function IntegrationsSection() {
 
         {/* Setup flow */}
         <div className="mcp-setup-card">
+          <p style={{ margin: 0 }}>
+            {t('settings.mcpLocalRuntimeOnly')}{' '}
+            <a
+              href="https://github.com/nexu-io/open-design/blob/main/docs/deployment/docker.md#connect-a-remote-coding-agent-over-mcp"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {t('settings.mcpRemoteSetup')}
+            </a>
+          </p>
           <div
             className="ds-picker"
             ref={pickerRef}

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const ar: Dict = {
+  'settings.mcpLocalRuntimeOnly': 'للبيئة المحلية فقط: يتطلب هذا الإعداد الجهاز أو الحاوية التي تشغّل OpenDesign. لوكيل برمجة على جهاز آخر، استخدم جسر SSH/Docker.',
+  'settings.mcpRemoteSetup': 'إعداد Docker عن بُعد',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const de: Dict = {
+  'settings.mcpLocalRuntimeOnly': 'Nur lokale Laufzeit: Diese Einrichtung benötigt den Rechner oder Container, auf dem OpenDesign läuft. Für einen Coding-Agent auf einem anderen Rechner verwenden Sie eine SSH/Docker-Verbindung.',
+  'settings.mcpRemoteSetup': 'Docker auf einem entfernten Rechner',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const en: Dict = {
+  'settings.mcpLocalRuntimeOnly': 'Local runtime only: this setup requires the machine or container running OpenDesign. For a coding agent on another machine, use an SSH/Docker bridge.',
+  'settings.mcpRemoteSetup': 'Remote Docker setup',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const esES: Dict = {
+  'settings.mcpLocalRuntimeOnly': 'Solo entorno local: esta configuración requiere la máquina o el contenedor que ejecuta OpenDesign. Para un agente en otra máquina, usa un puente SSH/Docker.',
+  'settings.mcpRemoteSetup': 'Configuración de Docker remoto',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const fa: Dict = {
+  'settings.mcpLocalRuntimeOnly': 'فقط محیط محلی: این تنظیم به دستگاه یا کانتینری نیاز دارد که OpenDesign را اجرا می‌کند. برای عامل کدنویسی روی دستگاه دیگر، از پل SSH/Docker استفاده کنید.',
+  'settings.mcpRemoteSetup': 'راه‌اندازی Docker از راه دور',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const fr: Dict = {
+  'settings.mcpLocalRuntimeOnly': 'Environnement local uniquement : cette configuration nécessite la machine ou le conteneur exécutant OpenDesign. Pour un agent sur une autre machine, utilisez un pont SSH/Docker.',
+  'settings.mcpRemoteSetup': 'Configuration Docker à distance',
   'invite.header.eyebrow': "Invitation d'équipe",
   'invite.loading': "Chargement de l'invitation…",
   'invite.landing.title': "Rejoindre l'équipe",

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const hu: Dict = {
+  'settings.mcpLocalRuntimeOnly': 'Csak helyi környezetben: ez a beállítás az OpenDesignt futtató gépet vagy konténert igényli. Másik gépen futó ügynökhöz használjon SSH/Docker hidat.',
+  'settings.mcpRemoteSetup': 'Távoli Docker beállítása',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const id: Dict = {
+  'settings.mcpLocalRuntimeOnly': 'Hanya lingkungan lokal: pengaturan ini memerlukan mesin atau container yang menjalankan OpenDesign. Untuk agen di mesin lain, gunakan penghubung SSH/Docker.',
+  'settings.mcpRemoteSetup': 'Pengaturan Docker jarak jauh',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const it: Dict = {
+  'settings.mcpLocalRuntimeOnly': 'Solo ambiente locale: questa configurazione richiede la macchina o il container che esegue OpenDesign. Per un agente su un\'altra macchina, usa un bridge SSH/Docker.',
+  'settings.mcpRemoteSetup': 'Configurazione Docker remoto',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const ja: Dict = {
+  'settings.mcpLocalRuntimeOnly': 'ローカル実行環境専用：この設定には OpenDesign を実行しているマシンまたはコンテナが必要です。別のマシンのコーディングエージェントには SSH/Docker ブリッジを使用してください。',
+  'settings.mcpRemoteSetup': 'リモート Docker の設定',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const ko: Dict = {
+  'settings.mcpLocalRuntimeOnly': '로컬 실행 환경 전용: 이 설정은 OpenDesign을 실행하는 컴퓨터 또는 컨테이너가 필요합니다. 다른 컴퓨터의 코딩 에이전트에는 SSH/Docker 브리지를 사용하세요.',
+  'settings.mcpRemoteSetup': '원격 Docker 설정',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const pl: Dict = {
+  'settings.mcpLocalRuntimeOnly': 'Tylko środowisko lokalne: ta konfiguracja wymaga komputera lub kontenera z uruchomionym OpenDesign. Dla agenta na innym komputerze użyj mostu SSH/Docker.',
+  'settings.mcpRemoteSetup': 'Konfiguracja zdalnego Dockera',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const ptBR: Dict = {
+  'settings.mcpLocalRuntimeOnly': 'Somente ambiente local: esta configuração requer a máquina ou o contêiner que executa o OpenDesign. Para um agente em outra máquina, use uma ponte SSH/Docker.',
+  'settings.mcpRemoteSetup': 'Configuração do Docker remoto',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const ru: Dict = {
+  'settings.mcpLocalRuntimeOnly': 'Только локальная среда: эта настройка требует машину или контейнер, где работает OpenDesign. Для агента на другой машине используйте мост SSH/Docker.',
+  'settings.mcpRemoteSetup': 'Настройка удалённого Docker',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const th: Dict = {
+  'settings.mcpLocalRuntimeOnly': 'สำหรับสภาพแวดล้อมภายในเท่านั้น: การตั้งค่านี้ต้องใช้เครื่องหรือคอนเทนเนอร์ที่รัน OpenDesign หากเอเจนต์เขียนโค้ดอยู่บนเครื่องอื่น ให้เชื่อมต่อผ่าน SSH/Docker',
+  'settings.mcpRemoteSetup': 'ตั้งค่า Docker ระยะไกล',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const tr: Dict = {
+  'settings.mcpLocalRuntimeOnly': 'Yalnızca yerel ortam: bu kurulum, OpenDesign çalıştıran makineyi veya konteyneri gerektirir. Başka bir makinedeki kodlama ajanı için SSH/Docker köprüsü kullanın.',
+  'settings.mcpRemoteSetup': 'Uzak Docker kurulumu',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const uk: Dict = {
+  'settings.mcpLocalRuntimeOnly': 'Лише локальне середовище: це налаштування потребує машини або контейнера, де працює OpenDesign. Для агента на іншій машині використовуйте міст SSH/Docker.',
+  'settings.mcpRemoteSetup': 'Налаштування віддаленого Docker',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1,6 +1,8 @@
 import type { Dict } from "../types";
 
 export const zhCN: Dict = {
+  'settings.mcpLocalRuntimeOnly': '仅适用于本地运行环境：此配置需要在运行 OpenDesign 的机器或容器中使用。其他机器上的编程助手请通过 SSH/Docker 桥接连接。',
+  'settings.mcpRemoteSetup': '远程 Docker 配置',
   'invite.header.eyebrow': "团队邀请",
   'invite.loading': "正在加载邀请…",
   'invite.landing.title': "加入团队",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1,6 +1,8 @@
 import type { Dict } from "../types";
 
 export const zhTW: Dict = {
+  'settings.mcpLocalRuntimeOnly': '僅適用於本機執行環境：此設定需要在執行 OpenDesign 的機器或容器中使用。其他機器上的程式碼助手請透過 SSH/Docker 橋接連線。',
+  'settings.mcpRemoteSetup': '遠端 Docker 設定',
   'invite.header.eyebrow': "團隊邀請",
   'invite.loading': "正在載入邀請…",
   'invite.landing.title': "加入團隊",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -988,6 +988,8 @@ export interface Dict {
   // MCP server settings
   'settings.mcpTitle': string;
   'settings.mcpHint': string;
+  'settings.mcpLocalRuntimeOnly': string;
+  'settings.mcpRemoteSetup': string;
   'settings.mcpDaemonError': string;
   'settings.mcpBuildDaemon': string;
   'settings.mcpNodeMissing': string;

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -91,6 +91,68 @@ networking override is required.
 ![OpenDesign home (desktop)](../screenshots/deployment/docker/01-open-design-home.png)
 ![OpenDesign home (mobile)](../screenshots/deployment/docker/03-open-design-mobile.png)
 
+## Connect a remote coding agent over MCP
+
+The setup snippets in **Settings -> MCP server** are local-runtime only. They
+launch a stdio helper using the executable, CLI entrypoint, and environment of
+the running OpenDesign daemon. With Docker, those belong to the container, not
+to the workstation displaying the Settings page. The same restriction applies
+to the install buttons and deep links in that panel.
+
+Changing the snippet's loopback URL to your public URL is not enough: the
+executable and CLI paths would still refer to the container. Forwarding only
+the HTTP port does not make those paths available either.
+
+For a coding agent on another machine, run the stdio helper inside the existing
+container through SSH. This is a deployment-specific bridge, not a remote HTTP
+MCP endpoint. First verify SSH access and Docker permissions from the workstation:
+
+```bash
+ssh user@docker-host docker inspect --format '{{.State.Running}}' open-design
+```
+
+Replace `user@docker-host` with your SSH destination and `open-design` with your
+running container name. Complete host-key verification and configure SSH key or
+agent authentication before configuring MCP; the client cannot answer interactive
+SSH prompts. The command above should print `true`.
+
+For a client that accepts `mcpServers` JSON, use this configuration on the
+workstation:
+
+```json
+{
+  "mcpServers": {
+    "open-design": {
+      "command": "ssh",
+      "args": [
+        "-T", "-o", "BatchMode=yes",
+        "user@docker-host",
+        "docker", "exec", "-i", "open-design",
+        "node", "/app/apps/daemon/dist/cli.js",
+        "mcp", "--daemon-url", "http://127.0.0.1:7456"
+      ]
+    }
+  }
+}
+```
+
+The CLI path and port above match the repository Docker image. Adjust them if
+your image differs. The workstation needs `ssh`; Node and the OpenDesign helper
+run inside the container. For a client running on the Docker host itself, use
+`docker` as the command and start the argument list at `exec`.
+
+Keep stdin open with `docker exec -i`, disable SSH terminal allocation with `-T`,
+and do not add Docker's `-t`: stdout carries the MCP protocol and must not contain
+terminal formatting or shell startup messages. The helper inherits the existing
+container environment. Preserve the deployment's data-root configuration as
+defined in [the daemon data directory contract](../../AGENTS.md#daemon-data-directory-contract).
+
+Reconnect the MCP client and confirm it can list OpenDesign tools and read a
+project you have access to. If SSH exits immediately, check authentication and
+Docker permissions; if the helper cannot reach the daemon, check container health
+and its internal port. This bridge does not require publishing another port or
+disabling the deployment's API authentication.
+
 ## Common Issues
 
 - `failed to connect to the docker API`: Docker Desktop is not running yet


### PR DESCRIPTION
Fixes #7734

## Why

Contributing a fix for the reported Docker setup issue; I did not encounter it in a personal deployment. Settings builds its MCP setup from the daemon's own executable and environment. A workstation accessing Docker through a reverse proxy cannot use those container-local paths. Replacing the loopback URL alone would still leave an unusable launch command.

## What users will see

Settings -> MCP server labels the setup as local-runtime only before the client picker, install actions, and copyable snippet. A link opens Docker deployment guidance with an SSH stdio bridge example and verification steps. Both new strings are translated in all 19 UI locales.

This implements the issue's local-only labeling and remote guidance option. It does not introduce a remote HTTP MCP transport.

## Surface area

- [x] **UI** - setup scope notice and documentation link in MCP Settings
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var** - no new capability or CLI behavior; documentation uses the existing MCP command
- [ ] **API / contract**
- [ ] **Extension point**
- [x] **i18n keys** - two keys, all 19 locales
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

No screenshot attached. The tools-dev runtime served the application and onboarding completed, but visual inspection of the MCP Settings panel was not completed before the local runtime stopped. Visual layout verification remains a review limitation; no screenshot-based verification is claimed.

## Bug fix verification

No new red/green test: the patch adds static setup copy and documentation, without changing command generation. Existing Settings interaction tests cover snippet rendering, client switching, and clipboard behavior; the locale suite checks dictionary alignment.

The documented helper path and internal port were checked against deploy/Dockerfile and deploy/docker-compose.yml. An actual SSH/Docker connection was not tested: Docker is unavailable on this Windows host. That validation remains outstanding.

## Validation

- `pnpm install --frozen-lockfile` - passed.
- `pnpm guard` - passed after workspace builds completed.
- `pnpm typecheck` - passed across the workspace.
- `pnpm i18n:check` - passed.
- `pnpm --filter @open-design/web test tests/i18n/locales.test.ts tests/components/SettingsDialog.execution.test.tsx` - rerun on the PR head before marking ready: 2 files, 167 tests passed.
- `git diff --check` - passed.
