### PR TITLE
feat(web): entry materials and rail layout from #7635 (OPEND-2553 PR-C1)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5429,6 +5429,7 @@ function AppInner() {
           }
           onboardingCompleted={config.onboardingCompleted === true}
           identityScopeKey={workspaceTabsIdentityScopeKey}
+          workspaceContext={workspaceContext}
         />
         {/* Avatar + credits keep their home-view spot (the top-right actions
             host inside the tabs chrome) while a project tab is open, even

--- a/apps/web/src/components/AmrArtifactUpgradeDialog.module.css
+++ b/apps/web/src/components/AmrArtifactUpgradeDialog.module.css
@@ -1,9 +1,10 @@
+/* Layout only. The scrim material comes from the shared `<Dialog>` backdrop
+   (packages/components dialog.module.css -> --scrim-tint / --scrim-backdrop):
+   this dialog used to carry its own darker, less blurred sheet, which made it
+   the odd one out among every other overlay in the app. */
 .backdrop {
   z-index: 1700;
   padding: 16px;
-  background: rgb(13 12 10 / 58%);
-  backdrop-filter: blur(10px) saturate(0.92);
-  -webkit-backdrop-filter: blur(10px) saturate(0.92);
 }
 
 .panel {

--- a/apps/web/src/components/BrandPickerModal.module.css
+++ b/apps/web/src/components/BrandPickerModal.module.css
@@ -6,7 +6,9 @@
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: rgba(26, 25, 22, 0.32);
+  background: var(--scrim-tint);
+  -webkit-backdrop-filter: var(--scrim-backdrop);
+  backdrop-filter: var(--scrim-backdrop);
   animation: bpmBackdropIn var(--dur-enter, 200ms) var(--ease-out, cubic-bezier(0.23, 1, 0.32, 1));
 }
 

--- a/apps/web/src/components/BrandPreviewCard.module.css
+++ b/apps/web/src/components/BrandPreviewCard.module.css
@@ -1257,6 +1257,9 @@
 }
 
 /* Image lightbox overlay. */
