### PR TITLE
fix(web): keep deck thumbnails on the deck's active theme

### DIFF
--- a/apps/web/src/components/DeckSlideThumbnail.tsx
+++ b/apps/web/src/components/DeckSlideThumbnail.tsx
@@ -137,10 +137,30 @@ export const DeckSlideThumbnail = memo(function DeckSlideThumbnail({
         root.appendChild(styleEl);
       }
 
+      // The canvas stands in for the deck's `<html>`/`<body>`, so it must wear
+      // their attributes: a deck that activates one of its themes with
+      // `<body data-theme="holm">` has every theme token behind
+      // `body[data-theme="holm"]`, and the parser re-points that selector at
+      // `.od-thumb-canvas[data-theme="holm"]`. Without the attribute here the
+      // rewritten rule matches nothing and the slide renders unthemed.
       const canvas = document.createElement('div');
-      canvas.className = 'od-thumb-canvas';
+      for (const [name, value] of parsed.canvasAttributes) {
+        try {
+          canvas.setAttribute(name, value);
+        } catch {
+          // Ignore invalid attribute names carried over from the source.
+        }
+      }
+      canvas.classList.add('od-thumb-canvas');
+      // Any inline style the source body carried (theme overrides live there
+      // too) stays, but the thumbnail's own sizing is appended last so it wins.
+      const inheritedStyle = canvas.getAttribute('style') ?? '';
+      const inheritedPrefix =
+        inheritedStyle.trim() && !inheritedStyle.trim().endsWith(';')
+          ? `${inheritedStyle};`
+          : inheritedStyle;
       canvas.style.cssText =
-        `position:absolute;top:0;left:0;transform-origin:top left;overflow:hidden;` +
+        `${inheritedPrefix}position:absolute;top:0;left:0;transform-origin:top left;overflow:hidden;` +
         `width:${parsed.designWidth}px;height:${parsed.designHeight}px;`;
 
       let mountPoint: HTMLElement = canvas;

--- a/apps/web/src/runtime/deck-thumbnail-parser.ts
+++ b/apps/web/src/runtime/deck-thumbnail-parser.ts
@@ -31,7 +31,8 @@ export type DeckThumbnailFallbackReason =
   | 'no-slides'
   | 'no-styles'
   | 'viewport-media-query'
-  | 'external-stylesheet';
+  | 'external-stylesheet'
+  | 'unresolved-theme-variable';
 
 /** One reconstructed wrapper element between the shadow root and the slide. */
 export interface DeckThumbnailAncestor {
@@ -57,6 +58,11 @@ export interface ParsedDeckThumbnails {
   /** Wrapper chain from outermost→innermost (excludes `<html>`/`<body>` and the
    *  slide itself), e.g. `[.deck-shell, .deck-stage]` or `[deck-stage]`. */
   ancestors: DeckThumbnailAncestor[];
+  /** `<html>`+`<body>` attributes the thumbnail canvas must carry. The canvas
+   *  is the shadow-tree stand-in for the document root chain, so a deck that
+   *  selects its active theme with `body[data-theme="holm"]` only matches once
+   *  the canvas actually wears `data-theme="holm"` (see `rewriteRootSelectors`). */
+  canvasAttributes: Array<[string, string]>;
   designWidth: number;
   designHeight: number;
 }
@@ -98,6 +104,7 @@ function unrenderable(reason: DeckThumbnailFallbackReason): ParsedDeckThumbnails
     fontFaces: '',
     fontLinks: [],
     ancestors: [],
+    canvasAttributes: [],
     designWidth: DEFAULT_DESIGN_WIDTH,
     designHeight: DEFAULT_DESIGN_HEIGHT,
   };
@@ -183,6 +190,16 @@ export function parseDeckThumbnails(html: string, baseHref?: string): ParsedDeck
   const absolutized = baseHref ? absolutizeCssUrls(withViewport, baseHref) : withViewport;
   const { css: withoutFonts, fontFaces } = extractFontFaces(absolutized);
   const styleText = rewriteRootSelectors(withoutFonts);
+  const canvasAttributes = collectCanvasAttributes(doc);
+
+  // Last line of defence for the whole rewrite pipeline: if the canvas still
+  // cannot resolve the custom properties it paints itself with, this deck would
+  // render as an unthemed (typically white-on-white) miniature. Render it in the
+  // isolated iframe instead of shipping a thumbnail that does not look like the
+  // slide.
+  if (findUnresolvedThemeVariable(styleText, canvasAttributes)) {
+    return unrenderable('unresolved-theme-variable');
+  }
 
   const ancestors = collectAncestors(slideEls[0]!);
   const slides = slideEls
@@ -196,6 +213,7 @@ export function parseDeckThumbnails(html: string, baseHref?: string): ParsedDeck
     fontFaces,
     fontLinks,
     ancestors,
+    canvasAttributes,
     designWidth: designSize.width,
     designHeight: designSize.height,
   };
@@ -480,19 +498,489 @@ function extractStylesheetImports(css: string): StylesheetImportExtraction {
   return { css: chunks.join(''), fontLinks, unsafe };
 }
 
-// Rewrite `:root`/`html` to `:host`, so document-level variables inherit into
-// the reconstructed slide. Body rules belong on the design canvas itself: host
-// page styles intentionally own the shadow host's dark thumbnail frame and win
-// over ordinary `:host` declarations, which used to hide transparent slides on
-// that dark frame. Applying body paint/layout to `.od-thumb-canvas` preserves
-// the source deck's paper/background inside the frame. Compound selectors like
-// `body.dark` are left untouched.
+const CANVAS_CLASS = 'od-thumb-canvas';
+const CANVAS_SELECTOR = `.${CANVAS_CLASS}`;
+const HOST_SELECTOR = ':host';
+
+// The shadow thumbnail has no `<html>` and no `<body>`. `.od-thumb-canvas` is
+// their stand-in: it is the outermost element of the slide's shadow tree and it
+// wears the merged `<html>`+`<body>` attributes (see `collectCanvasAttributes`),
+// so root-scoped selectors can be re-pointed at it and still discriminate.
+//
+// Rewrite rules, per compound selector:
+//   - `body`, and any `body[attr]` / `body.class` / `body#id` → `.od-thumb-canvas…`
+//     keeping the qualifiers, so `body[data-theme="holm"]` matches the canvas
+//     when (and only when) the source body actually carried that theme. A deck
+//     that ships eight themes and activates one via the body attribute
+//     therefore keeps exactly the active one — the other seven rewrite to
+//     `.od-thumb-canvas[data-theme="helix"]` etc. and match nothing.
+//   - bare `:root` / `html` → `:host`. Document-level custom properties belong
+//     on the host so they inherit into the whole shadow tree, and host page
+//     styles intentionally own the shadow host's dark thumbnail frame.
+//   - `:root`/`html` carrying a STRUCTURAL qualifier (`html[data-theme]`,
+//     `:root.dark`) → `.od-thumb-canvas…`, because the qualifier lives on an
+//     element the shadow tree no longer has; the canvas is the element that
+//     inherited it. Pseudo-only qualifiers (`html:hover`, `:root::before`) stay
+//     on `:host`, where they still describe the same box.
+// Adjacent canvas-derived compounds then collapse (`html[data-theme="x"] body`
+// → `.od-thumb-canvas[data-theme="x"]`), since both halves now name one element.
 function rewriteRootSelectors(css: string): string {
-  return css.replace(
-    /(^|[{};,])(\s*)(:root|html|body)(\s*)(?=[,{])/g,
-    (_whole, prefix: string, whitespace: string, selector: string, trailing: string) =>
-      `${prefix}${whitespace}${selector.toLowerCase() === 'body' ? '.od-thumb-canvas' : ':host'}${trailing}`,
-  );
+  return mapRulePreludes(css, rewriteSelectorList);
+}
+
+// Walk top-level CSS structure and hand every RULE prelude (the selector list
+// before a `{`) to `rewrite`. At-rule preludes (`@media …`, `@supports …`) and
+// keyframe stops (`from`, `0%`) are selector-shaped but are not element
+// selectors, so they pass through untouched; the rules nested inside an
+// `@media` block still get rewritten because they carry their own prelude.
+// Comments are already stripped upstream by `stripCssComments`.
+function mapRulePreludes(css: string, rewrite: (prelude: string) => string): string {
+  let out = '';
+  let segmentStart = 0;
+  let depth = 0;
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+  // Depths at which an `@keyframes` block was opened; its children are stops.
+  const keyframeDepths: number[] = [];
+
+  for (let i = 0; i < css.length; i += 1) {
+    const char = css[i]!;
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (char === '\\') escaped = true;
+      else if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (char === '{') {
+      const prelude = css.slice(segmentStart, i);
+      const trimmed = prelude.trim();
+      const insideKeyframes = keyframeDepths.length > 0;
+      out += trimmed.startsWith('@') || insideKeyframes ? prelude : rewrite(prelude);
+      if (/^@(?:-[\w-]+-)?keyframes\b/i.test(trimmed)) keyframeDepths.push(depth);
+      out += '{';
+      depth += 1;
+      segmentStart = i + 1;
+    } else if (char === '}') {
+      out += css.slice(segmentStart, i + 1);
+      depth = Math.max(0, depth - 1);
+      if (keyframeDepths.at(-1) === depth) keyframeDepths.pop();
+      segmentStart = i + 1;
+    } else if (char === ';') {
+      out += css.slice(segmentStart, i + 1);
+      segmentStart = i + 1;
+    }
+  }
+  return out + css.slice(segmentStart);
+}
+
+function rewriteSelectorList(prelude: string): string {
+  return splitTopLevel(prelude, ',')
+    .map((piece) => {
+      const leading = /^\s*/.exec(piece)?.[0] ?? '';
+      const trailing = /\s*$/.exec(piece)?.[0] ?? '';
+      const core = piece.slice(leading.length, piece.length - trailing.length);
+      if (!core) return piece;
+      return `${leading}${rewriteSelector(core)}${trailing}`;
+    })
+    .join(',');
+}
+
+type CompoundKind = 'canvas' | 'host' | 'other';
+
+interface RewrittenCompound {
+  combinator: string;
+  kind: CompoundKind;
+  /** Everything after the stand-in selector, e.g. `[data-theme="holm"]`. */
+  qualifiers: string;
+  text: string;
+}
+
+const ROOT_KEYWORD_RE = /^(:root|html|body)(?![\w-])/i;
+// `[`, `.` and `#` are the qualifiers that live ON the element; a compound that
+// carries one cannot survive as `:host`, because the attribute/class/id moved
+// to the canvas with `collectCanvasAttributes`.
+const STRUCTURAL_QUALIFIER_RE = /[[.#]/;
+
+function rewriteSelector(selector: string): string {
+  const parts = splitCompounds(selector).map<RewrittenCompound>(({ combinator, compound }) => {
+    const keyword = ROOT_KEYWORD_RE.exec(compound);
+    if (!keyword) return { combinator, kind: 'other', qualifiers: '', text: compound };
+    const qualifiers = compound.slice(keyword[0].length);
+    const isBody = keyword[1]!.toLowerCase() === 'body';
+    if (isBody || STRUCTURAL_QUALIFIER_RE.test(qualifiers)) {
+      return { combinator, kind: 'canvas', qualifiers, text: `${CANVAS_SELECTOR}${qualifiers}` };
+    }
+    return { combinator, kind: 'host', qualifiers, text: `${HOST_SELECTOR}${qualifiers}` };
+  });
+
+  // `html[data-theme="x"] body` names one element twice now; keep one compound
+  // carrying both sets of qualifiers instead of emitting a selector
+  // (`.od-thumb-canvas[…] .od-thumb-canvas`) that can never match.
+  const collapsed: RewrittenCompound[] = [];
+  for (const part of parts) {
+    const previous = collapsed.at(-1);
+    const joinedByDescent = part.combinator === '' || part.combinator === '>';
+    if (previous && previous.kind === 'canvas' && part.kind === 'canvas' && joinedByDescent) {
+      const qualifiers = `${previous.qualifiers}${part.qualifiers}`;
+      collapsed[collapsed.length - 1] = {
+        combinator: previous.combinator,
+        kind: 'canvas',
+        qualifiers,
+        text: `${CANVAS_SELECTOR}${qualifiers}`,
+      };
+      continue;
+    }
+    collapsed.push(part);
+  }
+
+  return collapsed
+    .map((part, index) => {
+      if (index === 0) return part.text;
+      return part.combinator === '' ? ` ${part.text}` : ` ${part.combinator} ${part.text}`;
+    })
+    .join('');
+}
+
+/** Split on a top-level separator, ignoring ones inside `[]`, `()` or strings. */
+function splitTopLevel(text: string, separator: string): string[] {
+  const pieces: string[] = [];
+  let current = '';
+  let brackets = 0;
+  let parens = 0;
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+  for (const char of text) {
+    if (quote) {
+      current += char;
+      if (escaped) escaped = false;
+      else if (char === '\\') escaped = true;
+      else if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      current += char;
+      continue;
+    }
+    if (char === '[') brackets += 1;
+    else if (char === ']') brackets = Math.max(0, brackets - 1);
+    else if (char === '(') parens += 1;
+    else if (char === ')') parens = Math.max(0, parens - 1);
+    if (char === separator && brackets === 0 && parens === 0) {
+      pieces.push(current);
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  pieces.push(current);
+  return pieces;
+}
+
+interface SelectorCompound {
+  /** `''` for the descendant combinator (and for the first compound). */
+  combinator: string;
+  compound: string;
+}
+
+/** Split a complex selector into its compounds and the combinators between. */
+function splitCompounds(selector: string): SelectorCompound[] {
+  const parts: SelectorCompound[] = [];
+  let current = '';
+  let pending = '';
+  let brackets = 0;
+  let parens = 0;
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+
+  const flush = () => {
+    if (!current) return;
+    parts.push({ combinator: parts.length === 0 ? '' : pending, compound: current });
+    current = '';
+    pending = '';
+  };
+
+  for (const char of selector) {
+    if (quote) {
+      current += char;
+      if (escaped) escaped = false;
+      else if (char === '\\') escaped = true;
+      else if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      current += char;
+      continue;
+    }
+    if (char === '[') brackets += 1;
+    else if (char === ']') brackets = Math.max(0, brackets - 1);
+    else if (char === '(') parens += 1;
+    else if (char === ')') parens = Math.max(0, parens - 1);
+    if (brackets === 0 && parens === 0) {
+      if (/\s/.test(char)) {
+        flush();
+        // Descendant, unless an explicit combinator is already pending
+        // (`a > b` sees a space, then `>`, then a space).
+        continue;
+      }
+      if (char === '>' || char === '+' || char === '~') {
+        flush();
+        pending = char;
+        continue;
+      }
+    }
+    current += char;
+  }
+  flush();
+  return parts;
+}
+
+// The canvas is the only element that can carry what `<html>`/`<body>` carried,
+// so it inherits both elements' attributes (body wins a name collision, classes
+// are unioned). Attributes come from untrusted deck markup and are applied to a
+// live element in the app-origin shadow DOM, so they go through the same
+// DOMPurify profile as the reconstructed wrapper chain.
+function collectCanvasAttributes(doc: Document): Array<[string, string]> {
+  const merged = new Map<string, string>();
+  const classes: string[] = [];
+  for (const el of [doc.documentElement, doc.body]) {
+    if (!el) continue;
+    for (const attr of Array.from(el.attributes)) {
+      if (attr.name.toLowerCase() === 'class') {
+        for (const token of attr.value.split(/\s+/)) {
+          if (token && !classes.includes(token)) classes.push(token);
+        }
+        continue;
+      }
+      merged.set(attr.name, attr.value);
+    }
+  }
+  if (classes.length > 0) merged.set('class', classes.join(' '));
+  if (merged.size === 0) return [];
+
+  const probe = doc.createElement('div');
+  for (const [name, value] of merged) {
+    try {
+      probe.setAttribute(name, value);
+    } catch {
+      // Ignore attribute names the source made up that the DOM rejects.
+    }
+  }
+  const clean = sanitizeThumbnailMarkup(probe.outerHTML);
+  if (!clean) return [];
+  return Array.from(clean.attributes).map((a) => [a.name, a.value] as [string, string]);
+}
+
+// Properties whose failure is visible as "this thumbnail does not look like the
+// slide at all": an unresolved `background`/`color` paints the canvas
+// transparent and the text in the inherited colour, which is how a deck ends up
+// rendering white-on-white.
+const CRITICAL_PAINT_PROPS = new Set(['background', 'background-color', 'color']);
+
+interface CanvasIdentity {
+  classes: Set<string>;
+  attributes: Map<string, string>;
+}
+
+function canvasIdentity(canvasAttributes: Array<[string, string]>): CanvasIdentity {
+  const attributes = new Map<string, string>();
+  const classes = new Set<string>([CANVAS_CLASS]);
+  for (const [name, value] of canvasAttributes) {
+    const lower = name.toLowerCase();
+    attributes.set(lower, value);
+    if (lower === 'class') {
+      for (const token of value.split(/\s+/)) if (token) classes.add(token);
+    }
+  }
+  attributes.set('class', [...classes].join(' '));
+  return { classes, attributes };
+}
+
+/**
+ * Detect the one failure the selector rewrite can still produce silently: the
+ * canvas paints itself with a custom property that no rule reaching the canvas
+ * defines, WHILE the deck does define that property somewhere the canvas cannot
+ * reach. That pairing is the signature of a root-scoped theme we failed to
+ * re-point — the deck has the colour, the thumbnail just cannot see it — and it
+ * renders as an unthemed miniature instead of the slide.
+ *
+ * The second half of the condition is what keeps this from being a door that is
+ * always shut. A deck that simply never defines `--shell` anywhere is not
+ * mis-rewritten; it renders identically in the iframe, so falling back would buy
+ * nothing. Only a variable that exists but is out of reach is evidence that the
+ * static clone lost the deck's theme.
+ *
+ * Returns the offending custom property, or null when nothing is out of reach.
+ */
+function findUnresolvedThemeVariable(
+  css: string,
+  canvasAttributes: Array<[string, string]>,
+): string | null {
+  const identity = canvasIdentity(canvasAttributes);
+  const definedOnCanvas = new Map<string, string>();
+  const definedOutOfReach = new Set<string>();
+  const paint = new Map<string, string>();
+
+  for (const block of iterateRuleBlocks(css)) {
+    const reachesCanvas = selectorListReachesCanvas(block.selector, identity);
+    for (const { property, value } of iterateDeclarations(block.body)) {
+      if (property.startsWith('--')) {
+        if (reachesCanvas) definedOnCanvas.set(property, value);
+        else definedOutOfReach.add(property);
+        continue;
+      }
+      if (reachesCanvas && CRITICAL_PAINT_PROPS.has(property)) paint.set(property, value);
+    }
+  }
+
+  for (const value of paint.values()) {
+    const missing = firstUnresolvedVar(value, definedOnCanvas, new Set());
+    if (missing && definedOutOfReach.has(missing)) return missing;
+  }
+  return null;
+}
+
+interface CssDeclaration {
+  property: string;
+  value: string;
+}
+
+function* iterateDeclarations(body: string): Generator<CssDeclaration> {
+  for (const raw of splitTopLevel(body, ';')) {
+    const colon = raw.indexOf(':');
+    if (colon < 0) continue;
+    const property = raw.slice(0, colon).trim().toLowerCase();
+    if (!property) continue;
+    yield { property, value: raw.slice(colon + 1).trim() };
+  }
+}
+
+/** `var(--x)` references with no fallback — the ones that can go unresolved. */
+const REQUIRED_VAR_RE = /var\(\s*(--[\w-]+)\s*([,)])/g;
+
+function firstUnresolvedVar(
+  value: string,
+  defined: Map<string, string>,
+  seen: Set<string>,
+): string | null {
+  for (const match of value.matchAll(REQUIRED_VAR_RE)) {
+    if (match[2] !== ')') continue;
+    const name = match[1]!;
+    if (seen.has(name)) continue;
+    seen.add(name);
+    const resolved = defined.get(name);
+    if (resolved === undefined) return name;
+    const nested = firstUnresolvedVar(resolved, defined, seen);
+    if (nested) return nested;
+  }
+  return null;
+}
+
+// Does any selector in this list put its SUBJECT on (or above) the canvas, so
+// that its declarations reach the canvas box? Deliberately biased towards "yes"
+// for anything this parser cannot read confidently: a false "yes" only keeps the
+// existing behaviour, while a false "no" would push a healthy deck onto the
+// iframe fallback for no reason.
+function selectorListReachesCanvas(selectorList: string, identity: CanvasIdentity): boolean {
+  if (selectorList.trim().startsWith('@')) return false;
+  for (const selector of splitTopLevel(selectorList, ',')) {
+    const subject = splitCompounds(selector.trim()).at(-1);
+    if (subject && compoundReachesCanvas(subject.compound, identity)) return true;
+  }
+  return false;
+}
+
+function compoundReachesCanvas(compound: string, identity: CanvasIdentity): boolean {
+  // A pseudo-element is a generated box, not the canvas; custom properties set
+  // on it do not inherit to the canvas's children.
+  if (compound.includes('::')) return false;
+  // `:host` is the canvas's ancestor, so its inherited values reach the canvas.
+  if (/^:host\b/i.test(compound)) return true;
+
+  let rest = compound;
+  const type = /^(\*|[a-zA-Z][\w-]*)/.exec(rest);
+  if (type) {
+    const tag = type[1]!.toLowerCase();
+    // `body`/`html`/`deck-stage`/… name elements the shadow tree does not have
+    // at this position; only the canvas's own tag (or the universal selector)
+    // can be the canvas.
+    if (tag !== '*' && tag !== 'div') return false;
+    rest = rest.slice(type[0].length);
+  }
+
+  while (rest.length > 0) {
+    const char = rest[0]!;
+    if (char === '.') {
+      const match = /^\.([\w-]+)/.exec(rest);
+      if (!match) return true;
+      if (!identity.classes.has(match[1]!)) return false;
+      rest = rest.slice(match[0].length);
+      continue;
+    }
+    if (char === '#') {
+      const match = /^#([\w-]+)/.exec(rest);
+      if (!match) return true;
+      if (identity.attributes.get('id') !== match[1]) return false;
+      rest = rest.slice(match[0].length);
+      continue;
+    }
+    if (char === '[') {
+      const end = rest.indexOf(']');
+      if (end < 0) return true;
+      if (!attributeSelectorMatches(rest.slice(1, end), identity)) return false;
+      rest = rest.slice(end + 1);
+      continue;
+    }
+    if (char === ':') {
+      // Pseudo-classes (`:not(…)`, `:hover`, `:nth-child(…)`) describe state or
+      // structure this static parser does not model; skip rather than guess.
+      const match = /^:[\w-]+(\([^)]*\))?/.exec(rest);
+      if (!match) return true;
+      rest = rest.slice(match[0].length);
+      continue;
+    }
+    return true;
+  }
+  return true;
+}
+
+const ATTRIBUTE_SELECTOR_RE =
+  /^\s*([\w-]+)\s*(?:([~|^$*]?=)\s*(?:"([^"]*)"|'([^']*)'|([^\s\]]+))\s*([iIsS])?)?\s*$/;
+
+function attributeSelectorMatches(inner: string, identity: CanvasIdentity): boolean {
+  const match = ATTRIBUTE_SELECTOR_RE.exec(inner);
+  if (!match) return true;
+  const actual = identity.attributes.get(match[1]!.toLowerCase());
+  if (actual === undefined) return false;
+  const operator = match[2];
+  if (!operator) return true;
+  const insensitive = (match[6] ?? '').toLowerCase() === 'i';
+  const have = insensitive ? actual.toLowerCase() : actual;
+  const want = (() => {
+    const raw = match[3] ?? match[4] ?? match[5] ?? '';
+    return insensitive ? raw.toLowerCase() : raw;
+  })();
+  switch (operator) {
+    case '=':
+      return have === want;
+    case '~=':
+      return want !== '' && have.split(/\s+/).includes(want);
+    case '|=':
+      return have === want || have.startsWith(`${want}-`);
+    case '^=':
+      return want !== '' && have.startsWith(want);
+    case '$=':
+      return want !== '' && have.endsWith(want);
+    case '*=':
+      return want !== '' && have.includes(want);
+    default:
+      return true;
+  }
 }
 
 // Lift `@font-face` blocks out; they're ignored inside a shadow root and must be

--- a/apps/web/tests/runtime/deck-thumbnail-theme-vars.test.ts
+++ b/apps/web/tests/runtime/deck-thumbnail-theme-vars.test.ts
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+//
+// Deck thumbnails render a slide as inert DOM in a shadow root instead of
+// running the whole deck in an iframe, so every selector the deck wrote against
+// `<html>`/`<body>` has to be re-pointed at something that exists in the shadow
+// tree. `design-templates/replit-deck` ships eight themes as
+// `body[data-theme="…"]` custom-property blocks and activates one with
+// `<body data-theme="holm">`. When only the BARE `body` selector was rewritten,
+// `.od-thumb-canvas { background: var(--bg); color: var(--fg) }` survived while
+// every `--bg`/`--fg` definition stayed behind an unmatched `body[data-theme]`
+// selector: the canvas fell back to a transparent background and an inherited
+// foreground, i.e. white text on white paper, in a rail that is supposed to
+// show what the slide looks like.
+//
+// These specs assert the rendered outcome (the canvas resolves the ACTIVE
+// theme's paint), not the shape of the rewrite, so they stay honest if the
+// rewrite is implemented differently.
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  parseDeckThumbnails,
+  type ParsedDeckThumbnails,
+} from '../../src/runtime/deck-thumbnail-parser';
+
+/** Repo-root-relative fixture path; jsdom rewrites `import.meta.url` to http. */
+function repoFile(relative: string): string {
+  let dir = process.cwd();
+  for (let i = 0; i < 8; i += 1) {
+    const candidate = join(dir, relative);
+    if (existsSync(candidate)) return candidate;
+    dir = dirname(dir);
+  }
+  throw new Error(`fixture not found: ${relative}`);
+}
+
+function readDeck(relative: string): string {
+  return readFileSync(repoFile(relative), 'utf8');
+}
+
+const HOLM_DECK = 'design-templates/replit-deck/examples/example-holm.html';
+const REPLIT_TEMPLATE = 'design-templates/replit-deck/assets/template.html';
+const SIMPLE_DECK = 'design-templates/simple-deck/example.html';
+
+/**
+ * Read `canvasAttributes` without assuming the field exists, so a tree without
+ * the fix fails on the paint assertion below (the thing users see) rather than
+ * on a TypeError while building the fixture.
+ */
+function canvasAttributesOf(parsed: ParsedDeckThumbnails): Array<[string, string]> {
+  const raw = (parsed as { canvasAttributes?: Array<[string, string]> }).canvasAttributes;
+  return Array.isArray(raw) ? raw : [];
+}
+
+interface CanvasPaint {
+  background: string;
+  color: string;
+}
+
+/**
+ * Rebuild the thumbnail canvas exactly as `DeckSlideThumbnail` does, then work
+ * out what the deck's stylesheet actually paints it with. Selector matching is
+ * jsdom's own `Element.matches`, so `[data-theme="holm"]` is evaluated for real
+ * rather than by re-implementing the parser's matcher.
+ */
+function resolveCanvasPaint(parsed: ParsedDeckThumbnails): CanvasPaint {
+  const canvas = document.createElement('div');
+  for (const [name, value] of canvasAttributesOf(parsed)) canvas.setAttribute(name, value);
+  canvas.classList.add('od-thumb-canvas');
+  document.body.appendChild(canvas);
+
+  const variables = new Map<string, string>();
+  const painted = new Map<string, string>();
+
+  for (const match of parsed.styleText.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    const selectorList = match[1] ?? '';
+    if (!selectorListPaintsCanvas(canvas, selectorList)) continue;
+    for (const declaration of (match[2] ?? '').split(';')) {
+      const colon = declaration.indexOf(':');
+      if (colon < 0) continue;
+      const property = declaration.slice(0, colon).trim().toLowerCase();
+      const value = declaration.slice(colon + 1).trim();
+      if (property.startsWith('--')) variables.set(property, value);
+      else if (property === 'background' || property === 'color') painted.set(property, value);
+    }
+  }
+
+  canvas.remove();
+  return {
+    background: expandVars(painted.get('background') ?? '', variables, 0),
+    color: expandVars(painted.get('color') ?? '', variables, 0),
+  };
+}
+
+function selectorListPaintsCanvas(canvas: HTMLElement, selectorList: string): boolean {
+  if (selectorList.trim().startsWith('@')) return false;
+  for (const raw of selectorList.split(',')) {
+    const selector = raw.trim();
+    if (!selector) continue;
+    // `:host` is the shadow host — the canvas's parent — so its inherited
+    // values reach the canvas. jsdom cannot evaluate `:host`, so treat a bare
+    // `:host` compound as matching and let everything else go through
+    // `matches()`.
+    if (/^:host(?::[\w-]+(?:\([^)]*\))?)*$/.test(selector)) return true;
+    try {
+      if (canvas.matches(selector)) return true;
+    } catch {
+      // Selector jsdom cannot parse; it is not one of ours.
+    }
+  }
+  return false;
+}
+
+/** Substitute `var(--x)`; leaves unresolved references visible in the output. */
+function expandVars(value: string, variables: Map<string, string>, depth: number): string {
+  if (depth > 8 || !value.includes('var(')) return value;
+  const substituted = value.replace(/var\(\s*(--[\w-]+)\s*\)/g, (whole, name: string) => {
+    const resolved = variables.get(name);
+    return resolved === undefined ? whole : resolved;
+  });
+  return substituted === value ? value : expandVars(substituted, variables, depth + 1);
+}
+
+describe('deck thumbnail theme variables', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('resolves the active theme on a deck that scopes its tokens to body[data-theme]', () => {
+    const parsed = parseDeckThumbnails(readDeck(HOLM_DECK));
+
+    expect(parsed.renderable).toBe(true);
+    const paint = resolveCanvasPaint(parsed);
+
+    // The `holm` theme's paper and ink, from the `body[data-theme="holm"]`
+    // block the source activates.
+    expect(paint.background).toBe('#e4dfd7');
+    expect(paint.color).toBe('#0f0f0e');
+    // The regression itself: neither value may stay an unresolved reference,
+    // and the slide may not end up painting its text in its background colour.
+    expect(paint.background).not.toContain('var(');
+    expect(paint.color).not.toContain('var(');
+    expect(paint.background).not.toBe(paint.color);
+  });
+
+  it('activates only the theme the deck selected, out of the eight it defines', () => {
+    const parsed = parseDeckThumbnails(readDeck(HOLM_DECK));
+    const paint = resolveCanvasPaint(parsed);
+
+    // Every sibling theme block declares its own `--bg`; if the rewrite made
+    // them all match, the last one in source order would win instead.
+    expect(paint.background).not.toBe('#fafafa'); // helix
+    expect(paint.background).not.toBe('#0b1524'); // bluehouse, last in the file
+  });
+
+  it('carries the source body attributes onto the thumbnail canvas', () => {
+    const parsed = parseDeckThumbnails(readDeck(HOLM_DECK));
+    expect(canvasAttributesOf(parsed)).toContainEqual(['data-theme', 'holm']);
+  });
+
+  it('keeps the control decks renderable and correctly painted', () => {
+    for (const [name, source] of [
+      ['replit-deck template', readDeck(REPLIT_TEMPLATE)],
+      ['simple-deck example', readDeck(SIMPLE_DECK)],
+    ] as const) {
+      const parsed = parseDeckThumbnails(source);
+      expect(parsed.renderable, `${name} should still render statically`).toBe(true);
+      const paint = resolveCanvasPaint(parsed);
+      expect(paint.background, `${name} background`).toMatch(/^#[0-9a-f]{3,8}$/i);
+      expect(paint.color, `${name} color`).toMatch(/^#[0-9a-f]{3,8}$/i);
+      expect(paint.background).not.toBe(paint.color);
+    }
+  });
+
+  it('rewrites html-scoped theme selectors onto the canvas too', () => {
+    const parsed = parseDeckThumbnails(`<!doctype html><html data-theme="dusk"><head><style>
+        html[data-theme="dusk"] { --bg: #101014; --fg: #f4f4f5; }
+        html[data-theme="dawn"] { --bg: #ffffff; --fg: #111111; }
+        body { background: var(--bg); color: var(--fg); }
+        .deck-stage { width: 1920px; height: 1080px; }
+      </style></head><body><div class="deck-stage">
+        <section class="slide" data-screen-label="01 Cover">Cover</section>
+      </div></body></html>`);
+
+    expect(parsed.renderable).toBe(true);
+    expect(resolveCanvasPaint(parsed)).toEqual({ background: '#101014', color: '#f4f4f5' });
+  });
+
+  it('collapses a root chain that names the canvas twice', () => {
+    const parsed = parseDeckThumbnails(`<!doctype html><html data-theme="dusk"><head><style>
+        html[data-theme="dusk"] body { --bg: #101014; --fg: #f4f4f5; }
+        body { background: var(--bg); color: var(--fg); }
+        .deck-stage { width: 1920px; height: 1080px; }
+      </style></head><body><div class="deck-stage">
+        <section class="slide" data-screen-label="01 Cover">Cover</section>
+      </div></body></html>`);
+
+    expect(parsed.renderable).toBe(true);
+    expect(resolveCanvasPaint(parsed)).toEqual({ background: '#101014', color: '#f4f4f5' });
+  });
+});
+
+describe('deck thumbnail unresolved-theme-variable fallback', () => {
+  // A deck whose theme attribute is only applied at runtime by its own script.
+  // Nothing static can put `data-theme` on the canvas, so the tokens stay out
+  // of reach and the static clone would render unthemed.
+  const scriptThemedDeck = `<!doctype html><html><head><style>
+      :root { --font-body: system-ui, sans-serif; }
+      body[data-theme="dusk"] { --bg: #101014; --fg: #f4f4f5; }
+      body { background: var(--bg); color: var(--fg); font-family: var(--font-body); }
+      .deck-stage { width: 1920px; height: 1080px; }
+    </style></head><body><div class="deck-stage">
+      <section class="slide" data-screen-label="01 Cover">Cover</section>
+    </div><script>document.body.dataset.theme = 'dusk';</script></body></html>`;
+
+  it('falls back to the iframe when canvas paint tokens stay out of reach', () => {
+    const parsed = parseDeckThumbnails(scriptThemedDeck);
+    expect(parsed.renderable).toBe(false);
+    expect(parsed.reason).toBe('unresolved-theme-variable');
+  });
+
+  it('renders the same deck statically once the theme is on the body', () => {
+    const parsed = parseDeckThumbnails(
+      scriptThemedDeck.replace('<body>', '<body data-theme="dusk">'),
+    );
+    expect(parsed.renderable).toBe(true);
+    expect(resolveCanvasPaint(parsed)).toEqual({ background: '#101014', color: '#f4f4f5' });
+  });
+
+  it('does not fall back when the deck simply never defines the variable', () => {
+    // A `var()` the deck never declares anywhere is the deck's own gap: the
+    // iframe would paint it exactly the same way, so falling back buys nothing.
+    // This is the case that would make the guard a door that is always shut.
+    const parsed = parseDeckThumbnails(`<!doctype html><html><head><style>
+        body { background: var(--never-declared); color: #222; }
+        .deck-stage { width: 1920px; height: 1080px; }
+      </style></head><body><div class="deck-stage">
+        <section class="slide" data-screen-label="01 Cover">Cover</section>
+      </div></body></html>`);
+
+    expect(parsed.renderable).toBe(true);
+  });
+
+  it('does not fall back for a deck whose tokens live on :root', () => {
+    const parsed = parseDeckThumbnails(`<!doctype html><html><head><style>
+        :root { --bg: #fafaf9; --fg: #1c1b1a; }
+        html, body { margin: 0; height: 100%; }
+        body { background: var(--bg); color: var(--fg); }
+        .deck-stage { width: 1920px; height: 1080px; }
+      </style></head><body><div class="deck-stage">
+        <section class="slide" data-screen-label="01 Cover">Cover</section>
+      </div></body></html>`);
+
+    expect(parsed.renderable).toBe(true);
+    expect(resolveCanvasPaint(parsed)).toEqual({ background: '#fafaf9', color: '#1c1b1a' });
+  });
+});


### PR DESCRIPTION
## Why

Found while hand-testing a deck: the page thumbnails in the deck rail rendered as
a blank, unthemed panel with near-invisible text — nothing like the slide they
were supposed to preview. Reproduced on the repo's own
`design-templates/replit-deck/examples/example-holm.html`.

Thumbnails no longer run the whole deck in an iframe; each one is rendered as
inert DOM inside a shadow root, which means every selector the deck wrote
against `<html>`/`<body>` has to be re-pointed at something the shadow tree
actually has. Only the **bare** `body` selector was being rewritten, and
`<html>`/`<body>` attributes were dropped entirely. That is enough for decks
whose tokens live on `:root`, and wrong for every deck that scopes its theme to
the root element:

```css
body { background: var(--bg); color: var(--fg); }   /* rewritten ✓ */
body[data-theme="holm"] { --bg: #e4dfd7; --fg: #0f0f0e; }  /* left as-is ✗ */
```

Measured in a real browser on the shadow root that ships today:

| | before | after |
|---|---|---|
| canvas `background-color` | `rgba(0, 0, 0, 0)` | `rgb(228, 223, 215)` |
| canvas `color` | inherited from the app | `rgb(15, 15, 14)` |
| `--bg` / `--fg` | **undefined** | `#e4dfd7` / `#0f0f0e` |
| display font | `system-ui` (fallback) | `"GT Super", "Tiempos Headline", …` |

A transparent canvas with the app's inherited text colour is what the user saw as
"white text on white paper".

This is not one deck. Sweeping every `design-templates/**/*.html` that renders
statically (42 of them), **18 decks** were painting the wrong colours:

* 5 `replit-deck` files (`body[data-theme="…"]`) resolved nothing at all.
* 13 `html-ppt-*` example decks (`<body class="tpl-…">` + `.tpl-… { --… }`)
  silently fell back to a generic `#ffffff` / `#111216`, including three dark
  decks that were rendering light.

## What users will see

Deck page thumbnails now look like the pages. A deck that picks one of several
built-in themes shows that theme's paper colour, ink colour and display font in
the rail, instead of a blank panel or a generic light one. Decks whose theme the
static renderer still cannot reproduce quietly go back to the old iframe
thumbnail rather than showing something wrong.

## Surface area

- [x] **UI** — deck thumbnail rail in `apps/web`
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

*(No CLI counterpart: this is a rendering fix inside an existing web-only
surface, not a new capability. `od` exposes no thumbnail-rail command to mirror.)*

## Screenshots

Before/after of `example-holm.html` slide 2, captured from the real shadow-root
thumbnail in Chrome, is attached separately — the measured computed values are in
the table above.

## Bug fix verification

- Test path: `apps/web/tests/runtime/deck-thumbnail-theme-vars.test.ts`
- Red on `main`, green on this branch: **yes** — 7 failed / 3 passed with the two
  source files restored from `origin/main`, 10 passed with the fix. The 3 that
  pass either way are the guard's "must NOT trigger" cases, which is the point:
  they are there to prove the new fallback is not a door that is always shut.
- The spec asserts the rendered outcome (the canvas resolves the **active**
  theme's `background`/`color`), not the shape of the rewrite, and drives
  selector matching through jsdom's own `Element.matches` rather than
  re-implementing the parser's matcher.

## What changed

**1. The rewrite now covers compound root selectors.**
`.od-thumb-canvas` is the shadow tree's stand-in for the `<html>`→`<body>` chain,
so it now *carries the merged attributes of both* (`canvasAttributes`, sanitized
through the same DOMPurify profile as the reconstructed wrapper chain). Only then
is it correct to re-point qualified selectors at it:

* `body`, `body[attr]`, `body.class`, `body#id`, and `body … .descendant` →
  `.od-thumb-canvas…`, qualifiers preserved.
* bare `:root` / `html` → `:host` (unchanged — document-level tokens belong on
  the host so they inherit into the whole tree).
* `html[attr]` / `:root.class` → `.od-thumb-canvas…`, because the qualifier
  describes an element the shadow tree no longer has and the canvas is what
  inherited it. Pseudo-only qualifiers (`html:hover`, `:root::before`) stay on
  `:host`, where they still describe the same box.
* Adjacent canvas-derived compounds collapse, so `html[data-theme="x"] body`
  becomes `.od-thumb-canvas[data-theme="x"]` and not a selector naming one
  element twice.

**Multi-theme decks fall out of this for free.** `example-holm.html` defines
eight themes and activates one. Each rewrites to
`.od-thumb-canvas[data-theme="helix"|"holm"|…]`; the canvas wears
`data-theme="holm"`, so exactly the active one matches and the other seven match
nothing — no last-rule-wins, no ordering dependency.

The single-regex rewrite is replaced by a small CSS scanner that hands only real
rule preludes to the selector rewriter, so `@media`/`@supports` preludes and
`@keyframes` stops are left alone.

**2. A new `unresolved-theme-variable` fallback reason**, because fixing the
rewrite alone would leave the next unforeseen shape failing just as silently.
Existing reasons only asked *can* we render statically — `example-holm.html` has
zero external stylesheets and zero viewport media queries, so it answered "yes"
and produced a blank thumbnail. Nothing asked whether the result resolves.

The new check triggers when the canvas paints itself with a custom property that
**no rule reaching the canvas defines, while the deck does define it somewhere
out of reach.** That second half is what keeps it from being an always-shut door:
a `var()` the deck never declares anywhere is the deck's own gap and renders
identically in the iframe, so falling back would buy nothing. Only a variable
that *exists but is unreachable* is evidence that the static clone lost the
deck's theme. Selector matching is deliberately biased toward "reaches the
canvas" for anything it cannot read confidently — a false yes only preserves
today's behaviour, a false no would push a healthy deck onto the iframe for no
reason.

Evidence it does not over-trigger: across all 192 `design-templates/**/*.html`,
**zero** decks changed their renderable/fallback verdict. The only differences
pre→post are the 18 decks that went from unresolved/wrong to correct colours.

## Validation

- `pnpm guard` — pass
- `pnpm --filter @open-design/web typecheck` — pass
- Full `apps/web` suite: **681 files / 7249 tests**, 328s. One pre-existing
  failure (`tests/runtime/preview-observability-bridge.test.ts`), reproduced
  identically with both changed source files restored from `origin/main`; it does
  not import anything this PR touches.
- All 21 deck-related test files: 151 tests, green.
- Structural safety of the new CSS scanner: for each of the 42 statically
  renderable templates, rule counts and declaration bodies are **byte-identical**
  pre→post and braces stay balanced — the rewrite touches selectors and nothing
  else.
- Real-browser check (Chrome, actual shadow root + `adoptedStyleSheets`), since
  jsdom cannot resolve `var()`: the computed values in the table above.

## Adjacent issues (not fixed here)

Visible in the same hand-test and left for its own red spec / PR: **the deck's
body pages overflow in the preview.** On `example-holm.html` the copy
("…lawyers who were never supposed…") runs into the author/stats row and is
clipped by the container — the page is not scaled to fit. It is a preview
layout/fit problem, independent of thumbnail theming, and the fix here makes it
more visible only because the correct (larger) serif display font is finally
being applied.
