### PR TITLE
fix(web): even out home template rows, deck posters, and the placeholder caret

### DIFF
--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -1185,13 +1185,20 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* Sized to the native caret it stands in for, not to the carousel's own line
+   box: Chromium draws the caret on the composer's 14px text 1px wide and 17px
+   tall (the font's ascent + descent), square-ended, in `caret-color`. The
+   1.5px bar that stretched to the 13px line minus a 3px margin pair came out
+   14px tall and visibly heavier, so focusing the field made the caret jump in
+   height and weight (OPEND-2698). Explicit height + centred, so a line-height
+   change cannot silently resize it again. */
 .home-hero__carousel-caret {
   flex: none;
-  width: 1.5px;
-  align-self: stretch;
-  margin: 3px 0 3px 2px;
+  width: 1px;
+  height: 17px;
+  align-self: center;
+  margin: 0 0 0 1px;
   background: var(--accent);
-  border-radius: 1px;
   animation: home-hero-caret-blink 1.05s steps(1, end) infinite;
 }
 @keyframes home-hero-caret-blink {
@@ -3109,7 +3116,7 @@
    name on the first line, the prompt it seeds on the second. Four rows are
    visible; the rest scroll. */
 .home-hero__plugin-presets {
-  /* One row's height: 8px top padding + 56px poster + 16px bottom padding.
+  /* One row's height: 12px top padding + 56px poster + 12px bottom padding.
      The POSTER is what sets it now — enlarged per product, it is taller than
      the two text lines beside it (17.5 title + 8 gap + 16.2 prompt = 41.7), so
      the row measures off the picture instead. The viewport below is cut to
@@ -3145,13 +3152,16 @@
      shrunk row squeezes the prompt line's box under its own text — which the
      ellipsis clip then cuts through the glyphs' bottoms. */
   flex: none;
-  /* 16px of air on the sides and below (per product), so the hover fill reads
-     as a rounded block around the two lines rather than a full-bleed band with
-     the text jammed against its left edge. The row's outer box still IS the
-     chip cluster's box above it — only the text inside moves in. The TOP is
-     8px (per product): stacked flush, two 16px edges met between every pair of
-     rows and pushed the run taller than it read. */
-  padding: 8px 16px 16px;
+  /* 16px of air on the sides (per product), so the hover fill reads as a
+     rounded block around the two lines rather than a full-bleed band with the
+     text jammed against its left edge. The row's outer box still IS the chip
+     cluster's box above it — only the text inside moves in. Vertically the
+     two edges are EQUAL, 12px each: the fill used to carry 8 above and 16
+     below (the pair once chosen so stacked rows did not double a 16px edge),
+     which left the poster and text visibly low inside the hover block
+     (OPEND-2687). 12 + 12 keeps the same 24px between neighbouring rows and
+     the same 80px pitch, so `--preset-row-h` above is unchanged. */
+  padding: 12px 16px;
   border: 0;
   border-radius: var(--radius-xlarge);
   background: transparent;
@@ -3199,6 +3209,21 @@
   height: 100%;
   object-fit: cover;
   display: block;
+}
+/* A hairline over the poster's edge, so a white or near-white still (a paper
+   document, a resume) does not merge into the page behind it (OPEND-2705).
+   Default treatment pending product/design sign-off. A pseudo element rather
+   than an inset shadow on the box: the box's own shadow is painted UNDER its
+   <img> child, so it would never show. Mixed down from the border token so it
+   is a quiet edge on a white page in light mode and stays soft on the dark
+   theme's panel ink, instead of a hard 1px line in either. */
+.home-hero__plugin-preset-row-thumb::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--border) 70%, transparent);
 }
 /* The two text lines, stacked — this is the column the row used to be. */
 .home-hero__plugin-preset-row-body {

--- a/apps/web/tests/styles/home-hero-preset-rows.test.ts
+++ b/apps/web/tests/styles/home-hero-preset-rows.test.ts
@@ -1,0 +1,75 @@
+// Measurement spec for the home template list (the rows under the composer
+// once a type is picked) and the composer's placeholder caret — OPEND-2687,
+// OPEND-2705, OPEND-2698. Values are pinned so a drift fails here before it
+// reaches a screenshot.
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const homeHeroCss = readFileSync(
+  new URL('../../src/styles/home/home-hero.css', import.meta.url),
+  'utf8',
+);
+
+function declarations(selector: string): string {
+  const cssWithoutComments = homeHeroCss.replace(/\/\*[\s\S]*?\*\//g, '');
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  const blocks: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  return blocks.join('\n');
+}
+
+describe('home hero — template list rows', () => {
+  it('OPEND-2687: the hover fill carries the same air above and below the row content', () => {
+    const row = declarations('.home-hero__plugin-preset-row');
+    // Symmetric vertical padding: the poster (56px) is the tallest thing in the
+    // row, so equal padding on both sides is what centres it in the fill.
+    expect(row).toMatch(/padding:\s*12px 16px;/);
+    expect(row).toMatch(/align-items:\s*center/);
+    // The row pitch is unchanged (12 + 56 + 12 = 80): the four-row viewport
+    // below is cut to exactly this height and must stay in sync.
+    expect(declarations('.home-hero__plugin-presets')).toMatch(/--preset-row-h:\s*80px/);
+    expect(declarations('.home-hero__plugin-preset-row-thumb')).toMatch(/height:\s*56px/);
+  });
+
+  it('OPEND-2705: a light poster keeps a visible edge against the page', () => {
+    // Default treatment pending product/design sign-off: a 1px hairline ring
+    // over the poster, mixed down from the border token so it reads on a white
+    // page in light mode without glaring in dark mode. Drawn by a pseudo
+    // element ON TOP of the image (an inset box-shadow on the box itself would
+    // be painted under the <img>).
+    const ring = declarations('.home-hero__plugin-preset-row-thumb::after');
+    expect(ring).toMatch(/content:\s*''/);
+    expect(ring).toMatch(/position:\s*absolute/);
+    expect(ring).toMatch(/inset:\s*0/);
+    expect(ring).toMatch(/border-radius:\s*inherit/);
+    expect(ring).toMatch(/pointer-events:\s*none/);
+    expect(ring).toMatch(
+      /box-shadow:\s*inset 0 0 0 1px color-mix\(in srgb, var\(--border\) 70%, transparent\)/,
+    );
+    // The thumb is the positioning context for that ring (and the eye badge).
+    expect(declarations('.home-hero__plugin-preset-row-thumb')).toMatch(/position:\s*relative/);
+  });
+});
+
+describe('home hero — placeholder caret', () => {
+  it('OPEND-2698: the typewriter caret matches the native caret it stands in for', () => {
+    const caret = declarations('.home-hero__carousel-caret');
+    // Native Chromium caret on the 14px composer text: 1px wide, 17px tall
+    // (font ascent + descent), in the editor's caret-color.
+    expect(caret).toMatch(/width:\s*1px/);
+    expect(caret).toMatch(/height:\s*17px/);
+    expect(caret).toMatch(/align-self:\s*center/);
+    expect(caret).toMatch(/background:\s*var\(--accent\)/);
+    // No vertical margins: the height is explicit now, not derived from the
+    // line box minus a margin — the old 3px pair is what shrank it to 14px.
+    expect(caret).not.toMatch(/margin:\s*3px/);
+    expect(caret).not.toMatch(/align-self:\s*stretch/);
+    expect(caret).not.toMatch(/width:\s*1\.5px/);
+    // Square ends, like the native caret — a 1px radius on a 1px bar rounds it off.
+    expect(caret).not.toMatch(/border-radius/);
+  });
+});

--- a/e2e/tests/scripts/bake-plugin-previews.test.ts
+++ b/e2e/tests/scripts/bake-plugin-previews.test.ts
@@ -77,3 +77,54 @@ describe('bake-plugin-previews vertical deck driver', () => {
     expect(windowScrollTo).not.toHaveBeenCalled();
   });
 });