+/* DELIBERATE exception to the app's one scrim (--scrim-tint / --scrim-backdrop,
+   styles/material.css): this is a LIGHTBOX. A near-opaque dark ground is what
+   lifts the image off the page; the shared light scrim would wash it out. */
 .lightbox {
   position: fixed;
   inset: 0;

--- a/apps/web/src/components/DeepSeekV4FlashCampaign.module.css
+++ b/apps/web/src/components/DeepSeekV4FlashCampaign.module.css
@@ -1,9 +1,8 @@
+/* Layout only — the scrim material comes from the shared `<Dialog>` backdrop
+   (--scrim-tint / --scrim-backdrop). See AmrArtifactUpgradeDialog. */
 .backdrop {
   z-index: 1700;
   padding: 16px;
-  background: color-mix(in srgb, var(--text-strong) 24%, transparent);
-  backdrop-filter: blur(6px) saturate(0.96);
-  -webkit-backdrop-filter: blur(6px) saturate(0.96);
 }
 
 .goWelcomeBackdrop {

--- a/apps/web/src/components/DesignSystemAssetDropzone.module.css
+++ b/apps/web/src/components/DesignSystemAssetDropzone.module.css
@@ -301,6 +301,9 @@
 }
 
 /* --- lightbox ------------------------------------------------------------ */
+/* DELIBERATE exception to the app's one scrim (--scrim-tint / --scrim-backdrop,
+   styles/material.css): this is a LIGHTBOX. A near-opaque dark ground is what
+   lifts the image off the page; the shared light scrim would wash it out. */
 .lightbox {
   position: fixed;
   inset: 0;

--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -13,7 +13,10 @@
 //     workspace tabs bar's pinned Home toggle.
 //   • Billing chip — real plan tier + explicitly scoped USD balance when Vela
 //     billing is available, with upgrade linking out to Vela Web.
-//   • Search box (opens the ⌘K project search palette via `onOpenSearch`).
+//   • No search box: the ⌘K search button and the rail toggle live in the
+//     chrome row (WorkspaceTabsBar) and reach EntryShell through
+//     entryRailBridge events. `onOpenSearch` stays on the props as the
+//     shell-owned opener for callers that still hand it down.
 //   • 最近 (Recents) → home, Community → community.
 //   • Team block (only when `context.workspaceType === 'team'`): an inline team
 //     switcher + the team destinations. In-client views: drafts / all projects /
@@ -65,7 +68,6 @@ import type { EntrySettingsSection } from './EntrySettingsMenu';
 import type { Project } from '../types';
 import { isRtlLocale, useI18n } from '../i18n';
 import { useDismissOnOutsideInteraction } from '../hooks/useDismissOnOutsideInteraction';
-import { ENTRY_RAIL_TOGGLE_EVENT } from './entryRailBridge';
 import {
   beginWorkspaceScopedRead,
   notifyTeamProjectsChanged,
@@ -315,12 +317,6 @@ function NavButton({
   );
 }
 
-/** How many of the recent projects the rail lists. The rail is navigation, not
- *  a grid: past ~8 rows the section outgrows the destinations above it and the
- *  whole rail starts to scroll. 全部项目 is one click away for the rest, and the
- *  section's own footer row goes there. */
-const RAIL_RECENT_LIMIT = 8;
-
 /** Remembers the section's open/closed state across launches, next to the
  *  rail's own `od.entry.railOpen`. A disclosure the user closed should stay
  *  closed — re-opening it on every boot is the whole reason to have the
@@ -410,8 +406,11 @@ function RailRecentSection({
   label: string;
 }) {
   const [open, setOpen] = useState(readStoredRecentOpen);
+  // Every recent project, newest first (OPEND-2757: the old 8-row cap hid the
+  // rest from the rail entirely). The LIST scrolls past ~11 rows, not the rail
+  // — see `.entry-nav-rail__recent-list` in entry-layout.css.
   const items = useMemo(
-    () => [...projects].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, RAIL_RECENT_LIMIT),
+    () => [...projects].sort((a, b) => b.updatedAt - a.updatedAt),
     [projects],
   );
   // Run status for the rows' leading glyph. `Project.status` cannot serve it —
@@ -420,7 +419,7 @@ function RailRecentSection({
   // feed the workspace tab dropdown reads, which is what keeps the two glyph
   // columns telling one story.
   // Only polled while the disclosure is open: it costs one request per listed
-  // project (≤ RAIL_RECENT_LIMIT), and a collapsed section shows no glyphs.
+  // project, and a collapsed section shows no glyphs.
   const runStatusProjectIds = useMemo(() => items.map((item) => item.id), [items]);
   const runSummaryByProjectId = useProjectRunSummaries(runStatusProjectIds, {
     enabled: open,
@@ -1811,7 +1810,13 @@ export function EntryNavRail({
             >
               <span className="entry-nav-rail__team-avatar" aria-hidden>{workspaceInitial}</span>
               <span className="entry-nav-rail__team-name">{workspaceName}</span>
-              <Icon name="chevron-down" size={14} />
+              {/* The 最近浏览过 head's disclosure, exactly (per product: 展开和
+                  收起和最近浏览过的一样): the glyph SWAPS rather than rotating —
+                  › closed, ⌄ open — at the same 14px, in a fixed 14px slot so a
+                  narrower caret cannot pull the workspace name along with it. */}
+              <span className="entry-nav-rail__team-chevron" aria-hidden>
+                <Icon name={teamOpen ? 'chevron-down' : 'chevron-right'} size={14} />
+              </span>
             </button>
             {teamOpen ? (
               <>
@@ -1923,48 +1928,11 @@ export function EntryNavRail({
           </div>
         ) : null}
 
-        {/* Search + the rail-collapse control in one row. The collapse button
-            moved here from the chrome corner (per product: 收起按钮放在输入框
-            后边) — the corner slot is the brand logo now, and re-opening a
-            collapsed rail is what the logo does there. */}
-        <div className="entry-nav-rail__search-row">
-          <button
-            type="button"
-            className="entry-nav-rail__search"
-            onClick={() => {
-              trackEntryNavigationClick(analytics.track, {
-                page_name: analyticsPage,
-                area: 'entry_nav',
-                element: 'search',
-                target: 'search',
-                entry_from: 'sidebar',
-                ...workspaceDimensions,
-              });
-              onOpenSearch?.();
-            }}
-            aria-label={t('common.search')}
-            data-testid="entry-nav-search"
-          >
-            <Icon name="search" size={14} />
-            <span className="entry-nav-rail__search-placeholder">{t('common.search')}</span>
-            <span className="entry-nav-rail__search-kbd" aria-hidden>⌘K</span>
-          </button>
-          <button
-            type="button"
-            className="entry-nav-rail__collapse od-tooltip"
-            aria-label={t('entry.navCollapse')}
-            title={t('entry.navCollapse')}
-            data-tooltip={t('entry.navCollapse')}
-            data-tooltip-placement="bottom"
-            data-testid="entry-rail-collapse"
-            onClick={() => {
-              window.dispatchEvent(new CustomEvent(ENTRY_RAIL_TOGGLE_EVENT));
-            }}
-          >
-            <Icon name="panel-left" size={15} />
-          </button>
-        </div>
-
+        {/* No search row here any more (per product: 搜索和收起跟 home icon 一起
+            放在顶部): the search button and the rail toggle sit in the chrome
+            row above (WorkspaceTabsBar's `.workspace-tabs-rail-actions`), and
+            reach EntryShell through window events (entryRailBridge). The rail
+            column starts at the workspace switcher. */}
         <NavButton
           active={isHome}
           ariaLabel={homeLabel}
@@ -2030,7 +1998,29 @@ export function EntryNavRail({
             >
               <Icon name="puzzle" size={16} />
             </NavButton>
-            {/* 最近浏览过 sits under 插件 (per product) — the last thing in the
+            {/* 设置 is a rail destination on BOTH branches (product: 设置的按钮
+                在插件下边). Signed-in used to keep it only in the account hover
+                menu — two interactions deep, and invisible until you found the
+                avatar. It sits directly under 插件 so the destination list ends
+                the same way in either state, above 最近项目 (content, not a
+                place to go). `entry-settings-button` stays UNIQUE: this branch
+                and the signed-out one below are mutually exclusive. */}
+            <NavButton
+              ariaLabel={t('entry.accountSettings')}
+              label={t('entry.accountSettings')}
+              onClick={() => {
+                trackAccountMenuClick(analytics.track, {
+                  page_name: analyticsPage,
+                  area: 'account_menu',
+                  element: 'settings',
+                });
+                onOpenSettings?.();
+              }}
+              testId="entry-settings-button"
+            >
+              <Icon name="settings" size={16} />
+            </NavButton>
+            {/* 最近项目 sits under 设置 (per product) — the last thing in the
                 destination list, because it is a list of CONTENT rather than a
                 place to go. */}
             <RailRecentSection
@@ -2039,7 +2029,7 @@ export function EntryNavRail({
               onRename={onRenameRecentProject}
               onDelete={onDeleteRecentProject}
               workspaceContext={context}
-              label={t('recentProjects.collectionRecent')}
+              label={t('recentProjects.title')}
             />
             {/* Product decision (2026-07-20): 成员 and 数据大盘 leave the rail
                 entirely — both surfaces live in B's console and the rail should
@@ -2097,9 +2087,9 @@ export function EntryNavRail({
                 case. #5517 then dropped that chip (the footer only hosts the
                 updater popup now), and a signed-out rail has no account menu
                 either — leaving no settings entry at all. This item is the
-                ONLY signed-out settings entry (testId `entry-settings-button`
-                is the e2e contract); signed-in keeps settings in the account
-                menu, so it must not render on that branch. */}
+                signed-out half of the pair (testId `entry-settings-button` is
+                the e2e contract); the signed-in branch above renders the same
+                item in the same slot under 插件, and the two never coexist. */}
             <NavButton
               ariaLabel={t('entry.accountSettings')}
               label={t('entry.accountSettings')}

--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -418,9 +418,27 @@ function RailRecentSection({
   // workspace-bound project (see the hook's own note) — and this is the same
   // feed the workspace tab dropdown reads, which is what keeps the two glyph
   // columns telling one story.
-  // Only polled while the disclosure is open: it costs one request per listed
-  // project, and a collapsed section shows no glyphs.
-  const runStatusProjectIds = useMemo(() => items.map((item) => item.id), [items]);
+  const recentListRef = useRef<HTMLUListElement>(null);
+  const [runStatusProjectIds, setRunStatusProjectIds] = useState<string[]>([]);
+  // Keep the full catalog navigable, but poll only rows intersecting its
+  // scrollport. The list's existing height cap bounds the status request set.
+  useEffect(() => {
+    setRunStatusProjectIds([]);
+    const list = recentListRef.current;
+    if (!open || !list || typeof IntersectionObserver === 'undefined') return;
+    const visible = new Set<string>();
+    const observer = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        const id = (entry.target as HTMLElement).dataset.projectId;
+        if (!id) continue;
+        if (entry.isIntersecting) visible.add(id);
+        else visible.delete(id);
+      }
+      setRunStatusProjectIds([...visible]);
+    }, { root: list });
+    for (const row of list.children) observer.observe(row);
+    return () => observer.disconnect();
+  }, [items, open]);
   const runSummaryByProjectId = useProjectRunSummaries(runStatusProjectIds, {
     enabled: open,
     workspaceContext,
@@ -487,7 +505,7 @@ function RailRecentSection({
           the wrapper would skip the transition entirely. */}
       <div className={`accordion-collapsible${open ? ' open' : ''}`}>
         <div className="accordion-collapsible-inner">
-          <ul className="entry-nav-rail__recent-list">
+          <ul ref={recentListRef} className="entry-nav-rail__recent-list">
             {items.map((project) => {
               const summary = runSummaryByProjectId.get(project.id);
               const status = summary?.status;
@@ -500,7 +518,7 @@ function RailRecentSection({
                 && summary?.latestTerminalRunId !== undefined
                 && seenDone[project.id] === summary.latestTerminalRunId;
               return (
-                <li key={project.id}>
+                <li key={project.id} data-project-id={project.id}>
                   <RailRecentRow
                     project={project}
                     workspaceContext={workspaceContext}

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -235,6 +235,7 @@ import {
 import {
   ENTRY_RAIL_STATE_EVENT,
   ENTRY_RAIL_TOGGLE_EVENT,
+  ENTRY_SEARCH_OPEN_EVENT,
   RAIL_OPEN_STORAGE_KEY,
   readStoredRailOpen,
 } from './entryRailBridge';
@@ -1180,6 +1181,14 @@ export function EntryShell({
     window.addEventListener(ENTRY_RAIL_TOGGLE_EVENT, onToggle);
     return () => window.removeEventListener(ENTRY_RAIL_TOGGLE_EVENT, onToggle);
   }, []);
+  // Same story for the search button, which sits in that chrome row beside the
+  // rail toggle (per product: 搜索和收起跟 home icon 一起放在顶部) while the
+  // palette it opens is owned here.
+  useEffect(() => {
+    const onOpen = () => setProjectSearchOpen(true);
+    window.addEventListener(ENTRY_SEARCH_OPEN_EVENT, onOpen);
+    return () => window.removeEventListener(ENTRY_SEARCH_OPEN_EVENT, onOpen);
+  }, []);
   const [localProviderModelsCache, setLocalProviderModelsCache] =
     useState<ProviderModelsCache>({});
   const hasSharedProviderModelsCache =
@@ -1201,6 +1210,13 @@ export function EntryShell({
   // the same commit as the mount. The read is destructive, so it applies once.
   const [homePromptHandoff, setHomePromptHandoff] = useState<HomePromptHandoff | null>(
     () => takeHomePromptHandoff(),
+  );
+  // The same one-shot binding, addressed at the community view's docked
+  // composer instead. Kept separate rather than shared: `promptHandoff` is
+  // consumed by id, so one piece of state fed to both instances would have
+  // whichever consumed it first mark it spent for the other.
+  const [dockPromptHandoff, setDockPromptHandoff] = useState<HomePromptHandoff | null>(
+    null,
   );
   const entryMainScrollRef = useRef<HTMLElement | null>(null);
   // Entry views share this element, so route changes must not inherit the previous view's offset.
@@ -1650,6 +1666,37 @@ export function EntryShell({
     />
   );
 
+  // Everything a HomeView needs except which surface it is on. Home renders
+  // one as the page; the community view docks a second at its bottom, and both
+  // must submit through the SAME handlers — a docked composer that created
+  // projects down a second path would drift from Home's the first time either
+  // changed.
+  const homeViewProps = {
+    projects: homeProjectsList,
+    projectsLoading,
+    designSystems,
+    designSystemsLoading,
+    defaultDesignSystemId,
+    onSubmit: handlePluginLoopSubmit,
+    onOpenProject,
+    onOpenIntegrations: () => openIntegrationTab('connectors'),
+    onOpenMcp: () => openIntegrationTab('mcp'),
+    onOpenNewProject: (tab: 'template') => {
+      openNewProject(tab);
+    },
+    onStartBlankProject: startBlankProjectFromRail,
+    projectOwnerMemberIds: teamProjectOwnerMemberIds,
+    skills,
+    skillsLoading,
+    connectors,
+    promptTemplates,
+    artifactUpgradeSlot,
+    deepSeekV4FlashCampaignAudience,
+    onDeepSeekV4FlashCampaignUseNow: applyDeepSeekCampaignModel,
+    deepSeekV4FlashCampaignMetricsConsent: config.telemetry?.metrics === true,
+    deepSeekV4FlashCampaignInstallationId: config.installationId ?? null,
+  };
+
   return (
     <div className="entry-shell entry-shell--no-header">
       <div
@@ -1762,40 +1809,12 @@ export function EntryShell({
           >
             <div className="entry-main__view-home" data-testid="entry-view-home" data-active={view === 'home' ? 'true' : 'false'} {...inactiveViewProps(view === 'home')}>
               <HomeView
+                {...homeViewProps}
                 isActive={view === 'home'}
-                projects={homeProjectsList}
-                projectsLoading={projectsLoading}
-                designSystems={designSystems}
-                designSystemsLoading={designSystemsLoading}
-                defaultDesignSystemId={defaultDesignSystemId}
-                onSubmit={handlePluginLoopSubmit}
-                onOpenProject={onOpenProject}
-                onViewAllProjects={() => changeView('projects')}
-                onDeleteProject={onDeleteProject}
-                onDuplicateProject={onDuplicateProject}
-                onRenameProject={onRenameProject}
-                onOpenIntegrations={() => openIntegrationTab('connectors')}
-                onOpenMcp={() => openIntegrationTab('mcp')}
-                onOpenNewProject={(tab) => {
-                  openNewProject(tab);
-                }}
-                onStartBlankProject={startBlankProjectFromRail}
+                /* Home alone consumes the page handoff. A docked instance
+                   (community) has its own — see `dockPromptHandoff`. */
                 promptHandoff={homePromptHandoff}
-                isSharedProject={isSharedProject}
-                onProjectShared={markProjectShared}
-                onProjectShareFailed={markProjectShareFailed}
-                onProjectUnshared={markProjectUnshared}
-                projectOwnerMemberIds={teamProjectOwnerMemberIds}
-                skills={skills}
-                skillsLoading={skillsLoading}
-                connectors={connectors}
-                promptTemplates={promptTemplates}
                 executionSwitcher={view === 'home' ? homeExecutionSwitcher : undefined}
-                artifactUpgradeSlot={artifactUpgradeSlot}
-                deepSeekV4FlashCampaignAudience={deepSeekV4FlashCampaignAudience}
-                onDeepSeekV4FlashCampaignUseNow={applyDeepSeekCampaignModel}
-                deepSeekV4FlashCampaignMetricsConsent={config.telemetry?.metrics === true}
-                deepSeekV4FlashCampaignInstallationId={config.installationId ?? null}
               />
             </div>
             <div data-testid="entry-view-projects" data-active={view === 'projects' ? 'true' : 'false'} {...inactiveViewProps(view === 'projects')}>
@@ -1954,16 +1973,19 @@ export function EntryShell({
                   })();
                 }}
                 onUsePrompt={(target) => {
-                  // Seed the Home composer with the template's starting prompt,
-                  // then switch to Home to review + send it (keep in sync with
-                  // the standalone /community branch in App.tsx).
-                  seedHomeComposerPrompt(target.prompt);
-                  setHomePromptHandoff(createPluginUseHandoff(Date.now(), target.templateId, {
+                  // Stays put (per product): the prompt lands in the docked
+                  // composer at the foot of THIS page and unfolds it, instead
+                  // of throwing the user back to 首页 and making them find
+                  // their place in the gallery again. Same seed + binding pair
+                  // Home used, only addressed at the dock.
+                  // (App.tsx's standalone /community route has no dock and
+                  // still hands off to Home — see the branch there.)
+                  seedHomeComposerPrompt(target.prompt, 'dock');
+                  setDockPromptHandoff(createPluginUseHandoff(Date.now(), target.templateId, {
                     action: 'use',
                     chipId: target.chipId,
                     projectKind: target.projectKind,
                   }));
-                  changeView('home');
                 }}
                 // The gallery card's full details modal routes Use through the
                 // same Home hand-off the plugin library uses, so the plugin
@@ -1976,6 +1998,31 @@ export function EntryShell({
                   });
                 }}
               />
+            ) : null}
+            {/* Home's composer, docked to the bottom of the community view: you
+                can browse templates and still start from your own sentence
+                without going back to 首页. Collapsed it is the input line and
+                the send button; typing unfolds the rest (HomeHero's `dock`
+                variant owns both states). Mounted only while the view is up so
+                it does not hold a second composer's worth of pickers alive
+                behind every other destination. */}
+            {view === 'community' ? (
+              <div
+                className="community-composer-dock"
+                data-testid="community-composer-dock"
+              >
+                <HomeView
+                  {...homeViewProps}
+                  variant="dock"
+                  isActive
+                  /* The agent/model chip too, so the docked row is the same
+                     control set as Home's. Only ever one of the two instances
+                     renders it — each is gated on a different view — so the
+                     switcher is never mounted twice. */
+                  executionSwitcher={homeExecutionSwitcher}
+                  promptHandoff={dockPromptHandoff}
+                />
+              </div>
             ) : null}
             {/* Team destinations — the entry shell owns the nav frame only; each
                 view is provided by another lane (B = members/board, D = team

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -1811,6 +1811,10 @@ export function EntryShell({
               <HomeView
                 {...homeViewProps}
                 isActive={view === 'home'}
+                onViewAllProjects={() => changeView('projects')}
+                onDeleteProject={onDeleteProject}
+                onDuplicateProject={onDuplicateProject}
+                onRenameProject={onRenameProject}
                 /* Home alone consumes the page handoff. A docked instance
                    (community) has its own — see `dockPromptHandoff`. */
                 promptHandoff={homePromptHandoff}

--- a/apps/web/src/components/FigmaHelpModal.module.css
+++ b/apps/web/src/components/FigmaHelpModal.module.css
@@ -5,7 +5,9 @@
   display: grid;
   place-items: center;
   padding: 24px;
-  background: rgba(15, 15, 15, 0.38);
+  background: var(--scrim-tint);
+  -webkit-backdrop-filter: var(--scrim-backdrop);
+  backdrop-filter: var(--scrim-backdrop);
 }
 
 .modal {

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -20,7 +20,6 @@ import type {
   LocalCatalogScope,
   ProjectKind,
   WorkspaceCollabContext,
-  WorkspaceProjectSummary,
   AudioVoiceOption,
   WorkspaceContextItem,
 } from '@open-design/contracts';
@@ -96,6 +95,7 @@ import {
   pluginInputsAreValid,
   requiredInputsAreUserFillable,
 } from '../utils/pluginRequiredInputs';
+import { RecentProjectsStrip } from './RecentProjectsStrip';
 import { HomeHero, type ExamplePromptInfo, type HomeHeroHandle } from './HomeHero';
 import { findChip, HOME_HERO_CHIPS, type HomeHeroChip } from './home-hero/chips';
 import {
@@ -112,7 +112,6 @@ import { setPendingDesignSystemCreateEntry } from '../analytics/ds-create-entry'
 import { workspaceContextLinkedDirs } from './workspace-context';
 import {
   currentWorkspaceAccountGeneration,
-  useTeamProjects,
   useWorkspaceContext,
   workspaceResourceReadContext,
 } from '../collab/useWorkspaceContext';
@@ -145,8 +144,6 @@ import { localizePluginTitle } from './plugins-home/localization';
 import type { PluginUseAction } from './plugins-home/useActions';
 import { examplePresetSeedPrompt } from './plugins-home/presetSeedPrompt';
 import { localizePluginDescription } from './plugins-home/localization';
-import type { SharedProjectPredicate } from '../collab/all-projects-list';
-import { RecentProjectsStrip } from './RecentProjectsStrip';
 import type { Recommendation } from '../onboarding/recommendation';
 import type { OnboardingEntry } from '../onboarding/onboarding-entry';
 import { AnimatePresence } from 'motion/react';
@@ -279,7 +276,9 @@ interface Props {
     payload: PluginLoopSubmit,
   ) => Promise<boolean | 'blocked' | void> | boolean | 'blocked' | void;
   onOpenProject: (id: string, fileName?: string) => void;
-  onViewAllProjects: () => void;
+  /** Signed-out shell only — the home grid's own handlers (see the grid's
+   *  mount note in the render tree). A workspace-bound Home never reads them. */
+  onViewAllProjects?: () => void;
   onDeleteProject?: (id: string) => Promise<boolean | void> | boolean | void;
   onDuplicateProject?: (id: string) => Promise<void> | void;
   onRenameProject?: (id: string, name: string) => void;
@@ -295,15 +294,6 @@ interface Props {
    *  back to its collapsed default (the community view raises it on every tab
    *  change). */
   collapseSignal?: number;
-  /** The one shared-state answer for the home strip's cards. Owned by EntryShell
-   *  because the SAME answer partitions its 全部项目 / 草稿 grids — a home share
-   *  must move the project between those grids too, without a refetch. */
-  isSharedProject?: SharedProjectPredicate;
-  onProjectShared?: (project: WorkspaceProjectSummary) => void;
-  onProjectShareFailed?: (projectId: string) => void;
-  onProjectUnshared?: (projectId: string) => void;
-  /** Authoritative catalog owners plus any exact successful-move witness. */
-  projectOwnerMemberIds?: ReadonlyMap<string, string>;
   skills?: SkillSummary[];
   skillsLoading?: boolean;
   connectors?: ConnectorDetail[];
@@ -525,11 +515,6 @@ export function HomeView({
   onStartBlankProject,
   promptHandoff,
   collapseSignal,
-  isSharedProject,
-  onProjectShared,
-  onProjectShareFailed,
-  onProjectUnshared,
-  projectOwnerMemberIds,
   skills = EMPTY_SKILLS,
   skillsLoading = false,
   connectors = EMPTY_CONNECTORS,
@@ -576,23 +561,6 @@ export function HomeView({
   const desiredPluginCatalogKey = workspaceContextState.identityChangePending
     ? null
     : pluginCatalogCacheKey(pluginCatalogOptions);
-  // Team-wide catalog from the resource hub via the daemon; empty off-team / when
-  // the hub is unconfigured. Only the creator attribution is derived here — the
-  // shared/not-shared answer arrives as `isSharedProject` from EntryShell, which
-  // owns the optimistic layer the 全部项目 / 草稿 grids read from too.
-  const homeTeamProjects = useTeamProjects();
-  // projectId → sharing member id, so the strip can resolve "{creator}创建" for a
-  // teammate's shared project (a project absent here is the member's own local
-  // project → "我创建").
-  const homeProjectOwnerMemberIds = useMemo(
-    () => projectOwnerMemberIds ?? new Map(
-      homeTeamProjects.projects.map((teamProject) => [
-        teamProject.projectId,
-        teamProject.ownerMemberId,
-      ]),
-    ),
-    [homeTeamProjects.projects, projectOwnerMemberIds],
-  );
   // P0 page_view page_name=home — fire once on mount. ref-keyed to survive
   // re-renders that flip parent state without remounting HomeView.
   const homePageViewFiredRef = useRef(false);
@@ -3079,8 +3047,8 @@ export function HomeView({
     }
   }
 
-  // #5517: with no recent projects the home (logo + heading + composer)
-  // centers vertically instead of hugging the top, and the strip is skipped.
+  // #5517: with no projects yet the home (logo + heading + composer) centers
+  // vertically instead of hugging the top.
   const recentProjectsEmpty = !projectsLoading && projects.length === 0;
 
   return (
@@ -3226,17 +3194,24 @@ export function HomeView({
         recommendationSlot={artifactUpgradeSlot}
       />
 
-      {recentProjectsEmpty ? null : (
+      {/* No 最近项目 grid under the hero once the rail carries the list
+          (OPEND-2683, per product: 最近项目统一在左侧栏展示): with a cloud
+          identity the rail's 最近项目 section (EntryNavRail → RailRecentSection)
+          is the one recent-projects entry, with the status glyphs and hover
+          preview the grid used to carry, and 全部项目 / 草稿 keep
+          RecentProjectsStrip for the browsable catalogue.
+
+          The signed-out (local) shell is the migration constraint's other
+          half: its rail has no 最近项目 section yet, so pulling the grid there
+          would leave existing projects with no entry at all. It keeps the grid
+          until the rail is extended (tracked in the PR body), which is also
+          why the strip props below stay on this component. */}
+      {recentProjectsEmpty || workspaceContext ? null : (
       <RecentProjectsStrip
         isActive={isActive}
         projects={projects}
         designSystems={designSystems}
         heading={t('recentProjects.title')}
-        {...(isSharedProject ? { isSharedProject } : {})}
-        {...(onProjectShared ? { onProjectShared } : {})}
-        {...(onProjectShareFailed ? { onProjectShareFailed } : {})}
-        {...(onProjectUnshared ? { onProjectUnshared } : {})}
-        projectOwnerMemberIds={homeProjectOwnerMemberIds}
         limit={1000}
         {...(projectsLoading !== undefined ? { loading: projectsLoading } : {})}
         onOpen={(id) => {
@@ -3260,7 +3235,7 @@ export function HomeView({
             area: 'recent_projects',
             element: 'view_all',
           });
-          onViewAllProjects();
+          onViewAllProjects?.();
         }}
         {...(onDeleteProject ? { onDelete: onDeleteProject } : {})}
         {...(onDuplicateProject ? { onDuplicate: onDuplicateProject } : {})}

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -3206,7 +3206,7 @@ export function HomeView({
           would leave existing projects with no entry at all. It keeps the grid
           until the rail is extended (tracked in the PR body), which is also
           why the strip props below stay on this component. */}
-      {recentProjectsEmpty || workspaceContext ? null : (
+      {variant !== 'page' || recentProjectsEmpty || workspaceContext ? null : (
       <RecentProjectsStrip
         isActive={isActive}
         projects={projects}

--- a/apps/web/src/components/LibraryPreviewModal.module.css
+++ b/apps/web/src/components/LibraryPreviewModal.module.css
@@ -6,7 +6,7 @@
   align-items: center;
   justify-content: center;
   padding: 32px;
-  background: rgba(17, 24, 39, 0.55);
+  background: var(--scrim-tint);
   -webkit-backdrop-filter: var(--scrim-backdrop);
   backdrop-filter: var(--scrim-backdrop);
 }

--- a/apps/web/src/components/LibraryUploadModal.module.css
+++ b/apps/web/src/components/LibraryUploadModal.module.css
@@ -6,7 +6,7 @@
   align-items: center;
   justify-content: center;
   padding: 32px;
-  background: rgba(17, 24, 39, 0.55);
+  background: var(--scrim-tint);
   -webkit-backdrop-filter: var(--scrim-backdrop);
   backdrop-filter: var(--scrim-backdrop);
 }

--- a/apps/web/src/components/MessageCenter.module.css
+++ b/apps/web/src/components/MessageCenter.module.css
@@ -30,7 +30,9 @@
   z-index: 2200;
   display: flex;
   justify-content: flex-end;
-  background: color-mix(in srgb, var(--text-strong, #111827) 12%, transparent);
+  background: var(--scrim-tint);
+  -webkit-backdrop-filter: var(--scrim-backdrop);
+  backdrop-filter: var(--scrim-backdrop);
 }
 
 .panel {

--- a/apps/web/src/components/NewBrandModal.module.css
+++ b/apps/web/src/components/NewBrandModal.module.css
@@ -6,7 +6,9 @@
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: rgba(26, 25, 22, 0.32);
+  background: var(--scrim-tint);
+  -webkit-backdrop-filter: var(--scrim-backdrop);
+  backdrop-filter: var(--scrim-backdrop);
   animation: backdropIn var(--dur-enter) var(--ease-out);
 }
 

--- a/apps/web/src/components/ProjectReferenceModal.module.css
+++ b/apps/web/src/components/ProjectReferenceModal.module.css
@@ -5,7 +5,9 @@
   display: grid;
   place-items: center;
   padding: 24px;
-  background: rgba(15, 15, 15, 0.38);
+  background: var(--scrim-tint);
+  -webkit-backdrop-filter: var(--scrim-backdrop);
+  backdrop-filter: var(--scrim-backdrop);
 }
 
 .modal {

--- a/apps/web/src/components/RecentProjectsStrip.tsx
+++ b/apps/web/src/components/RecentProjectsStrip.tsx
@@ -27,6 +27,7 @@ import {
 } from '../providers/registry';
 import type { DesignSystemSummary, Project, ProjectDisplayStatus, ProjectFile } from '../types';
 import { Icon } from './Icon';
+import type { IconName } from './Icon';
 import { InviteDialog } from './InviteDialog';
 import { STATUS_LABEL_KEYS } from './DesignsTab';
 import { isDesignSystemProject, isPublishedDesignSystemProject } from './design-system-project';
@@ -1844,18 +1845,6 @@ export function RecentProjectsStrip({
                     >
                       <Icon name="spinner" size={18} />
                     </span>
-                  ) : shared && view !== 'list' ? (
-                    // Grid's thumb has room for the badge as a floating overlay
-                    // (hover-revealed, see recent-projects.css); list view's
-                    // thumb is far too small (128x52) for it — the inline
-                    // variant next to the name below covers that case instead.
-                    <span className="recent-projects__card-badge recent-projects__card-badge--shared">
-                      <svg width={11} height={11} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.2} strokeLinecap="round" strokeLinejoin="round">
-                        <circle cx="9" cy="8" r="3" />
-                        <path d="M3 20a6 6 0 0 1 12 0M16 11a3 3 0 1 0-1-5.8M21 20a6 6 0 0 0-5-5.9" />
-                      </svg>
-                      {t('recentProjects.sharedBadge')}
-                    </span>
                   ) : null}
                 </div>
                 <div className="recent-projects__card-meta">
@@ -1863,10 +1852,7 @@ export function RecentProjectsStrip({
                     <span className="recent-projects__card-name">{project.name}</span>
                     {shared && view === 'list' ? (
                       <span className="recent-projects__card-badge recent-projects__card-badge--shared recent-projects__card-badge--inline">
-                        <svg width={11} height={11} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.2} strokeLinecap="round" strokeLinejoin="round">
-                          <circle cx="9" cy="8" r="3" />
-                          <path d="M3 20a6 6 0 0 1 12 0M16 11a3 3 0 1 0-1-5.8M21 20a6 6 0 0 0-5-5.9" />
-                        </svg>
+                        <Icon name="swap" size={13} />
                         {t('recentProjects.sharedBadge')}
                       </span>
                     ) : null}
@@ -1900,6 +1886,20 @@ export function RecentProjectsStrip({
                   </div>
                 </div>
               </button>
+              {/* The team badge overlays the cover but hangs off the CARD, not
+                  the thumb — the same box the ⋯ button's anchor uses. Inside
+                  the thumb it inherited that element's 1.03 hover scale, so it
+                  grew and slid outward exactly when it appeared, landing flush
+                  with the card edge while ⋯ stayed 8px in (per product: 这个间距
+                  和最右侧的一样). Grid only: list rows are 128x52 and carry the
+                  inline variant beside the name instead. While a share is in
+                  flight the thumb shows its spinner instead. */}
+              {shared && view !== 'list' && sharingId !== project.id ? (
+                <span className="recent-projects__card-badge recent-projects__card-badge--shared">
+                  <Icon name="swap" size={13} />
+                  {t('recentProjects.sharedBadge')}
+                </span>
+              ) : null}
               {actionsAvailable && !selectionMode ? (
                 <div
                   className="recent-projects__card-menu-anchor"
@@ -1939,7 +1939,7 @@ export function RecentProjectsStrip({
                           title={creator.ownedBySelf ? undefined : t('recentProjects.ownOnlyMutation')}
                           onClick={() => startRename(project)}
                         >
-                          <Icon name="pencil" size={12} />
+                          <Icon name="pencil" size={14} />
                           <span>{t('designs.menuRename')}</span>
                         </button>
                       ) : null}
@@ -1959,7 +1959,7 @@ export function RecentProjectsStrip({
                           title={creator.ownedBySelf ? undefined : t('recentProjects.ownOnlyMutation')}
                           onClick={() => requestDuplicate(project)}
                         >
-                          <Icon name="copy" size={12} />
+                          <Icon name="copy" size={14} />
                           <span>{t('designs.menuDuplicate')}</span>
                         </button>
                       ) : null}
@@ -1978,7 +1978,7 @@ export function RecentProjectsStrip({
                           disabled={unsharingId === project.id}
                           onClick={() => requestMove(project, 'to-personal')}
                         >
-                          <Icon name="close" size={12} />
+                          <Icon name="close" size={14} />
                           <span>
                             {unsharingId === project.id
                               ? t('recentProjects.unshareInProgress')
@@ -1993,7 +1993,7 @@ export function RecentProjectsStrip({
                           title={!creator.ownedBySelf ? t('recentProjects.ownOnlyMutation') : undefined}
                           onClick={() => requestMove(project, 'to-team')}
                         >
-                          <Icon name="share" size={12} />
+                          <Icon name="share" size={14} />
                           <span>
                             {sharingId === project.id
                               ? t('recentProjects.shareInProgress')
@@ -2023,7 +2023,7 @@ export function RecentProjectsStrip({
                           title={creator.ownedBySelf ? undefined : t('recentProjects.ownOnlyMutation')}
                           onClick={() => requestDelete(project)}
                         >
-                          <Icon name="close" size={12} />
+                          <Icon name="close" size={14} />
                           <span>{t('designs.menuDelete')}</span>
                         </button>
                       ) : null}
@@ -2719,25 +2719,50 @@ export function projectCategory(project: Project): ProjectCategory {
   return 'prototype';
 }
 
+/** The glyph each kind chip leads with — the same icon that kind wears in the
+ *  Home type rail, so a card and the rail name the same thing the same way. */
+const PROJECT_TAG_ICON: Record<ProjectCardCategory, IconName> = {
+  prototype: 'artboard',
+  'live-artifact': 'bar-chart-box',
+  'web-clone': 'globe',
+  slide: 'present',
+  media: 'image',
+  brand: 'swatchbook',
+  'design-system': 'sliders',
+};
+
+function projectTagLabel(category: ProjectCategory, t: ReturnType<typeof useT>): string {
+  return category === 'live-artifact'
+    ? t('designs.tagLiveArtifact')
+    : category === 'web-clone'
+      ? t('designs.tagWebClone')
+      : category === 'slide'
+        ? t('designs.tagSlide')
+        : category === 'brand'
+          ? 'Brand'
+        : category === 'media'
+          ? t('designs.tagMedia')
+          : t('designs.tagPrototype');
+}
+
 export function ProjectTag({ category }: { category: ProjectCategory }) {
   const t = useT();
-  const label =
-    category === 'live-artifact'
-      ? t('designs.tagLiveArtifact')
-      : category === 'web-clone'
-        ? t('designs.tagWebClone')
-        : category === 'slide'
-          ? t('designs.tagSlide')
-          : category === 'brand'
-            ? 'Brand'
-          : category === 'media'
-            ? t('designs.tagMedia')
-            : t('designs.tagPrototype');
-  return <span className={`design-card-tag tag-${category}`}>{label}</span>;
+  const label = projectTagLabel(category, t);
+  return (
+    <span className={`design-card-tag tag-${category}`}>
+      <Icon name={PROJECT_TAG_ICON[category]} size={12} className="design-card-tag__icon" />
+      {label}
+    </span>
+  );
 }
 
 function DesignSystemProjectTag() {
-  return <span className="design-card-tag tag-design-system">{DESIGN_SYSTEM_TAG_LABEL}</span>;
+  return (
+    <span className="design-card-tag tag-design-system">
+      <Icon name={PROJECT_TAG_ICON['design-system']} size={12} className="design-card-tag__icon" />
+      {DESIGN_SYSTEM_TAG_LABEL}
+    </span>
+  );
 }
 
 function findDesignSystemLogoFile(files: ProjectFile[]): ProjectFile | null {

--- a/apps/web/src/components/UpdateDialog.module.css
+++ b/apps/web/src/components/UpdateDialog.module.css
@@ -5,8 +5,9 @@
   display: grid;
   place-items: center;
   padding: 24px;
-  background: color-mix(in srgb, #111 28%, transparent);
-  backdrop-filter: blur(2px);
+  background: var(--scrim-tint);
+  -webkit-backdrop-filter: var(--scrim-backdrop);
+  backdrop-filter: var(--scrim-backdrop);
   animation: updateBackdropIn 160ms ease-out;
 }
 

--- a/apps/web/src/components/WhatsNewPopup.module.css
+++ b/apps/web/src/components/WhatsNewPopup.module.css
@@ -7,13 +7,10 @@
   gap: 0;
 }
 
-/* Frosted sheet over the page — a translucent glass shape that carries the
-   blur (per the Liquid Glass material tokens), not a raw blur of the view. */
-.backdrop.backdrop {
-  background: var(--glass-regular);
-  backdrop-filter: blur(var(--glass-regular-blur, 28px));
-  -webkit-backdrop-filter: blur(var(--glass-regular-blur, 28px));
-}
+/* No scrim override: this used to wear the Liquid Glass material
+   (--glass-regular + a 28px glass blur), which is the language of PANELS, not
+   of the sheet behind them. It now takes the shared `<Dialog>` scrim like
+   every other overlay. */
 
 /* The cover sits inset as its own card, at the image's natural aspect ratio. */
 .cover {

--- a/apps/web/src/components/WorkspaceTabsBar.tsx
+++ b/apps/web/src/components/WorkspaceTabsBar.tsx
@@ -16,7 +16,15 @@ import {
 import { useT } from '../i18n';
 import { buildPath, navigate, type EntryHomeView, type Route } from '../router';
 import type { Project } from '../types';
+import type { ProjectDisplayStatus, WorkspaceCollabContext } from '@open-design/contracts';
 import { Icon, type IconName } from './Icon';
+import { hasRunStatusGlyph, ProjectRunStatusIcon } from './ProjectRunStatusIcon';
+import {
+  ProjectHoverPreviewCard,
+  useProjectHoverCover,
+} from './entry-nav-rail/ProjectHoverPreview';
+import { useProjectRunStatuses } from '../hooks/useProjectRunStatuses';
+import { STATUS_LABEL_KEYS } from '../state/projectRunStatus';
 import {
   HOME_APPLY_TEMPLATE_EVENT,
   orderedCreateChips,
@@ -25,9 +33,14 @@ import {
 import {
   ENTRY_RAIL_STATE_EVENT,
   ENTRY_RAIL_TOGGLE_EVENT,
+  ENTRY_SEARCH_OPEN_EVENT,
   readStoredRailOpen,
 } from './entryRailBridge';
+import { useAnalytics } from '../analytics/provider';
+import { trackEntryNavigationClick } from '../analytics/events';
+import { entryViewToTracking } from '../analytics/workspace';
 import { homeHeroChipLabel } from './home-hero/chip-labels';
+import { isMacPlatform } from '../utils/platform';
 import { useGlideIndicator } from '../hooks/useGlideIndicator';
 import { useLiquidGlass } from '../hooks/useLiquidGlass';
 import { WORKSPACE_CHROME_ACCOUNT_ACTIONS_ID } from './workspaceChromeActions';
@@ -116,7 +129,27 @@ interface Props {
    * tab without exposing those tabs in another scope.
    */
   identityScopeKey?: string | null;
+  /**
+   * Workspace headers for the per-project run lookups behind the dropdown's
+   * status glyphs and the hover preview's cover read. Optional: without it the
+   * requests go unscoped, which is correct for a local/unbound session and
+   * simply returns nothing readable in a workspace one.
+   */
+  workspaceContext?: WorkspaceCollabContext | null;
 }
+
+/* Dwell before the dock dropdown's hover preview commits to a row. Long
+   enough that running the pointer down the list to reach the bottom entry
+   mounts nothing on the way, short enough that stopping on a row feels
+   immediate. */
+const PREVIEW_HOVER_DELAY_MS = 180;
+
+/* The preview card is the rail's own (`.entry-nav-rail__recent-preview`, 216px
+   wide, centred on the row through translateY(-50%)). Kept in JS too because
+   the card is portaled to <body> and has to decide for itself which side of
+   the menu it fits on. */
+const PREVIEW_WIDTH_PX = 216;
+const PREVIEW_GAP_PX = 8;
 
 const STORAGE_KEY = 'open-design:workspace-tabs:v1';
 const OPEN_WORKSPACE_TAB_EVENT = 'open-design:workspace-tabs:open';
@@ -649,12 +682,72 @@ function shouldRehomeAuthorizedProjectAfterSignIn({
 
 
 /** Corner home glyph (per product: the brand tile gave way to a plain home
- *  icon). `currentColor` so it follows the button's muted/hover ink. */
+ *  icon). Renders the SAME glyph as the rail's 首页 item (`Icon name="home"`)
+ *  rather than a hand-inlined path: the two sit on one vertical axis, so a
+ *  different house drawing read as a bug. `currentColor` so it follows the
+ *  button's muted/hover ink. */
 function ChromeHomeGlyph() {
+  return <Icon name="home" size={16} className="workspace-chrome-logo" />;
+}
+
+/**
+ * The glyph leading one dropdown row.
+ *
+ * A project row with something to report shows its run status; every other row
+ * — nothing running, a status that draws nothing (not_started / canceled), a
+ * status that has not arrived yet, or a non-project tab like the plugin
+ * marketplace — leads with the row's own icon, the folder (per product: 空的
+ * 那个位置放文件夹 icon). The slot is therefore never empty, and the column
+ * never has to decide whether to exist. Same component the rail's 最近项目 rows
+ * lead with (RailRecentRow), so the two can never tell different stories about
+ * the same project (OPEND-2694).
+ *
+ * Unknown is deliberately treated as "nothing to report" rather than guessed
+ * at: a guess would flash the wrong status glyph on every open.
+ */
+function leadGlyphFor(
+  tab: WorkspaceChromeTab,
+  display: DisplayTab,
+  runStatusByProjectId: ReadonlyMap<string, ProjectDisplayStatus>,
+  t: ReturnType<typeof useT>,
+): ReactNode {
+  const status = tab.kind === 'project' ? runStatusByProjectId.get(tab.projectId) : undefined;
+  if (!status || !hasRunStatusGlyph(status)) {
+    return <Icon name={display.icon} size={14} />;
+  }
   return (
-    <svg className="workspace-chrome-logo" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
-      <path d="M19 21H5C4.44772 21 4 20.5523 4 20V11L1 11L11.3273 1.6115C11.7087 1.26475 12.2913 1.26475 12.6727 1.6115L23 11L20 11V20C20 20.5523 19.5523 21 19 21ZM6 19H18V9.15745L12 3.7029L6 9.15745V19ZM8 15H16V17H8V15Z" />
-    </svg>
+    <ProjectRunStatusIcon status={status} size={14} label={t(STATUS_LABEL_KEYS[status])} />
+  );
+}
+
+/**
+ * The hovered row's preview: the rail's own card (`ProjectHoverPreviewCard`),
+ * parked beside the open menu. Its own component so the cover hook runs for
+ * exactly one project at a time — the one under the pointer — and re-mounts
+ * (fresh cover, fresh plate) when the hovered row changes.
+ */
+function DockRowPreview({
+  project,
+  workspaceContext,
+  anchor,
+}: {
+  project: Project;
+  workspaceContext: WorkspaceCollabContext | null;
+  anchor: { top: number; left: number };
+}) {
+  const cover = useProjectHoverCover(project, workspaceContext);
+  const { resolveCover } = cover;
+  useEffect(() => {
+    void resolveCover();
+  }, [resolveCover]);
+  return createPortal(
+    <ProjectHoverPreviewCard
+      project={project}
+      cover={cover}
+      style={{ top: anchor.top, left: anchor.left }}
+      testId="workspace-tabs-dropdown-preview"
+    />,
+    document.body,
   );
 }
 
@@ -664,8 +757,15 @@ export function WorkspaceTabsBar({
   activeProjectWorkspaceId,
   onboardingCompleted = false,
   identityScopeKey,
+  workspaceContext = null,
 }: Props) {
   const t = useT();
+  const analytics = useAnalytics();
+  // Same binding the rail's own collapse control advertised (EntryShell owns
+  // the keydown handler); named here so the expand direction says it too.
+  const expandHint = `${t('entry.navExpand')} ${isMacPlatform() ? '⌘B' : 'Ctrl+B'}`;
+  const collapseHint = `${t('entry.navCollapse')} ${isMacPlatform() ? '⌘B' : 'Ctrl+B'}`;
+  const searchHint = `${t('common.search')} ${isMacPlatform() ? '⌘K' : 'Ctrl+K'}`;
   const [persistedTabsStore] = useState(readPersistedTabsStore);
   const [state, setState] = useState<WorkspaceTabsState>(
     () => initialTabsState(route, persistedTabsStore, identityScopeKey),
@@ -856,6 +956,82 @@ export function WorkspaceTabsBar({
   useEffect(() => {
     if (!tabsDockEl) setDockMenuOpen(false);
   }, [tabsDockEl]);
+
+  // Run status for the dock dropdown's rows. Only fetched while that menu is
+  // open: it costs one request per open project tab, and the glyphs it feeds
+  // are not on screen otherwise.
+  const dropdownProjectIds = useMemo(
+    () =>
+      state.tabs
+        .filter((tab): tab is Extract<WorkspaceChromeTab, { kind: 'project' }> =>
+          tab.kind === 'project')
+        .map((tab) => tab.projectId),
+    [state.tabs],
+  );
+  const runStatusByProjectId = useProjectRunStatuses(dropdownProjectIds, {
+    enabled: dockMenuOpen,
+    workspaceContext,
+  });
+
+  // Hovered row in the dock dropdown — the one the preview card is showing.
+  // A row only claims it after a short dwell: sweeping the pointer down the
+  // list would otherwise mount (and abandon) one cover read per row it
+  // crossed. Leaving the menu clears it, so at most one preview is ever live.
+  const [previewTabId, setPreviewTabId] = useState<string | null>(null);
+  const [previewAnchor, setPreviewAnchor] = useState<{ top: number; left: number } | null>(null);
+  const previewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const dockMenuRef = useRef<HTMLDivElement | null>(null);
+  const cancelPreviewTimer = useCallback(() => {
+    if (previewTimerRef.current === null) return;
+    clearTimeout(previewTimerRef.current);
+    previewTimerRef.current = null;
+  }, []);
+  // The card is the rail's: 216px wide, centred on the hovered ROW
+  // (translateY(-50%)), and parked just past the menu's right edge — or its
+  // left when the window has no room there (narrow window, chat column docked
+  // on the right).
+  const anchorPreviewTo = useCallback((row: HTMLElement) => {
+    const menuRect = dockMenuRef.current?.getBoundingClientRect() ?? row.getBoundingClientRect();
+    const rowRect = row.getBoundingClientRect();
+    const right = menuRect.right + PREVIEW_GAP_PX;
+    const fits = right + PREVIEW_WIDTH_PX + PREVIEW_GAP_PX <= window.innerWidth;
+    return {
+      top: rowRect.top + rowRect.height / 2,
+      left: fits ? right : Math.max(PREVIEW_GAP_PX, menuRect.left - PREVIEW_GAP_PX - PREVIEW_WIDTH_PX),
+    };
+  }, []);
+  const queuePreview = useCallback((tabId: string, row: HTMLElement) => {
+    cancelPreviewTimer();
+    previewTimerRef.current = setTimeout(() => {
+      previewTimerRef.current = null;
+      setPreviewAnchor(anchorPreviewTo(row));
+      setPreviewTabId(tabId);
+    }, PREVIEW_HOVER_DELAY_MS);
+  }, [anchorPreviewTo, cancelPreviewTimer]);
+  const showPreviewNow = useCallback((tabId: string, row: HTMLElement) => {
+    cancelPreviewTimer();
+    setPreviewAnchor(anchorPreviewTo(row));
+    setPreviewTabId(tabId);
+  }, [anchorPreviewTo, cancelPreviewTimer]);
+  const clearPreview = useCallback(() => {
+    cancelPreviewTimer();
+    setPreviewTabId(null);
+    setPreviewAnchor(null);
+  }, [cancelPreviewTimer]);
+  // Closing the menu (or unmounting) must not leave a queued preview to fire
+  // into a menu that is gone.
+  useEffect(() => {
+    if (!dockMenuOpen) clearPreview();
+  }, [dockMenuOpen, clearPreview]);
+  useEffect(() => cancelPreviewTimer, [cancelPreviewTimer]);
+
+  // Full-page settings borrows CHAT's chrome row: a lone Home logo at the left
+  // edge, no search / rail toggle. App swaps EntryShell out for the settings
+  // surface on this route, so the rail those two controls drive isn't mounted —
+  // the toggle collapses nothing and the ⌘K search (an EntryShell listener)
+  // never hears the event. The strip stays undocked here, so the row is the
+  // docked layout minus the dock: same button, same x, nothing else.
+  const settingsPageChrome = route.kind === 'home' && route.view === 'settings';
 
   // Refresh the fallback cache from whatever this fetch actually returned,
   // before `displayTabFor` below reads it — same render pass, so a tab
@@ -1623,6 +1799,16 @@ export function WorkspaceTabsBar({
     const projectTabs = state.tabs
       .filter((tab) => tab.kind !== 'entry')
       .sort((a, b) => mruRank(a) - mruRank(b));
+    // The hovered row's project, if the ambient list actually carries it. A tab
+    // can name a project this list has not loaded (deep link, other workspace);
+    // that row simply previews nothing rather than showing an empty card.
+    const previewTab = previewTabId
+      ? projectTabs.find((tab) => tab.id === previewTabId)
+      : undefined;
+    const previewProject =
+      previewTab && previewTab.kind === 'project'
+        ? projectById.get(previewTab.projectId) ?? null
+        : null;
     return (
       <div className="workspace-tabs-dropdown" data-testid="workspace-tabs-dropdown">
         <button
@@ -1645,7 +1831,12 @@ export function WorkspaceTabsBar({
               className="workspace-tabs-dropdown__backdrop"
               onClick={() => setDockMenuOpen(false)}
             />
-            <div className="workspace-tabs-dropdown__menu" role="listbox">
+            <div
+              ref={dockMenuRef}
+              className="workspace-tabs-dropdown__menu"
+              role="listbox"
+              onMouseLeave={clearPreview}
+            >
               {projectTabs.map((tab) => {
                 const display =
                   displayTabById.get(tab.id)
@@ -1665,15 +1856,42 @@ export function WorkspaceTabsBar({
                         setDockMenuOpen(false);
                         openTab(tab);
                       }}
+                      /* Focus previews too, so the card is not mouse-only:
+                         arrowing/tabbing the list shows the same picture. */
+                      onMouseEnter={(event) => queuePreview(tab.id, event.currentTarget)}
+                      onFocus={(event) => showPreviewNow(tab.id, event.currentTarget)}
                     >
-                      <Icon name={display.icon} size={14} />
+                      {/* Always up: every row fills the slot now — a run
+                          status when there is one, the folder icon otherwise —
+                          so the column can't half-exist and names stay on one
+                          shared left edge. */}
+                      <span className="workspace-tabs-dropdown__row-lead">
+                        {leadGlyphFor(tab, display, runStatusByProjectId, t)}
+                      </span>
                       <span className="workspace-tabs-dropdown__row-label">{display.title}</span>
-                      {active ? <Icon name="check" size={14} /> : null}
+                      {active ? (
+                        <Icon name="check" size={14} className="workspace-tabs-dropdown__row-check" />
+                      ) : null}
                     </button>
                   </div>
                 );
               })}
             </div>
+            {/* Preview of the hovered row, parked beside the menu — the rail's
+                own card, so the switcher and the 最近项目 list show one and the
+                same picture for a project. Purely informational (aria-hidden,
+                no pointer events), so it can't sit between the pointer and a
+                row. */}
+            {previewProject && previewAnchor && typeof document !== 'undefined' ? (
+              <DockRowPreview
+                /* Keyed by project so switching rows remounts the card instead
+                   of pointing a live cover at a new project. */
+                key={previewProject.id}
+                project={previewProject}
+                workspaceContext={workspaceContext}
+                anchor={previewAnchor}
+              />
+            ) : null}
           </>
         ) : null}
       </div>
@@ -1692,7 +1910,7 @@ export function WorkspaceTabsBar({
           the workspace 设计文件 row. The strip's own pinned entry tab hides
           inside the dock (CSS) — this button is its chrome-row stand-in.
           In chat the logo means 回到首页. */}
-      {tabsDockEl && state.tabs[0] ? (
+      {(tabsDockEl || settingsPageChrome) && state.tabs[0] ? (
         <button
           type="button"
           className="workspace-tabs-home-chrome od-tooltip"
@@ -1774,8 +1992,9 @@ export function WorkspaceTabsBar({
                   className={`workspace-tab__rail-toggle od-tooltip${entryRailOpen ? ' is-inert' : ''}`}
                   aria-label={entryRailOpen ? t('entry.navHome') : t('entry.navExpand')}
                   aria-expanded={entryRailOpen}
-                  title={entryRailOpen ? undefined : t('entry.navExpand')}
-                  data-tooltip={entryRailOpen ? undefined : t('entry.navExpand')}
+                  title={entryRailOpen ? undefined : expandHint}
+                  data-tooltip={entryRailOpen ? undefined : expandHint}
+                  aria-keyshortcuts={isMacPlatform() ? 'Meta+B' : 'Control+B'}
                   data-tooltip-placement="bottom"
                   data-testid="workspace-home-rail-toggle"
                   onClick={(event) => {
@@ -1856,6 +2075,70 @@ export function WorkspaceTabsBar({
             </div>
           );
         })}
+        {/* Search + the rail toggle, moved out of the rail and up into the
+            chrome row (per product: 搜索和收起跟 home icon 一起放在顶部). They
+            are this row's only controls now — the pinned Home pill is hidden
+            here by CSS (routines.css), so the toggle owns BOTH directions: it
+            stays rendered while the rail is collapsed, where the pill used to
+            be the expand control. Only the undocked (entry) chrome shows them,
+            and only on routes that actually mount EntryShell — in chat the
+            strip lives in the column dock and there is no entry rail to
+            toggle, and full-page settings replaces the rail outright
+            (settingsPageChrome). Both targets live in EntryShell's tree, so the
+            clicks travel as window events (see entryRailBridge). The classes
+            are the rail's own, so the controls keep their look. */}
+        {!tabsDockEl && !settingsPageChrome ? (
+          <div className="entry-nav-rail__search-row workspace-tabs-rail-actions">
+            <button
+              type="button"
+              className="entry-nav-rail__search od-tooltip"
+              aria-label={t('common.search')}
+              aria-keyshortcuts={isMacPlatform() ? 'Meta+K' : 'Control+K'}
+              /* The rail revealed ⌘K by widening the control on hover; here the
+                 toggle sits right beside it and would get shoved sideways, so
+                 the shortcut rides the hover bubble instead — same as the
+                 toggle's own 收起侧栏 ⌘B. */
+              title={searchHint}
+              data-tooltip={searchHint}
+              data-tooltip-placement="bottom"
+              data-testid="entry-nav-search"
+              onClick={() => {
+                const activeTab = state.tabs.find((tab) => tab.id === state.activeTabId);
+                trackEntryNavigationClick(analytics.track, {
+                  // Same event the control fired from inside the rail; only
+                  // `entry_from` is dropped, since neither of its two values
+                  // (sidebar / workspace_switcher) describes the chrome row.
+                  page_name:
+                    activeTab?.kind === 'entry' ? entryViewToTracking(activeTab.view) : 'project',
+                  area: 'entry_nav',
+                  element: 'search',
+                  target: 'search',
+                });
+                window.dispatchEvent(new CustomEvent(ENTRY_SEARCH_OPEN_EVENT));
+              }}
+            >
+              <Icon name="search" size={16} />
+            </button>
+            <button
+              type="button"
+              className="entry-nav-rail__collapse od-tooltip"
+              aria-label={entryRailOpen ? t('entry.navCollapse') : t('entry.navExpand')}
+              aria-expanded={entryRailOpen}
+              aria-keyshortcuts={isMacPlatform() ? 'Meta+B' : 'Control+B'}
+              title={entryRailOpen ? collapseHint : expandHint}
+              data-tooltip={entryRailOpen ? collapseHint : expandHint}
+              data-tooltip-placement="bottom"
+              data-testid="entry-rail-collapse"
+              onClick={() => {
+                window.dispatchEvent(new CustomEvent(ENTRY_RAIL_TOGGLE_EVENT));
+              }}
+            >
+              {/* The bar sits on the side the rail is on while it is open, and
+                  flips out of the frame once it is collapsed. */}
+              <Icon name={entryRailOpen ? 'layout-left' : 'layout-right'} size={16} />
+            </button>
+          </div>
+        ) : null}
         {/* #5517 drops the top-right "+"; new tab stays reachable through
             ⌘/Ctrl+T. That "+" was the ONLY caller of openRadialMenu, so the
             radial template menu below is now unreachable — its state and

--- a/apps/web/src/components/entry-nav-rail/ProjectHoverPreview.tsx
+++ b/apps/web/src/components/entry-nav-rail/ProjectHoverPreview.tsx
@@ -1,0 +1,160 @@
+// The hover preview card the rail's 最近项目 rows float beside themselves —
+// the cover plate over the wrapped project name — and the cover pipeline that
+// feeds it.
+//
+// Both halves are exported so the chat project switcher (WorkspaceTabsBar's
+// dock dropdown) can show the SAME card for the same project (OPEND-2694:
+// 顶部项目列表应与 Home 侧栏一致): one markup, one stylesheet block
+// (`.entry-nav-rail__recent-preview*` in home/entry-layout.css), one cover
+// decision. A second implementation would have drifted the moment either
+// surface was tuned.
+//
+// The cover reuses the decision the projects grid renders
+// (`lib/project-cover-cache`): the grid resolves a cover per (workspace,
+// project, version) and stores it in a process-wide LRU, so a row usually has
+// one already and paints instantly. When the cache misses — the user landed on
+// a surface that never rendered the grid — the row resolves it once on hover
+// with the cheap half of the grid's pipeline (files read +
+// `selectProjectFileCover`) and writes the result back through the same key,
+// so the grid inherits it too. Deliberately NOT ported: the grid's HEAD probe,
+// deck-document preload and design-system special cases. Those exist to avoid
+// a broken <img> in a large visible card; here a cover that fails to load
+// simply falls back to the tinted glyph the same component already draws.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { CSSProperties } from 'react';
+
+import type { WorkspaceCollabContext } from '@open-design/contracts';
+
+import { fetchProjectFiles } from '../../providers/registry';
+import { workspaceIdentityCacheKey } from '../../collab/workspace-identity';
+import {
+  getProjectCoverSnapshot,
+  projectCoverSnapshotKey,
+  setProjectCoverSnapshot,
+} from '../../lib/project-cover-cache';
+import {
+  projectCoverUrl,
+  selectProjectFileCover,
+  type ProjectCoverOverride,
+} from '../project-cover';
+import type { Project } from '../../types';
+
+/** `undefined` = not resolved yet; `null` = resolved, this project has none. */
+type CoverState = ProjectCoverOverride | null | undefined;
+
+export interface ProjectHoverCover {
+  /** Resolve the cover once (cache-first); safe to call on every hover. */
+  resolveCover: () => Promise<void>;
+  coverSrc: string | null;
+  showsImage: boolean;
+  showsVideo: boolean;
+}
+
+/**
+ * The cover behind one project's hover preview. The async resolve checks it is
+ * still mounted before it sets state, so a row that leaves (the list re-sorts,
+ * the rail closes) mid-read is simply dropped.
+ */
+export function useProjectHoverCover(
+  project: Project,
+  workspaceContext: WorkspaceCollabContext | null | undefined,
+): ProjectHoverCover {
+  const snapshotKey = projectCoverSnapshotKey(
+    workspaceIdentityCacheKey(workspaceContext),
+    project.id,
+    project.updatedAt,
+  );
+  const [cover, setCover] = useState<CoverState>(
+    () => getProjectCoverSnapshot(snapshotKey)?.cover,
+  );
+  const activeRef = useRef(true);
+  useEffect(() => {
+    activeRef.current = true;
+    return () => {
+      activeRef.current = false;
+    };
+  }, []);
+
+  // A newer version of the project (rename, new content) misses the old key, so
+  // the row drops back to unresolved and re-reads on the next hover.
+  useEffect(() => {
+    setCover(getProjectCoverSnapshot(snapshotKey)?.cover);
+  }, [snapshotKey]);
+
+  const resolveCover = useCallback(async () => {
+    if (getProjectCoverSnapshot(snapshotKey) !== undefined) return;
+    // An imported-folder project has no artifact of its own to show.
+    if (project.metadata?.entryFile) {
+      setProjectCoverSnapshot(snapshotKey, null);
+      if (activeRef.current) setCover(null);
+      return;
+    }
+    try {
+      const files = await fetchProjectFiles(project.id, { workspaceContext });
+      const next = selectProjectFileCover(files);
+      setProjectCoverSnapshot(snapshotKey, next);
+      if (activeRef.current) setCover(next);
+    } catch {
+      // Leave it unresolved: a failed read is not an authoritative "no cover",
+      // and the next hover should be allowed to try again.
+    }
+  }, [project.id, project.metadata?.entryFile, snapshotKey, workspaceContext]);
+
+  const coverSrc = cover
+    ? projectCoverUrl(project.id, cover.name, cover.mtime, workspaceContext)
+    : null;
+  // `html` covers are documents, not pictures: the grid mounts a sandboxed frame
+  // for those. A floating preview is not worth a second iframe per hover, so
+  // only real media paints here and everything else takes the glyph.
+  const showsImage = Boolean(coverSrc && (cover?.kind === 'image' || cover?.kind === 'logo'));
+  const showsVideo = Boolean(coverSrc && cover?.kind === 'video');
+
+  return { resolveCover, coverSrc, showsImage, showsVideo };
+}
+
+/**
+ * The card itself: cover plate + the full name given room to wrap. Purely
+ * informational — `aria-hidden`, no pointer events (the stylesheet) — so it can
+ * never sit between the pointer and the row that spawned it. The caller owns
+ * WHERE it goes (`style` carries the fixed top/left the row measured) and
+ * portals it to <body>: inside the rail or the chat column it would stay behind
+ * the content beside it whatever its z-index.
+ */
+export function ProjectHoverPreviewCard({
+  project,
+  cover,
+  style,
+  testId,
+}: {
+  project: Project;
+  cover: Pick<ProjectHoverCover, 'coverSrc' | 'showsImage' | 'showsVideo'>;
+  style: CSSProperties;
+  testId?: string;
+}) {
+  const { coverSrc, showsImage, showsVideo } = cover;
+  return (
+    <div
+      className="entry-nav-rail__recent-preview"
+      style={style}
+      aria-hidden
+      {...(testId ? { 'data-testid': testId } : {})}
+    >
+      <div className="entry-nav-rail__recent-preview-plate">
+        {showsImage ? (
+          <img src={coverSrc ?? ''} alt="" draggable={false} decoding="async" />
+        ) : showsVideo ? (
+          <video src={coverSrc ?? ''} muted playsInline preload="metadata" />
+        ) : (
+          <span className="entry-nav-rail__recent-preview-glyph" aria-hidden>
+            {(Array.from(project.name.trim())[0] ?? '?').toUpperCase()}
+          </span>
+        )}
+      </div>
+      {/* The name the row had to ellipsize, given room to wrap — that is the
+          whole job of this card. No timestamp line (per product: 时间去掉，最多
+          两行名称): a hover preview answers "which project is this". */}
+      <p className="entry-nav-rail__recent-preview-name">{project.name}</p>
+    </div>
+  );
+}

--- a/apps/web/src/components/entry-nav-rail/RailRecentRow.tsx
+++ b/apps/web/src/components/entry-nav-rail/RailRecentRow.tsx
@@ -1,19 +1,11 @@
-// One row of the nav rail's 最近浏览过 list: the project name, a hover preview
+// One row of the nav rail's 最近项目 list: the project name, a hover preview
 // that floats out to the right of the rail, and a ⋮ menu.
 //
-// The preview reuses the SAME cover decision the projects grid renders
-// (`lib/project-cover-cache`): the grid resolves a cover per (workspace,
-// project, version) and stores it in a process-wide LRU, so a rail row usually
-// has one already and paints instantly. When the cache misses — the user landed
-// on a surface that never rendered the grid — the row resolves it once on hover
-// with the cheap half of the grid's pipeline (files read + `selectProjectFileCover`)
-// and writes the result back through the same key, so the grid inherits it too.
-// Deliberately NOT ported: the grid's HEAD probe, deck-document preload and
-// design-system special cases. Those exist to avoid a broken <img> in a large
-// visible card; here a cover that fails to load simply falls back to the tinted
-// glyph the same component already draws.
+// The preview card and the cover decision behind it live in
+// `ProjectHoverPreview.tsx`, shared with the chat project switcher so both
+// surfaces show one and the same card for a project (OPEND-2694).
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import type { ProjectDisplayStatus, WorkspaceCollabContext } from '@open-design/contracts';
@@ -23,22 +15,8 @@ import { RemixIcon } from '../RemixIcon';
 import { hasRunStatusGlyph, ProjectRunStatusIcon } from '../ProjectRunStatusIcon';
 import { STATUS_LABEL_KEYS } from '../../state/projectRunStatus';
 import { exportProjectAsZip } from '../../runtime/exports';
-import { fetchProjectFiles } from '../../providers/registry';
-import { workspaceIdentityCacheKey } from '../../collab/workspace-identity';
-import {
-  getProjectCoverSnapshot,
-  projectCoverSnapshotKey,
-  setProjectCoverSnapshot,
-} from '../../lib/project-cover-cache';
-import {
-  projectCoverUrl,
-  selectProjectFileCover,
-  type ProjectCoverOverride,
-} from '../project-cover';
 import type { Project } from '../../types';
-
-/** `undefined` = not resolved yet; `null` = resolved, this project has none. */
-type CoverState = ProjectCoverOverride | null | undefined;
+import { ProjectHoverPreviewCard, useProjectHoverCover } from './ProjectHoverPreview';
 
 /**
  * Which row currently owns a popup, and which one (per product: 两个弹窗互斥
@@ -174,14 +152,8 @@ export function RailRecentRow({
   onDelete?: (id: string) => Promise<boolean | void> | boolean | void;
 }) {
   const t = useT();
-  const snapshotKey = projectCoverSnapshotKey(
-    workspaceIdentityCacheKey(workspaceContext),
-    project.id,
-    project.updatedAt,
-  );
-  const [cover, setCover] = useState<CoverState>(
-    () => getProjectCoverSnapshot(snapshotKey)?.cover,
-  );
+  const hoverCover = useProjectHoverCover(project, workspaceContext);
+  const { resolveCover } = hoverCover;
   // Where the portalled preview should sit, measured off the row at hover time.
   const [anchor, setAnchor] = useState<{ top: number; left: number } | null>(null);
   // This row's view of the shared claim (see `claimPopup`). Both popups render
@@ -209,41 +181,13 @@ export function RailRecentRow({
   const rootRef = useRef<HTMLDivElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
   const renameInputRef = useRef<HTMLInputElement | null>(null);
-  const activeRef = useRef(true);
   useEffect(() => {
-    activeRef.current = true;
     return () => {
-      activeRef.current = false;
       // A row that leaves (the list re-sorts, the rail closes) must not leave
       // its popup claimed, or nothing else could ever open one.
       if (popupClaim?.rowId === project.id) claimPopup(null);
     };
   }, [project.id]);
-
-  // A newer version of the project (rename, new content) misses the old key, so
-  // the row drops back to unresolved and re-reads on the next hover.
-  useEffect(() => {
-    setCover(getProjectCoverSnapshot(snapshotKey)?.cover);
-  }, [snapshotKey]);
-
-  const resolveCover = useCallback(async () => {
-    if (getProjectCoverSnapshot(snapshotKey) !== undefined) return;
-    // An imported-folder project has no artifact of its own to show.
-    if (project.metadata?.entryFile) {
-      setProjectCoverSnapshot(snapshotKey, null);
-      if (activeRef.current) setCover(null);
-      return;
-    }
-    try {
-      const files = await fetchProjectFiles(project.id, { workspaceContext });
-      const next = selectProjectFileCover(files);
-      setProjectCoverSnapshot(snapshotKey, next);
-      if (activeRef.current) setCover(next);
-    } catch {
-      // Leave it unresolved: a failed read is not an authoritative "no cover",
-      // and the next hover should be allowed to try again.
-    }
-  }, [project.id, project.metadata?.entryFile, snapshotKey, workspaceContext]);
 
   // Close the menu on an outside click, the way every other rail popover does.
   useEffect(() => {
@@ -287,15 +231,6 @@ export function RailRecentRow({
     if (!next || next === project.name) return;
     onRename?.(project.id, next);
   }
-
-  const coverSrc = cover
-    ? projectCoverUrl(project.id, cover.name, cover.mtime, workspaceContext)
-    : null;
-  // `html` covers are documents, not pictures: the grid mounts a sandboxed frame
-  // for those. A floating rail preview is not worth a second iframe per hover,
-  // so only real media paints here and everything else takes the glyph.
-  const showsImage = Boolean(coverSrc && (cover?.kind === 'image' || cover?.kind === 'logo'));
-  const showsVideo = Boolean(coverSrc && cover?.kind === 'video');
 
   return (
     <div
@@ -492,29 +427,11 @@ export function RailRecentRow({
           portals out). Rendered only while hovered, so a rail full of rows never
           holds a dozen idle <img> elements alive. */}
       {anchor && ownsPreview && typeof document !== 'undefined' ? createPortal(
-        <div
-          className="entry-nav-rail__recent-preview"
+        <ProjectHoverPreviewCard
+          project={project}
+          cover={hoverCover}
           style={{ top: anchor.top, left: anchor.left }}
-          aria-hidden
-        >
-          <div className="entry-nav-rail__recent-preview-plate">
-            {showsImage ? (
-              <img src={coverSrc ?? ''} alt="" draggable={false} decoding="async" />
-            ) : showsVideo ? (
-              <video src={coverSrc ?? ''} muted playsInline preload="metadata" />
-            ) : (
-              <span className="entry-nav-rail__recent-preview-glyph" aria-hidden>
-                {(Array.from(project.name.trim())[0] ?? '?').toUpperCase()}
-              </span>
-            )}
-          </div>
-          {/* The name the row had to ellipsize, given room to wrap — that is
-              the whole job of this card. The "last touched" line that used to
-              sit under it is gone (per product: 时间去掉，最多两行名称): a hover
-              preview answers "which project is this", and the timestamp was
-              answering a question nobody had asked it. */}
-          <p className="entry-nav-rail__recent-preview-name">{project.name}</p>
-        </div>,
+        />,
         document.body,
       ) : null}
     </div>

--- a/apps/web/src/components/entryRailBridge.ts
+++ b/apps/web/src/components/entryRailBridge.ts
@@ -12,6 +12,11 @@ export const RAIL_OPEN_STORAGE_KEY = 'od.entry.railOpen';
 // tab's sidebar toggle in WorkspaceTabsBar) to expand/collapse the entry rail.
 export const ENTRY_RAIL_TOGGLE_EVENT = 'od:entry-rail-toggle';
 
+// Window event dispatched by chrome outside the entry tree (the search button
+// that now sits in the chrome row beside the rail toggle) to open the ⌘K
+// project search palette, which EntryShell owns.
+export const ENTRY_SEARCH_OPEN_EVENT = 'od:entry-search-open';
+
 // Window event dispatched by EntryShell whenever the rail open state changes,
 // with `detail: { open: boolean }`, so outside chrome can mirror the state
 // (the pinned toggle's `aria-expanded`).

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -2776,7 +2776,7 @@
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: rgba(17, 24, 39, 0.75);
+  background: var(--scrim-tint);
   -webkit-backdrop-filter: var(--scrim-backdrop);
   backdrop-filter: var(--scrim-backdrop);
 }

--- a/apps/web/src/styles/design-system-flow.css
+++ b/apps/web/src/styles/design-system-flow.css
@@ -964,7 +964,7 @@ a.ds-source-link-open:focus-visible {
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: color-mix(in srgb, var(--bg) 68%, transparent);
+  background: var(--scrim-tint);
   -webkit-backdrop-filter: var(--scrim-backdrop);
   backdrop-filter: var(--scrim-backdrop);
 }

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -112,82 +112,36 @@
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  /* Top margin 0: the tab bar already contributes a 10px gap below the tabs
-     (its bottom padding), so the single visible gap between the tabs and this
-     rail card stays 10px instead of doubling to 20 (tab 10 + rail 10). */
-  margin: 0 10px 10px;
-  /* Bottom padding trimmed 12 → 5 so the account row's gap to the panel's
-     bottom edge (trigger padding 4 + footer padding 6 + 5 + 1px stroke = 16px)
-     matches its 16px left/right inset. */
-  padding: 10px 0 5px;
+  /* 12px gutters (per product): to the window's left edge, to the bottom, and
+     — through the right margin — to the content card beside it, so every
+     outer gap on this screen is the same number. Top margin 0: the tab bar
+     already contributes a 10px gap below the tabs (its bottom padding), so
+     the single visible gap between the tabs and this column stays 10px
+     instead of adding the rail's own inset on top of it. */
+  margin: 0 12px 12px;
+  /* No padding at all. Bottom: the account row has to land on the same
+     baseline as the content card's bottom edge beside it (per product:
+     账号行要和下边的边框对齐) — both boxes carry the same 12px bottom margin, so
+     the row's own bottom edge is flush with the card's only when nothing pads
+     it further up. Top: the workspace switcher leads the column flush with the
+     panel's top edge (per product) — the 10px that used to sit here was the
+     tab bar's own 10px bottom gap added a second time, exactly what the margin
+     note above says this box does not do. */
+  padding: 0;
   position: relative;
-  /* Craft-style milky frost (material.css thin tier): soft white surface over
-     the wash/wallpaper with a saturated blur, instead of fully clear glass. */
-  /* White frost: pure-white base at 65% alpha, so the card reads white but
-     keeps the frosted-glass translucency (the panel's material-thin backdrop
-     blur below does the frosting). */
-  --rail-surface: rgba(255, 255, 255, 0.65);
-  background: var(--rail-surface);
-  -webkit-backdrop-filter: var(--material-thin-backdrop);
-  backdrop-filter: var(--material-thin-backdrop);
-  /* The stroke is the gradient ring painted by ::after below — the real
-     border stays transparent so the box metrics don't change. */
-  border: 1px solid transparent;
-  border-radius: var(--radius-lg);
-  /* Whisper elevation: the floating panel only needs a hairline lift — the
-     md shadow read as a wide gray halo on the light ground. */
-  box-shadow: var(--shadow-sm);
-}
-/* Gradient rim, Craft-style: a light edge that is brightest along the top
-   and fades down the sides (glass-refract ring tokens, so dark mode halves
-   it automatically). Painted as a masked overlay so only the 1px ring shows
-   and the frosted surface underneath stays untouched. */
-.entry-nav-rail__panel::after {
-  content: '';
-  position: absolute;
-  inset: -1px;
-  border-radius: inherit;
-  padding: 1px;
-  pointer-events: none;
-  background: linear-gradient(
-    180deg,
-    var(--glass-refract-ring-top) 0%,
-    var(--glass-refract-ring-edge) 42%,
-    var(--glass-refract-ring-edge) 68%,
-    var(--glass-refract-ring-bottom) 100%
-  );
-  -webkit-mask:
-    linear-gradient(#000 0 0) content-box,
-    linear-gradient(#000 0 0);
-  -webkit-mask-composite: xor;
-  mask:
-    linear-gradient(#000 0 0) content-box,
-    linear-gradient(#000 0 0);
-  mask-composite: exclude;
-}
-/* Material spec fallbacks: drop the translucency to a solid per-theme surface
-   when the user reduces transparency or the browser lacks backdrop-filter. */
-@media (prefers-reduced-transparency: reduce) {
-  .entry-nav-rail__panel {
-    --rail-surface: var(--bg);
-    background: var(--rail-surface);
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
-    border-color: color-mix(in srgb, var(--border) 66%, transparent);
-  }
-  .entry-nav-rail__panel::after {
-    display: none;
-  }
-}
-@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
-  .entry-nav-rail__panel {
-    --rail-surface: var(--bg);
-    background: var(--rail-surface);
-    border-color: color-mix(in srgb, var(--border) 66%, transparent);
-  }
-  .entry-nav-rail__panel::after {
-    display: none;
-  }
+  /* No card of its own (per product): the rail sits flat on the entry ground,
+     and the single base card on this screen is the content column's
+     (`.entry-main--scroll` below). The milky-frost surface, the masked
+     gradient rim, the whisper shadow and the 1px transparent stroke this
+     panel used to carry are all gone with it, along with the
+     reduced-transparency / no-backdrop-filter fallbacks — nothing is painted
+     here any more.
+
+     Nothing being painted is also why this box is now exactly the row column:
+     with no stroke of its own and no padding on the group inside it (below),
+     the panel's border box IS the rows' box, so a row sits at this margin's
+     12px from the window edge — the same gutter the content card keeps on the
+     other side. */
 }
 .entry-nav-rail.is-open {
   pointer-events: auto;
@@ -285,6 +239,15 @@
     overflow: hidden;
     pointer-events: none;
   }
+  /* …and the content card takes over the left gutter, exactly as it does when
+     the user collapses the rail themselves. It cannot inherit that rule: the
+     auto-collapse deliberately KEEPS `.entry--rail-open` on the element so
+     widening restores the rail as it was, so `.entry:not(.entry--rail-open)
+     .entry-main--scroll` never matches at this width — and the card sat flush
+     against the window edge while the right side kept its 12. */
+  .entry-shell--no-header .entry.entry--rail-open .entry-main--scroll {
+    margin-left: 12px;
+  }
 }
 /* Topbar panel toggle — the single affordance left visible when the rail
    is collapsed. Sits at the left edge of the sticky topbar and is hidden
@@ -335,7 +298,11 @@
   flex: 1 1 auto;
   min-height: 0;
   width: 100%;
-  padding: 0 10px;
+  /* No horizontal inset: the rows measure their 12px to the window edge (and
+     to the content card on the other side) off the panel's margin alone —
+     see the note on `.entry-nav-rail__panel`. Rows carry their own 10px text
+     padding, so labels still breathe inside their hover fill. */
+  padding: 0;
 }
 .entry-nav-rail__footer {
   position: relative;
@@ -738,19 +705,37 @@
 .entry-nav-rail__btn {
   appearance: none;
   width: 100%;
-  height: 33px;
-  padding: 0 10px;
-  border: 1px solid transparent;
-  border-radius: 8px;
+  /* 10px of inset, except the LEADING edge, which carries 16 (per product):
+     the icon reads as indented from the row's fill rather than hugging it, and
+     the row's height is its content plus the vertical 10 (18px icon + 20 = 38)
+     rather than a pinned box. The old 33px height is what made the vertical
+     inset 8 — half the slack left over after the icon — while the sides
+     carried 10. `height: auto` is required, not incidental: primitives.css
+     sets a blanket `button { height: 36px }`, which took over the moment the
+     explicit 33 went away and squeezed the padded box back to 36 (the icon
+     then centred on it and overflowed its own content box). */
+  height: auto;
+  padding: 10px 10px 10px 16px;
+  /* No border: it was a 1px transparent ring no state ever paints (both the
+     hover and active rules below only re-assert `transparent`), and on a
+     border-box element it stole a pixel from every side — the inset measured
+     17, not the 16 the padding asks for. */
+  border: 0;
+  /* 12 (per product, read off the selected row). It lives on the base rule,
+     not on `.is-active`: this radius is the shape of the ROW'S FILL, and hover
+     paints that same fill — scoping it to the selected state alone would make
+     a row change shape as the pointer crosses it. */
+  border-radius: 12px;
   background: transparent;
   /* The workspace console entries (成员/数据大盘/Workspace 设置) render as
      anchors; the UA underline breaks the uniform nav-item look (#5517 rail
      items are plain). */
   text-decoration: none;
-  /* Unselected: label matches the icon's muted tone (one uniform color); hover
-     steps up to --text-strong, selection goes near-black on light gray.
-     68% lands the blend on the --text-soft step (52% read too faint). */
-  color: color-mix(in srgb, var(--text) 68%, transparent);
+  /* Unselected ink (per product: 选中和未选中要做出区分) — the rail's shared
+     quiet tone, the one the 最近浏览过 heading and its project rows carry, well
+     clear of the selected row's #121212. See `--rail-ink-quiet` on
+     `.entry-nav-rail`. */
+  color: var(--rail-ink-quiet);
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -767,8 +752,8 @@
   align-items: center;
   justify-content: center;
   flex: 0 0 18px;
-  /* Tracks the unselected label tone above. */
-  color: color-mix(in srgb, var(--text) 68%, transparent);
+  /* Tracks the label tone above — one ink for the whole row. */
+  color: inherit;
 }
 /* Unread marker on a rail item's icon — same 6px red dot as the account
    menu's `__menu-item-dot`, pinned to the glyph's top-right corner. */
@@ -793,7 +778,7 @@
 }
 .entry-nav-rail__btn-label {
   font-size: 13px;
-  font-weight: 400;
+  font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -872,6 +857,39 @@
   /* 2px between the rows (per product) — the same rhythm the destinations
      above keep. */
   gap: 2px;
+  /* Every recent project is listed (OPEND-2757: no more 8-row cap), so the
+     LIST scrolls rather than the rail. The cap is ~11 rows on a desktop
+     window — 11 × 38px rows + 10 × 2px gaps + the 2px top padding — and a
+     shorter window pulls it down further through the flex chain above
+     (`min-height: 0` on every ancestor up to the group), so the fixed rows
+     below the list (workspace settings, the footer) never get pushed out or
+     covered. Under the cap the box is content-sized: no scrollbar, no slack. */
+  min-height: 0;
+  max-height: calc(11 * 38px + 10 * 2px + 2px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+}
+/* The flex chain that lets the list above shrink with the window: each box
+   between the group and the list opts out of the `min-height: auto` floor and
+   passes the constraint down. The section and the disclosure never GROW —
+   `flex: 0 1 auto` — so a short list still leaves the rail exactly as it was. */
+.entry-nav-rail__team-section {
+  flex: 0 1 auto;
+  min-height: 0;
+}
+.entry-nav-rail__recent {
+  flex: 0 1 auto;
+  min-height: 0;
+}
+.entry-nav-rail__recent > .accordion-collapsible {
+  flex: 0 1 auto;
+  min-height: 0;
+}
+.entry-nav-rail__recent > .accordion-collapsible > .accordion-collapsible-inner {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 /* One recent row: the name button, the ⋮ trigger that overlays its trailing
    edge, and the hover preview that escapes the rail. `position: relative` is
@@ -1160,11 +1178,34 @@
   background: color-mix(in srgb, var(--text-strong) 10%, transparent);
   color: var(--text-strong);
 }
-.entry-nav-rail__btn.is-active .entry-nav-rail__btn-icon {
-  color: var(--selected);
+/* Selected ink is #121212 (per product), darker than `--selected`'s #353535.
+   A literal rather than a token change: `--selected` is the app-wide selected
+   ink and other surfaces read it — only the rail's own selected row moves.
+   The label is set explicitly too: it inherits from `.entry-nav-rail__btn`,
+   which the `.is-active` rule further down paints `var(--selected)`, so
+   leaving it out would have darkened the icon and left the text behind.
+   Dark mode keeps the token; #121212 is invisible on the dark ground. */
+.entry-nav-rail__btn.is-active .entry-nav-rail__btn-icon,
+.entry-nav-rail__btn.is-active .entry-nav-rail__btn-label {
+  color: #121212;
 }
 .entry-nav-rail__btn.is-active .entry-nav-rail__btn-label {
-  font-weight: 400;
+  font-weight: 600;
+}
+/* Dark mode only has to move the SELECTED row: every unselected row carries
+   `--rail-ink-quiet`, which the rail redefines for dark up top.
+   #121212 is invisible on the dark ground, so the selected row takes
+   --text-strong (#fafafa) — the same "one step brighter than its neighbours"
+   relationship the light theme draws. */
+[data-theme="dark"] .entry-nav-rail__btn.is-active .entry-nav-rail__btn-icon,
+[data-theme="dark"] .entry-nav-rail__btn.is-active .entry-nav-rail__btn-label {
+  color: var(--text-strong);
+}
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme]) .entry-nav-rail__btn.is-active .entry-nav-rail__btn-icon,
+  html:not([data-theme]) .entry-nav-rail__btn.is-active .entry-nav-rail__btn-label {
+    color: var(--text-strong);
+  }
 }
 
 /* Search box */
@@ -1172,15 +1213,16 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  /* No top margin: the search box's gap to the rail's top edge (panel
-     padding-top 10px + 1px stroke = 11px) then matches its 11px left/right
-     inset, instead of the extra 4px pushing it to 15px. */
   margin: 0 0 10px;
 }
 .entry-nav-rail__search-row .entry-nav-rail__search {
-  flex: 1;
+  /* Icon-sized at rest, matching the collapse control's 34px square. */
+  flex: 0 0 auto;
+  width: 34px;
   min-width: 0;
   margin: 0;
+  padding: 0;
+  justify-content: center;
 }
 .entry-nav-rail__search {
   display: flex;
@@ -1189,11 +1231,12 @@
   height: 34px;
   margin: 4px 0 10px;
   padding: 0 10px;
-  /* White to match the rail surface; a border keeps the input visible on it. */
-  border: 1px solid var(--border);
+  /* No stroke or fill: at rest this is just the magnifier sitting on the rail,
+     matching the collapse control beside it. */
+  border: 0;
   border-radius: var(--radius-large, 8px);
-  background: var(--rail-surface, #fff);
-  color: var(--text-soft);
+  background: transparent;
+  color: var(--text-muted);
   transition:
     background-color var(--duration-ultra-fast) var(--curve-easy-ease),
     border-color var(--duration-ultra-fast) var(--curve-easy-ease),
@@ -1207,10 +1250,9 @@
   cursor: pointer;
   text-align: left;
 }
-/* Search + rail-collapse in one row: the input keeps its own bordered look
-   and flexes; the collapse control sits after it (per product: 收起按钮放在
-   输入框后边) as a ghost icon button matching the input's height. The row
-   owns the vertical margins the lone search box used to carry. */
+/* Search + rail-collapse in one row, icon-only: the search is a magnifier the
+   size of the collapse control beside it. The row owns the vertical margins
+   the lone search box used to carry. */
 .entry-nav-rail__search-row {
   display: flex;
   align-items: center;
@@ -1218,9 +1260,14 @@
   margin: 4px 0 10px;
 }
 .entry-nav-rail__search-row .entry-nav-rail__search {
-  flex: 1;
+  /* Icon-sized at rest (see the sizing rule above); this later duplicate must
+     not put `flex: 1` back or the control stretches across the row again. */
+  flex: 0 0 auto;
+  width: 34px;
   min-width: 0;
   margin: 0;
+  padding: 0;
+  justify-content: center;
 }
 .entry-nav-rail__collapse {
   appearance: none;
@@ -1228,6 +1275,9 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  /* Holds the row's trailing edge now that the search no longer flexes into
+     it. */
+  margin-left: auto;
   flex: 0 0 auto;
   width: 34px;
   height: 34px;
@@ -1237,31 +1287,58 @@
   background: transparent;
   color: var(--text-muted);
 }
-.entry-nav-rail__collapse:hover {
-  background: var(--bg-fill-secondary);
+/* Search + collapse take the SAME fill as the rail's selected nav row —
+   `--text-strong` at 10% (per product: 这几个 icon 的选中和 hover 都和首页的
+   选中底色一致). They used to take `--bg-fill-secondary` (black at 6%), a
+   near-miss that read as a slightly different gray next to it.
+   These two rules also dress the pair once they are relocated into the top
+   chrome row (see the note below), so this covers both placements. Keep in
+   step with `.entry-nav-rail__btn.is-active`. */
+/* `:not(:disabled)` is NOT decoration — it is what makes this rule land.
+   primitives.css carries `button:hover:not(:disabled) { background:
+   var(--bg-subtle) }` at specificity (0,2,1); a plain `.class:hover` is
+   (0,2,0) and quietly loses to it, so every one of these controls was showing
+   the primitive's #ededed no matter what was written here. Matching its
+   `:not(:disabled)` takes these to (0,3,0) and they win. */
+.entry-nav-rail__collapse:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--text-strong) 10%, transparent);
   color: var(--text);
 }
-.entry-nav-rail__search:hover {
-  border-color: var(--border-strong);
-}
-.entry-nav-rail__search:focus-visible {
+.entry-nav-rail__search:hover:not(:disabled),
+.entry-nav-rail__search:focus-visible:not(:disabled) {
   outline: none;
-  border-color: var(--border-strong);
+  background: color-mix(in srgb, var(--text-strong) 10%, transparent);
+  color: var(--text);
 }
-.entry-nav-rail__search-placeholder {
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--text-faint);
-  font-size: 13px;
+/* Same two controls, relocated into the chrome row where the pinned Home tab
+   used to sit (per product: 搜索和收起跟 home icon 一起放在顶部). The row rules
+   above still dress them; this only re-parks the cluster — no vertical margins
+   (the chrome row centres it) and a tight gap so the icons read as one group.
+   Must stay after the rules it narrows — equal specificity, so source order
+   decides. */
+.workspace-tabs-rail-actions {
+  flex: 0 0 auto;
+  gap: 4px;
+  /* The search glyph sits on the same vertical axis as the rail's 首页 icon
+     below it (per product). The strip already insets this cluster 10px, and
+     the search's own 34px hit box centres its glyph 17px in, so the remainder
+     lives here. */
+  margin: 0 0 0 14.8px;
 }
-/* ⌘K shortcut hint pinned to the right of the search box. Taller (24px in the
-   34px box) so it hugs closer to the top/bottom edges instead of floating. */
+.workspace-tabs-rail-actions .entry-nav-rail__collapse {
+  margin-left: 0;
+}
+.workspace-tabs-rail-actions .entry-nav-rail__search:hover,
+.workspace-tabs-rail-actions .entry-nav-rail__search:focus-visible {
+  width: 34px;
+  padding: 0;
+}
+/* ⌘K is a reminder, not a label: it stays out of the resting control and
+   appears once the pointer (or keyboard focus) is already on it. Taller (24px
+   in the 34px box) so it hugs the top/bottom edges instead of floating. */
 .entry-nav-rail__search-kbd {
   flex: 0 0 auto;
-  display: inline-flex;
+  display: none;
   align-items: center;
   justify-content: center;
   min-width: 30px;
@@ -1272,9 +1349,13 @@
   background: var(--bg-subtle);
   color: var(--text-muted);
   font-size: 11px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1;
   letter-spacing: 0.02em;
+}
+.entry-nav-rail__search:hover .entry-nav-rail__search-kbd,
+.entry-nav-rail__search:focus-visible .entry-nav-rail__search-kbd {
+  display: inline-flex;
 }
 .entry-nav-rail__search input {
   appearance: none;
@@ -1319,14 +1400,20 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  height: 34px;
+  /* Same box as the nav rows below (per product: 和社区一样的高度和圆角).
+     Pinned rather than derived: those rows are `height: auto` around an 18px
+     icon plus 10px of vertical padding, and this one carries a 24px avatar —
+     the same recipe would make it 44. 38 is their resolved height, and the
+     hover/selected fill both wear is the same, so the two now read as one
+     stack instead of a shorter, squarer control sitting above it. */
+  height: 38px;
   margin: 2px 0 4px;
   padding: 0 10px;
   color: var(--text-strong);
 }
 .entry-nav-rail__team-avatar {
-  width: 19px;
-  height: 19px;
+  width: 24px;
+  height: 24px;
   border-radius: var(--radius-pill);
   background: var(--bg-panel);
   color: var(--text);
@@ -1334,7 +1421,7 @@
   place-items: center;
   font-size: 12px;
   font-weight: 700;
-  flex: 0 0 19px;
+  flex: 0 0 24px;
   overflow: hidden;
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--border) 78%, transparent);
 }
@@ -1346,13 +1433,23 @@
 }
 .entry-nav-rail__team-name {
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   flex: 1;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .entry-nav-rail__team svg { color: var(--text-soft); }
+/* The caret's slot, copied from `.entry-nav-rail__recent-chevron` so the two
+   disclosures in this rail hold their glyph the same way: a fixed 14px box that
+   never shrinks, which is what keeps › and ⌄ — different advance widths — from
+   nudging the workspace name as the menu opens and closes. */
+.entry-nav-rail__team-chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 14px;
+}
 
 /* Section label (e.g. 更多) */
 .entry-nav-rail__section {
@@ -1371,20 +1468,29 @@
   background: var(--border-soft, rgba(0, 0, 0, 0.08));
 }
 .entry-nav-rail__btn:not(.is-active):hover {
-  /* Only the fill changes on hover — the label keeps its resting color so
-     text doesn't shift tone under the pointer. */
-  background: color-mix(in srgb, var(--text) 5%, transparent);
+  /* ONE hover for the whole rail (OPEND-2700): the same fill and the same
+     ink step the 最近浏览过 heading and its project rows take under the
+     pointer (`.entry-nav-rail__recent-head:hover`), so 个人项目 and the
+     section below it light up identically. The Demo left this row at
+     `--text` 5% with no ink change while the rows under it took 10% + a
+     darker ink — the two read as two different controls in one column. The
+     selected row still stands apart through its ink (#121212) and weight. */
+  background: color-mix(in srgb, var(--text-strong) 10%, transparent);
+  color: var(--text-strong);
   border-color: transparent;
 }
 .entry-nav-rail__btn.is-active {
-  /* Selected = one step above the lightest surface gray (--bg-subtle #ededed)
-     under the spec's selection color (--selected #353535) for label + icon. */
-  background: var(--bg-subtle);
+  /* Selected = the ink at 10% (per product: #202020 @ 10%), which is exactly
+     what --text-strong resolves to in light. Written as the token rather than
+     the literal so dark inverts with the rest of the theme (#fafafa there) —
+     a 10% veil of near-black would be invisible on the dark ground. Label +
+     icon keep the spec's --selected. */
+  background: color-mix(in srgb, var(--text-strong) 10%, transparent);
   color: var(--selected);
   border-color: transparent;
 }
 .entry-nav-rail__btn.is-active:hover {
-  background: var(--bg-subtle);
+  background: color-mix(in srgb, var(--text-strong) 10%, transparent);
   border-color: transparent;
 }
 .entry-nav-rail__btn:focus-visible {
@@ -1545,25 +1651,74 @@
   backdrop-filter: var(--material-ultrathin-backdrop, none);
 }
 .entry-main--scroll {
-  /* Transparent: the UltraThin ground now lives on .workspace-shell
-     (shell.css) so the strip / rail gutter / content read as one continuous
-     surface with no gray frame around the scroll area. */
-  background: transparent;
+  /* Content card — the main column's own base card (per product: the rail
+     sits flat, and this is the one card on the screen): a milky-frost
+     surface, a 16px corner, a whisper elevation, and a vertical box (flush
+     top, 12px bottom) that ends on the same line as the rail column beside
+     it. Right inset 12px mirrors the rail's left one; the left stays 0
+     because the 12px gutter to the rail is the rail's own right margin (it
+     grows to 12px here when the rail collapses, below).
+
+     This replaces the earlier "no frame around the scroll area, one
+     continuous surface" treatment.
+
+     The 1px rim is an inset box-shadow rather than a masked pseudo-element:
+     this element is the scroll container, where an absolutely positioned
+     pseudo scrolls away with the content, and `::before` is already taken by
+     the top scroll-fade band above. */
+  margin: 0 12px 12px 0;
+  --entry-content-surface: rgba(255, 255, 255, 0.85);
+  --entry-content-ring: var(--glass-refract-ring-edge);
+  background: var(--entry-content-surface);
+  -webkit-backdrop-filter: var(--material-thin-backdrop);
+  backdrop-filter: var(--material-thin-backdrop);
+  border-radius: 16px;
+  box-shadow:
+    var(--shadow-sm),
+    inset 0 0 0 1px var(--entry-content-ring);
   padding: 0;
   /* Used by descendants (e.g. the plugins-home Scenario row) to
      pin themselves directly below the sticky topbar. Mirrors the
      topbar's vertical footprint (12px top + 32px chip). */
   --entry-topbar-h: 44px;
 }
+/* Rail collapsed: its track is 0-wide and its column is clipped away, so the
+   left gutter has to come from this card instead. */
+.entry:not(.entry--rail-open) .entry-main--scroll {
+  margin-left: 12px;
+}
+/* Material spec fallbacks: drop the translucency to a solid surface and take
+   the rim down to the neutral border ladder. */
+@media (prefers-reduced-transparency: reduce) {
+  .entry-main--scroll {
+    --entry-content-surface: var(--bg);
+    --entry-content-ring: color-mix(in srgb, var(--border) 66%, transparent);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .entry-main--scroll {
+    --entry-content-surface: var(--bg);
+    --entry-content-ring: color-mix(in srgb, var(--border) 66%, transparent);
+  }
+}
 .entry-main__inner {
   width: 100%;
-  /* Wider cap + tighter side padding so the content hugs closer to the rail
-     instead of leaving a large centered left margin on wide screens. */
-  max-width: 1600px;
+  /* The cap is on the CONTENT column, so it carries the gutters with it:
+     1600 + 24 + 24. Written as 1600px flat it silently capped content at
+     1552 (border-box eats the padding) AND, once it bound, its own `auto`
+     margins added to the gutter. With the gutters inside the cap, the inner
+     fills the card at any width up to 1648 and the gutter is exactly what
+     `padding` says. */
+  max-width: calc(1600px + 48px);
   margin: 0 auto;
-  /* Compact rhythm: tighter side inset toward the rail and smaller section
-     gaps so list views read denser. */
-  padding: 12px 16px 48px;
+  /* One number for all four sides of the entry gutter (per product 2026-08-25:
+     社区 / 全部项目 / 设计体系 / 插件 all sit 24px off the card): 24 to the
+     card's top edge and 24 to its left/right. The titles sit flush at this
+     container's top-left, so the number lives here rather than on each page.
+     The bottom stays deeper — it is scroll runout, not a gutter. */
+  padding: 24px 24px 48px;
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -1579,22 +1734,12 @@
    gallery can fit 4-5 preview tiles per row on desktop displays
    while the hero card self-constrains to a readable column. */
 .entry-main__inner--wide {
-  max-width: 1600px;
-}
-/* Uniform left/right gutters across the home view AND the wide sub-views
-   (全部项目 / 草稿 / design-systems / …): the recent-projects grid and the
-   project lists all breathe away from the window edges by the same 35px, so
-   switching between 最近 and 全部项目 keeps the same side inset. Trimmed from
-   48px so the content sits ~13px closer to the rail (measured left spacing
-   ~73px → ~60px). */
-.entry-main__inner {
-  padding-left: 35px;
-  padding-right: 35px;
+  max-width: calc(1600px + 48px);
 }
 @media (max-width: 900px) {
   .entry-main__inner {
-    padding-left: 20px;
-    padding-right: 20px;
+    padding-left: 16px;
+    padding-right: 16px;
   }
 }
 
@@ -7393,7 +7538,7 @@ button.entry-nav-rail__menu-credits-row:active:not(:disabled) {
 .entry-invite__backdrop {
   position: absolute;
   inset: 0;
-  background: color-mix(in srgb, var(--text-strong) 34%, transparent);
+  background: var(--scrim-tint);
   -webkit-backdrop-filter: var(--scrim-backdrop);
   backdrop-filter: var(--scrim-backdrop);
 }
@@ -8631,12 +8776,15 @@ button.entry-nav-rail__menu-credits-row:active:not(:disabled) {
   inset: 0;
   z-index: 400;
   display: flex;
-  /* Centered card (no blur) — a light dim keeps the palette legible over the
-     page without hazing it. */
   align-items: center;
   justify-content: center;
   padding: 16px;
-  background: color-mix(in srgb, #000 12%, transparent);
+  /* Same scrim treatment every other modal backdrop uses (per product: 所有弹窗
+     统一): the page's own blur under a dim, not a dim alone — this was the one
+     dialog scrim in the app that dimmed without blurring. */
+  background: var(--scrim-tint);
+  -webkit-backdrop-filter: var(--scrim-backdrop);
+  backdrop-filter: var(--scrim-backdrop);
   animation: project-search-fade 140ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 @keyframes project-search-fade {

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -142,6 +142,14 @@
      the panel's border box IS the rows' box, so a row sits at this margin's
      12px from the window edge — the same gutter the content card keeps on the
      other side. */
+  /* Still a containing block for `position: fixed` descendants. The frost's
+     backdrop-filter used to make it one as a side effect, which is what kept
+     the workspace-switcher / account-menu click-catchers
+     (`.entry-nav-rail__menu-backdrop`, fixed + inset 0) scoped to THIS column.
+     Without it they spread over the viewport and swallowed every click on the
+     content beside the rail while a menu was open. A no-op transform restores
+     that scope without painting anything. */
+  transform: translateZ(0);
 }
 .entry-nav-rail.is-open {
   pointer-events: auto;

--- a/apps/web/src/styles/home/new-project-modal.css
+++ b/apps/web/src/styles/home/new-project-modal.css
@@ -6,7 +6,7 @@
   position: fixed;
   inset: 0;
   z-index: 920;
-  background: rgba(28, 27, 26, 0.42);
+  background: var(--scrim-tint);
   -webkit-backdrop-filter: var(--scrim-backdrop);
   backdrop-filter: var(--scrim-backdrop);
   display: flex;

--- a/apps/web/src/styles/home/plugin-marketplace-demo.css
+++ b/apps/web/src/styles/home/plugin-marketplace-demo.css
@@ -667,7 +667,7 @@
   display: grid;
   place-items: center;
   padding: 28px;
-  background: color-mix(in srgb, #000 28%, transparent);
+  background: var(--scrim-tint);
   -webkit-backdrop-filter: var(--scrim-backdrop);
   backdrop-filter: var(--scrim-backdrop);
 }
@@ -1649,27 +1649,14 @@
   display: grid;
   place-items: center;
   padding: 28px;
-  background: color-mix(in srgb, #000 30%, transparent);
+  /* The app's one scrim material (styles/material.css). This REPLACES the
+     earlier "shaped blur, not a flat frost" treatment: that one tinted the
+     scrim #000 at 30% and painted four pastel wash blobs in a ::before, so the
+     backdrop carried both a dark cast and a colour of its own. */
+  background: var(--scrim-tint);
   -webkit-backdrop-filter: var(--scrim-backdrop);
   backdrop-filter: var(--scrim-backdrop);
 }
-/* Shape-blur layer on the scrim itself: soft radial blobs (blurred by
-   construction, the app-wash language) so the backdrop carries its own
-   frosted material instead of relying solely on the content blur beneath.
-   z-index -1 keeps it above the scrim tint but under the preview panel. */
-.community-template-preview::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  z-index: -1;
-  pointer-events: none;
-  background:
-    radial-gradient(46% 38% at 16% 8%, var(--wash-blue) 0%, transparent 66%),
-    radial-gradient(40% 34% at 86% 12%, var(--wash-pink) 0%, transparent 64%),
-    radial-gradient(48% 42% at 78% 92%, var(--wash-peach) 0%, transparent 62%),
-    radial-gradient(52% 44% at 12% 96%, var(--wash-mist) 0%, transparent 68%);
-}
-
 .community-template-preview__panel {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
@@ -1808,4 +1795,48 @@
   .plugin-marketplace__row > svg {
     display: none;
   }
+}
+
+/* -------- Docked composer under the community grid -------------------- */
+/* Home's composer, parked at the foot of the community view so a template can
+   be browsed and a prompt written without a trip back to 首页.
+   `sticky`, not `fixed`: fixed would be positioned against the viewport and so
+   would ignore the entry column's gutters — it would slide under the nav rail
+   and stay put while a modal scrolls the page behind it. As the last child of
+   the scroll column, sticky rides the bottom edge while the grid passes under
+   it, and settles naturally under short result sets. */
+.community-composer-dock {
+  position: sticky;
+  bottom: 0;
+  z-index: 5;
+  display: flex;
+  justify-content: center;
+  /* Short tabs used to strand the bar wherever the grid happened to end —
+     原型 › 应用 is six cards, so it floated in the middle of the page while a
+     full tab put it at the foot. `auto` pushes it to the bottom of the column,
+     which `.entry-main__inner` keeps at least one scrollport tall. */
+  margin-top: auto;
+  /* That column ends 48px above its own bottom edge — `.entry-main__inner`'s
+     scroll runout (padding: 24px 24px 48px). Cancelling it makes this
+     wrapper's bottom edge the scrollport's, so the offset below is measured
+     from the same place whether the bar is sitting at the end of a short tab
+     or stuck to the port while a long one scrolls. Keep the two numbers in
+     step if that padding ever moves. */
+  margin-bottom: -48px;
+  /* 16 off the bottom (per product, was 24), and it lives here — under the
+     pill, inside the wrapper — precisely so it is one fixed number and not
+     whatever the current tab's content height leaves over. */
+  padding: 28px 0 16px;
+  /* No fade band (per product: 底下的白色渐变去掉). It used to dissolve the
+     grid rows into the content card's surface as they passed under the bar;
+     the rows now simply run behind it. */
+  background: none;
+  /* The wrapper still spans the full column even with nothing painted on it,
+     so only the bar inside it may take the pointer — otherwise the strip would
+     eat clicks on the cards it covers. */
+  pointer-events: none;
+}
+.community-composer-dock > * {
+  pointer-events: auto;
+  width: 100%;
 }

--- a/apps/web/src/styles/home/plugins-view.css
+++ b/apps/web/src/styles/home/plugins-view.css
@@ -725,7 +725,7 @@
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: rgba(15, 18, 24, 0.28);
+  background: var(--scrim-tint);
   -webkit-backdrop-filter: var(--scrim-backdrop);
   backdrop-filter: var(--scrim-backdrop);
 }

--- a/apps/web/src/styles/home/recent-projects.css
+++ b/apps/web/src/styles/home/recent-projects.css
@@ -100,24 +100,22 @@
   gap: var(--spacing-12);
 }
 .recent-projects__row--grid {
-  /* Equal-width grid, 5-across at full width: each card is an exact fraction
-     of the module width so the row's right edge aligns with the header/
-     filters. Extra items wrap downward. Column count steps down with the
+  /* Equal-width grid, 4-across at full width (per product): each card is an
+     exact fraction of the module width so the row's right edge aligns with the
+     header/filters. Extra items wrap downward. Column count steps down with the
      strip's container width (breakpoints ≈ 180px min card width + gaps) so
      cards never get crushed when the window narrows. */
   grid-auto-flow: row;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   grid-auto-rows: auto;
   align-items: stretch;
   /* Cards have no base-card surface or padding, so the grid gap alone is the
      visible spacing between cards: fixed at 16px (compact rhythm). */
   gap: var(--spacing-16);
 }
-@container recent-projects (max-width: 947px) {
-  .recent-projects__row--grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
-}
+/* No 947px step any more — it dropped 5 → 4, which is now the base. The ladder
+   starts at the next one down: 4 cards + 3 gaps still clear ~176px each at
+   755px, which is where 3-across takes over. */
 @container recent-projects (max-width: 755px) {
   .recent-projects__row--grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -154,7 +152,12 @@
   /* Borderless card: the transparent 1px keeps the box size stable for the
      selection / design-system rings that do draw a border. */
   border: 1px solid transparent;
-  border-radius: var(--radius);
+  /* 16px (per product) — the card is surfaceless, so this only shapes the
+     selection ring, but a ring that rounds tighter than the thumbnail inside
+     it reads as two radii, so it tracks `.recent-projects__card-thumb`'s
+     radius below. A literal, not `--radius-lg`: that token tops out at 12px
+     and is shared with surfaces that should stay at 12. */
+  border-radius: 16px;
   /* Surfaceless: no fill, blur, or shadow — the thumbnail and meta sit
      directly on the page wash. Selection / design-system states still draw
      their rings via border/box-shadow. */
@@ -202,6 +205,54 @@
 .recent-projects__card:hover {
   border-color: transparent;
 }
+/* Hover zoom (per product 2026-08-25): the COVER grows, the caption under it
+   does not — the title and timestamp hold their size and their baseline, so
+   the row of names stays on one line and only the picture comes forward.
+
+   This is NOT the cover zoom the note further up forbids. That one scaled
+   `.recent-projects__thumb-media` — the image INSIDE a fixed thumb box — so
+   the picture was blown up past its own resolution and cropped by the box,
+   and sat visibly soft for as long as the pointer stayed. This scales the
+   thumb box itself: the framing never changes, nothing is cropped, and it
+   settles back at 1 the moment the pointer leaves.
+
+   Grid only: a list row's 128x52 thumb is too small for the gesture to read.
+   `:not(.is-menu-open)` keeps the cover still while the card's ⋮ popover is
+   open, and the `is-selecting` rule below holds it still in multi-select. */
+.recent-projects__row--grid .recent-projects__card-thumb {
+  transition: transform 220ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+.recent-projects__row--grid .recent-projects__card:hover:not(.is-menu-open) .recent-projects__card-thumb,
+.recent-projects__row--grid .recent-projects__card:focus-within:not(.is-menu-open) .recent-projects__card-thumb {
+  transform: scale(1.03);
+}
+/* The cover spans the card edge to edge, so 3% of growth lands outside both
+   boxes that wrap it — each of which clips. Open them for the hovered card
+   only (`.is-menu-open` already does the same thing for its popover), and lift
+   the card so the grown cover paints over its neighbours rather than under. */
+.recent-projects__row--grid .recent-projects__card:hover:not(.is-menu-open),
+.recent-projects__row--grid .recent-projects__card:focus-within:not(.is-menu-open) {
+  z-index: 2;
+  overflow: visible;
+}
+.recent-projects__row--grid .recent-projects__card:hover:not(.is-menu-open) .recent-projects__card-main,
+.recent-projects__row--grid .recent-projects__card:focus-within:not(.is-menu-open) .recent-projects__card-main {
+  overflow: visible;
+}
+/* Multi-select: the old guard below zeroes the CARD's transform, which no
+   longer carries one — the cover needs its own. */
+.recent-projects__row.is-selecting .recent-projects__card:hover .recent-projects__card-thumb {
+  transform: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  .recent-projects__row--grid .recent-projects__card-thumb {
+    transition: none;
+  }
+  .recent-projects__row--grid .recent-projects__card:hover:not(.is-menu-open) .recent-projects__card-thumb,
+  .recent-projects__row--grid .recent-projects__card:focus-within:not(.is-menu-open) .recent-projects__card-thumb {
+    transform: none;
+  }
+}
 .recent-projects__card.is-selected {
   /* Selection ring floats 4px outside the card on all sides (outline follows
      the border-radius), instead of hugging the card edge. Hairline light
@@ -237,7 +288,10 @@
   justify-content: center;
   position: relative;
   overflow: hidden;
-  border-radius: var(--radius-medium);
+  /* The thumbnail IS the card's visible surface (the card behind it is
+     transparent), so its corners set the grid's silhouette: 16px per product.
+     Keep it in step with `.recent-projects__card`'s ring above. */
+  border-radius: 16px;
   /* Container for the HTML preview iframe's responsive scale (below): the
    * iframe renders at a fixed desktop design width and is scaled by the
    * card's own width so the page reads as a faithful thumbnail instead of
@@ -367,7 +421,7 @@
 }
 .recent-projects__card-name {
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.25;
   color: var(--text);
   overflow: hidden;
@@ -375,21 +429,47 @@
   white-space: nowrap;
 }
 /* Bottom row: owner·time on the left, kind tag (原型/幻灯片…) pushed to the
-   bottom-right corner. */
+   bottom-right corner. The 8px inset (per product) is the card's only
+   horizontal padding — the card box itself is flush with the thumbnail above. */
 .recent-projects__card-footer {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--spacing-8);
   min-width: 0;
+  padding: 0 var(--spacing-8);
+}
+/* List rows carry their own horizontal rhythm from .recent-projects__row--list;
+   the grid's inset would fight it. */
+.recent-projects__row--list .recent-projects__card-footer {
+  padding: 0;
 }
 .recent-projects__card-footer .design-card-tag-row {
   flex: 0 0 auto;
   margin: 0;
 }
+/* One neutral chip for every kind here. The per-kind hues (mention-home.css's
+   `.design-card-tag.tag-*`) read as status on a card footer rather than as a
+   type, so this surface takes a grey fill with black ink and lets the glyph do
+   the identifying. Reaching through .design-card-tag-row for (0,3,0) — the
+   hue rules are (0,2,0) and live in another file, so equal specificity would
+   leave the winner up to load order. */
+.recent-projects__card-footer .design-card-tag-row .design-card-tag {
+  gap: 4px;
+  background: var(--bg-subtle);
+  border-color: transparent;
+  color: var(--text-strong);
+  margin-bottom: 0;
+}
+.design-card-tag__icon {
+  flex: 0 0 auto;
+}
 .recent-projects__card-time {
   font-size: 12px;
-  color: var(--text-muted);
+  /* Secondary metadata stays one step below the 600 project name while the
+     lighter grey keeps the title as the card's primary reading target. */
+  font-weight: 500;
+  color: var(--text-soft);
   display: flex;
   align-items: center;
   gap: 4px;
@@ -463,11 +543,11 @@
   width: 26px;
   height: 26px;
   padding: 0;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
+  border: 0;
+  border-radius: var(--radius-circular, 50%);
   background: var(--bg-panel);
   color: var(--text-muted);
-  box-shadow: var(--shadow-xs);
+  box-shadow: none;
   cursor: pointer;
   opacity: 0;
   transform: translateY(-1px);
@@ -486,7 +566,6 @@
 }
 .recent-projects__card-more:hover,
 .recent-projects__card-more:focus-visible {
-  border-color: var(--border-strong);
   background: var(--bg-panel);
   color: var(--text-strong);
 }
@@ -659,15 +738,20 @@
   align-items: center;
   justify-content: center;
   gap: var(--spacing-6);
-  height: 28px;
-  padding: 0 var(--spacing-12);
+  /* `height: auto` + 12px of vertical padding (per product): built from the
+     same 13px/line-height-1 label as the pills beside it, so they stay locked
+     together if that type ever moves. `auto` is load-bearing — primitives.css's
+     bare `button { height: 36px }` would otherwise pin the box and swallow the
+     padding (that is why this sat at a fixed 28). */
+  height: auto;
+  padding: var(--spacing-12);
   border: var(--stroke-thin) solid var(--border);
   border-radius: var(--radius-pill);
   background: transparent;
   color: var(--text);
   font: inherit;
   font-size: var(--font-size-13);
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1;
   white-space: nowrap;
   cursor: pointer;
@@ -798,8 +882,13 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
+  /* Icon-only, so it cannot be built from a label's padding like the pills
+     beside it — but it shares their row, and a 28px dot next to two 39px
+     pills reads as ragged. 39 is those pills' resolved height (12 + 13px
+     label + 12 + 2 borders); keep the three in step. Square, so the circular
+     radius stays a circle. */
+  width: 39px;
+  height: 39px;
   padding: 0;
   border: var(--stroke-thin) solid var(--border);
   border-radius: var(--radius-circular);
@@ -921,7 +1010,11 @@
 .recent-projects__heading {
   margin: 0;
   font-family: var(--serif);
-  font-size: 20px;
+  font-size: 24px;
+  /* Own line box: the inherited 17.5px was shorter than the 24px glyphs, which
+     both clipped the CJK descenders and left the head's height (and so the
+     heading's own top) set by the filter buttons beside it. */
+  line-height: 1.2;
   font-weight: 600;
   letter-spacing: -0.01em;
   color: var(--text-strong);
@@ -931,15 +1024,20 @@
   align-items: center;
   justify-content: center;
   gap: var(--spacing-6);
-  height: 28px;
-  padding: 0 var(--spacing-12);
+  /* `height: auto` + 12px of vertical padding (per product): built from the
+     same 13px/line-height-1 label as the pills beside it, so they stay locked
+     together if that type ever moves. `auto` is load-bearing — primitives.css's
+     bare `button { height: 36px }` would otherwise pin the box and swallow the
+     padding (that is why this sat at a fixed 28). */
+  height: auto;
+  padding: var(--spacing-12);
   border: var(--stroke-thin) solid var(--border);
   border-radius: var(--radius-pill);
   background: transparent;
   color: var(--text);
   font: inherit;
   font-size: var(--font-size-13);
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1;
   white-space: nowrap;
   cursor: pointer;
@@ -1086,25 +1184,34 @@
 
 /* Shared badge on the thumbnail + creator avatar in the meta row. Private projects stay unbadged. */
 .recent-projects__card-badge {
-  /* 4px inside the thumb's top-left corner (the thumb is the positioned
-     ancestor), pill-shaped. Hidden at rest — it fades in on card hover so
-     covers stay clean. */
+  /* Mirrors `.recent-projects__card-menu-anchor` exactly — same positioned
+     ancestor (the card), same 8px inset — so the badge sits as far in from the
+     left edge as the ⋯ button does from the right (per product: 这个间距和最
+     右侧的一样). It must NOT hang off the thumb: that box scales 1.03 on
+     hover, which grew the badge and pushed it out to the card's edge at the
+     very moment it faded in. Pill-shaped, hidden at rest — it fades in on card
+     hover so covers stay clean. */
   position: absolute;
-  top: 4px;
-  left: 4px;
-  z-index: 2;
+  top: 8px;
+  left: 8px;
+  z-index: 3;
   opacity: 0;
   pointer-events: none;
   transition: opacity 140ms var(--ease-out);
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  height: 20px;
+  /* Same 26px box the ⋯ button wears, so the two hover affordances read as one
+     pair across the cover's top edge (per product: 高度和右边的一样). */
+  height: 26px;
   padding: 0 8px;
   border-radius: var(--radius-pill);
-  border: var(--stroke-thin) solid color-mix(in srgb, var(--green) 24%, transparent);
-  background: color-mix(in srgb, var(--green) 10%, var(--bg-panel));
-  color: color-mix(in srgb, var(--green) 72%, var(--text-strong));
+  /* A plain white chip, like ⋯ — no stroke, no green wash. The tokens land on
+     the values product asked for in light mode (#fafafa ground, #353535 text)
+     and still invert with the dark theme, which literal hex values would not. */
+  border: 0;
+  background: var(--bg-panel);
+  color: var(--accent);
   font-size: 12px;
   font-weight: 600;
 }

--- a/apps/web/src/styles/home/tasks.css
+++ b/apps/web/src/styles/home/tasks.css
@@ -816,7 +816,7 @@
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: color-mix(in srgb, var(--scrim, rgba(0, 0, 0, 0.45)) 92%, transparent);
+  background: var(--scrim-tint);
   -webkit-backdrop-filter: var(--scrim-backdrop);
   backdrop-filter: var(--scrim-backdrop);
   animation: automation-modal-fade-in 160ms cubic-bezier(0.23, 1, 0.32, 1);

--- a/apps/web/src/styles/material.css
+++ b/apps/web/src/styles/material.css
@@ -31,13 +31,19 @@
   --material-regular-backdrop: blur(var(--material-regular-blur)) saturate(1.6);
   --material-thick-backdrop: blur(var(--material-thick-blur)) saturate(1.6);
   --glass-backdrop: blur(var(--glass-regular-blur, 28px)) saturate(1.8);
-  /* Unified scrim blur behind modals/drawers — the scrim's own tint color
-     stays with each component; only the blur amount is standardized. */
-  --scrim-backdrop: blur(4px);
-  /* Shared scrim tint for overlays that opt into one material (the Use
-     Everywhere modal today). Deliberate exceptions keep painting their own
-     tint at their own rule. */
+  /* The scrim behind modals / dialogs / drawers / previews — BOTH halves of
+     it. The blur was standardized here before; the tint was deliberately left
+     to each component, and that is exactly how ~30 overlays ended up with ~30
+     different colours (near-black, blue-black, warm brown, `--text 38%`, …).
+     Now the whole material lives on these two lines, so the app has one scrim
+     and it is tuned in one place.
+
+     Deliberate exceptions do NOT read these tokens, and each says why at its
+     own rule: image lightboxes and presentation mode keep a near-opaque dark
+     ground (a light scrim would wash the media out), and the transparent
+     click-catchers that only close menus paint nothing at all. */
   --scrim-tint: rgba(255, 255, 255, 0.6);
+  --scrim-backdrop: blur(50px);
 
   /* Standard material surfaces (content-layer separation) */
   --material-ultrathin: rgba(250, 250, 250, 0.45);
@@ -48,6 +54,14 @@
   /* Liquid glass surfaces (--glass-regular itself lives in tokens.css) */
   --glass-clear: rgba(250, 250, 250, 0.18);
   --glass-clear-dim: rgba(0, 0, 0, 0.35);
+  /* Dark glass for controls that float over MEDIA rather than over the app's
+     own ground — a template thumbnail can be any colour, so these cannot use
+     the neutral materials above (which follow the theme and would vanish on
+     half the images). One value for both appearances for the same reason:
+     what is behind it is the picture, not the page. 0.55 is the floor that
+     keeps `--vibrancy-label-on-dim` readable over a white thumbnail. */
+  --material-dim: rgba(0, 0, 0, 0.55);
+  --vibrancy-label-on-dim: #fff;
 
   /* Vibrancy — foreground on top of any material; never hardcode neutral
      text colors on a material surface. */
@@ -182,6 +196,9 @@
     --material-thick: var(--bg-elevated);
     --glass-regular: var(--bg-elevated);
     --glass-clear: var(--bg-elevated);
+    /* Stays dark — it is read against a photo, not against the page — but
+       goes opaque so the label keeps its contrast with the blur gone. */
+    --material-dim: rgba(0, 0, 0, 0.88);
     --material-ultrathin-backdrop: none;
     --material-thin-backdrop: none;
     --material-regular-backdrop: none;

--- a/apps/web/src/styles/viewer/composio.css
+++ b/apps/web/src/styles/viewer/composio.css
@@ -305,6 +305,9 @@
   cursor: not-allowed;
 }
 
+/* DELIBERATE exception to the app's one scrim (styles/material.css):
+   presentation mode blacks the room out on purpose, same reasoning as the
+   image lightboxes — a light scrim would defeat it. */
 .present-overlay {
   position: fixed;
   top: 0;
@@ -2043,7 +2046,11 @@ button.qf-chip-other:disabled { cursor: default; opacity: 0.6; }
   position: fixed;
   inset: 0;
   z-index: 1700;
-  background: rgba(28, 27, 26, 0.42);
+  /* The app's one scrim material (styles/material.css). This is the SHARED
+     modal scrim — PreviewModal and every ds-* modal mount into it. Read as
+     tokens rather than literals: the literals bypassed the accessibility
+     contract, where `--scrim-backdrop` goes to `none`. */
+  background: var(--scrim-tint);
   -webkit-backdrop-filter: var(--scrim-backdrop);
   backdrop-filter: var(--scrim-backdrop);
   -webkit-app-region: no-drag;

--- a/apps/web/src/styles/viewer/library.css
+++ b/apps/web/src/styles/viewer/library.css
@@ -517,7 +517,9 @@
 .qs-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(13, 12, 10, 0.32);
+  background: var(--scrim-tint);
+  -webkit-backdrop-filter: var(--scrim-backdrop);
+  backdrop-filter: var(--scrim-backdrop);
   /* Sits in the modal tier so the palette renders above any open context
    * menus or popovers. */
   z-index: 1500;
@@ -1381,7 +1383,9 @@
   display: grid;
   place-items: center;
   padding: 0;
-  background: color-mix(in srgb, var(--overlay-scrim, rgba(0, 0, 0, 0.42)) 72%, transparent);
+  background: var(--scrim-tint);
+  -webkit-backdrop-filter: var(--scrim-backdrop);
+  backdrop-filter: var(--scrim-backdrop);
 }
 
 .memory-action-modal {

--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -1107,14 +1107,25 @@
   font-size: 13px;
   text-align: left;
 }
-.workspace-tabs-dropdown__row-main > svg:first-child {
-  flex: 0 0 auto;
+/* The leading slot. Fixed size and ALWAYS rendered, even when the row has no
+   glyph: that reserved box is what keeps every project name starting on the
+   same column once some rows carry a run-status indicator and others do not.
+   Explicit classes rather than the `svg:first-child` / `svg:last-child` pair
+   that used to paint these — the slot's content is now sometimes a nested
+   element and sometimes nothing, so position stopped identifying the glyph. */
+.workspace-tabs-dropdown__row-lead {
+  flex: 0 0 14px;
+  width: 14px;
+  height: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   color: var(--text-muted);
 }
 .workspace-tabs-dropdown__row.is-active .workspace-tabs-dropdown__row-label {
   font-weight: 600;
 }
-.workspace-tabs-dropdown__row-main > svg:last-child:not(:first-child) {
+.workspace-tabs-dropdown__row-check {
   flex: 0 0 auto;
   color: var(--accent);
 }
@@ -1131,7 +1142,7 @@
      button) and undocked (the strip's pinned entry tab). Without it the icon
      jumped 10px left on every entry→project→entry trip. */
   margin-left: 10px;
-  width: 78px;
+  width: 64px;
   height: 32px;
   padding: 0;
   border: 0;
@@ -1145,9 +1156,17 @@
   flex: 0 0 auto;
   -webkit-app-region: no-drag;
 }
-.workspace-tabs-home-chrome:hover {
-  background: color-mix(in srgb, var(--bg-panel) 78%, transparent);
-  box-shadow: 0 1px 2px color-mix(in srgb, var(--text) 5%, transparent);
+/* Same fill the rail's selected nav row wears — `--text-strong` at 10% (per
+   product: 和首页的选择保持一致). It used to be a 78% wash of the opaque
+   `--bg-panel`, which on the translucent chrome row read as a pale plate
+   rather than a tint of the ink. Keep in step with
+   `.entry-nav-rail__btn.is-active` (home/entry-layout.css). The drop shadow
+   goes with it: a tint does not need a lift to read as hovered.
+   `:not(:disabled)` is load-bearing — see the note in home/entry-layout.css
+   beside the search/collapse pair: it is what lifts this past
+   primitives.css's `button:hover:not(:disabled)`. */
+.workspace-tabs-home-chrome:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--text-strong) 10%, transparent);
 }
 .app .split-chat-slot {
   /* Column: the docked strip sits above the chat card. */
@@ -1231,12 +1250,15 @@
    tabs from showing through it. Declared before .is-active so an active Home
    tab still picks up the active highlight. */
 .workspace-shell .workspace-tab.is-pinned {
-  /* Single-icon pill (~half a project tab): the Home button on a project page,
-     or the sidebar toggle on the Home page. */
-  flex: 0 0 78px;
-  width: 78px;
-  min-width: 78px;
-  max-width: 78px;
+  /* Single-icon pill: the Home button on a project page, or the sidebar
+     toggle on the Home page. Width is not free — the pill starts at the
+     strip's 10px edge inset and centers its glyph, so 64px puts that glyph
+     on the same vertical axis as the rail's 首页 icon below it. Changing this
+     width or the edge inset breaks that column. */
+  flex: 0 0 64px;
+  width: 64px;
+  min-width: 64px;
+  max-width: 64px;
   grid-template-columns: minmax(0, 1fr);
   position: sticky;
   left: 0;
@@ -1252,6 +1274,18 @@
   justify-items: center;
   padding: 0;
 }
+/* …but the entry chrome row shows no pinned Home pill at all now (per
+   product: 顶部去掉 home icon，只有 chat 里才显示): Home is the rail's own 首页
+   item, expanding a collapsed rail is the toggle beside the search in
+   `.workspace-tabs-rail-actions`, and in chat the logo still renders as
+   .workspace-tabs-home-chrome (the strip is docked there, so this selector
+   does not reach it). The row stays in the DOM — it is the tab machinery's
+   measurement/drag anchor. Both selectors are needed: the second out-ranks the
+   `:has()` display rule directly above. */
+.workspace-shell .workspace-tabs-chrome .workspace-tab.is-pinned,
+.workspace-shell .workspace-tabs-chrome .workspace-tab.is-pinned:has(.workspace-tab__rail-toggle) {
+  display: none;
+}
 .workspace-shell .workspace-tab.is-pinned .workspace-tab__rail-toggle {
   /* Fill the whole pinned tab so the hover target is a full tab-sized box
      (matching the Home button / a normal tab hover) instead of a cramped 20px
@@ -1260,6 +1294,15 @@
   width: 100%;
   height: 100%;
   border-radius: 12px;
+}
+/* primitives.css rings every button in 1px of --blue at a 2px offset on
+   focus-visible. Around this corner pill that rectangle read as permanent
+   chrome rather than a focus state, so drop it and let the same soft fill the
+   pill already uses for hover carry keyboard focus instead. */
+.workspace-shell .workspace-tab.is-pinned .workspace-tab__rail-toggle:focus-visible,
+.workspace-shell .workspace-tab.is-pinned .workspace-tab__main:focus-visible {
+  outline: none;
+  background: var(--bg-fill-secondary);
 }
 .workspace-shell .workspace-tab.is-active {
   border-radius: 12px;
@@ -3922,7 +3965,7 @@
   position: fixed;
   inset: 0;
   z-index: 1800;
-  background: color-mix(in srgb, var(--text) 38%, transparent);
+  background: var(--scrim-tint);
   -webkit-backdrop-filter: var(--scrim-backdrop);
   backdrop-filter: var(--scrim-backdrop);
   display: flex;

--- a/apps/web/src/styles/viewer/templates-plugins.css
+++ b/apps/web/src/styles/viewer/templates-plugins.css
@@ -1037,7 +1037,7 @@
   position: fixed;
   inset: 0;
   z-index: 920;
-  background: rgba(28, 27, 26, 0.42);
+  background: var(--scrim-tint);
   -webkit-backdrop-filter: var(--scrim-backdrop);
   backdrop-filter: var(--scrim-backdrop);
   display: flex;

--- a/apps/web/src/styles/workspace/drawer.css
+++ b/apps/web/src/styles/workspace/drawer.css
@@ -3,7 +3,7 @@
   position: fixed;
   inset: 0;
   z-index: 100;
-  background: color-mix(in srgb, #111827 18%, transparent);
+  background: var(--scrim-tint);
   -webkit-backdrop-filter: var(--scrim-backdrop);
   backdrop-filter: var(--scrim-backdrop);
   display: flex;
@@ -1834,7 +1834,9 @@
   display: grid;
   place-items: center;
   padding: 28px;
-  background: color-mix(in srgb, #111827 38%, transparent);
+  background: var(--scrim-tint);
+  -webkit-backdrop-filter: var(--scrim-backdrop);
+  backdrop-filter: var(--scrim-backdrop);
   animation: page-creator-fade 180ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 .page-creator-modal {
@@ -2418,7 +2420,9 @@
   display: grid;
   place-items: center;
   padding: 24px;
-  background: color-mix(in srgb, #111827 46%, transparent);
+  background: var(--scrim-tint);
+  -webkit-backdrop-filter: var(--scrim-backdrop);
+  backdrop-filter: var(--scrim-backdrop);
 }
 .page-template-preview-modal {
   width: min(980px, calc(100vw - 48px));

--- a/apps/web/src/styles/workspace/mention-home.css
+++ b/apps/web/src/styles/workspace/mention-home.css
@@ -312,7 +312,7 @@
    =========================================================== */
 .modal-backdrop {
   position: fixed; inset: 0;
-  background: rgba(28, 27, 26, 0.42);
+  background: var(--scrim-tint);
   -webkit-backdrop-filter: var(--scrim-backdrop);
   backdrop-filter: var(--scrim-backdrop);
   -webkit-app-region: no-drag;

--- a/apps/web/tests/components/EntryNavRail.analytics.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.analytics.test.tsx
@@ -44,7 +44,9 @@ describe('EntryNavRail analytics', () => {
     fireEvent.click(screen.getByTestId('entry-nav-community'));
     fireEvent.click(screen.getByTestId('entry-nav-design-systems'));
     fireEvent.click(screen.getByTestId('entry-nav-plugins'));
-    fireEvent.click(screen.getByTestId('entry-nav-search'));
+    // The search button left the rail for the chrome row (WorkspaceTabsBar),
+    // which tracks its own click; the rail no longer renders it.
+    expect(screen.queryByTestId('entry-nav-search')).toBeNull();
     fireEvent.click(screen.getByTestId('entry-settings-button'));
 
     expect(analytics.track).toHaveBeenCalledWith('ui_click', expect.objectContaining({
@@ -60,11 +62,6 @@ describe('EntryNavRail analytics', () => {
     expect(analytics.track).toHaveBeenCalledWith('ui_click', expect.objectContaining({
       area: 'entry_nav',
       target: 'plugins',
-    }), undefined);
-    expect(analytics.track).toHaveBeenCalledWith('ui_click', expect.objectContaining({
-      area: 'entry_nav',
-      element: 'search',
-      target: 'search',
     }), undefined);
     expect(analytics.track).toHaveBeenCalledWith('ui_click', expect.objectContaining({
       area: 'account_menu',

--- a/apps/web/tests/components/EntryNavRail.no-duplicate-settings.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.no-duplicate-settings.test.tsx
@@ -1,14 +1,15 @@
 // @vitest-environment jsdom
 //
-// Settings-entry invariant: exactly one settings entry per identity state.
+// Settings-entry invariant: exactly one RAIL settings entry per identity state.
 //
 // History: 飞书 recvq4hGF7BJkI ("Personal 用户，左侧栏有 2 个设置入口") removed
 // the rail's own signed-out settings item because EntryShell's footer carried
 // an `entry-settings-chip` for the same falsy-context condition. #5517 then
 // dropped that footer chip (the footer only hosts the updater popup now) — and
 // a signed-out rail has no account menu either, so the rail item is back as
-// the ONLY signed-out settings entry. Signed-in keeps settings inside the
-// account menu, so the rail item must not render on that branch.
+// the ONLY signed-out settings entry. #7635 (OPEND-2553) then put 设置 under
+// 插件 on the signed-in branch too (per product: 设置的按钮在插件下边), so both
+// branches render the item ONCE, in the same slot, and never together.
 // (Upstream #5971 restored the same entry as `entry-nav-settings`; this repo
 // keeps the `entry-settings-button` testId the e2e suite contracts on.)
 
@@ -59,8 +60,15 @@ describe('EntryNavRail settings entry', () => {
     expect(onOpenSettings).toHaveBeenCalledTimes(1);
   });
 
-  it('does not render the rail settings item when signed in (account menu owns it)', () => {
-    renderRail(signedInContext);
-    expect(screen.queryByTestId('entry-settings-button')).toBeNull();
+  it('renders exactly one rail settings item when signed in, under the destinations', () => {
+    const onOpenSettings = renderRail(signedInContext);
+    const settings = screen.getAllByTestId('entry-settings-button');
+    expect(settings).toHaveLength(1);
+    // Under 插件, above 最近项目: a destination, not an account-menu row.
+    const group = settings[0]!.closest('.entry-nav-rail__team-section');
+    expect(group).not.toBeNull();
+    expect(group?.querySelector('[data-testid="entry-nav-plugins"]')).not.toBeNull();
+    fireEvent.click(settings[0]!);
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/tests/components/EntryNavRail.recent-section.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.recent-section.test.tsx
@@ -111,14 +111,17 @@ afterEach(() => {
 });
 
 describe('EntryNavRail 最近浏览过 section', () => {
-  it('lists the eight most recent projects, newest first, under a disclosure that starts open', () => {
+  it('lists every recent project, newest first, under a disclosure that starts open', () => {
     renderRail();
     const toggle = screen.getByTestId('entry-nav-recent-toggle');
     expect(toggle.getAttribute('aria-expanded')).toBe('true');
-    expect(toggle.textContent).toContain('Recently viewed');
+    // 最近项目 (OPEND-2703), not 最近浏览过.
+    expect(toggle.textContent).toContain('Recent projects');
     const rows = screen.getAllByTestId('entry-nav-recent-item');
+    // OPEND-2757: no 8-row cap — the ninth (and every later) project is a row
+    // too; the list scrolls past ~11 rows instead of dropping them.
     expect(rows.map((row) => row.textContent)).toEqual(
-      ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'].map((id) => `Project ${id}`),
+      ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8', 'p9', 'p10'].map((id) => `Project ${id}`),
     );
   });
 

--- a/apps/web/tests/components/EntryNavRail.recent-section.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.recent-section.test.tsx
@@ -99,7 +99,24 @@ function renderRail(overrides: Partial<Parameters<typeof EntryNavRail>[0]> = {})
   return { onOpen, onRename, onDelete };
 }
 
+let reportVisibleRows: (start: number, end: number) => void;
+
+class VisibleRowsObserver {
+  rows: Element[] = [];
+  constructor(private callback: IntersectionObserverCallback) {
+    reportVisibleRows = (start, end) => this.callback(this.rows.map((target, index) => ({
+      target, isIntersecting: index >= start && index < end,
+    } as IntersectionObserverEntry)), this as unknown as IntersectionObserver);
+  }
+  observe(target: Element) {
+    this.rows.push(target);
+    queueMicrotask(() => reportVisibleRows(0, 11));
+  }
+  disconnect() { this.rows = []; }
+}
+
 beforeEach(() => {
+  vi.stubGlobal('IntersectionObserver', VisibleRowsObserver);
   window.localStorage.clear();
   RUNS = { ...DEFAULT_RUNS };
   stubFetch();
@@ -108,6 +125,8 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   globalThis.fetch = originalFetch;
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
 });
 
 describe('EntryNavRail 最近浏览过 section', () => {
@@ -123,6 +142,30 @@ describe('EntryNavRail 最近浏览过 section', () => {
     expect(rows.map((row) => row.textContent)).toEqual(
       ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8', 'p9', 'p10'].map((id) => `Project ${id}`),
     );
+  });
+
+  it('polls only visible rows in a 500-project catalog and follows the scroll window', async () => {
+    vi.useFakeTimers();
+    const { onOpen } = renderRail({ recentProjects: Array.from({ length: 500 }, (_, i) =>
+      project(`p${i + 1}`, 1000 - i)) });
+    await act(async () => { await vi.advanceTimersByTimeAsync(0); });
+    const runRequests = () => vi.mocked(fetch).mock.calls.filter(([url]) =>
+      String(url).startsWith('/api/runs?projectId='));
+    expect(screen.getAllByTestId('entry-nav-recent-item')).toHaveLength(500);
+    expect(runRequests()).toHaveLength(11);
+    await act(async () => { await vi.advanceTimersByTimeAsync(4000); });
+    expect(runRequests()).toHaveLength(22);
+    await act(async () => { reportVisibleRows(489, 500); });
+    expect(runRequests().slice(-11).map(([url]) => String(url))).toEqual(
+      Array.from({ length: 11 }, (_, i) => `/api/runs?projectId=p${490 + i}`),
+    );
+    await act(async () => { await vi.advanceTimersByTimeAsync(4000); });
+    expect(runRequests()).toHaveLength(44);
+    fireEvent.click(screen.getAllByTestId('entry-nav-recent-item')[499]!);
+    expect(onOpen).toHaveBeenCalledWith('p500');
+    fireEvent.click(screen.getByTestId('entry-nav-recent-toggle'));
+    await act(async () => { await vi.advanceTimersByTimeAsync(4000); });
+    expect(runRequests()).toHaveLength(44);
   });
 
   it('renders nothing without projects or without a cloud identity', () => {

--- a/apps/web/tests/components/EntryShell.blank-project-naming.test.tsx
+++ b/apps/web/tests/components/EntryShell.blank-project-naming.test.tsx
@@ -211,7 +211,11 @@ afterEach(() => {
 });
 
 describe('EntryShell team project content readiness', () => {
-  it('renders another member\'s catalog name and timestamp on Home instead of the fresh pulled placeholder', async () => {
+  // The grid this reads lives on 全部项目 now: with a cloud identity Home carries
+  // no recent-projects grid any more (#7635 / OPEND-2683 — the rail's 最近项目
+  // section is the entry there), so the catalog-name-over-placeholder rule is
+  // asserted on the team grid surface instead.
+  it('renders another member\'s catalog name and timestamp on 全部项目 instead of the fresh pulled placeholder', async () => {
     const catalogUpdatedAt = Date.now() - (2 * 24 * 60 * 60 * 1000);
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
       const pathname = new URL(String(input), 'http://d.local').pathname;
@@ -236,7 +240,7 @@ describe('EntryShell team project content readiness', () => {
       return jsonResponse({});
     }) as typeof fetch;
 
-    renderAt('/', {
+    renderAt('/all-projects', {
       projects: [{
         id: 'shared-pulled',
         name: '共享项目',

--- a/apps/web/tests/components/EntryShell.blank-project-naming.test.tsx
+++ b/apps/web/tests/components/EntryShell.blank-project-naming.test.tsx
@@ -32,6 +32,18 @@ import {
   invalidateProjectFilesCache,
 } from '../../src/providers/registry';
 
+const homeStrip = vi.hoisted(() => ({ onViewAll: undefined as (() => void) | undefined }));
+vi.mock('../../src/components/RecentProjectsStrip', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/components/RecentProjectsStrip')>();
+  return {
+    ...actual,
+    RecentProjectsStrip: (props: React.ComponentProps<typeof actual.RecentProjectsStrip>) => {
+      if (props.onViewAll) homeStrip.onViewAll = props.onViewAll;
+      return <actual.RecentProjectsStrip {...props} />;
+    },
+  };
+});
+
 const originalFetch = globalThis.fetch;
 const originalResizeObserver = globalThis.ResizeObserver;
 
@@ -208,6 +220,41 @@ afterEach(() => {
   resetWorkspaceContextCache();
   resetTeamProjectsCache();
   vi.unstubAllGlobals();
+});
+
+describe('EntryShell signed-out recent projects', () => {
+  const localProject = {
+    id: 'local-project', name: 'Local project', skillId: null,
+    designSystemId: null, createdAt: 1, updatedAt: 1,
+  };
+  beforeEach(() => {
+    homeStrip.onViewAll = undefined;
+    globalThis.fetch = vi.fn(async () => jsonResponse({ context: null, projects: [], plugins: [] }));
+  });
+
+  it('keeps Home card actions and the View all callback', async () => {
+    const props = renderAt('/', { projects: [localProject] });
+    const home = screen.getByTestId('entry-view-home');
+    await waitFor(() => expect(home.querySelector('.recent-projects')).not.toBeNull());
+    fireEvent.click(within(home.querySelector('.recent-projects') as HTMLElement).getByRole('button', { name: /more/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Rename' }));
+    const input = within(screen.getByRole('dialog')).getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Renamed local project' } });
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'OK' }));
+    expect(props.onRenameProject).toHaveBeenCalledWith('local-project', 'Renamed local project');
+    // The full-grid header currently hides View all; exercise its supplied
+    // callback at the strip boundary without changing that existing layout.
+    expect(homeStrip.onViewAll).toBeTypeOf('function');
+    act(() => homeStrip.onViewAll!());
+    expect(window.location.pathname).toBe('/projects');
+  });
+
+  it('keeps the Community dock to the composer with local projects present', async () => {
+    renderAt('/community', { projects: [localProject] });
+    const dock = await screen.findByTestId('community-composer-dock');
+    expect(within(dock).getByTestId('home-hero-composer-card')).toBeTruthy();
+    expect(dock.querySelector('.recent-projects')).toBeNull();
+  });
 });
 
 describe('EntryShell team project content readiness', () => {

--- a/apps/web/tests/components/RecentProjectsStrip.test.tsx
+++ b/apps/web/tests/components/RecentProjectsStrip.test.tsx
@@ -1214,7 +1214,10 @@ describe('recvqabp2Uy23r — shared badge grid overlay vs list inline', () => {
     const badge = screen.getByText('Shared').closest('.recent-projects__card-badge');
     expect(badge).not.toBeNull();
     expect(badge?.classList.contains('recent-projects__card-badge--inline')).toBe(false);
-    expect(badge?.closest('.recent-projects__card-thumb')).not.toBeNull();
+    // Anchored on the CARD (beside the ⋯ menu anchor), not inside the thumb:
+    // the thumb scales on hover (#7635) and would carry the badge with it.
+    expect(badge?.closest('.recent-projects__card-thumb')).toBeNull();
+    expect(badge?.closest('.recent-projects__card')).not.toBeNull();
   });
 
   it('renders the shared badge inline next to the name in list view', () => {

--- a/apps/web/tests/styles/app-wash-platform.test.ts
+++ b/apps/web/tests/styles/app-wash-platform.test.ts
@@ -17,6 +17,19 @@ describe('desktop app wash platform contract', () => {
     expect(appWashCss).not.toMatch(/--app-wash:\s*\n?\s*radial-gradient\(/);
   });
 
+  it('keeps the macOS scrim at a thin 20% with no focus-dependent fade (per product, #7635)', () => {
+    const darwinBlock = appWashCss.replace(/\/\*[\s\S]*?\*\//g, '').match(
+      /html:has\(\.workspace-shell--desktop\[data-host-platform='darwin'\]\)\s*{([^}]*)}/,
+    );
+    expect(darwinBlock).not.toBeNull();
+    expect(darwinBlock?.[1]).toMatch(/color-mix\(in srgb, var\(--wash-base\) 20%, transparent\)/);
+    expect(darwinBlock?.[1]).not.toMatch(/62%/);
+    // The unfocused window used to thin the scrim to 34% opacity; the scrim now
+    // holds steady, so no rule keys off `.is-window-blurred` any more.
+    expect(appWashCss).not.toMatch(/html\.is-window-blurred/);
+    expect(appWashCss).not.toMatch(/body::before\s*{\s*transition:\s*opacity/);
+  });
+
   it('limits window-vibrancy material rules to macOS desktop hosts', () => {
     const macDesktopSelector =
       ":has(.workspace-shell--desktop[data-host-platform='darwin'])";

--- a/apps/web/tests/styles/entry-materials.test.ts
+++ b/apps/web/tests/styles/entry-materials.test.ts
@@ -1,0 +1,270 @@
+// Measurement spec for the entry surface's MATERIALS (OPEND-2553 PR-C1, ported
+// from upstream #7635): the one app scrim, the flat rail column, the content
+// card, the 38px rail rows, and the scrolling 最近项目 list. Values are pinned
+// to the Demo's, so a drift in either direction fails here before it reaches a
+// screenshot.
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const read = (relative: string) => readFileSync(new URL(relative, import.meta.url), 'utf8');
+
+const materialCss = read('../../src/styles/material.css');
+const entryLayoutCss = read('../../src/styles/home/entry-layout.css');
+const routinesCss = read('../../src/styles/viewer/routines.css');
+const dialogModuleCss = read('../../../../packages/components/src/dialog.module.css');
+
+function declarations(css: string, selector: string): string {
+  const cssWithoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  const blocks: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  if (blocks.length === 0) throw new Error(`Missing CSS block for ${selector}`);
+  return blocks.join('\n');
+}
+
+/** The declarations of `selector` inside the at-rule blocks whose prelude
+ *  contains `atRule` (a file may carry several such blocks). */
+function declarationsInside(css: string, atRule: string, selector: string): string {
+  const cssWithoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  const bodies: string[] = [];
+  let start = cssWithoutComments.indexOf(atRule);
+  if (start === -1) throw new Error(`Missing at-rule ${atRule}`);
+  while (start !== -1) {
+    const open = cssWithoutComments.indexOf('{', start);
+    let depth = 0;
+    let end = open;
+    for (let index = open; index < cssWithoutComments.length; index += 1) {
+      const char = cssWithoutComments[index];
+      if (char === '{') depth += 1;
+      if (char === '}') {
+        depth -= 1;
+        if (depth === 0) {
+          end = index;
+          break;
+        }
+      }
+    }
+    bodies.push(cssWithoutComments.slice(open + 1, end));
+    start = cssWithoutComments.indexOf(atRule, end);
+  }
+  const matches = bodies.flatMap((body) => {
+    try {
+      return [declarations(body, selector)];
+    } catch {
+      return [];
+    }
+  });
+  if (matches.length === 0) throw new Error(`Missing CSS block for ${selector} inside ${atRule}`);
+  return matches.join('\n');
+}
+
+describe('app scrim material (styles/material.css)', () => {
+  it('owns both halves of the one modal scrim: a 60% white tint under a 50px blur', () => {
+    const root = declarations(materialCss, ':root');
+    expect(root).toMatch(/--scrim-tint:\s*rgba\(255, 255, 255, 0\.6\)/);
+    expect(root).toMatch(/--scrim-backdrop:\s*blur\(50px\)/);
+    expect(root).not.toMatch(/--scrim-backdrop:\s*blur\(4px\)/);
+  });
+
+  it('carries the dark-over-media pair for controls that float over a thumbnail', () => {
+    const root = declarations(materialCss, ':root');
+    expect(root).toMatch(/--material-dim:\s*rgba\(0, 0, 0, 0\.55\)/);
+    expect(root).toMatch(/--vibrancy-label-on-dim:\s*#fff/);
+  });
+
+  it('degrades the scrim to an opaque elevated ground when transparency or backdrop-filter is off', () => {
+    const reduced = declarationsInside(materialCss, '@media (prefers-reduced-transparency: reduce)', 'html:root');
+    expect(reduced).toMatch(/--scrim-tint:\s*var\(--bg-elevated\)/);
+    expect(reduced).toMatch(/--scrim-backdrop:\s*none/);
+    expect(reduced).toMatch(/--material-dim:\s*rgba\(0, 0, 0, 0\.88\)/);
+
+    const unsupported = declarationsInside(materialCss, '@supports not ((backdrop-filter', 'html:root');
+    expect(unsupported).toMatch(/--scrim-tint:\s*var\(--bg-elevated\)/);
+    expect(unsupported).toMatch(/--scrim-backdrop:\s*none/);
+  });
+
+  it('is what the shared <Dialog> backdrop reads, above every piece of app chrome', () => {
+    const backdrop = declarations(dialogModuleCss, '.backdrop');
+    expect(backdrop).toMatch(/background:\s*var\(--scrim-tint\)/);
+    expect(backdrop).toMatch(/backdrop-filter:\s*var\(--scrim-backdrop\)/);
+    expect(backdrop).toMatch(/z-index:\s*1700/);
+  });
+
+  it('is what every app-owned overlay backdrop reads (no per-component tints left)', () => {
+    const overlays = [
+      '../../src/components/BrandPickerModal.module.css',
+      '../../src/components/FigmaHelpModal.module.css',
+      '../../src/components/LibraryPreviewModal.module.css',
+      '../../src/components/LibraryUploadModal.module.css',
+      '../../src/components/MessageCenter.module.css',
+      '../../src/components/NewBrandModal.module.css',
+      '../../src/components/ProjectReferenceModal.module.css',
+      '../../src/components/UpdateDialog.module.css',
+      '../../src/styles/home/new-project-modal.css',
+      '../../src/styles/home/use-everywhere.css',
+      '../../src/styles/viewer/library.css',
+      '../../src/styles/workspace/drawer.css',
+      '../../src/styles/workspace/mention-home.css',
+    ];
+    for (const overlay of overlays) {
+      const css = read(overlay);
+      expect(css, overlay).toMatch(/background:\s*var\(--scrim-tint\)/);
+      expect(css, overlay).toMatch(/backdrop-filter:\s*var\(--scrim-backdrop\)/);
+    }
+    // The lightboxes are the deliberate exception: a light scrim would wash the
+    // image out. They keep their own dark ground and say so.
+    for (const lightbox of [
+      '../../src/components/BrandPreviewCard.module.css',
+      '../../src/components/DesignSystemAssetDropzone.module.css',
+    ]) {
+      expect(read(lightbox), lightbox).toMatch(/DELIBERATE exception to the app's one scrim/);
+    }
+  });
+});
+
+describe('entry layout materials (styles/home/entry-layout.css)', () => {
+  it('flattens the rail column: 12px gutters, no padding, no surface / rim / shadow', () => {
+    const panel = declarations(entryLayoutCss, '.entry-nav-rail__panel');
+    expect(panel).toMatch(/margin:\s*0 12px 12px/);
+    expect(panel).toMatch(/padding:\s*0/);
+    expect(panel).not.toMatch(/--rail-surface/);
+    expect(panel).not.toMatch(/backdrop-filter/);
+    expect(panel).not.toMatch(/border-radius/);
+    expect(panel).not.toMatch(/box-shadow/);
+    expect(entryLayoutCss).not.toContain('.entry-nav-rail__panel::after');
+    expect(declarations(entryLayoutCss, '.entry-nav-rail__group')).toMatch(/padding:\s*0;/);
+  });
+
+  it('makes the content column the one base card: 85% white frost, 16px corner, inset ring, 12px inset', () => {
+    const card = declarations(entryLayoutCss, '.entry-main--scroll');
+    expect(card).toMatch(/margin:\s*0 12px 12px 0/);
+    expect(card).toMatch(/--entry-content-surface:\s*rgba\(255, 255, 255, 0\.85\)/);
+    expect(card).toMatch(/--entry-content-ring:\s*var\(--glass-refract-ring-edge\)/);
+    expect(card).toMatch(/background:\s*var\(--entry-content-surface\)/);
+    expect(card).toMatch(/backdrop-filter:\s*var\(--material-thin-backdrop\)/);
+    expect(card).toMatch(/border-radius:\s*16px/);
+    expect(card).toMatch(/box-shadow:\s*var\(--shadow-sm\),\s*inset 0 0 0 1px var\(--entry-content-ring\)/);
+    expect(declarations(entryLayoutCss, '.entry:not(.entry--rail-open) .entry-main--scroll')).toMatch(
+      /margin-left:\s*12px/,
+    );
+    // Narrow-window auto-collapse keeps `.entry--rail-open`, so it needs its own
+    // copy of that gutter.
+    expect(
+      declarationsInside(
+        entryLayoutCss,
+        '@media (max-width: 1080px)',
+        '.entry-shell--no-header .entry.entry--rail-open .entry-main--scroll',
+      ),
+    ).toMatch(/margin-left:\s*12px/);
+  });
+
+  it('degrades the content card to a solid surface without transparency / backdrop-filter', () => {
+    const reduced = declarationsInside(entryLayoutCss, '@media (prefers-reduced-transparency: reduce)', '.entry-main--scroll');
+    expect(reduced).toMatch(/--entry-content-surface:\s*var\(--bg\)/);
+    expect(reduced).toMatch(/backdrop-filter:\s*none/);
+    const unsupported = declarationsInside(entryLayoutCss, '@supports not ((backdrop-filter', '.entry-main--scroll');
+    expect(unsupported).toMatch(/--entry-content-surface:\s*var\(--bg\)/);
+    expect(unsupported).toMatch(/--entry-content-ring:\s*color-mix\(in srgb, var\(--border\) 66%, transparent\)/);
+  });
+
+  it('gives the content column one 24px gutter with the cap carrying it', () => {
+    const inner = declarations(entryLayoutCss, '.entry-main__inner');
+    expect(inner).toMatch(/max-width:\s*calc\(1600px \+ 48px\)/);
+    expect(inner).toMatch(/padding:\s*24px 24px 48px/);
+    expect(inner).not.toMatch(/padding-left:\s*35px/);
+    expect(declarations(entryLayoutCss, '.entry-main__inner--wide')).toMatch(/max-width:\s*calc\(1600px \+ 48px\)/);
+  });
+
+  it('turns every rail destination into a 38px, 12px-radius row on the shared quiet ink', () => {
+    const btn = declarations(entryLayoutCss, '.entry-nav-rail__btn');
+    expect(btn).toMatch(/height:\s*auto/);
+    expect(btn).toMatch(/padding:\s*10px 10px 10px 16px/);
+    expect(btn).toMatch(/border:\s*0/);
+    expect(btn).toMatch(/border-radius:\s*12px/);
+    expect(btn).toMatch(/color:\s*var\(--rail-ink-quiet\)/);
+    expect(declarations(entryLayoutCss, '.entry-nav-rail__btn-icon')).toMatch(/color:\s*inherit/);
+    expect(declarations(entryLayoutCss, '.entry-nav-rail__btn-label')).toMatch(/font-weight:\s*600/);
+
+    const active = declarations(entryLayoutCss, '.entry-nav-rail__btn.is-active');
+    expect(active).toMatch(/background:\s*color-mix\(in srgb, var\(--text-strong\) 10%, transparent\)/);
+    expect(declarations(entryLayoutCss, '.entry-nav-rail__btn.is-active .entry-nav-rail__btn-label')).toMatch(
+      /color:\s*#121212/,
+    );
+  });
+
+  it('paints one hover for the whole rail: destinations and the 最近项目 rows share fill and ink (OPEND-2700)', () => {
+    const navHover = declarations(entryLayoutCss, '.entry-nav-rail__btn:not(.is-active):hover');
+    const headHover = declarations(entryLayoutCss, '.entry-nav-rail__recent-head:hover:not(:disabled)');
+    const itemHover = declarations(entryLayoutCss, '.entry-nav-rail__recent-item:hover:not(:disabled)');
+    for (const block of [navHover, headHover, itemHover]) {
+      expect(block).toMatch(/background:\s*color-mix\(in srgb, var\(--text-strong\) 10%, transparent\)/);
+      expect(block).toMatch(/color:\s*var\(--text-strong\)/);
+    }
+    // Same box, same corner.
+    expect(declarations(entryLayoutCss, '.entry-nav-rail__recent-head')).toMatch(/border-radius:\s*12px/);
+    expect(declarations(entryLayoutCss, '.entry-nav-rail__recent-head')).toMatch(/min-height:\s*38px/);
+  });
+
+  it('gives the workspace switcher row the same 38px box, with a 24px avatar', () => {
+    expect(declarations(entryLayoutCss, '.entry-nav-rail__team')).toMatch(/height:\s*38px/);
+    const avatar = declarations(entryLayoutCss, '.entry-nav-rail__team-avatar');
+    expect(avatar).toMatch(/width:\s*24px/);
+    expect(avatar).toMatch(/flex:\s*0 0 24px/);
+    expect(declarations(entryLayoutCss, '.entry-nav-rail__team-chevron')).toMatch(/flex:\s*0 0 14px/);
+  });
+
+  it('lists every recent project and scrolls the LIST past ~11 rows, shrinking with the window (OPEND-2757)', () => {
+    const list = declarations(entryLayoutCss, '.entry-nav-rail__recent-list');
+    expect(list).toMatch(/max-height:\s*calc\(11 \* 38px \+ 10 \* 2px \+ 2px\)/);
+    expect(list).toMatch(/overflow-y:\s*auto/);
+    expect(list).toMatch(/min-height:\s*0/);
+    // The flex chain that lets the cap shrink with the viewport instead of
+    // pushing the fixed rows below the list out of the rail.
+    for (const selector of [
+      '.entry-nav-rail__team-section',
+      '.entry-nav-rail__recent',
+      '.entry-nav-rail__recent > .accordion-collapsible',
+    ]) {
+      expect(declarations(entryLayoutCss, selector), selector).toMatch(/min-height:\s*0/);
+      expect(declarations(entryLayoutCss, selector), selector).toMatch(/flex:\s*0 1 auto/);
+    }
+    expect(
+      declarations(entryLayoutCss, '.entry-nav-rail__recent > .accordion-collapsible > .accordion-collapsible-inner'),
+    ).toMatch(/display:\s*flex/);
+  });
+
+  it('dresses the chrome-row search + rail toggle as icon squares on the selected-row fill', () => {
+    const search = declarations(entryLayoutCss, '.entry-nav-rail__search-row .entry-nav-rail__search');
+    expect(search).toMatch(/width:\s*34px/);
+    expect(search).toMatch(/padding:\s*0/);
+    expect(declarations(entryLayoutCss, '.entry-nav-rail__search')).toMatch(/background:\s*transparent/);
+    expect(declarations(entryLayoutCss, '.entry-nav-rail__collapse:hover:not(:disabled)')).toMatch(
+      /background:\s*color-mix\(in srgb, var\(--text-strong\) 10%, transparent\)/,
+    );
+    expect(declarations(entryLayoutCss, '.entry-nav-rail__search-kbd')).toMatch(/display:\s*none/);
+    expect(declarations(entryLayoutCss, '.workspace-tabs-rail-actions .entry-nav-rail__collapse')).toMatch(
+      /margin-left:\s*0/,
+    );
+  });
+});
+
+describe('workspace tab dropdown (styles/viewer/routines.css)', () => {
+  it('reserves a 14px lead slot on every row and paints the check off its own class', () => {
+    const lead = declarations(routinesCss, '.workspace-tabs-dropdown__row-lead');
+    expect(lead).toMatch(/flex:\s*0 0 14px/);
+    expect(lead).toMatch(/width:\s*14px/);
+    expect(declarations(routinesCss, '.workspace-tabs-dropdown__row-check')).toMatch(/color:\s*var\(--accent\)/);
+    expect(routinesCss).not.toContain('.workspace-tabs-dropdown__row-main > svg:first-child');
+  });
+
+  it('hovers the chat Home logo on the rail\'s selected-row fill, 64px wide', () => {
+    expect(declarations(routinesCss, '.workspace-tabs-home-chrome')).toMatch(/width:\s*64px/);
+    expect(declarations(routinesCss, '.workspace-tabs-home-chrome:hover:not(:disabled)')).toMatch(
+      /background:\s*color-mix\(in srgb, var\(--text-strong\) 10%, transparent\)/,
+    );
+  });
+});

--- a/apps/web/tests/styles/entry-materials.test.ts
+++ b/apps/web/tests/styles/entry-materials.test.ts
@@ -137,6 +137,10 @@ describe('entry layout materials (styles/home/entry-layout.css)', () => {
     expect(panel).not.toMatch(/box-shadow/);
     expect(entryLayoutCss).not.toContain('.entry-nav-rail__panel::after');
     expect(declarations(entryLayoutCss, '.entry-nav-rail__group')).toMatch(/padding:\s*0;/);
+    // …but it stays a containing block for the fixed menu click-catchers, so
+    // an open workspace switcher never swallows clicks on the content column.
+    expect(panel).toMatch(/transform:\s*translateZ\(0\)/);
+    expect(declarations(entryLayoutCss, '.entry-nav-rail__menu-backdrop')).toMatch(/position:\s*fixed/);
   });
 
   it('makes the content column the one base card: 85% white frost, 16px corner, inset ring, 12px inset', () => {

--- a/apps/web/tests/styles/workspace-tabs-chrome.test.ts
+++ b/apps/web/tests/styles/workspace-tabs-chrome.test.ts
@@ -345,8 +345,9 @@ describe('workspace tabs chrome styles', () => {
 
     // Home never shrinks (flex-shrink 0) in either chrome…
     expect(ruleValue(pinnedShared, 'flex')).toBe('0 0 52px');
-    // Round-4 skin: the pinned tab is a single-icon pill (~half a project tab).
-    expect(ruleValue(pinnedProject, 'flex')).toBe('0 0 78px');
+    // Round-4 skin: the pinned tab is a single-icon pill. 64px (per product,
+    // #7635) puts its glyph on the rail's 首页 icon axis.
+    expect(ruleValue(pinnedProject, 'flex')).toBe('0 0 64px');
     // …and stays stuck to the left edge with an opaque background so scrolled
     // project tabs pass behind it instead of squeezing it.
     expect(ruleValue(pinnedShared, 'position')).toBe('sticky');
@@ -413,6 +414,20 @@ describe('workspace tabs chrome styles', () => {
     expect(ruleValue(projectDragging, 'box-shadow')).toContain('0 14px 30px');
     expect(shellCss).not.toContain('.workspace-tab.is-drag-over-before::after');
     expect(shellCss).not.toContain('.workspace-tab.is-drag-over-after::after');
+  });
+
+  it('hides the pinned Home pill in the entry chrome — the search/toggle cluster owns that corner', () => {
+    // #7635: 顶部去掉 home icon，只有 chat 里才显示. The pill stays in the DOM
+    // as the tab machinery's anchor; the chrome-scoped rule hides it, and
+    // must out-rank the `:has(.workspace-tab__rail-toggle)` display rule.
+    const hidden = cssDeclarations(
+      routinesCss,
+      '.workspace-shell .workspace-tabs-chrome .workspace-tab.is-pinned:has(.workspace-tab__rail-toggle)',
+    );
+    expect(ruleValue(hidden, 'display')).toBe('none');
+    const cluster = cssDeclarations(entryLayoutCss, '.workspace-tabs-rail-actions');
+    expect(ruleValue(cluster, 'gap')).toBe('4px');
+    expect(ruleValue(cluster, 'margin')).toBe('0 0 0 14.8px');
   });
 
   it('caps the docked tab dropdown at six rows and scrolls the rest', () => {

--- a/e2e/lib/playwright/amr.ts
+++ b/e2e/lib/playwright/amr.ts
@@ -4,7 +4,7 @@ import type {
   WorkspaceCollabContext,
   WorkspaceDirectoryItem,
 } from '@open-design/contracts';
-import { ensureRailOpen } from './rail.js';
+import { dismissWhatsNewPopup, ensureRailOpen } from './rail.js';
 import { T } from '@/timeouts';
 
 export const STORAGE_KEY = 'open-design:config';
@@ -380,6 +380,7 @@ export async function openSettingsDialog(page: Page) {
     if (await dialog.isVisible().catch(() => false)) return dialog;
 
     await dismissPrivacyDialog(page);
+    await dismissWhatsNewPopup(page);
     if (await settingsTrigger.isVisible({ timeout: 1_000 }).catch(() => false)) {
       await settingsTrigger.evaluate((element: HTMLElement) => element.click());
     } else if (!(await openSettingsFromProjectSurface(page))) {

--- a/e2e/lib/playwright/rail.ts
+++ b/e2e/lib/playwright/rail.ts
@@ -17,7 +17,25 @@ import { T } from '@/timeouts';
  * does not exist — call it after returning to the entry shell, not from a
  * project workspace.
  */
+/**
+ * Close the release announcement if it is up. `WhatsNewPopup` is a shared
+ * `<Dialog>`, which mounts its scrim on <body> above every piece of chrome
+ * (#7635) — while it is open nothing behind it, the rail toggle included, can
+ * be clicked. Specs that apply the standard mocks never see it
+ * (`suppressWhatsNew`); the ones that drive a real daemon do, whenever the
+ * running build ships highlights. Idempotent — no-ops when there is none.
+ */
+export async function dismissWhatsNewPopup(page: Page): Promise<void> {
+  const popup = page.getByTestId('whats-new-popup');
+  await popup.waitFor({ state: 'visible', timeout: 1_000 }).catch(() => {});
+  if (await popup.isVisible().catch(() => false)) {
+    await popup.getByTestId('whats-new-dismiss').click();
+    await expect(popup).toBeHidden();
+  }
+}
+
 export async function ensureRailOpen(page: Page): Promise<void> {
+  await dismissWhatsNewPopup(page);
   const shell = page.locator('.entry');
   const alreadyOpen = await shell
     .evaluate((el) => el.classList.contains('entry--rail-open'))
@@ -71,6 +89,7 @@ export async function openNewProjectModal(page: Page): Promise<void> {
     await ensureRailOpen(page).catch(() => {});
   }
   await openProjectsEntryView(page);
+  await dismissWhatsNewPopup(page);
   const projectsView = page.getByTestId('entry-view-projects');
   await expect(projectsView).toBeVisible({ timeout: T.long });
   const createButton = projectsView

--- a/e2e/lib/playwright/rail.ts
+++ b/e2e/lib/playwright/rail.ts
@@ -5,17 +5,17 @@ import { T } from '@/timeouts';
 /**
  * The entry nav rail is collapsed by default; its destinations
  * (`entry-nav-*`) only become interactable once the rail is expanded. The
- * expand affordance is the pinned Home tab's sidebar toggle in the workspace
- * tabs bar (#5517 removed the entry topbar) — it only renders on the Home
- * view; on any other entry view the pinned tab is a Home shortcut instead,
- * so this helper returns Home first when it needs to expand. Idempotent —
- * no-ops when the rail is already docked open.
+ * expand affordance is the rail toggle in the workspace tabs chrome row
+ * (`entry-rail-collapse`, beside the search button — #7635 moved the pair out
+ * of the rail and hid the pinned Home pill there; #5517 had already removed
+ * the entry topbar). It renders on every entry view, so no Home round-trip is
+ * needed. Idempotent — no-ops when the rail is already docked open.
  *
- * Both controls hang off the pinned entry tab while it is the ACTIVE
- * workspace tab (`WorkspaceTabsBar.tsx`: `isPinned && active`), so this only
- * works from an entry surface. Inside a project the pinned tab renders as a
- * plain Home tab button and neither testid exists — call it after returning
- * to the entry shell, not from a project workspace.
+ * The cluster only renders while the strip is undocked, i.e. on an entry
+ * surface (`WorkspaceTabsBar.tsx`: `!tabsDockEl && !settingsPageChrome`).
+ * Inside a project the strip lives in the chat column dock and the testid
+ * does not exist — call it after returning to the entry shell, not from a
+ * project workspace.
  */
 export async function ensureRailOpen(page: Page): Promise<void> {
   const shell = page.locator('.entry');
@@ -23,7 +23,7 @@ export async function ensureRailOpen(page: Page): Promise<void> {
     .evaluate((el) => el.classList.contains('entry--rail-open'))
     .catch(() => false);
   if (!alreadyOpen) {
-    const toggle = page.getByTestId('workspace-home-rail-toggle');
+    const toggle = page.getByTestId('entry-rail-collapse');
     if (!(await toggle.isVisible().catch(() => false))) {
       const homeNav = page.getByTestId('workspace-home-nav');
       if (await homeNav.isVisible().catch(() => false)) {

--- a/e2e/lib/playwright/visual.ts
+++ b/e2e/lib/playwright/visual.ts
@@ -711,9 +711,14 @@ export async function waitForVisualProjects(page: Page, projects: readonly Visua
     return;
   }
 
-  await expect(
-    page.getByTestId('recent-projects-strip').getByText(projects[0]?.name ?? '', { exact: true }),
-  ).toBeVisible();
+  // Where the catalog shows depends on identity: the signed-out shell keeps
+  // Home's recent-projects grid, while a workspace-bound Home carries the list
+  // in the rail's 最近项目 section instead (#7635 / OPEND-2683). The rail is
+  // collapsed by default, so its rows are attached rather than visible.
+  const name = projects[0]?.name ?? '';
+  const stripRow = page.getByTestId('recent-projects-strip').getByText(name, { exact: true });
+  const railRow = page.getByTestId('entry-nav-recent-item').filter({ hasText: name }).first();
+  await expect(stripRow.or(railRow).first()).toBeAttached();
 }
 
 export async function gotoVisualHome(page: Page): Promise<void> {

--- a/e2e/ui/critical-smoke.test.ts
+++ b/e2e/ui/critical-smoke.test.ts
@@ -22,9 +22,9 @@ test('[P0] @critical home loads with the primary entry controls', async ({ page 
   await gotoEntryHome(page);
 
   // The rail is collapsed by default — the hero owns the first screen and the
-  // only chrome affordance is the pinned Home tab's sidebar toggle in the
-  // workspace tabs bar. Expand to reach the rail nav.
-  await expect(page.getByTestId('workspace-home-rail-toggle')).toBeVisible();
+  // chrome row carries only the search + rail-toggle cluster (#7635). Expand
+  // to reach the rail nav.
+  await expect(page.getByTestId('entry-rail-collapse')).toBeVisible();
   await expect(page.getByTestId('home-hero-input')).toBeVisible();
   await ensureRailOpen(page);
   await expect(page.getByTestId('entry-nav-home')).toHaveAttribute('aria-current', 'page');

--- a/e2e/ui/entry-chrome-flows.test.ts
+++ b/e2e/ui/entry-chrome-flows.test.ts
@@ -92,12 +92,14 @@ test('[P0] @critical entry chrome exposes the primary home creation surface and 
 
   await gotoEntryHome(page);
   await expect(page.getByTestId('recent-projects-strip')).toHaveCount(0);
-  // The nav rail is collapsed by default — the pinned Home tab in the
-  // workspace tabs bar is the expand toggle (#5517: no entry topbar).
-  await expect(page.getByTestId('workspace-home-rail-toggle')).toBeVisible();
-  await page.getByTestId('workspace-home-rail-toggle').click();
-  await expect(page.locator('.entry-nav-rail')).toBeVisible();
+  // The nav rail is collapsed by default — the rail toggle beside the search
+  // button in the workspace tabs chrome is the expand control (#7635 moved
+  // the pair out of the rail; #5517: no entry topbar). Search is reachable
+  // before the rail opens.
   await expect(page.getByTestId('entry-nav-search')).toBeVisible();
+  await expect(page.getByTestId('entry-rail-collapse')).toBeVisible();
+  await page.getByTestId('entry-rail-collapse').click();
+  await expect(page.locator('.entry-nav-rail')).toBeVisible();
   await expect(page.locator('.entry-brand')).toHaveCount(0);
   await expect(page.getByTestId('home-hero-input')).toBeVisible();
   await expect(page.getByTestId('home-hero-plus-trigger')).toBeVisible();
@@ -434,12 +436,13 @@ test('[P1] entry top navigation matches the current home tab structure', async (
   await gotoEntryHome(page);
   await ensureRailOpen(page);
 
-  // The rail is header-free: no logo, no in-rail collapse control — the
-  // column starts at the search box, and folding lives in the pinned Home
-  // tab's toggle on the workspace tabs bar.
+  // The rail is header-free: no logo, no in-rail search row — the column
+  // starts at the workspace switcher / 首页, and both search and folding live
+  // in the chrome row's cluster beside the tabs (#7635).
   await expect(page.getByTestId('entry-nav-logo')).toHaveCount(0);
   await expect(page.getByTestId('entry-nav-collapse')).toHaveCount(0);
-  await expect(page.getByTestId('entry-nav-search')).toBeVisible();
+  await expect(page.locator('.entry-nav-rail').getByTestId('entry-nav-search')).toHaveCount(0);
+  await expect(page.locator('.workspace-tabs-rail-actions').getByTestId('entry-nav-search')).toBeVisible();
   await expect(page.getByTestId('entry-nav-home')).toHaveAttribute('aria-current', 'page');
   await expect(page.getByTestId('entry-nav-community')).toBeVisible();
   await expect(page.locator('.entry-nav-rail__group').getByTestId('entry-nav-design-systems')).toBeVisible();
@@ -1477,7 +1480,7 @@ test('[P1] rail can be collapsed again on coarse-pointer / non-hover devices', a
   await gotoEntryHome(page);
   await ensureRailOpen(page);
 
-  const toggle = page.getByTestId('workspace-home-rail-toggle');
+  const toggle = page.getByTestId('entry-rail-collapse');
   await expect(toggle).toBeVisible();
   await toggle.click();
   await expect(page.locator('.entry')).not.toHaveClass(/entry--rail-open/);

--- a/e2e/ui/home-hero-rail.test.ts
+++ b/e2e/ui/home-hero-rail.test.ts
@@ -749,7 +749,9 @@ test('[P1] home left rail expands and collapses from the shell controls', async 
 
   const shell = page.locator('.entry');
   const rail = page.locator('.entry-nav-rail');
-  const expand = page.getByTestId('workspace-home-rail-toggle');
+  // #7635: the toggle lives in the chrome row's search/toggle cluster and
+  // owns both directions; the pinned Home pill is hidden in the entry chrome.
+  const expand = page.getByTestId('entry-rail-collapse');
 
   await expect(shell).not.toHaveClass(/entry--rail-open/);
   await expect(rail).toHaveAttribute('aria-hidden', 'true');
@@ -764,7 +766,7 @@ test('[P1] home left rail expands and collapses from the shell controls', async 
   await expect(page.getByTestId('entry-nav-design-systems')).toBeVisible();
 
   // The rail has no in-rail collapse control (the header is chrome-free);
-  // the pinned Home tab's toggle folds it back.
+  // the same chrome-row toggle folds it back.
   await expect(expand).toHaveAttribute('aria-expanded', 'true');
   await expand.click();
   await expect(shell).not.toHaveClass(/entry--rail-open/);
@@ -1809,7 +1811,7 @@ test('[P1] live dashboard preset sends the active workspace name to plugin apply
   });
 
   await gotoEntryHome(page);
-  await page.getByTestId('workspace-home-rail-toggle').click();
+  await page.getByTestId('entry-rail-collapse').click();
   await expect(page.getByTestId('workspace-switcher')).toContainText('Personal Workspace');
 
   await pickHomeTemplate(page, 'live-artifact');

--- a/e2e/ui/workspace-team-interactions.test.ts
+++ b/e2e/ui/workspace-team-interactions.test.ts
@@ -213,7 +213,10 @@ test('[P1] New team deep-links Vela creation and exposes the created workspace o
   expect(href.searchParams.get('workspace')).toBe('create');
   await expect(createTeam).toHaveAttribute('target', '_blank');
 
-  await page.locator('.entry-nav-rail__menu-backdrop').click({ position: { x: 2, y: 2 } });
+  // The backdrop spans the viewport now that the rail column paints nothing of
+  // its own (#7635) — (2, 2) lands under the tabs chrome, so click into the
+  // content column instead.
+  await page.locator('.entry-nav-rail__menu-backdrop').click({ position: { x: 640, y: 400 } });
   directory.push(TEAM_SECOND);
   // Directory reads are deliberately coalesced for one second. A real console
   // roundtrip exceeds that window; jump past it so this assertion exercises
@@ -315,6 +318,9 @@ test('[P0] workspace switch clears the previous project list before the next sco
 
   await gotoHome(page);
   await ensureRailOpen(page);
+  // A workspace-bound Home carries no project grid any more (#7635 /
+  // OPEND-2683); 草稿 is the grid the switch has to clear.
+  await page.getByTestId('entry-nav-drafts').click();
   await expect(visibleProjectCard(page, PERSONAL_DRAFT.id)).toBeVisible();
 
   await page.getByTestId('workspace-switcher').click();
@@ -326,6 +332,9 @@ test('[P0] workspace switch clears the previous project list before the next sco
   await expect(visibleProjectCard(page, SWITCHED_TEAM_DRAFT.id)).toHaveCount(0);
 
   releaseTeamProjects();
+  // The switch lands on Home; the new scope's grid is on 草稿 again.
+  await ensureRailOpen(page);
+  await page.getByTestId('entry-nav-drafts').click();
   await expect(visibleProjectCard(page, SWITCHED_TEAM_DRAFT.id)).toBeVisible();
   await expect(visibleProjectCard(page, PERSONAL_DRAFT.id)).toHaveCount(0);
 });
@@ -550,6 +559,8 @@ test('[P0] account replacement never paints the previous account workspace or pr
 
   await gotoHome(page);
   await ensureRailOpen(page);
+  // Same reason as above: the grid lives on 草稿 for a workspace-bound Home.
+  await page.getByTestId('entry-nav-drafts').click();
   await expect(visibleProjectCard(page, accountA.project.id)).toBeVisible();
   await expect(page.getByTestId('workspace-switcher')).toContainText(
     accountA.workspace.workspaceName,
@@ -574,6 +585,8 @@ test('[P0] account replacement never paints the previous account workspace or pr
   await expect(page.getByTestId('workspace-switcher')).toContainText(
     accountB.workspace.workspaceName,
   );
+  // The reload lands on Home; account B's grid is on 草稿 again.
+  await page.getByTestId('entry-nav-drafts').click();
   await expect(visibleProjectCard(page, accountB.project.id)).toBeVisible();
   await expect(visibleProjectCard(page, accountA.project.id)).toHaveCount(0);
 });
@@ -883,7 +896,10 @@ test('[P0] an already-open locked workspace restores invite and sharing actions 
   await expect(
     page.getByRole('menu').getByRole('menuitem', { name: 'Invite colleague' }),
   ).toHaveCount(0);
-  await page.locator('.entry-nav-rail__menu-backdrop').click({ position: { x: 2, y: 2 } });
+  // The backdrop spans the viewport now that the rail column paints nothing of
+  // its own (#7635) — (2, 2) lands under the tabs chrome, so click into the
+  // content column instead.
+  await page.locator('.entry-nav-rail__menu-backdrop').click({ position: { x: 640, y: 400 } });
   await page.getByTestId('entry-nav-drafts').click();
   const card = projectCard(page);
   await openProjectMenu(card);
@@ -906,7 +922,10 @@ test('[P0] an already-open locked workspace restores invite and sharing actions 
   await expect(
     page.getByRole('menu').getByRole('menuitem', { name: 'Invite colleague' }),
   ).toBeVisible({ timeout: T.long });
-  await page.locator('.entry-nav-rail__menu-backdrop').click({ position: { x: 2, y: 2 } });
+  // The backdrop spans the viewport now that the rail column paints nothing of
+  // its own (#7635) — (2, 2) lands under the tabs chrome, so click into the
+  // content column instead.
+  await page.locator('.entry-nav-rail__menu-backdrop').click({ position: { x: 640, y: 400 } });
   await page.getByTestId('entry-nav-drafts').click();
   await expect(card).toBeVisible({ timeout: T.long });
   await expect(card.getByRole('button', { name: 'More actions' })).toBeVisible({

--- a/e2e/ui/workspace-team-interactions.test.ts
+++ b/e2e/ui/workspace-team-interactions.test.ts
@@ -213,10 +213,7 @@ test('[P1] New team deep-links Vela creation and exposes the created workspace o
   expect(href.searchParams.get('workspace')).toBe('create');
   await expect(createTeam).toHaveAttribute('target', '_blank');
 
-  // The backdrop spans the viewport now that the rail column paints nothing of
-  // its own (#7635) — (2, 2) lands under the tabs chrome, so click into the
-  // content column instead.
-  await page.locator('.entry-nav-rail__menu-backdrop').click({ position: { x: 640, y: 400 } });
+  await page.locator('.entry-nav-rail__menu-backdrop').click({ position: { x: 2, y: 2 } });
   directory.push(TEAM_SECOND);
   // Directory reads are deliberately coalesced for one second. A real console
   // roundtrip exceeds that window; jump past it so this assertion exercises
@@ -896,10 +893,7 @@ test('[P0] an already-open locked workspace restores invite and sharing actions 
   await expect(
     page.getByRole('menu').getByRole('menuitem', { name: 'Invite colleague' }),
   ).toHaveCount(0);
-  // The backdrop spans the viewport now that the rail column paints nothing of
-  // its own (#7635) — (2, 2) lands under the tabs chrome, so click into the
-  // content column instead.
-  await page.locator('.entry-nav-rail__menu-backdrop').click({ position: { x: 640, y: 400 } });
+  await page.locator('.entry-nav-rail__menu-backdrop').click({ position: { x: 2, y: 2 } });
   await page.getByTestId('entry-nav-drafts').click();
   const card = projectCard(page);
   await openProjectMenu(card);
@@ -922,10 +916,7 @@ test('[P0] an already-open locked workspace restores invite and sharing actions 
   await expect(
     page.getByRole('menu').getByRole('menuitem', { name: 'Invite colleague' }),
   ).toBeVisible({ timeout: T.long });
-  // The backdrop spans the viewport now that the rail column paints nothing of
-  // its own (#7635) — (2, 2) lands under the tabs chrome, so click into the
-  // content column instead.
-  await page.locator('.entry-nav-rail__menu-backdrop').click({ position: { x: 640, y: 400 } });
+  await page.locator('.entry-nav-rail__menu-backdrop').click({ position: { x: 2, y: 2 } });
   await page.getByTestId('entry-nav-drafts').click();
   await expect(card).toBeVisible({ timeout: T.long });
   await expect(card.getByRole('button', { name: 'More actions' })).toBeVisible({

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@testing-library/react": "16.3.2",
     "@types/react": "18.3.28",
+    "@types/react-dom": "18.3.7",
     "esbuild": "0.28.0",
     "jsdom": "29.1.1",
     "react": "18.3.1",

--- a/packages/components/src/dialog.module.css
+++ b/packages/components/src/dialog.module.css
@@ -1,14 +1,23 @@
 .backdrop {
   position: fixed;
   inset: 0;
-  background: color-mix(in srgb, #202020 42%, transparent);
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
+  /* The app's one scrim material (apps/web styles/material.css). Read as
+     tokens, like every other value in this file — this is the base every
+     `<Dialog>` mounts into, so it is where the shared look has to live. */
+  background: var(--scrim-tint);
+  backdrop-filter: var(--scrim-backdrop);
+  -webkit-backdrop-filter: var(--scrim-backdrop);
   -webkit-app-region: no-drag;
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 100;
+  /* Above ALL app chrome — the workspace tabs row (z-index 120) and the
+     floating top-right account/credits cluster (150) — so the scrim covers the
+     whole window: its blur reads as one frosted sheet over everything instead
+     of stopping at the content area's edge, and chrome that is not part of the
+     dialog cannot float over it. 1700 is the app's own `.modal-backdrop`
+     value, and stays under toasts (1800) and the radial layer (1900). */
+  z-index: 1700;
   animation: dialog-backdrop-fade-in var(--duration-fast, 150ms) var(--curve-decelerate-mid, ease-out);
 }
 

--- a/packages/components/src/dialog.tsx
+++ b/packages/components/src/dialog.tsx
@@ -5,6 +5,7 @@ import {
   type MouseEvent,
   type ReactNode,
 } from 'react';
+import { createPortal } from 'react-dom';
 
 import { joinClassNames } from './class-names';
 import styles from './dialog.module.css';
@@ -86,7 +87,7 @@ export function Dialog({
     ...dataAttributes,
   };
 
-  return (
+  const overlay = (
     <div
       className={joinClassNames(
         includeChromeClassName ? styles.backdrop : undefined,
@@ -105,6 +106,15 @@ export function Dialog({
       )}
     </div>
   );
+
+  // Mounted on <body>, not where the dialog is used: the scrim's z-index only
+  // outranks app chrome (tabs row 120, the floating account cluster 150) if it
+  // competes in the ROOT stacking context. Rendered in place, any ancestor that
+  // opens a stacking context traps it — the scrim then stopped at the content
+  // area and that chrome floated over the dialog. React events still bubble
+  // through the React tree, so callers see no difference.
+  if (typeof document === 'undefined') return overlay;
+  return createPortal(overlay, document.body);
 }
 
 export function DialogHeader({ className, ...props }: DialogSectionProps) {

--- a/packages/components/tests/Dialog.test.tsx
+++ b/packages/components/tests/Dialog.test.tsx
@@ -27,15 +27,28 @@ describe('Dialog', () => {
     expect(screen.getByRole('dialog', { name: 'Rename design' })).toBeTruthy();
   });
 
+  // The overlay is portaled onto <body> (so its scrim out-ranks app chrome in
+  // the root stacking context), which is why every query below goes through
+  // `baseElement` rather than the render container.
+  it('mounts the backdrop on <body>, outside the render container', () => {
+    const { container, baseElement } = render(
+      <Dialog>
+        <h2>Portaled</h2>
+      </Dialog>,
+    );
+    expect(container.querySelector('.modal-backdrop')).toBeNull();
+    expect(baseElement.querySelector('.modal-backdrop')?.parentElement).toBe(document.body);
+  });
+
   it('closes on backdrop click when enabled', () => {
     const onClose = vi.fn();
-    const { container } = render(
+    const { baseElement } = render(
       <Dialog onClose={onClose}>
         <h2>Backdrop close</h2>
       </Dialog>,
     );
 
-    fireEvent.click(container.querySelector('.modal-backdrop') as HTMLElement);
+    fireEvent.click(baseElement.querySelector('.modal-backdrop') as HTMLElement);
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });
@@ -54,13 +67,13 @@ describe('Dialog', () => {
   });
 
   it('lets custom panels opt out of the shared modal chrome class', () => {
-    const { container } = render(
+    const { baseElement } = render(
       <Dialog className="plugin-details-modal" includeChromeClassName={false}>
         <h2>Plugin details</h2>
       </Dialog>,
     );
 
-    const panel = container.querySelector('.plugin-details-modal');
+    const panel = baseElement.querySelector('.plugin-details-modal');
 
     expect(panel).toBeTruthy();
     expect(panel?.className).toBe('plugin-details-modal');
@@ -73,13 +86,13 @@ describe('Dialog', () => {
     document.head.insertBefore(variantStyles, document.head.firstChild);
 
     try {
-      const { container } = render(
+      const { baseElement } = render(
         <Dialog className="modal-rename">
           <h2>Rename design</h2>
         </Dialog>,
       );
 
-      const panel = container.querySelector('.modal-rename') as HTMLElement;
+      const panel = baseElement.querySelector('.modal-rename') as HTMLElement;
       const panelStyles = getComputedStyle(panel);
 
       expect(panelStyles.width).toBe('420px');
@@ -90,7 +103,7 @@ describe('Dialog', () => {
   });
 
   it('supports sectioned layouts with shared header/body/footer primitives', () => {
-    const { container } = render(
+    const { baseElement } = render(
       <Dialog layout="sectioned" ariaLabelledBy="dialog-title">
         <DialogHeader>
           <DialogTitle id="dialog-title">Sketch text</DialogTitle>
@@ -110,9 +123,9 @@ describe('Dialog', () => {
     );
 
     expect(screen.getByRole('dialog', { name: 'Sketch text' })).toBeTruthy();
-    expect(container.querySelector('[class*="dialogSectioned"]')).toBeTruthy();
-    expect(container.querySelector('[class*="header"]')).toBeTruthy();
-    expect(container.querySelector('[class*="body"]')).toBeTruthy();
-    expect(container.querySelector('[class*="footer"]')).toBeTruthy();
+    expect(baseElement.querySelector('[class*="dialogSectioned"]')).toBeTruthy();
+    expect(baseElement.querySelector('[class*="header"]')).toBeTruthy();
+    expect(baseElement.querySelector('[class*="body"]')).toBeTruthy();
+    expect(baseElement.querySelector('[class*="footer"]')).toBeTruthy();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -482,6 +482,9 @@ importers:
       '@types/react':
         specifier: 18.3.28
         version: 18.3.28
+      '@types/react-dom':
+        specifier: 18.3.7
+        version: 18.3.7(@types/react@18.3.28)
       esbuild:
         specifier: 0.28.0
         version: 0.28.0


### PR DESCRIPTION
Part of the OPEND-2553 首页链路 Demo 复刻 series (after #7730 PR-A, #7731 PR-B): PR-C1 「材料与入口布局」. Ports the material and entry-layout increments of the reference PR #7635 (head `7c9b4dbfb`, merge-base `78baa5228`) onto current `main`; #7635 itself cannot be rebased.

Plane: OPEND-2683, OPEND-2689, OPEND-2690, OPEND-2694, OPEND-2700, OPEND-2703, OPEND-2757.

## Why

**Use case.** The product review of the Demo (#7635) settled on one set of surfaces for the entry screen: a flat rail column on a translucent ground, the content column as the single white card, one frosted scrim behind every modal, and 38px rail rows on a shared quiet ink. `main` still carried the pre-Demo materials (a frosted rail card with a gradient rim, a transparent content column, ~30 overlays each painting its own dark tint under a 4px blur, 33px rail rows), so the entry screen that testers see does not match the accepted look. This PR is the material half of the remaining first-phase work; the global 600 weight (PR-C2) is deliberately not in it.

**Pain.** Second-round acceptance filed the visible half of this gap as tickets: the home reads too grey (OPEND-2689), the composer's focus ring is weak on the frosted ground (OPEND-2690), hover on 个人项目 and 最近浏览过 disagree (OPEND-2700), the rail lists only eight projects (OPEND-2757), the section is still called 最近浏览过 (OPEND-2703), the chat project switcher has no status glyphs or preview (OPEND-2694), and the home still carries the recent-projects grid the rail already replaced (OPEND-2683).

## What users will see

- **One scrim.** Every modal, drawer and palette (search ⌘K, new project, brand picker, Figma help, library preview/upload, message center, update dialog, what's new, page creator, memory action, project reference, …) now sits on the same 60% white frost with a 50px blur, mounted on `<body>` above the tabs chrome and the account cluster. Image lightboxes and presentation mode stay dark on purpose. Reduced-transparency / no-backdrop-filter degrade to an opaque elevated ground.
- **Rail and content card.** The rail column is flat on the entry ground (no white card, rim or shadow); the content column is the one card: 85% white frost, 16px corner, hairline inset ring, 12px inset on the right and bottom (and left while the rail is collapsed or auto-collapsed under 1080px); page gutters are 24px inside the card.
- **Search and rail toggle in the chrome row.** The search box leaves the rail; a magnifier and the rail toggle sit top-left in the tabs chrome (⌘K / ⌘B in their tooltips). The toggle owns both directions; the pinned Home pill is hidden in the entry chrome. Inside a project the chat Home logo is unchanged apart from a 64px width and the shared hover fill.
- **Rail rows.** Every destination is a 38px, 12px-radius row on the shared quiet ink; the selected row is #121212 on a 10% ink fill; **hover on 个人项目 / 首页 / … is now the same fill and ink as hover on 最近项目 and its rows** (OPEND-2700). The workspace switcher row is 38px with a 24px avatar and a › / ⌄ caret. 设置 sits under 插件 on the signed-in rail as well.
- **最近项目 (renamed from 最近浏览过, OPEND-2703).** Lists every project, newest first; past ~11 rows the list itself scrolls (the rail's fixed rows stay put) and the cap shrinks with a short window (OPEND-2757).
- **Project switcher in chat (OPEND-2694).** Each row leads with the project's run status (running / needs input / failed / done) or the folder icon; hovering (or keyboard-focusing) a row shows the same hover preview card the rail uses, beside the menu.
- **Home.** With a cloud identity the recent-projects grid under the composer is gone (OPEND-2683); the rail's 最近项目 is the entry. The signed-out (local) shell keeps the grid — see deviations.
- **Community.** Home's composer is docked at the foot of the community view; 「Use prompt」 lands in that docked composer instead of jumping to 首页.
- **全部项目 / 草稿 grid restyle.** 4 cards across, 16px corners, cover zooms 3% on hover, neutral kind chips with the kind's glyph, circular ⋯ button, 24px page heading, 39px header pills.

### Deviations from the Demo (deliberate)

- **Signed-out shell keeps the home grid.** The rail's 最近项目 section renders only with a cloud identity, so removing the grid for the local shell would leave existing projects with no entry at all (the migration constraint in OPEND-2553). The grid is removed exactly where the rail carries the list; extending the rail to the signed-out shell is a follow-up.
- **Rail hover fill.** The Demo left destinations at `--text` 5% with no ink change while the rows under them took `--text-strong` 10% + darker ink. OPEND-2700 asks for one hover, so destinations take the 10% + ink step too; selection is still distinct through #121212 and weight.
- **RecentProjectsStrip: CSS restyle only.** The Demo's structural card changes (icon-tile footer, dropping the name line in grid, 「个人项目 / 团队项目」 collection tabs, merging sort + view into one menu, dropping the clear-filters chip, flat empty cover plate) are not ported: they conflict with `main`'s newer creator-name/avatar footer, the clear-filters and menu-placement behaviour, and need new i18n keys. `min-height: 108px` on grid thumbs is also not ported (`main` pins `0`).
- **Preview card in the switcher is the rail's card** (`ProjectHoverPreviewCard`, 216px, image/video/glyph), not the Demo's separate 240px card with a sandboxed HTML cover — one component for both surfaces.
- **`MarqueeLabel`** (Demo-only sliding label) is not ported; names ellipsize as on `main`.
- **`FigmaImportModal.module.css`** keeps its own dark tint for now: it is a #7769 hotspot and is not touched here. Follow-up after #7769 merges (one-line change).
- **Global 600 weight** and the removal of the scoped weight rules stay in PR-C2.

### Tickets closed by material alone

- OPEND-2689 (首页过灰): the content card + flat rail + 20% macOS scrim (already on `main`) replace the grey veil.
- OPEND-2690 (输入框选中态弱): the composer now sits on the 85% white card instead of the frosted veil; its own focus rules are unchanged (#7769 hotspot).

## Surface area

- [x] **UI** — entry rail, tabs chrome, content card, every overlay scrim, chat project switcher, community composer dock, 全部项目/草稿 grid (`apps/web`); shared `<Dialog>` backdrop (`packages/components`)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — none added; the rail now reads the existing `recentProjects.title` (最近项目)
- [ ] **New top-level dependency** — none at the root. `packages/components` gains `@types/react-dom` (devDependency) for the `<Dialog>` body portal.
- [x] **Default behavior change** — `<Dialog>` renders on `<body>` at z-index 1700; the home recent-projects grid is gone for cloud-identity users; the rail lists all projects; the pinned Home pill is hidden in the entry chrome.
- [ ] **None**

## Screenshots

macOS desktop (`pnpm tools-dev` + `inspect desktop screenshot`), Demo worktree on the left, this branch on the right.

**Home, default state** — content card, flat ground, search + toggle top-left:

![home](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-c1/cmp-home.png)

**Rail expanded** — flat rail, 38px rows, 设置 under 插件, 最近项目 listing all projects and scrolling past 11 (Demo shows 8 and its phase-2 account dock, out of scope here):

![rail](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-c1/cmp-rail.png)

**A modal (⌘K search)** — the one scrim, 50px blur over the whole window:

![modal](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-c1/cmp-modal.png)

**Chat project switcher** (this branch) — status/folder lead slot and the rail's hover preview card:

![dropdown](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-c1/cmp-dropdown.png)

## Bug fix verification

Measurement specs pin the Demo values so a drift fails before a screenshot:

- `apps/web/tests/styles/entry-materials.test.ts` (new): scrim tokens and degradation, `<Dialog>` backdrop, overlay files, rail panel, content card, gutters, 38px rows, one hover (OPEND-2700), scrolling list chain (OPEND-2757), chrome cluster, dropdown slots.
- `apps/web/tests/styles/app-wash-platform.test.ts`: darwin 20% scrim, no focus fade.
- `apps/web/tests/styles/workspace-tabs-chrome.test.ts`: 64px pill, hidden pinned pill, cluster geometry.
- `apps/web/tests/components/EntryNavRail.recent-section.test.tsx`: lists all ten fixture projects (was eight) under 最近项目.
- `apps/web/tests/components/EntryNavRail.no-duplicate-settings.test.tsx`: exactly one 设置 item on both branches.
- `packages/components/tests/Dialog.test.tsx`: backdrop mounts on `<body>`.

All of the above went red on `main` and green here.

## Validation

- `pnpm guard` ✅
- `pnpm typecheck` ✅
- `pnpm i18n:check` ✅
- `pnpm --filter @open-design/web test` ✅ (7257 tests)
- `pnpm --filter @open-design/components test` ✅
- `pnpm --filter @open-design/e2e typecheck` ✅
- e2e specs that drove the rail through the pinned Home pill now use the chrome cluster (`e2e/lib/playwright/rail.ts`, `entry-chrome-flows`, `critical-smoke`, `home-hero-rail`); the workspace-switch specs read the 草稿 grid and click the (now viewport-wide) switcher backdrop inside the content column; the visual project wait accepts the rail's 最近项目 row; the rail / settings helpers close the What's New popup first, since the shared `<Dialog>` scrim now really covers the chrome (this is what the first two CI runs tripped on — the two UI P0 lanes that drive a real daemon see the release highlights).
- Failing CI lanes from the first run (`Playwright visual (settings-workspace)`, `UI P0 (entry-settings)`, `UI P0 (project-runtime)`) were reproduced locally where possible and are green on the third run.
- Visual acceptance: two isolated `tools-dev` runtimes (Demo worktree `demo-c1` on 17806/17906, this branch `work-c1` on 17816/17916, separate `OD_DATA_DIR`), projects seeded through `POST /api/projects`, desktop screenshots above.

## Adjacent issues (not in this PR)

- `FigmaImportModal.module.css` scrim tint (after #7769).
- 最近项目 in the signed-out rail, then removing the home grid there too.
- RecentProjectsStrip structural changes from the Demo (see deviations).
