### PR TITLE
fix(analytics): call posthog.reset() on logout to prevent cross-user identity aliasing

### DIFF
--- a/apps/web/src/analytics/client.ts
+++ b/apps/web/src/analytics/client.ts
@@ -479,6 +479,21 @@ export function applyIdentity(installationId: string | null): void {
   }
 }
 
+// Called when the authenticated user logs out (e.g. AmrLoginPill handleLogout).
+// Clears PostHog's anonymous ID and all persisted identity so that a
+// subsequent login on the same device starts from a clean anonymous session
+// rather than inheriting the previous user's distinct_id and person record.
+// Also clears resolvedDeviceId so the next init re-registers fresh properties.
+export function resetAnalyticsOnLogout(): void {
+  if (!client) return;
+  try {
+    client.reset();
+    resolvedDeviceId = null;
+  } catch {
+    // best-effort — never throw out of a logout path.
+  }
+}
+
 // Push the cached super-property payload back onto the PostHog client. Used
 // after reset()/identify() flows; takes an optional override patch so the
 // caller can swap fields (e.g. a rotated device_id) without re-deriving the

--- a/apps/web/src/components/AmrLoginPill.tsx
+++ b/apps/web/src/components/AmrLoginPill.tsx
@@ -23,6 +23,7 @@ import {
   resolveAmrAuthTracking,
 } from '../analytics/amr-auth';
 import { useI18n } from '../i18n';
+import { resetAnalyticsOnLogout } from '../analytics/client';
 import {
   AMR_LOGIN_STATUS_EVENT,
   AMR_LOGIN_POLL_INTERVAL_MS,
@@ -731,6 +732,7 @@ export function AmrLoginPill({
   const performLogout = useCallback(async () => {
     setErrorMessage(null);
     setPending('logout');
+    resetAnalyticsOnLogout(); // clear PostHog identity before server-side logout
     const result = await velaLogout();
     loginStartedAtRef.current = null;
     loginPendingRef.current = false;


### PR DESCRIPTION
## Why

PostHog's anonymous ID and persisted identity survived logout in the AMR/Vela integration. If a second user logs in on the same device after the first logs out, their `posthog.identify()` aliases them to the previous user's person record permanently — corrupting person counts, funnel attribution, and retention for both users. This is happening now, not hypothetically.

Found via PostHog audit report: `Infrastructure/posthog-audit-report-20260906.md`

## What users will see

No visible change. PostHog now gets a clean anonymous session after every logout, so each login is tracked as an independent identity.

## Changes

### `apps/web/src/analytics/client.ts`
Added `resetAnalyticsOnLogout()` — a new exported function that calls `client.reset()` and clears `resolvedDeviceId`. Follows the exact same pattern as the existing `applyConsent()` and `applyIdentity()` helpers rather than importing `posthog-js` directly in the component.

### `apps/web/src/components/AmrLoginPill.tsx`
Imported `resetAnalyticsOnLogout` and called it inside `performLogout` immediately before `velaLogout()`.

## Audit scope

Grepped the full `apps/web/src/` for every `logout`, `signOut`, and `velaLogout` call site. **One logout path exists** — `performLogout` in `AmrLoginPill.tsx` (the single caller of `velaLogout()`). No other exit paths were missing `posthog.reset()`.

## Surface area

- [x] Bug fix
- [x] Analytics / PostHog identity
- [ ] CLI
- [ ] i18n keys
- [ ] New dependencies

## Test plan

- Typecheck passes with no new errors (`pnpm --filter @open-design/web typecheck` — pre-existing errors in `client.ts:42`, `219`, `256` and in `tests/` are on `origin/main` baseline, not introduced here)
- Log out → log in as a different account → confirm PostHog assigns a fresh anonymous ID to the second session with no aliasing to the first user's person record