### PR TITLE
fix(dsh): support DeepSeek Harness 0.1.2-rc.1, now npm's latest

### DIFF
--- a/apps/daemon/src/runtimes/defs/deepseek-harness.ts
+++ b/apps/daemon/src/runtimes/defs/deepseek-harness.ts
@@ -59,20 +59,25 @@ export const deepseekHarnessAgentDef = {
     // who followed our instructions land on an "untested version" warning the
     // week after we bumped the installer. Accept the release line; a version
     // off it still warns.
-    supportedVersions: ['0.1.0-rc.8', '0.1.1-rc.2'],
+    supportedVersions: ['0.1.0-rc.8', '0.1.1-rc.2', '0.1.2-rc.1'],
     // The line, not one point on it. Scoping this to `0.1.0-rc.N` was still a
     // pin: upstream shipped `0.1.1-rc.1` two days later and every user on it
-    // was told their CLI was untested.
+    // was told their CLI was untested. `0.1.2-rc.1` then became npm's `latest`,
+    // and the same warning came back for everyone who installed without naming
+    // a version — the widening has to happen per patch line, every time.
     //
     // Prerelease acceptance may never exceed what `packages/dsh-runtime`'s peer
     // ranges can install, or this suppresses the warning for a version whose
     // companion cannot resolve — a worse failure than the warning, and silent.
     // semver admits a prerelease only against a comparator sharing its exact
     // major.minor.patch AND carrying a prerelease, so the accepted release
-    // candidates are precisely the peers' tuples and floors: `0.1.0-rc.6+` and
-    // any `0.1.1-rc.N`. Stable releases on the line need no such comparator.
+    // candidates are precisely the peers' tuples and floors: `0.1.0-rc.6+`, any
+    // `0.1.1-rc.N`, any `0.1.2-rc.N`. One alternative per peer comparator, on
+    // purpose — a new upstream patch line needs an edit in both files or in
+    // neither. Stable releases on the line need no such comparator.
     // `e2e/tests/dsh-installer-version-policy.test.ts` holds the two together.
-    supportedVersionPattern: /^0\.1\.\d+$|^0\.1\.0-rc\.(?:[6-9]|[1-9]\d+)$|^0\.1\.1-rc\.\d+$/u,
+    supportedVersionPattern:
+      /^0\.1\.\d+$|^0\.1\.0-rc\.(?:[6-9]|[1-9]\d+)$|^0\.1\.1-rc\.\d+$|^0\.1\.2-rc\.\d+$/u,
     requireVersion: true,
     parse: parseDeepSeekHarnessVersion,
   },

