### PR TITLE
fix(ci): make the DSH upstream drift card readable

### DIFF
--- a/.github/scripts/dsh-upstream-drift.ts
+++ b/.github/scripts/dsh-upstream-drift.ts
@@ -52,6 +52,25 @@ export interface DriftVerdict {
   latest: string;
   /** Whether the agent def would accept `latest` without an untested warning. */
   accepted: boolean;
+  /**
+   * When the registry published `latest`, ISO-8601, or `null` when it did not
+   * say. Nullable on purpose — see `readPublishedAt`.
+   */
+  publishedAt: string | null;
+}
+
+interface CardBlock {
+  tag: string;
+  text?: { tag: string; content: string };
+}
+
+export interface DriftCard {
+  config: { wide_screen_mode: boolean };
+  elements: CardBlock[];
+  header: {
+    template: "orange" | "red";
+    title: { content: string; tag: "plain_text" };
+  };
 }
 
 function requiredEnv(name: string): string {
@@ -101,47 +120,111 @@ export function classifyDrift(args: {
   accepted: boolean;
   latest: string;
   pinned: string;
+  publishedAt: string | null;
 }): DriftVerdict {
-  const { accepted, latest, pinned } = args;
-  if (!accepted) return { accepted, latest, pinned, severity: "unsupported" };
-  if (latest !== pinned) return { accepted, latest, pinned, severity: "behind" };
-  return { accepted, latest, pinned, severity: "in-sync" };
+  const { accepted, latest, pinned, publishedAt } = args;
+  const facts = { accepted, latest, pinned, publishedAt };
+  if (!accepted) return { ...facts, severity: "unsupported" };
+  if (latest !== pinned) return { ...facts, severity: "behind" };
+  return { ...facts, severity: "in-sync" };
 }
 
-async function fetchLatestVersion(): Promise<string> {
+/**
+ * When the registry says `version` was published, or `null` when it does not.
+ *
+ * Nullable rather than throwing, and deliberately so: the publish date is one
+ * sentence of context on an alert whose entire reason to exist is being sent.
+ * A registry that answers with a compact packument (no `time` map at all), a
+ * `time` map that has not caught up with `dist-tags`, or a non-string entry
+ * must cost the card that sentence — never the alert.
+ */
+export function readPublishedAt(packument: unknown, version: string): string | null {
+  if (typeof packument !== "object" || packument === null) return null;
+  const time = (packument as { time?: unknown }).time;
+  if (typeof time !== "object" || time === null) return null;
+  const published = (time as Record<string, unknown>)[version];
+  return typeof published === "string" && published.length > 0 ? published : null;
+}
+
+/**
+ * `2026-09-03（4 天前）` — the date plus the one thing a bare date does not
+ * answer: whether this landed this morning or has been sitting for a fortnight.
+ * `null` for anything unparseable, so callers can drop the clause entirely.
+ */
+export function describePublishedAt(publishedAt: string | null, now: Date): string | null {
+  if (publishedAt === null) return null;
+  const at = new Date(publishedAt);
+  if (Number.isNaN(at.getTime())) return null;
+  const day = at.toISOString().slice(0, 10);
+  const elapsed = Math.round(
+    (Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()) -
+      Date.UTC(at.getUTCFullYear(), at.getUTCMonth(), at.getUTCDate())) /
+      86_400_000,
+  );
+  if (elapsed < 0) return day;
+  if (elapsed === 0) return `${day}（今天）`;
+  return `${day}（${elapsed} 天前）`;
+}
+
+async function fetchLatestRelease(): Promise<{ latest: string; publishedAt: string | null }> {
+  // The compact packument (`application/vnd.npm.install-v1+json`) carries only
+  // name / dist-tags / versions / modified — it has no `time` map, so the card
+  // could never say when upstream shipped. This runs once a day; the full
+  // document is worth its bytes.
   const response = await fetch(`${REGISTRY}/${encodeURIComponent(PACKAGE)}`, {
-    headers: { accept: "application/vnd.npm.install-v1+json" },
+    headers: { accept: "application/json" },
   });
   if (!response.ok) {
     throw new Error(`registry returned HTTP ${response.status} for ${PACKAGE}`);
   }
-  const body = (await response.json()) as { "dist-tags"?: Record<string, string> };
-  const latest = body["dist-tags"]?.latest;
+  const body = (await response.json()) as unknown;
+  const tags = (body as { "dist-tags"?: Record<string, string> })["dist-tags"];
+  const latest = tags?.latest;
   if (!latest) throw new Error(`${PACKAGE} has no dist-tag "latest"`);
-  return latest;
+  return { latest, publishedAt: readPublishedAt(body, latest) };
 }
 
-export function buildCard(verdict: DriftVerdict): Record<string, unknown> {
+/**
+ * The card a maintainer wakes up to.
+ *
+ * Read top to bottom it answers, in this order: what check is this, what
+ * happened, why it matters, what to change. An earlier version led with a
+ * verdict as its headline and opened its body with semver theory, and the
+ * maintainer who received it could not tell what the message even was. So the
+ * headline names the check and nothing else — severity is carried by the header
+ * template, which Feishu renders before a single word of text — and the first
+ * sentence is three facts with no reasoning attached: the upstream version,
+ * when it shipped, and what we still pin.
+ */
+export function buildCard(verdict: DriftVerdict, now: Date = new Date()): DriftCard {
   const blocking = verdict.severity === "unsupported";
-  const headline = blocking
-    ? `DeepSeek Harness ${verdict.latest} 不在我们支持的范围内`
-    : `DeepSeek Harness 已发布 ${verdict.latest}，我们还钉在 ${verdict.pinned}`;
+  const released = describePublishedAt(verdict.publishedAt, now);
+  const when = released === null ? "" : `，发布于 ${released}`;
+  const situation =
+    `上游 \`${PACKAGE}\` 已发布 \`${verdict.latest}\`${when}。` +
+    `我们的安装脚本目前钉在 \`${verdict.pinned}\`。`;
+  // The bold lead sentence gets its own line: markdown will not close a `**`
+  // run that is followed straight by a CJK character, so `**…。**装到` renders
+  // the asterisks literally.
   const consequence = blocking
     ? [
-        `装到 \`${verdict.latest}\` 的用户会被告知「未经测试」，`,
-        "而且 `packages/dsh-runtime` 的 peer 范围很可能直接解析失败——",
-        "semver 要求同 major.minor.patch 且自身带 prerelease 的比较器，",
-        "所以每条新的 prerelease 线都得单独加一个比较器，组件才装得上。",
-      ].join("")
-    : `按我们安装脚本装的用户会拿到 \`${verdict.pinned}\`，比 registry 的 \`latest\` 旧。`;
+        `**\`${verdict.latest}\` 不在我们声明支持的范围内。**`,
+        "装到这个版本的用户，CLI 会在设置里被标成「未经测试」，" +
+          "而且 `packages/dsh-runtime` 的 peer 范围多半直接解析不出来，组件根本装不上。",
+        "（semver 只在比较器带同一 major.minor.patch、且自身也带 prerelease 标签时才放行一个 prerelease，" +
+          "所以每条新的 prerelease 线都得单独加一个比较器。）",
+      ].join("\n")
+    : [
+        `**\`${verdict.latest}\` 我们是支持的，只是安装脚本还没跟上。**`,
+        `照我们的一行安装命令装的用户会拿到 \`${verdict.pinned}\`，` +
+          "比 registry 上的 `latest` 旧一档——能用，但不是最新的。",
+      ].join("\n");
 
   return {
     config: { wide_screen_mode: true },
     elements: [
-      {
-        tag: "div",
-        text: { tag: "lark_md", content: `${consequence}` },
-      },
+      { tag: "div", text: { tag: "lark_md", content: situation } },
+      { tag: "div", text: { tag: "lark_md", content: consequence } },
       { tag: "hr" },
       {
         tag: "div",
@@ -158,12 +241,12 @@ export function buildCard(verdict: DriftVerdict): Record<string, unknown> {
     ],
     header: {
       template: blocking ? "red" : "orange",
-      title: { content: headline, tag: "plain_text" },
+      title: { content: "DeepSeek Harness 上游新版检测", tag: "plain_text" },
     },
   };
 }
 
-function signedEnvelope(card: Record<string, unknown>): Record<string, unknown> {
+function signedEnvelope(card: DriftCard): Record<string, unknown> {
   const body = { card, msg_type: "interactive" };
   const signSecret = process.env.FEISHU_SIGN_SECRET?.trim() ?? "";
   if (signSecret.length === 0) return body;
@@ -210,7 +293,7 @@ export function interpretFeishuResponse(args: {
   };
 }
 
-async function postFeishu(card: Record<string, unknown>): Promise<void> {
+async function postFeishu(card: DriftCard): Promise<void> {
   const webhook = requiredEnv("FEISHU_WEBHOOK");
   for (let attempt = 1; attempt <= 5; attempt += 1) {
     const response = await fetch(webhook, {
@@ -242,12 +325,13 @@ async function run(dryRun: boolean): Promise<void> {
   const defSource = readRepoFile(AGENT_DEF);
   const pattern = readAcceptedPattern(defSource);
   const listed = readListedVersions(defSource);
-  const latest = await fetchLatestVersion();
+  const { latest, publishedAt } = await fetchLatestRelease();
   const accepted = listed.includes(latest) || (pattern?.test(latest) ?? false);
-  const verdict = classifyDrift({ accepted, latest, pinned });
+  const verdict = classifyDrift({ accepted, latest, pinned, publishedAt });
 
   console.log(
     `[dsh-drift] pinned=${verdict.pinned} latest=${verdict.latest} ` +
+      `published=${verdict.publishedAt ?? "unknown"} ` +
       `accepted=${verdict.accepted} severity=${verdict.severity}`,
   );
 
@@ -280,6 +364,20 @@ function selfCheck(): void {
     throw new Error("self-check could not read the listed versions");
   }
 
+  const registryAnswer = {
+    "dist-tags": { latest: "0.1.1-rc.2" },
+    name: PACKAGE,
+    time: { "0.1.0-rc.8": "2026-08-21T09:02:11.000Z", "0.1.1-rc.2": "2026-09-03T06:21:52.107Z" },
+  };
+  if (readPublishedAt(registryAnswer, "0.1.1-rc.2") !== "2026-09-03T06:21:52.107Z") {
+    throw new Error("self-check could not read the publish date out of a packument");
+  }
+  // The compact packument has no `time` map. Degrading, not throwing, is the
+  // whole contract: an alert without a date still beats no alert.
+  if (readPublishedAt({ "dist-tags": { latest: "0.1.1-rc.2" } }, "0.1.1-rc.2") !== null) {
+    throw new Error("self-check expected a missing publish date to read as null");
+  }
+
   // The state that shipped twice: the installer and the def agreed with each
   // other and both were behind the registry. Anything that reports this as
   // healthy has lost the only thing this check is for.
@@ -287,19 +385,51 @@ function selfCheck(): void {
     accepted: false,
     latest: "0.1.1-rc.2",
     pinned: "0.1.0-rc.8",
+    publishedAt: "2026-09-03T06:21:52.107Z",
   });
   if (missed.severity !== "unsupported") {
     throw new Error("self-check expected the shipped-twice state to be unsupported");
   }
-  if (String(buildCard(missed).header).length === 0) {
-    throw new Error("self-check expected a card for a drifted verdict");
+
+  // `String(card.header)` is "[object Object]" whatever the card says, so the
+  // assertion that used to stand here could never fail. Read the fields a human
+  // reads instead: the card has to name the check, and its body has to carry
+  // all three facts — upstream version, publish date, what we pin — including
+  // on the blocking branch, which once mentioned no pinned version at all.
+  const card = buildCard(missed, new Date("2026-09-07T00:00:00.000Z"));
+  const body = card.elements.map((element) => element.text?.content ?? "").join("\n");
+  if (!card.header.title.content.includes("新版检测")) {
+    throw new Error("self-check expected the headline to name the check");
+  }
+  for (const fact of [missed.latest, missed.pinned, "2026-09-03"]) {
+    if (!body.includes(fact)) {
+      throw new Error(`self-check expected the card body to state ${fact}`);
+    }
+  }
+  const undated = buildCard({ ...missed, publishedAt: null });
+  const undatedBody = undated.elements.map((element) => element.text?.content ?? "").join("\n");
+  if (!undatedBody.includes(missed.latest) || undatedBody.includes("Invalid Date")) {
+    throw new Error("self-check expected an undated verdict to still produce a readable card");
   }
 
-  const behind = classifyDrift({ accepted: true, latest: "0.1.2", pinned: "0.1.1-rc.2" });
+  const behind = classifyDrift({
+    accepted: true,
+    latest: "0.1.2",
+    pinned: "0.1.1-rc.2",
+    publishedAt: null,
+  });
   if (behind.severity !== "behind") {
     throw new Error("self-check expected an accepted-but-older latest to be behind");
   }
-  const synced = classifyDrift({ accepted: true, latest: "0.1.1-rc.2", pinned: "0.1.1-rc.2" });
+  if (buildCard(behind).header.template !== "orange") {
+    throw new Error("self-check expected a non-blocking verdict to stay orange");
+  }
+  const synced = classifyDrift({
+    accepted: true,
+    latest: "0.1.1-rc.2",
+    pinned: "0.1.1-rc.2",
+    publishedAt: null,
+  });
   if (synced.severity !== "in-sync") {
     throw new Error("self-check expected an exact match to be in-sync");
   }

--- a/e2e/tests/scripts/dsh-upstream-drift.test.ts
+++ b/e2e/tests/scripts/dsh-upstream-drift.test.ts
@@ -10,12 +10,15 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  type DriftCard,
   buildCard,
   classifyDrift,
+  describePublishedAt,
   interpretFeishuResponse,
   readAcceptedPattern,
   readListedVersions,
   readPinnedVersion,
+  readPublishedAt,
 } from '../../../.github/scripts/dsh-upstream-drift.ts';
 
 const repoRoot = fileURLToPath(new URL('../../../', import.meta.url));
@@ -23,6 +26,19 @@ const INSTALLER_SH = `${repoRoot}tools/release/resources/dsh-bootstrap/install-d
 const AGENT_DEF = `${repoRoot}apps/daemon/src/runtimes/defs/deepseek-harness.ts`;
 const DRIFT_SCRIPT = `${repoRoot}.github/scripts/dsh-upstream-drift.ts`;
 const WORKFLOW = `${repoRoot}.github/workflows/dsh-upstream-drift.yml`;
+
+/** A fixed "now" so the card's relative age is a fact, not a moving target. */
+const NOW = new Date('2026-09-07T00:00:00.000Z');
+const PUBLISHED_AT = '2026-09-03T06:21:52.107Z';
+
+function headlineOf(card: DriftCard): string {
+  return card.header.title.content;
+}
+
+/** Everything the reader actually reads under the headline. */
+function bodyOf(card: DriftCard): string {
+  return card.elements.map((element) => element.text?.content ?? '').join('\n');
+}
 
 describe('DeepSeek Harness upstream drift', () => {
   it('reads what we currently ship out of the real files', async () => {
@@ -61,19 +77,162 @@ describe('DeepSeek Harness upstream drift', () => {
       accepted: false,
       latest: '0.1.1-rc.2',
       pinned: '0.1.0-rc.8',
+      publishedAt: PUBLISHED_AT,
     });
 
     expect(verdict.severity).toBe('unsupported');
-    expect(JSON.stringify(buildCard(verdict))).toContain('0.1.1-rc.2');
+    expect(JSON.stringify(buildCard(verdict, NOW))).toContain('0.1.1-rc.2');
   });
 
   it('separates "we ship an older version" from "we do not support theirs"', () => {
     expect(
-      classifyDrift({ accepted: true, latest: '0.1.2', pinned: '0.1.1-rc.2' }).severity,
+      classifyDrift({
+        accepted: true,
+        latest: '0.1.2',
+        pinned: '0.1.1-rc.2',
+        publishedAt: PUBLISHED_AT,
+      }).severity,
     ).toBe('behind');
     expect(
-      classifyDrift({ accepted: true, latest: '0.1.1-rc.2', pinned: '0.1.1-rc.2' }).severity,
+      classifyDrift({
+        accepted: true,
+        latest: '0.1.1-rc.2',
+        pinned: '0.1.1-rc.2',
+        publishedAt: PUBLISHED_AT,
+      }).severity,
     ).toBe('in-sync');
+  });
+
+  // The maintainer who received this card could not tell what it was: the
+  // headline jumped straight to a verdict, so nothing said "an upstream release
+  // was detected" or where the message came from. The check's name belongs in
+  // the headline; how bad it is belongs in the header colour, which is the one
+  // thing a Feishu card renders before any text.
+  it('names the check in the headline instead of announcing a verdict there', () => {
+    const blocking = buildCard(
+      classifyDrift({
+        accepted: false,
+        latest: '0.1.2-rc.1',
+        pinned: '0.1.1-rc.2',
+        publishedAt: PUBLISHED_AT,
+      }),
+      NOW,
+    );
+    const behind = buildCard(
+      classifyDrift({
+        accepted: true,
+        latest: '0.1.2',
+        pinned: '0.1.1-rc.2',
+        publishedAt: PUBLISHED_AT,
+      }),
+      NOW,
+    );
+
+    expect(headlineOf(blocking)).toContain('DeepSeek Harness');
+    expect(headlineOf(blocking)).toContain('新版检测');
+    // Same check, same name. Severity travels in the template, not the title.
+    expect(headlineOf(behind)).toBe(headlineOf(blocking));
+    expect(blocking.header.template).toBe('red');
+    expect(behind.header.template).toBe('orange');
+  });
+
+  // The blocking branch used to be the least informative one: its body never
+  // mentioned `pinned` at all, so the most urgent card was the one that hid
+  // what we currently ship. Both severities owe the reader the same three
+  // facts before any explanation: what upstream released, when, and where we
+  // still sit.
+  it.each([
+    { accepted: false, latest: '0.1.2-rc.1', severity: 'unsupported' },
+    { accepted: true, latest: '0.1.2', severity: 'behind' },
+  ])('states upstream version, publish date and our pin ($severity)', (scenario) => {
+    const verdict = classifyDrift({
+      accepted: scenario.accepted,
+      latest: scenario.latest,
+      pinned: '0.1.1-rc.2',
+      publishedAt: PUBLISHED_AT,
+    });
+    expect(verdict.severity).toBe(scenario.severity);
+
+    const body = bodyOf(buildCard(verdict, NOW));
+
+    expect(body).toContain(scenario.latest);
+    expect(body).toContain('0.1.1-rc.2');
+    expect(body).toContain('2026-09-03');
+    // "Is this fresh, or has it been sitting for two weeks?" is the question a
+    // bare timestamp still leaves open.
+    expect(body).toContain('4 天前');
+
+    // What happened comes before why it matters: the semver rationale used to
+    // be the opening sentence of the card.
+    const firstBlock = buildCard(verdict, NOW).elements[0]?.text?.content ?? '';
+    expect(firstBlock).toContain(scenario.latest);
+    expect(firstBlock).toContain('0.1.1-rc.2');
+    expect(firstBlock).not.toContain('semver');
+
+    // The three-file checklist is the useful half of the old card; keep it.
+    expect(body).toContain('packages/dsh-runtime/package.json');
+  });
+
+  // The publish date is decoration on an alert whose only job is to be sent.
+  // A registry response without it must cost the card one sentence, not the
+  // whole alert.
+  it('drops the publish date rather than the alert when the registry omits it', () => {
+    const card = buildCard(
+      classifyDrift({
+        accepted: false,
+        latest: '0.1.2-rc.1',
+        pinned: '0.1.1-rc.2',
+        publishedAt: null,
+      }),
+      NOW,
+    );
+    const body = bodyOf(card);
+
+    expect(headlineOf(card)).toContain('新版检测');
+    expect(body).toContain('0.1.2-rc.1');
+    expect(body).toContain('0.1.1-rc.2');
+    expect(body).not.toContain('null');
+    expect(body).not.toContain('Invalid Date');
+    expect(body).not.toContain('NaN');
+  });
+
+  // The compact packument (`application/vnd.npm.install-v1+json`) carries only
+  // name / dist-tags / versions / modified — no `time` map at all — so reading
+  // the publish date has to survive every shape short of the full document.
+  it('reads the publish date out of a packument, and null out of anything else', () => {
+    const full = {
+      'dist-tags': { latest: '0.1.2-rc.1' },
+      name: '@deepseek-ai/dsh',
+      time: {
+        '0.1.1-rc.2': '2026-08-21T09:02:11.000Z',
+        '0.1.2-rc.1': PUBLISHED_AT,
+        created: '2026-01-04T00:00:00.000Z',
+        modified: PUBLISHED_AT,
+      },
+    };
+
+    expect(readPublishedAt(full, '0.1.2-rc.1')).toBe(PUBLISHED_AT);
+    expect(readPublishedAt(full, '9.9.9')).toBeNull();
+    // The compact packument shape.
+    expect(
+      readPublishedAt(
+        { 'dist-tags': { latest: '0.1.2-rc.1' }, modified: PUBLISHED_AT, name: 'x' },
+        '0.1.2-rc.1',
+      ),
+    ).toBeNull();
+    expect(readPublishedAt({ time: { '0.1.2-rc.1': 17 } }, '0.1.2-rc.1')).toBeNull();
+    expect(readPublishedAt(null, '0.1.2-rc.1')).toBeNull();
+    expect(readPublishedAt('not json', '0.1.2-rc.1')).toBeNull();
+  });
+
+  it('turns a publish timestamp into a date plus an age, and garbage into nothing', () => {
+    expect(describePublishedAt(PUBLISHED_AT, NOW)).toContain('2026-09-03');
+    expect(describePublishedAt(PUBLISHED_AT, NOW)).toContain('4 天前');
+    expect(describePublishedAt('2026-09-07T01:00:00.000Z', new Date('2026-09-07T05:00:00Z'))).toBe(
+      '2026-09-07（今天）',
+    );
+    expect(describePublishedAt(null, NOW)).toBeNull();
+    expect(describePublishedAt('yesterday-ish', NOW)).toBeNull();
   });
 
   it('rebuilds the accepted pattern from source rather than restating it', () => {


### PR DESCRIPTION
## Why

The `dsh-upstream-drift` watcher fired for real, and the maintainer who received the card
came back with: *"这个卡片很让人困惑.. 标题应该是类似 xx 新版检测 之类的, 然后说明 xx 新版 xx 时候发布"* —
the card is confusing, the title should say **what check this is**, and the body should say
**when the new upstream version was published**.

That is a fair read of what the card actually said. Four things were wrong with it:

1. **The headline was a verdict, not a name.** `DeepSeek Harness 0.1.2-rc.1 不在我们支持的范围内`
   tells you the conclusion but never tells you an upstream release was detected, that this is
   an automated daily watch, or where the message came from.
2. **The blocking branch never named our pin.** `buildCard()` only used `verdict.pinned` on the
   non-blocking path, so the most urgent card was the one that hid what we currently ship.
3. **No publish date at all**, so there was no way to tell "shipped this morning" from
   "has been sitting for two weeks" — which is exactly the judgement the reader has to make.
4. **The body opened with semver theory.** Why-it-matters came before what-happened.

I hit this while following up on the alert itself, so this is scratching the itch of the one
person the tool is built for. It is operational pain, not a product bug: an alert nobody can
parse is an alert that gets ignored, and this one exists because the same DSH pin drift shipped
twice without anyone noticing.

## What users will see

The "user" here is the maintainer who gets the Feishu card. The daily `dsh-upstream-drift`
workflow posts the same card on the same trigger — only its wording and information order change.

**Before** (real `node .github/scripts/dsh-upstream-drift.ts run --dry-run` against the live registry):

```json
{
  "header": {
    "template": "red",
    "title": { "content": "DeepSeek Harness 0.1.2-rc.1 不在我们支持的范围内", "tag": "plain_text" }
  },
  "elements": [
    { "tag": "div", "text": { "tag": "lark_md", "content": "装到 `0.1.2-rc.1` 的用户会被告知「未经测试」，而且 `packages/dsh-runtime` 的 peer 范围很可能直接解析失败——semver 要求同 major.minor.patch 且自身带 prerelease 的比较器，所以每条新的 prerelease 线都得单独加一个比较器，组件才装得上。" } },
    { "tag": "hr" },
    { "tag": "div", "text": { "tag": "lark_md", "content": "**三处要一起改**（漏掉第三条会让组件装不上，不只是警告）：\n1. `tools/release/resources/dsh-bootstrap/install-dsh.sh` 和 `.ps1` — 版本 + `--before` 时间窗\n2. `apps/daemon/src/runtimes/defs/deepseek-harness.ts` — 接受的发布线\n3. `packages/dsh-runtime/package.json` — peer 范围加一条比较器" } }
  ]
}
```

Note what is missing: the word `0.1.1-rc.2` — the version we actually pin — appears nowhere.

**After** (same command, same live registry state):

```json
{
  "header": {
    "template": "red",
    "title": { "content": "DeepSeek Harness 上游新版检测", "tag": "plain_text" }
  },
  "elements": [
    { "tag": "div", "text": { "tag": "lark_md", "content": "上游 `@deepseek-ai/dsh` 已发布 `0.1.2-rc.1`，发布于 2026-09-03（4 天前）。我们的安装脚本目前钉在 `0.1.1-rc.2`。" } },
    { "tag": "div", "text": { "tag": "lark_md", "content": "**`0.1.2-rc.1` 不在我们声明支持的范围内。**\n装到这个版本的用户，CLI 会在设置里被标成「未经测试」，而且 `packages/dsh-runtime` 的 peer 范围多半直接解析不出来，组件根本装不上。\n（semver 只在比较器带同一 major.minor.patch、且自身也带 prerelease 标签时才放行一个 prerelease，所以每条新的 prerelease 线都得单独加一个比较器。）" } },
    { "tag": "hr" },
    { "tag": "div", "text": { "tag": "lark_md", "content": "**三处要一起改**（漏掉第三条会让组件装不上，不只是警告）：\n1. `tools/release/resources/dsh-bootstrap/install-dsh.sh` 和 `.ps1` — 版本 + `--before` 时间窗\n2. `apps/daemon/src/runtimes/defs/deepseek-harness.ts` — 接受的发布线\n3. `packages/dsh-runtime/package.json` — peer 范围加一条比较器" } }
  ]
}
```

The non-blocking (`behind`) card gets the same treatment — same headline, same three opening
facts, `orange` template:

```json
{
  "header": { "template": "orange", "title": { "content": "DeepSeek Harness 上游新版检测", "tag": "plain_text" } },
  "elements": [
    { "tag": "div", "text": { "tag": "lark_md", "content": "上游 `@deepseek-ai/dsh` 已发布 `0.1.2`，发布于 2026-09-03（4 天前）。我们的安装脚本目前钉在 `0.1.1-rc.2`。" } },
    { "tag": "div", "text": { "tag": "lark_md", "content": "**`0.1.2` 我们是支持的，只是安装脚本还没跟上。**\n照我们的一行安装命令装的用户会拿到 `0.1.1-rc.2`，比 registry 上的 `latest` 旧一档——能用，但不是最新的。" } },
    { "tag": "hr" },
    { "tag": "div", "text": { "tag": "lark_md", "content": "**三处要一起改**（漏掉第三条会让组件装不上，不只是警告）：…" } }
  ]
}
```

What changed, in words:

- **Headline names the check**, identically on both severities. Severity travels in the header
  template (`red` / `orange`), which Feishu renders before a single word of text — so putting it
  in the title was spending the title on something the card already showed.
- **First sentence is three facts, no reasoning**: what upstream released, when it was published
  (with the elapsed days, because a bare date still leaves "is this fresh?" open), and what our
  installer still pins. Both severities, so the blocking card is no longer the least informative one.
- **Consequence second**, worded differently for `unsupported` (won't install) vs `behind`
  (works, just older). The semver rationale survives, compressed into a parenthetical behind it
  instead of being the opening clause.
- **The three-file checklist is untouched** — it was the useful half of the old card.

### How the publish date is fetched

`fetchLatestVersion` asked npm for the compact packument
(`accept: application/vnd.npm.install-v1+json`), whose top level is only
`name / dist-tags / versions / modified` — **no `time` map**, so the publish date was simply not
in the response. It now requests the full document (`accept: application/json`) and reads
`time[latest]`. The document is bigger; this workflow runs once a day.

`readPublishedAt()` degrades to `null` for every shape short of that — no `time` map, a `time` map
that has not caught up with `dist-tags`, a non-string entry, a non-object body. The date is one
sentence of decoration on an alert whose entire reason to exist is being sent; losing the alert to
salvage a timestamp would invert the point of the script, which its own module docblock and
`interpretFeishuResponse`'s docstring both already argue. Covered by a test and by `self-check`.

### Also: a self-check assertion that could never fail

`self-check` contained:

```js
if (String(buildCard(missed).header).length === 0) {
  throw new Error("self-check expected a card for a drifted verdict");
}
```

`String({})` is `"[object Object]"` — length 15, never 0 — so this guarded nothing, and what it
guarded nothing over was `buildCard`, i.e. exactly the function this PR rewrites. It now reads the
fields a human reads: the headline names the check, and the body carries all three facts
(upstream version, publish date, our pin) on the blocking branch specifically. It also asserts the
undated path still produces a readable card, and that a non-blocking verdict stays `orange`.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — CI script + its e2e behavior test only. No product surface, no new dependency,
      no workflow change (`.github/workflows/dsh-upstream-drift.yml` is untouched).

## Screenshots

None — the rendered surface is a Feishu card, and its exact JSON is quoted above. The card was
never posted to the real webhook during this work; every capture is `run --dry-run`, which prints
the payload and exits without contacting Feishu.

## Bug fix verification

- Test path: `e2e/tests/scripts/dsh-upstream-drift.test.ts`
- Did the test go red before the source change and green after? **yes.**

Red first, with the new tests in place and `.github/scripts/dsh-upstream-drift.ts` restored to its
`origin/main` content:

```
 FAIL  … > names the check in the headline instead of announcing a verdict there
AssertionError: expected 'DeepSeek Harness 0.1.2-rc.1 不在我们支持的范围内' to contain '新版检测'

 FAIL  … > states upstream version, publish date and our pin ('unsupported')
AssertionError: expected '装到 `0.1.2-rc.1` 的用户会被告知「未经测试」，而且 `pac…' to contain '0.1.1-rc.2'

 FAIL  … > states upstream version, publish date and our pin ('behind')
AssertionError: expected '按我们安装脚本装的用户会拿到 `0.1.1-rc.2`，比 registr…' to contain '0.1.2'

 FAIL  … > drops the publish date rather than the alert when the registry omits it
AssertionError: expected 'DeepSeek Harness 0.1.2-rc.1 不在我们支持的范围内' to contain '新版检测'

 FAIL  … > reads the publish date out of a packument, and null out of anything else
TypeError: readPublishedAt is not a function

 FAIL  … > turns a publish timestamp into a date plus an age, and garbage into nothing
TypeError: describePublishedAt is not a function

 Test Files  1 failed (1)
      Tests  6 failed | 10 passed (16)
```

The second failure is the reported defect stated as an assertion: the `unsupported` card's body
does not contain `0.1.1-rc.2`, the version we pin.

Green after the change:

```
 Test Files  1 passed (1)
      Tests  16 passed (16)
```

Removal re-verification: the red run above **is** the removal check — the tests were run against
the branch's test file with the implementation reverted to `origin/main`, so every new assertion
is demonstrably load-bearing rather than vacuously true.

## Validation

- `pnpm guard` — exit 0
- `pnpm typecheck` — exit 0
- `pnpm --filter @open-design/e2e typecheck` — exit 0 (strict: `noUncheckedIndexedAccess`,
  `exactOptionalPropertyTypes`)
- `e2e/node_modules/.bin/vitest run -c vitest.config.ts tests/scripts/dsh-upstream-drift.test.ts`
  — 16 passed
- `e2e/node_modules/.bin/vitest run -c vitest.config.ts tests/scripts` — 19 files, 151 passed
  (no collateral damage to sibling script contracts)
- `node .github/scripts/dsh-upstream-drift.ts self-check` — passed
- `node --experimental-strip-types .github/scripts/dsh-upstream-drift.ts self-check` — passed
  (the exact invocation the workflow uses)
- `node .github/scripts/dsh-upstream-drift.ts run --dry-run` — real registry round-trip, card JSON
  quoted above. Never run without `--dry-run`; no Feishu webhook was contacted.

The existing `does not touch the network when imported` case still passes — `fetch` stays inside
`fetchLatestRelease`, not at module scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8MaA1ABkvbnfaYUKw3UH3
