### PR TITLE
fix(web): preserve newer project status refreshes

### DIFF
--- a/apps/web/src/hooks/useProjectRunStatuses.ts
+++ b/apps/web/src/hooks/useProjectRunStatuses.ts
@@ -55,12 +55,16 @@ export function useProjectRunSummaries(
       return undefined;
     }
     let cancelled = false;
+    let nextRefreshGeneration = 0;
+    let lastAppliedRefreshGeneration = 0;
 
     const refresh = async () => {
+      const refreshGeneration = ++nextRefreshGeneration;
       const results = await Promise.all(
         ids.map((id) => listRunsForProject(id, workspaceContextRef.current)),
       );
-      if (cancelled) return;
+      if (cancelled || refreshGeneration < lastAppliedRefreshGeneration) return;
+      lastAppliedRefreshGeneration = refreshGeneration;
       // An unreadable project yields null; skipping it leaves that row blank
       // rather than asserting a status nobody verified.
       const runs = results.flatMap((result) => result?.runs ?? []);

--- a/apps/web/tests/components/EntryNavRail.refresh-order.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.refresh-order.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen, within } from '@testing-library/react';
+import type { ChatRunStatusResponse, WorkspaceCollabContext } from '@open-design/contracts';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+
+import { EntryNavRail } from '../../src/components/EntryNavRail';
+import { I18nProvider } from '../../src/i18n';
+import { RUNS_CHANGED_EVENT } from '../../src/providers/daemon';
+import type { Project } from '../../src/types';
+
+const context = {
+  workspaceId: 'ws-personal',
+  workspaceType: 'personal',
+  workspaceMemberId: 'wm-1',
+  role: 'owner',
+  memberStatus: 'active',
+  lifecycleState: 'active',
+  billingState: 'free',
+  planId: null,
+  providerMode: 'platform_credits',
+  seatSummary: { seatLimit: 1, usedSeats: 1, availableSeats: 0, isSeatFull: true },
+  permissions: {
+    canManageMembers: true,
+    canManageBilling: true,
+    canInviteMembers: true,
+    canManageAutoRecharge: true,
+    canShareProjects: true,
+    canWriteSyncedFiles: true,
+    canViewWorkspaceSettings: true,
+    canManageSharedResources: true,
+  },
+} satisfies WorkspaceCollabContext;
+
+const projects = ['p1', 'p2'].map((id, index) => ({
+  id,
+  name: `Project ${id}`,
+  skillId: null,
+  designSystemId: null,
+  createdAt: 1,
+  updatedAt: 10 - index,
+})) satisfies Project[];
+
+type PendingRequest = {
+  readonly projectId: string;
+  readonly resolve: (response: Response) => void;
+};
+
+const pendingRequests: PendingRequest[] = [];
+
+function run(
+  projectId: string,
+  status: ChatRunStatusResponse['status'],
+  updatedAt: number,
+): ChatRunStatusResponse {
+  return {
+    id: `${projectId}-${status}-${updatedAt}`,
+    projectId,
+    conversationId: null,
+    assistantMessageId: null,
+    agentId: 'claude',
+    status,
+    createdAt: updatedAt,
+    updatedAt,
+  };
+}
+
+async function answer(
+  requestIndex: number,
+  status: ChatRunStatusResponse['status'],
+  updatedAt: number,
+): Promise<void> {
+  const request = pendingRequests[requestIndex];
+  if (!request) throw new Error(`No pending request at index ${requestIndex}`);
+  const body = {
+    runs: [
+      run(request.projectId, 'succeeded', 0),
+      ...(status === 'running' ? [run(request.projectId, 'succeeded', 1)] : []),
+      run(request.projectId, status, updatedAt),
+    ],
+    awaitingInputProjectIds: [],
+  };
+  await act(async () => {
+    request.resolve(
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  window.localStorage.clear();
+  pendingRequests.length = 0;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      const match = /^\/api\/runs\?projectId=([^&]+)$/.exec(url);
+      const encodedProjectId = match?.[1];
+      if (!encodedProjectId) return Promise.resolve(new Response('{}', { status: 200 }));
+      return new Promise<Response>((resolve) => {
+        pendingRequests.push({ projectId: decodeURIComponent(encodedProjectId), resolve });
+      });
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+it('keeps a newer Running rail state when an older two-project batch completes last', async () => {
+  // Given the rail starts one request per recent project.
+  render(
+    <I18nProvider initial="en">
+      <EntryNavRail
+        view="home"
+        onViewChange={() => {}}
+        onNewProject={() => {}}
+        open
+        context={context}
+        recentProjects={projects}
+      />
+    </I18nProvider>,
+  );
+  expect(pendingRequests.map(({ projectId }) => projectId)).toEqual(['p1', 'p2']);
+
+  // When p1's old response is held by slow p2 while a newer batch applies Running.
+  await answer(0, 'succeeded', 1);
+  await act(async () => window.dispatchEvent(new Event(RUNS_CHANGED_EVENT)));
+  expect(pendingRequests.map(({ projectId }) => projectId)).toEqual(['p1', 'p2', 'p1', 'p2']);
+  await answer(2, 'running', 2);
+  await answer(3, 'succeeded', 1);
+  const firstRow = screen.getAllByTestId('entry-nav-recent-item')[0];
+  if (!firstRow) throw new Error('Expected the first recent project row');
+  expect(within(firstRow).getByRole('img', { name: 'Running' })).toBeTruthy();
+
+  // Then releasing old p2 cannot apply the stale whole-batch terminal snapshot for p1.
+  await answer(1, 'succeeded', 1);
+  expect(within(firstRow).getByRole('img', { name: 'Running' })).toBeTruthy();
+});

--- a/apps/web/tests/components/EntryNavRail.refresh-order.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.refresh-order.test.tsx
@@ -47,6 +47,19 @@ type PendingRequest = {
 };
 
 const pendingRequests: PendingRequest[] = [];
+let reportVisibleRows: () => void = () => {};
+
+// The feature branch polls only rows reported visible by IntersectionObserver.
+class VisibleRowsObserver {
+  private rows: Element[] = [];
+  constructor(callback: IntersectionObserverCallback) {
+    reportVisibleRows = () => callback(this.rows.map((target) => ({
+      target, isIntersecting: true,
+    } as IntersectionObserverEntry)), this as unknown as IntersectionObserver);
+  }
+  observe(target: Element) { this.rows.push(target); }
+  disconnect() { this.rows = []; }
+}
 
 function run(
   projectId: string,
@@ -92,6 +105,8 @@ async function answer(
 
 beforeEach(() => {
   vi.useFakeTimers();
+  reportVisibleRows = () => {};
+  vi.stubGlobal('IntersectionObserver', VisibleRowsObserver);
   window.localStorage.clear();
   pendingRequests.length = 0;
   vi.stubGlobal(
@@ -128,6 +143,7 @@ it('keeps a newer Running rail state when an older two-project batch completes l
       />
     </I18nProvider>,
   );
+  await act(async () => reportVisibleRows());
   expect(pendingRequests.map(({ projectId }) => projectId)).toEqual(['p1', 'p2']);
 
   // When p1's old response is held by slow p2 while a newer batch applies Running.

--- a/apps/web/tests/hooks/useProjectRunStatuses.refresh-order.test.tsx
+++ b/apps/web/tests/hooks/useProjectRunStatuses.refresh-order.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from '@testing-library/react';
+import type { ChatRunStatusResponse } from '@open-design/contracts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useProjectRunSummaries } from '../../src/hooks/useProjectRunStatuses';
+import { RUNS_CHANGED_EVENT } from '../../src/providers/daemon';
+
+type PendingRequest = {
+  readonly projectId: string;
+  readonly resolve: (response: Response) => void;
+};
+
+const pendingRequests: PendingRequest[] = [];
+
+function run(
+  projectId: string,
+  status: ChatRunStatusResponse['status'],
+  updatedAt: number,
+): ChatRunStatusResponse {
+  return {
+    id: `${projectId}-${updatedAt === 0 ? 'history' : 'current'}`,
+    projectId,
+    conversationId: null,
+    assistantMessageId: null,
+    agentId: 'claude',
+    status,
+    createdAt: updatedAt === 0 ? 0 : 1,
+    updatedAt,
+  };
+}
+
+function snapshot(
+  projectId: string,
+  status: ChatRunStatusResponse['status'],
+  updatedAt: number,
+): { readonly runs: ChatRunStatusResponse[]; readonly awaitingInputProjectIds: string[] } {
+  return {
+    runs: [
+      run(projectId, 'succeeded', 0),
+      run(projectId, status, updatedAt),
+    ],
+    awaitingInputProjectIds: [],
+  };
+}
+
+async function answer(
+  requestIndex: number,
+  body: ReturnType<typeof snapshot>,
+): Promise<void> {
+  const request = pendingRequests[requestIndex];
+  if (!request) throw new Error(`No pending request at index ${requestIndex}`);
+  await act(async () => {
+    request.resolve(
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+  });
+}
+
+async function announceRunsChanged(): Promise<void> {
+  await act(async () => window.dispatchEvent(new Event(RUNS_CHANGED_EVENT)));
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  pendingRequests.length = 0;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      const match = /^\/api\/runs\?projectId=([^&]+)$/.exec(url);
+      const encodedProjectId = match?.[1];
+      if (!encodedProjectId) return Promise.resolve(new Response('{}', { status: 200 }));
+      return new Promise<Response>((resolve) => {
+        pendingRequests.push({ projectId: decodeURIComponent(encodedProjectId), resolve });
+      });
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('useProjectRunSummaries refresh ordering', () => {
+  it('keeps a newer active snapshot when an older terminal refresh completes last', async () => {
+    // Given two overlapping refreshes for the same project.
+    const hook = renderHook(() => useProjectRunSummaries(['p1']));
+    await announceRunsChanged();
+
+    // When a distinct new run starts, its snapshot retains the old terminal history.
+    const terminalSnapshot = snapshot('p1', 'succeeded', 1);
+    const activeSnapshot = {
+      ...terminalSnapshot,
+      runs: [...terminalSnapshot.runs, { ...run('p1', 'running', 2), id: 'p1-next' }],
+    };
+    await answer(1, activeSnapshot);
+    expect(hook.result.current.get('p1')?.status).toBe('running');
+    await answer(0, terminalSnapshot);
+
+    // Then the stale terminal response cannot roll the project backward.
+    expect(hook.result.current.get('p1')?.status).toBe('running');
+  });
+
+  it('keeps a newer terminal snapshot when an older active refresh completes last', async () => {
+    // Given an active run that finishes while two refreshes overlap.
+    const hook = renderHook(() => useProjectRunSummaries(['p1']));
+    await announceRunsChanged();
+
+    // When the terminal snapshot applies before the stale active snapshot resolves.
+    await answer(1, snapshot('p1', 'succeeded', 3));
+    expect(hook.result.current.get('p1')?.status).toBe('succeeded');
+    await answer(0, snapshot('p1', 'running', 2));
+
+    // Then the stale active response cannot resurrect the finished run.
+    expect(hook.result.current.get('p1')?.status).toBe('succeeded');
+  });
+
+  it('applies useful slow-poll results while a later refresh is still pending', async () => {
+    // Given every poll overlaps the next four-second interval.
+    const hook = renderHook(() => useProjectRunSummaries(['p1']));
+    await act(async () => vi.advanceTimersByTimeAsync(4_000));
+    expect(pendingRequests).toHaveLength(2);
+
+    // When the first useful response arrives after the second refresh started.
+    await answer(0, snapshot('p1', 'running', 1));
+
+    // Then it makes progress instead of waiting for the latest-started refresh.
+    expect(hook.result.current.get('p1')?.status).toBe('running');
+
+    // When another interval starts before the second response arrives.
+    await act(async () => vi.advanceTimersByTimeAsync(4_000));
+    expect(pendingRequests).toHaveLength(3);
+    await answer(1, snapshot('p1', 'succeeded', 2));
+
+    // Then the newer completed response can still advance the visible state.
+    expect(hook.result.current.get('p1')?.status).toBe('succeeded');
+  });
+
+  it('ignores completions from a previous project set', async () => {
+    // Given the effect changes from one project set to another.
+    const hook = renderHook(
+      ({ projectIds }: { readonly projectIds: readonly string[] }) =>
+        useProjectRunSummaries(projectIds),
+      { initialProps: { projectIds: ['p1'] } },
+    );
+    hook.rerender({ projectIds: ['p2'] });
+
+    // When the current set resolves before the previous set.
+    await answer(1, snapshot('p2', 'running', 2));
+    await answer(0, snapshot('p1', 'succeeded', 1));
+
+    // Then teardown keeps the old effect from replacing the current snapshot.
+    expect(hook.result.current.get('p2')?.status).toBe('running');
+    expect(hook.result.current.has('p1')).toBe(false);
+  });
+
+  it('stays empty after an in-flight refresh is disabled', async () => {
+    // Given an enabled refresh is still pending.
+    const hook = renderHook(
+      ({ enabled }: { readonly enabled: boolean }) =>
+        useProjectRunSummaries(['p1'], { enabled }),
+      { initialProps: { enabled: true } },
+    );
+
+    // When the hook is disabled before that refresh completes.
+    hook.rerender({ enabled: false });
+    expect(hook.result.current.size).toBe(0);
+    await answer(0, snapshot('p1', 'succeeded', 1));
+
+    // Then the disabled effect remains empty and starts no replacement request.
+    expect(hook.result.current.size).toBe(0);
+    expect(pendingRequests).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Fixes #7823

## Why

I followed up on the confirmed recent-project status race after the maintainer invited the narrow contribution. When mount, event, and polling refreshes overlap, an older whole-project snapshot can finish last and make the rail show stale activity or completion state, which makes current project progress unreliable.

## What users will see

The Recently viewed rail keeps the newest status snapshot it has already shown. A delayed older refresh no longer changes Running back to Completed or resurrects Running after completion. Slow requests can still update the rail while a later poll remains pending.

## Surface area

- [x] **UI** — fixes status behavior in the existing Recently viewed rail
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes a product default without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Chromium component fixture with the production rail, hook, provider, and fold. Only fetch response order is controlled, and polling is paused for screenshot staging; this is not a full-app/daemon E2E run. Both images show the moment after the older two-project batch finishes. The committed slow-polling regression separately uses virtual time to verify useful progress while newer polls remain pending.

| Base `c5ae6292` — incorrectly Completed | Fix `9c0a0405` — Running retained |
| --- | --- |
| ![Baseline: stale completion replaces Running](https://raw.githubusercontent.com/roian6/open-design/evidence/issue-7823-refresh-order/baseline-stale.png) | ![Fix: Running remains after stale completion](https://raw.githubusercontent.com/roian6/open-design/evidence/issue-7823-refresh-order/candidate-retained.png) |

## Bug fix verification

- Test paths: `apps/web/tests/hooks/useProjectRunStatuses.refresh-order.test.tsx` and `apps/web/tests/components/EntryNavRail.refresh-order.test.tsx`
- Did the tests go red on the base and green on this branch? yes
- RED: 2 hook ordering assertions and 1 real rail assertion failed on `c5ae6292c464094de80d0191fab50144bff8a027`; the failures were behavioral, not setup/import errors.
- GREEN: focused tests pass 6/6; focused plus directly adjacent suites pass 40/40.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/hooks/useProjectRunStatuses.refresh-order.test.tsx tests/components/EntryNavRail.refresh-order.test.tsx tests/components/EntryNavRail.recent-section.test.tsx tests/state/projectRunStatus.test.ts tests/components/ProjectRunStatusIcon.test.tsx --maxWorkers=2 --reporter=verbose` — 40 passed
- `pnpm --filter @open-design/web typecheck` — passed
- `pnpm guard` — passed
- `pnpm typecheck` — passed
- `pnpm --filter @open-design/web build` — passed
- `git diff --check` — passed