--- a/apps/daemon/tests/runtimes/version-policy.test.ts
+++ b/apps/daemon/tests/runtimes/version-policy.test.ts
@@ -120,6 +120,13 @@ describe('runtime version policy', () => {
     // the registry serves". These are the versions actually published there.
     ['0.1.1-rc.1', undefined],
     ['0.1.1-rc.2', undefined],
+    // Upstream then moved `latest` to `0.1.2-rc.1`, so this is what a user who
+    // installs `@deepseek-ai/dsh` without naming a version has on their machine.
+    // Every new patch line needs its own alternative in the pattern: semver's
+    // prerelease rule is per major.minor.patch tuple, and the peer ranges in
+    // `packages/dsh-runtime` obey the same rule, so a line we accept here but
+    // do not add there is a version we bless and then cannot equip.
+    ['0.1.2-rc.1', undefined],
     // A stable release on a line we support should not read as untested.
     ['0.1.1', undefined],
     // Still off the line, still warns. The point is to stop pinning, not to

--- a/e2e/tests/dsh-installer-version-policy.test.ts
+++ b/e2e/tests/dsh-installer-version-policy.test.ts
@@ -177,9 +177,16 @@ describe('accepted DeepSeek Harness versions can actually install their companio
     expect(overclaimed).toEqual([]);
   });
 
-  // The two versions the review named, pinned explicitly so a future widening
-  // has to face them rather than quietly passing a filter that matches nothing.
-  it('accepts what upstream serves and refuses the line the peers cannot reach', async () => {
+  // Both authorities have to cover a release line for it to be usable, and both
+  // have to be widened by hand — the def with a `major.minor.patch-rc.N`
+  // alternative, the peers with a comparator carrying that same tuple. Naming
+  // the shipped lines one by one is what forces a widening to face them, rather
+  // than quietly passing a filter that happens to match nothing.
+  //
+  // Each line upstream has actually released and we have taken on belongs here.
+  // A line we have not taken on belongs in the refusal below, so widening can
+  // never degenerate into "accept everything".
+  it('covers every release line we support with both the def and the peers', async () => {
     const [def, manifest] = await Promise.all([
       readFile(AGENT_DEF, 'utf8'),
       readFile(PEER_MANIFEST, 'utf8'),
@@ -189,8 +196,21 @@ describe('accepted DeepSeek Harness versions can actually install their companio
     expect(accepts(def, '0.1.1-rc.2')).toBe(true);
     expect(peerCanInstall(ranges, '0.1.1-rc.2')).toBe(true);
 
-    expect(peerCanInstall(ranges, '0.1.2-rc.1')).toBe(false);
-    expect(accepts(def, '0.1.2-rc.1')).toBe(false);
+    // `0.1.2-rc.1` became npm's `latest` dist-tag on 2026-09-03, so this is what
+    // a user who installs `@deepseek-ai/dsh` without naming a version gets.
+    expect(accepts(def, '0.1.2-rc.1')).toBe(true);
+    expect(peerCanInstall(ranges, '0.1.2-rc.1')).toBe(true);
+  });
+
+  it('refuses a release line neither authority has been widened to', async () => {
+    const [def, manifest] = await Promise.all([
+      readFile(AGENT_DEF, 'utf8'),
+      readFile(PEER_MANIFEST, 'utf8'),
+    ]);
+    const ranges = dshPeerRanges(manifest);
+
+    expect(peerCanInstall(ranges, '0.2.0-rc.1')).toBe(false);
+    expect(accepts(def, '0.2.0-rc.1')).toBe(false);
   });
 
   // A bump that updates one peer and forgets the rest is the realistic way this

--- a/packages/dsh-runtime/package.json
+++ b/packages/dsh-runtime/package.json
@@ -48,11 +48,11 @@
   "peerDependencies": {
     "@deepseek-ai/cordis": ">=4.0.1",
     "@deepseek-ai/cordis-plugin-loader": ">=1.0.2",
-    "@deepseek-ai/dsh-agent": ">=0.1.0-rc.6 || >=0.1.1-rc.0",
-    "@deepseek-ai/dsh-agent-default-model": ">=0.1.0-rc.6 || >=0.1.1-rc.0",
-    "@deepseek-ai/dsh-invariants": ">=0.1.0-rc.6 || >=0.1.1-rc.0",
-    "@deepseek-ai/dsh-llm": ">=0.1.0-rc.6 || >=0.1.1-rc.0",
-    "@deepseek-ai/dsh-session": ">=0.1.0-rc.6 || >=0.1.1-rc.0"
+    "@deepseek-ai/dsh-agent": ">=0.1.0-rc.6 || >=0.1.1-rc.0 || >=0.1.2-rc.0",
+    "@deepseek-ai/dsh-agent-default-model": ">=0.1.0-rc.6 || >=0.1.1-rc.0 || >=0.1.2-rc.0",
+    "@deepseek-ai/dsh-invariants": ">=0.1.0-rc.6 || >=0.1.1-rc.0 || >=0.1.2-rc.0",
+    "@deepseek-ai/dsh-llm": ">=0.1.0-rc.6 || >=0.1.1-rc.0 || >=0.1.2-rc.0",
+    "@deepseek-ai/dsh-session": ">=0.1.0-rc.6 || >=0.1.1-rc.0 || >=0.1.2-rc.0"
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "4.0.1",

--- a/tools/release/resources/dsh-bootstrap/install-dsh.ps1
+++ b/tools/release/resources/dsh-bootstrap/install-dsh.ps1
@@ -6,7 +6,7 @@ $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 
 $NodeVersion = '24.19.0'
-$DshVersion = '0.1.1-rc.2'
+$DshVersion = '0.1.2-rc.1'
 $PnpmVersion = '11.7.0'
 # Freeze npm's view of the registry to just after $DshVersion was published.
 #
@@ -21,7 +21,7 @@ $PnpmVersion = '11.7.0'
 #
 # The cutoff must stay LATER than $DshVersion's publish time and EARLIER than
 # the next release candidate's. Update both values together.
-$DshResolutionCutoff = '2026-08-21T13:00:00Z'
+$DshResolutionCutoff = '2026-09-03T07:00:00Z'
 
 function Fail([string]$Message) {
   throw "DeepSeek Harness installer: $Message"

--- a/tools/release/resources/dsh-bootstrap/install-dsh.sh
+++ b/tools/release/resources/dsh-bootstrap/install-dsh.sh
@@ -2,7 +2,7 @@
 set -eu
 
 NODE_VERSION='24.19.0'
-DSH_VERSION='0.1.1-rc.2'
+DSH_VERSION='0.1.2-rc.1'
 PNPM_VERSION='11.7.0'
 # Freeze npm's view of the registry to just after DSH_VERSION was published.
 #
@@ -17,7 +17,7 @@ PNPM_VERSION='11.7.0'
 #
 # The cutoff must stay LATER than DSH_VERSION's publish time and EARLIER than
 # the next release candidate's. Update both values together.
-DSH_RESOLUTION_CUTOFF='2026-08-21T13:00:00Z'
+DSH_RESOLUTION_CUTOFF='2026-09-03T07:00:00Z'
 
 NO_LAUNCH=0
 
@@ -139,7 +139,10 @@ else
     Darwin) os=darwin ;;
     Linux)
       os=linux
-      [ ! -f /etc/alpine-release ] || fail 'Alpine Linux is not supported by the official Node.js archive. Install Node.js 24 and run npx @deepseek-ai/dsh@0.1.0-rc.6 web.'
+      # Interpolated, not spelled out: this fallback named a release candidate
+      # two patch lines behind DSH_VERSION, because nothing points at it when
+      # the pin above moves. There is one dsh version in this file.
+      [ ! -f /etc/alpine-release ] || fail "Alpine Linux is not supported by the official Node.js archive. Install Node.js 24 and run npx @deepseek-ai/dsh@$DSH_VERSION web."
       ;;
     *) fail "unsupported operating system: $os" ;;
   esac


### PR DESCRIPTION
## Why

**Use case.** I was checking what a user actually gets today when they follow our
own DeepSeek Harness install instructions, and ran
`.github/scripts/dsh-upstream-drift.ts run --dry-run` — the watcher we added
precisely so a third person would not have to be the one to notice. It came back
`severity=unsupported`. This is the third time upstream has moved a release line
out from under us, and the first time our own alarm caught it before a user did.

**Pain.** `@deepseek-ai/dsh@0.1.2-rc.1` was published on 2026-09-03 and is now
npm's `latest` dist-tag, so it is what anyone who installs without naming a
version ends up with. We were pinned to `0.1.1-rc.2` (2026-08-21), and both of
our authorities rejected the new line:

- `apps/daemon/src/runtimes/defs/deepseek-harness.ts` did not accept
  `0.1.2-rc.1`, so Settings labelled the user's CLI **untested**.
- `packages/dsh-runtime`'s peer ranges (`>=0.1.0-rc.6 || >=0.1.1-rc.0`) evaluate
  to **false** for `0.1.2-rc.1` — semver only admits a prerelease against a
  comparator sharing its exact `major.minor.patch` *and* carrying a prerelease of
  its own. So the companion component could not install at all. That is the
  worse half: the warning is visible, this is silent.

So a user on npm's default version was told their setup was untested and then
could not equip the connection component either.

Related but not closed by this PR: #7193 reports the same defect class for
`0.1.0-rc.7`; that version already passes on `main` (the `[6-9]` alternative
covers it), so this PR does not close it.

## What users will see

Users who install DeepSeek Harness — via our one-liner or via plain
`npx @deepseek-ai/dsh` — get `0.1.2-rc.1`, and Settings no longer flags it as an
untested version. The `dsh` connection component now resolves and installs
against that line instead of failing to resolve.

Also user-visible: the Alpine Linux fallback message in `install-dsh.sh` used to
tell people to run `npx @deepseek-ai/dsh@0.1.0-rc.6` — two patch lines stale. It
now interpolates `$DSH_VERSION`, so it can never drift from the pin again.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [x] **Default behavior change** — the version our installer hands a user moves from `0.1.1-rc.2` to `0.1.2-rc.1`, and the daemon stops warning about the `0.1.2-rc.N` line
- [ ] **None**

No screenshots: no UI surface changed. The user-visible difference is the absence
of the "untested version" diagnostic, which is asserted directly in
`apps/daemon/tests/runtimes/version-policy.test.ts`.

## Bug fix verification

**Test paths that reproduce the bug**

- `e2e/tests/dsh-installer-version-policy.test.ts` — the two authorities agreeing
  across the app boundary.
- `apps/daemon/tests/runtimes/version-policy.test.ts` — the shipped policy run
  through the real `detectAgent` code path, where the user-visible
  `untested-version` diagnostic is produced.

**Did it go red first? Yes.** Both files previously *pinned the broken state*
(`expect(accepts(def, '0.1.2-rc.1')).toBe(false)`), so step one was flipping the
assertions to the invariant with no source change at all.

<details>
<summary>Red 1 — e2e, daemon def rejects npm's <code>latest</code></summary>

```
 FAIL  tests/dsh-installer-version-policy.test.ts > accepted DeepSeek Harness versions can actually install their companion > covers every release line we support with both the def and the peers
AssertionError: expected false to be true // Object.is equality

- Expected
+ Received

- true
+ false

 ❯ tests/dsh-installer-version-policy.test.ts:201:40
    201|     expect(accepts(def, '0.1.2-rc.1')).toBe(true);
       |                                        ^

 Test Files  1 failed (1)
      Tests  1 failed | 6 passed (7)
```
</details>

<details>
<summary>Red 2 — e2e, peer ranges cannot install it (same test, assertion order swapped so the second half is reached)</summary>

```
 FAIL  tests/dsh-installer-version-policy.test.ts > accepted DeepSeek Harness versions can actually install their companion > covers every release line we support with both the def and the peers
AssertionError: expected false to be true // Object.is equality

 ❯ tests/dsh-installer-version-policy.test.ts:201:50
    201|     expect(peerCanInstall(ranges, '0.1.2-rc.1')).toBe(true);
       |                                                  ^

 Test Files  1 failed (1)
      Tests  1 failed | 6 passed (7)
```
</details>

<details>
<summary>Red 3 — daemon, the actual user-visible diagnostic</summary>

```
 FAIL  tests/runtimes/version-policy.test.ts > runtime version policy > accepts 0.1.2-rc.1 on the shipped DeepSeek Harness policy
AssertionError: expected 'untested-version' to be undefined // Object.is equality

- Expected:
undefined

+ Received:
"untested-version"

 Test Files  1 failed (1)
      Tests  1 failed | 16 passed (17)
```
</details>

<details>
<summary>Green after the fix</summary>

```
$ e2e: vitest run tests/dsh-installer-version-policy.test.ts tests/scripts/dsh-upstream-drift.test.ts
 Test Files  2 passed (2)
      Tests  17 passed (17)

$ apps/daemon: vitest run tests/runtimes/version-policy.test.ts
 Test Files  1 passed (1)
      Tests  17 passed (17)
```
</details>

**Negative control kept.** The widened test is split so it cannot decay into
"accept everything": `refuses a release line neither authority has been widened
to` asserts `0.2.0-rc.1` is still rejected by *both* the def and the peers, and
the pre-existing `still rejects a version off the declared release line` keeps
`0.0.9` and `not-a-version` failing. The `MATRIX` overclaim test still runs both
sides over every version upstream has shipped.

**Un-implementation re-check** — each change reverted alone, to confirm it is
actually held by a test rather than riding along:

| Reverted alone | Result |
| --- | --- |
| peer ranges in `packages/dsh-runtime/package.json` | **red** — `never claims support for a version the peer ranges reject` reports `overclaimed: ['0.1.2-rc.1']`, plus the new invariant test |
| `supportedVersions` + `supportedVersionPattern` in the agent def | **red** — e2e `accepts the version both installers pin`, the new invariant test, daemon `untested-version`, *and* the drift dry-run flips back to `severity=unsupported` |
| `DSH_VERSION` in both installers | **green — no test covers this.** Reported honestly rather than papered over; see below. |

### The installer version has no test backstop

Reverting `DSH_VERSION` to `0.1.1-rc.2` in both installers left everything green:
e2e 17/17, `tools/release` 82/82. That is expected and not a gap I widened — the
def deliberately accepts *both* the `0.1.1-rc.N` and `0.1.2-rc.N` lines, so
whichever the installer pins, the cross-boundary agreement test is satisfied.
There is no assertion anywhere that ties `DSH_VERSION` to the registry, because
no unit test should reach the network.

What does catch it is the drift watcher, which is exactly what it exists for:

```
# installer reverted to 0.1.1-rc.2, everything else fixed
$ node .github/scripts/dsh-upstream-drift.ts run --dry-run
[dsh-drift] pinned=0.1.1-rc.2 latest=0.1.2-rc.1 accepted=true severity=behind
{ ...card... }
```

`DSH_RESOLUTION_CUTOFF` / `$DshResolutionCutoff` likewise have **zero** coverage
— nothing in the repo reads either symbol outside the installers themselves, so
the sh/ps1 parity of that value is maintained by hand. Both are set to
`2026-09-03T07:00:00Z`: later than `0.1.2-rc.1`'s publish time
(`2026-09-03T06:21:52.107Z`) and earlier than any successor, since the registry
currently has nothing newer.

### Drift watcher, before and after

Before (on `main`):

```
$ node .github/scripts/dsh-upstream-drift.ts run --dry-run
[dsh-drift] pinned=0.1.1-rc.2 latest=0.1.2-rc.1 accepted=false severity=unsupported
{
  "config": { "wide_screen_mode": true },
  "elements": [ ... "装到 `0.1.2-rc.1` 的用户会被告知「未经测试」，而且 `packages/dsh-runtime` 的 peer 范围很可能直接解析失败" ... ],
  "header": { "template": "red", "title": { "content": "DeepSeek Harness 0.1.2-rc.1 不在我们支持的范围内", "tag": "plain_text" } }
}
```

After (this branch) — in sync, no card emitted:

```
$ node .github/scripts/dsh-upstream-drift.ts run --dry-run
[dsh-drift] pinned=0.1.2-rc.1 latest=0.1.2-rc.1 accepted=true severity=in-sync

$ node .github/scripts/dsh-upstream-drift.ts self-check
[dsh-drift] self-check passed
```

## Adjacent issues

### `packages/dsh-runtime`'s `dependencies` / `devDependencies` stay at `0.1.1-rc.2` — deliberately

The peer ranges say *what a user's install may be*; `dependencies` and
`devDependencies` say *what we build and test against*. After this PR those
disagree: the installer ships `0.1.2-rc.1` while
`dependencies["@deepseek-ai/dsh-cmdline"]` and the five `devDependencies` sit at
`0.1.1-rc.2`. I investigated bumping them and decided **not to** in this PR.

I ran the experiment: bumped all six to `0.1.2-rc.1` and reinstalled. Build,
typecheck and tests all passed —

```
dsh-runtime typecheck: clean
dsh-runtime build:     clean
dsh-runtime test:      1 file, 12 tests passed
```

— but `pnpm install` emitted **11 unmet peer warnings**, four distinct:

```
unmet peer @deepseek-ai/cordis@^4.0.2                 (we pin 4.0.1)
unmet peer @deepseek-ai/cordis-plugin-loader@^1.0.3   (we pin 1.0.2)
unmet peer @deepseek-ai/dsh-scope@^0.1.2-rc.1         (resolved 0.1.0-rc.6)
unmet peer @deepseek-ai/dsh-settings@^0.1.2-rc.1      (resolved 0.1.0-rc.6)
```

Two reasons the green does not license the bump:

1. **The green is weak evidence.** Every `@deepseek-ai/dsh-*` import in
   `packages/dsh-runtime/src/` is `import type` except `parseCmdline`
   (`dsh-cmdline`) and `SessionId` (`dsh-session`), so the build erases almost
   all of it, and the 12-test suite covers our own protocol frames rather than
   any dsh integration. A passing build proves the type surface still lines up,
   not that the runtime works against a `0.1.2-rc.1` host.
2. **The resulting tree is the exact state the installer's `--before` window
   exists to prevent.** Our direct deps land on `0.1.2-rc.1` while `dsh-scope`
   and `dsh-settings` resolve to `0.1.0-rc.6` — a mixed generation, and the
   installer comment documents that dsh generations are mutually exclusive.
   `cordis@^4.0.2` / `cordis-plugin-loader@^1.0.3` also want their own bump, and
   those live on a separate version line that (per
   `e2e/tests/dsh-installer-version-policy.test.ts`) "never moves with dsh".

**Recommendation:** treat the dev-dependency bump as its own change — bump
`cordis` to `>=4.0.2` and `cordis-plugin-loader` to `>=1.0.3` alongside the six
dsh packages, land the `pnpm-lock.yaml` churn separately, and verify against a
real `dsh 0.1.2-rc.1` host rather than against a build that erases the imports.
Nothing about that blocks the fix in this PR: the peer ranges and the accepted
line are what a *user's* install is measured against, and they are correct now.

### `apps/landing-page/public/install-dsh.*` no longer exists

The header comment in `.github/scripts/dsh-upstream-drift.ts` still says the
landing `public/install-dsh.*` copies "must stay byte-identical until
extraction". `apps/landing-page/public/` is not in the tree at all any more, so
that instruction is stale. Left alone here to keep this diff to the version fix.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/daemon build` (run separately — `noUncheckedIndexedAccess` means a green typecheck is not a green build)
- `pnpm --filter @open-design/dsh-runtime typecheck` / `build` / `test`
- `e2e`: `vitest run tests/dsh-installer-version-policy.test.ts tests/scripts/dsh-upstream-drift.test.ts` — 17 passed
- `apps/daemon`: `vitest run tests/runtimes/version-policy.test.ts` — 17 passed
- `tools/release`: full package suite — 82 passed
- `node .github/scripts/dsh-upstream-drift.ts run --dry-run` → `severity=in-sync`, no card
- `node .github/scripts/dsh-upstream-drift.ts self-check` → passed
- `sh -n tools/release/resources/dsh-bootstrap/install-dsh.sh` → clean; rendered the Alpine fallback to confirm it interpolates to `npx @deepseek-ai/dsh@0.1.2-rc.1 web`
- `install-dsh.ps1` was not parse-checked — no `pwsh` on this machine. Its change is the two string literals, matched to the sh values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8MaA1ABkvbnfaYUKw3UH3