+
+describe('bake-plugin-previews deck entry reset', () => {
+  // OPEND-2702: probing the advancing input moves the deck off its first
+  // slide, and a deck that persists its position (`#/2` in the URL hash, or
+  // web storage) reopened there after the reload — so the poster baked the
+  // agenda page, not the cover. The reset must clear both before the reload.
+  it('[P1] clears a persisted slide position so the reload lands on the cover', async () => {
+    const scriptUrl = new URL('../../../scripts/bake-plugin-previews.mjs', import.meta.url).href;
+    const { resetDeckEntryState } = await import(/* @vite-ignore */ scriptUrl) as {
+      resetDeckEntryState: () => { hadHash: boolean; clearedStorage: boolean };
+    };
+
+    const replaceState = vi.fn();
+    const localClear = vi.fn();
+    const sessionClear = vi.fn();
+    const location = { hash: '#/2', pathname: '/api/plugins/example-deck/preview', search: '?v=1' };
+    Object.assign(globalThis, {
+      window: {
+        location,
+        history: { replaceState },
+        localStorage: { clear: localClear },
+        sessionStorage: { clear: sessionClear },
+      },
+    });
+
+    expect(resetDeckEntryState()).toEqual({ hadHash: true, clearedStorage: true });
+    expect(replaceState).toHaveBeenCalledWith(null, '', '/api/plugins/example-deck/preview?v=1');
+    expect(localClear).toHaveBeenCalledTimes(1);
+    expect(sessionClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('[P2] reports a deck that persisted nothing without touching history', async () => {
+    const scriptUrl = new URL('../../../scripts/bake-plugin-previews.mjs', import.meta.url).href;
+    const { resetDeckEntryState } = await import(/* @vite-ignore */ scriptUrl) as {
+      resetDeckEntryState: () => { hadHash: boolean; clearedStorage: boolean };
+    };
+
+    const replaceState = vi.fn();
+    Object.assign(globalThis, {
+      window: {
+        location: { hash: '', pathname: '/api/plugins/example-deck/preview', search: '' },
+        history: { replaceState },
+        localStorage: { clear: () => { throw new Error('storage disabled'); } },
+        sessionStorage: { clear: () => { throw new Error('storage disabled'); } },
+      },
+    });
+
+    expect(resetDeckEntryState()).toEqual({ hadHash: false, clearedStorage: false });
+    expect(replaceState).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/bake-plugin-previews.mjs
+++ b/scripts/bake-plugin-previews.mjs
@@ -65,7 +65,12 @@ import { pathToFileURL } from 'node:url';
 //       the outer black canvas into posters/clips; a plugin declared with
 //       `od.mode: deck` now takes the slide-walk path by default instead of
 //       being misclassified as a vertically scrolling page.
-const BAKE_VERSION = 6;
+//   v7: return a deck to its FIRST slide before capture. Probing the advancing
+//       input moves the deck on, and a deck that persists its position (`#/2`
+//       in the URL hash, or web storage) reopened there after the reload — so
+//       24 of the official decks baked their agenda page as the poster instead
+//       of the cover (OPEND-2702). Bumped so every deck re-bakes.
+const BAKE_VERSION = 7;
 
 // ---- config ---------------------------------------------------------------
 const BASE_URL = process.env.BASE_URL || 'http://127.0.0.1:17579';
@@ -375,10 +380,34 @@ async function walkSlides(page, driver) {
   return Math.max(SLIDE_MS, Date.now() - t0);
 }
 
+// Runs INSIDE the page (via page.evaluate — keep it self-contained, no outer
+// scope). Undo whatever the driver probe persisted about the deck's position,
+// so the reload that follows opens the deck on its first slide again.
+// Two places a deck keeps that: the URL fragment (`#/2` — reloads preserve it,
+// so a hash-routed deck reopened on the slide the probe left it at and baked
+// that as its poster) and web storage (a "resume where you were" key). Both
+// are cleared; the fragment through replaceState so the reload is a plain one
+// and no `hashchange` fires first. Storage access can throw (disabled, opaque
+// origin), which is reported rather than fatal — the hash is the common case.
+export function resetDeckEntryState() {
+  const hadHash = Boolean(window.location.hash);
+  if (hadHash) {
+    window.history.replaceState(null, '', window.location.pathname + window.location.search);
+  }
+  let clearedStorage = false;
+  try {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    clearedStorage = true;
+  } catch {}
+  return { hadHash, clearedStorage };
+}
+
 // Probe which input advances a fixed-viewport deck: press the arrow key, then
 // nudge the wheel, watching deckSignal for a real slide change. Returns 'arrow',
 // 'wheel', or null when nothing moves it (a single static screen). Advances the
-// deck as a side effect, so callers that go on to capture reload first.
+// deck as a side effect, so callers that go on to capture must reset the
+// deck's persisted position (resetDeckEntryState) and reload first.
 async function probeDeckDriver(page) {
   const sig0 = await page.evaluate(deckSignal, DECK_SCAN_CAP);
   await driveDeck(page, 'arrow');
@@ -484,6 +513,10 @@ async function bakeOne(browser, id, hash, motion) {
   if (isDeck) {
     capW = DECK_W; capH = DECK_H;
     await page.setViewport({ width: capW, height: capH, deviceScaleFactor: 1 });
+    // The probe advanced the deck; the reload alone does not bring it back when
+    // the deck remembers its slide (see resetDeckEntryState) — the poster is
+    // the first captured frame, and it must be the cover.
+    try { await page.evaluate(resetDeckEntryState); } catch {}
     try { await page.reload({ waitUntil: 'domcontentloaded', timeout: 25000 }); } catch {}
     await sleep(1000);
   }


### PR DESCRIPTION
## Why

Four acceptance findings on the Home composer from the OPEND-2553 "首页链路 Demo 一比一复刻" round (PR-E of phase one), all filed by QA against the current `main`:

- **OPEND-2687** — after picking 文档, hovering a template row draws a fill with 8px above the content and 16px below, so the poster and the two text lines sit low inside it.
- **OPEND-2702** — after picking 幻灯片, deck thumbnails show an inner slide (the agenda page) instead of the cover. Example: 像顶级 pre-seed 创始人一样写种子路演.
- **OPEND-2698** — the blinking caret at the end of the rotating placeholder is shorter and heavier than the native caret that appears when the field is focused, so focusing the field makes the caret visibly jump.
- **OPEND-2705** — in 文档, a white or near-white poster (临床病例报告, 极简简历, …) merges into the page; the thumbnail has no readable edge.

The pain is the user-facing polish gap between `main` and the Demo the product team signed off on. None of the four is a targeted change in the Demo (upstream #7635); they are fixed here against the ticket descriptions, in the same `home-hero.css` / `HomeHero.tsx` row structure the Demo uses, so PR-C1 and #7808 (template curation) stay conflict-free — this PR touches no template data and no other home-hero rule.

## What users will see

- **Template rows (文档 / 幻灯片 / …):** hovering a row now shows the fill with equal air above and below the poster and text. Row height, spacing between rows, and the four-row viewport are unchanged.
- **Every template poster** carries a 1px hairline edge, so white-paper documents no longer dissolve into the page. **Default treatment, pending product/design confirmation** — the ticket leaves the exact treatment (hairline / plate / soft shadow) to design; the hairline is the quietest option and is the only thing to revisit if design prefers another.
- **Composer placeholder caret:** the caret that blinks after the typed placeholder is now the same 1px × 17px bar as the native caret, so clicking into the field no longer changes the caret's height or weight.
- **Deck thumbnails:** after the next preview bake, every slide template's thumbnail on Home (and in the Community gallery, which shares the same poster) shows its cover instead of its second slide. This PR fixes the bake recipe and bumps `BAKE_VERSION` to 7; the checked-in manifest is refreshed by the existing `bake-plugin-previews` workflow on merge (its rolling manifest PR), so thumbnails change once that lands, not at merge time of this PR.

## Surface area

- [x] **UI** — home composer template rows and placeholder caret in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [x] **Default behavior change** — `scripts/bake-plugin-previews.mjs` bumps `BAKE_VERSION` 6 → 7, so the next bake sweep re-renders every plugin preview (same mechanism as v5/v6); no runtime behaviour changes for existing users before that sweep lands.
- [ ] **None** — internal refactor, docs, tests, or translation update only

CLI: not applicable — this PR changes styling of an existing UI surface and a build-time asset script; there is no capability behind it that the `od` CLI would expose.

## Screenshots

Entry point — Home, 文档 picked, first row hovered (after):

![entry](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-e-screenshots/entry-home-document.jpg)

**OPEND-2687 + OPEND-2705** — before / after, first row hovered. Top: 8px / 16px fill and posters without an edge. Bottom: 12px / 12px fill and the hairline ring.

![doc rows](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-e-screenshots/2687-2705-doc-rows.jpg)

**OPEND-2698** — caret before / after, unfocused (placeholder caret) vs focused (native caret). Measured in a 2× Playwright capture: before 1.5px × 14px vs 1px × 17px; after both 1px × 17px on the same baseline.

![caret](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-e-screenshots/2698-caret.jpg)

**OPEND-2702** — the bake sequence reproduced on the real preview URLs of three affected decks (fs-creative-voltage, huashu-slides, hps-bauhaus). Row 1: fresh load (cover). Row 2: the old probe → reload sequence (agenda page — this is what the checked-in posters show). Row 3: probe → `resetDeckEntryState` → reload (cover).

![deck reset](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-e-screenshots/2702-deck-reset.jpg)

Home 幻灯片 list on `main` today, showing the agenda-page thumbnails:

![deck rows before](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-e-screenshots/2702-deck-rows-before.jpg)

## Bug fix verification

- OPEND-2687 / 2705 / 2698 — `apps/web/tests/styles/home-hero-preset-rows.test.ts` pins the row padding, the poster ring, and the caret metrics. Red on `main` (3 failed), green on this branch.
- OPEND-2702 — `e2e/tests/scripts/bake-plugin-previews.test.ts` (`deck entry reset` block) covers the new exported `resetDeckEntryState`: a persisted `#/2` hash is replaced and storage cleared; a deck that persisted nothing leaves history untouched. Red on `main` (export missing), green here.
- OPEND-2702 root cause: `probeDeckDriver` presses the arrow key to learn how the deck advances, which moves it to slide 2 and, for hash-routed decks, writes `#/2` (or `#/1` zero-based) into the URL. The `page.reload()` that follows keeps the fragment, so the screencast — and the poster, which is its first frame — starts on the agenda page. 24 official deck templates persist their slide in the hash (two of them also in storage); the 55 that do not already bake their cover, which is why e.g. `html-ppt-pitch-deck` looks right. No template is missing a cover; nothing in the templates needs changing. Verified end-to-end with Playwright against the daemon's preview route (screenshot above); a local full bake was not possible (no `ffmpeg` on this machine), so the manifest refresh is left to CI.

Affected decks (all re-bake under v7): hps-y2k-chrome, hps-true-blueprint, huashu-pentagram-grid, ve-terminal-mono, fs-electric-studio, huashu-bento-insight, huashu-slides, huashu-sparkline-arc, huashu-golden-circle, fs-editorial-forest, hps-retro-tv, ve-midnight-editorial, hps-memphis-pop, fs-notebook-tabs, fs-emerald-editorial, huashu-keynote-black, deck-open-slide-canvas, huashu-annual-letter, huashu-takram-soft-tech, frontend-slides, huashu-luxe-whitespace, hps-academic-paper, hps-bauhaus, fs-creative-voltage.

## Validation

- `pnpm guard` ✅
- `pnpm typecheck` ✅
- `pnpm --filter @open-design/web test` ✅ (681 files, 7230 passed, 1 expected fail, 11 skipped)
- `pnpm --filter @open-design/e2e typecheck` ✅
- `pnpm --filter @open-design/e2e exec vitest run tests/scripts/bake-plugin-previews.test.ts` ✅
- Visual check on `pnpm tools-dev run web --namespace e-home --daemon-port 17806 --web-port 17906` with Playwright captures at 1440×900 @2× (screenshots above). Dark theme is not reachable in the app today (`FORCED_APP_THEME` pins `data-theme` to light), so the ring's dark-mode mix is pinned by test only.
- No i18n changes (`pnpm i18n:check` not applicable).

## Adjacent issues (not in this PR)

- The placeholder carousel types at 13px while the home composer's own text is 14px (`.home-hero__lexical .composer-editable`), so the placeholder is one size smaller than what the user types. Out of OPEND-2698's scope (caret only); worth its own ticket if product wants them matched.
