### PR TITLE
fix(preview): unblock the branch's two red jobs, and fix what one of them was hiding

### DIFF
--- a/apps/daemon/tests/project-file-range.test.ts
+++ b/apps/daemon/tests/project-file-range.test.ts
@@ -5,9 +5,47 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
+import { PREVIEW_RUNTIME_CAPABILITIES } from '@open-design/contracts/runtime/preview-runtime';
+
 import { parseByteRange, resolveProjectFilePath } from '../src/projects.js';
 import { startServer } from '../src/server.js';
 import { load } from 'cheerio';
+
+/**
+ * The scoped preview origin must advertise every capability whose module it
+ * installs, and install a module for every capability it advertises.
+ *
+ * This is a fail-closed contract, not a formatting detail. The bootstrap's
+ * `register()` returns early unless the capability is in `available`
+ * (apps/daemon/src/http/preview-runtime-bootstrap.ts), so a module that ships
+ * without being advertised is dead code the host can never switch on — deck
+ * navigation, tweaks, or the palette would silently stop working with the
+ * bridge still sitting in the document. The reverse gap is just as bad: an
+ * advertised capability with no module makes the host negotiate a mode nothing
+ * answers.
+ *
+ * Asserting the two sets against each other (rather than pinning the rendered
+ * `var available=[...]` text) is what keeps this honest when the capability
+ * contract legitimately grows: adding a capability to
+ * `PREVIEW_RUNTIME_CAPABILITIES` without wiring both halves here goes red,
+ * while wiring both halves stays green without editing this assertion.
+ */
+function expectScopedPreviewAdvertisesEveryInstalledCapability(body: string): void {
+  const advertisedJson = body.match(/var available=(\[[^\]]*\]);/u)?.[1];
+  expect(advertisedJson, 'preview runtime bootstrap did not declare available capabilities').toBeTruthy();
+  const advertised = JSON.parse(advertisedJson!) as string[];
+
+  // `register(capability,` in the bootstrap's own definition is the parameter
+  // name, not a call; every real registration passes a quoted literal.
+  const installed = [...body.matchAll(/register\((['"])([a-z_]+)\1,/gu)].map((match) => match[2]!);
+  expect(installed.length).toBeGreaterThan(0);
+
+  expect([...new Set(installed)].sort()).toEqual([...advertised].sort());
+  // The converged transport is the full-capability one: it serves the document
+  // at a real URL with every bridge installed, so nothing in the shared
+  // contract may be missing from it.
+  expect([...advertised].sort()).toEqual([...PREVIEW_RUNTIME_CAPABILITIES].sort());
+}
 
 // ---------------------------------------------------------------------------
 // parseByteRange — RFC 7233 unit tests
@@ -1887,7 +1925,7 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     expect(html.body).toContain('data-od-preview-observability');
     expect(html.body).toContain("register(\"observability\"");
     expect(html.body).toContain('data-od-preview-runtime');
-    expect(html.body).toContain('"content_measurement","scroll","snapshot","observability","selection","comment","inspect","draw","tweaks","palette","deck","edit"');
+    expectScopedPreviewAdvertisesEveryInstalledCapability(html.body);
     expect(html.body).toContain("register('tweaks'");
     expect(html.body).toContain("register('palette'");
     expect(html.body).toContain("register('edit'");

--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -1613,6 +1613,41 @@ body:has(.artifact-version-panel) .ws-tabs-file-actions-before {
 .viewer.is-tab-present .live-artifact-refresh-notice {
   display: none;
 }
+/*
+ * Presenting covers the workspace chrome, and this rule is the only reason it
+ * can. Without it the top strip of every presented document sits under the tab
+ * chrome — painted over and, worse, not clickable, because the chrome eats the
+ * pointer events.
+ *
+ * The reason is not the z-index below, which is why raising that number does
+ * nothing. `.app` carries the entrance fade (`entrance.css`: `animation:
+ * od-fade-in … both`). `od-fade-in` animates `opacity`, and
+ * `animation-fill-mode: both` keeps that animation in effect for the life of
+ * the element — so `.app` is permanently a stacking context, at `z-index:
+ * auto`. Everything inside it, the promoted `.viewer-body` included, is sorted
+ * *within* `.app`; its 1050 competes with its siblings inside `.app`, never
+ * with the chrome's `z-index: 120`, which lives in the root context as a
+ * sibling of `.app`'s ancestor.
+ *
+ * Measured, not reasoned: raising `.viewer-body` to 999999 changes nothing,
+ * and the chrome stops covering the slide only once its own z-index drops
+ * below 1 — it is competing against `.app`'s effective 0, not against 1050.
+ * Removing just `.app`'s animation also fixes it, and restoring it brings the
+ * bug back.
+ *
+ * So the surface to lift is `.app` itself. The promoted document cannot be
+ * moved out of it — that would re-mount the iframe and drop the running page,
+ * which is the whole point of promoting in place — so its stacking context is
+ * lifted for the duration of the presentation instead. 1050 slots deliberately
+ * between the letterbox ground (`.present-backdrop`, 1049) and the exit
+ * control (`.present-overlay`, 1060), both of which are portaled to <body> and
+ * so sit in the root context: the ground stays under the slide and the exit
+ * stays reachable above it.
+ */
+.workspace-shell:has(.viewer.is-tab-present) .app {
+  position: relative;
+  z-index: 1050;
+}
 /* Presenting promotes the document the user is already looking at, in place.
    The alternative — a second iframe inside the overlay — would start a fresh
    browsing context and drop the running page's JS heap, canvases and timers, so

--- a/e2e/ui/app-manual-edit.test.ts
+++ b/e2e/ui/app-manual-edit.test.ts
@@ -788,7 +788,15 @@ test('[P0] deck presentation host exit remains usable after the sandboxed slide 
 
   const overlay = page.locator('.present-overlay');
   await expect(overlay).toBeVisible();
-  const presentedSlide = overlay.frameLocator('iframe[title="present"]');
+  // Presenting is a view change, not a navigation. The document the user was
+  // already looking at is promoted to fill the window and the overlay carries
+  // only host chrome above it, so the overlay owning no browsing context of
+  // its own is part of the invariant rather than an implementation detail: a
+  // second iframe here — even at the same URL — would drop the JS heap,
+  // timers and canvas contexts the running deck is holding.
+  await expect(overlay.locator('iframe')).toHaveCount(0);
+  await expect(page.locator('.html-viewer.is-tab-present')).toBeVisible();
+  const presentedSlide = artifactPreviewFrame(page);
   const slideHeading = presentedSlide.getByRole('heading', { name: 'Slide One' });
   await expect(slideHeading).toBeVisible();
   await slideHeading.click();


### PR DESCRIPTION
## Why

`fix/streaming-html-preview-bridge` (PR #7353, the preview runtime convergence) was red on two core jobs, long enough that the branch could not land. This is a clearing job for #7353.

Both reds looked like the same thing: an assertion pinning *what the pre-convergence product looked like* rather than *what must stay true*. Neither test file had been edited on the branch — both are byte-identical to `main`; what moved underneath them was the product. Because a loosened assertion and a real fix are indistinguishable at review time, each red was decided against the running product before anything was touched.

One of them was not a stale assertion. Correcting its selector advanced the spec into a real regression: presenting a deck left the top strip of the slide covered by the workspace chrome and dead to clicks. That is fixed here, with the mechanism explained rather than worked around.

## What users will see

**Presenting a deck in this tab is now genuinely full-bleed.** Before, the workspace tab chrome stayed painted over the top ~52px of the slide, and that strip did not respond to clicks — clicking a title near the top of a slide did nothing. Now the presented document covers the chrome, and the whole slide is clickable. The exit control and the letterbox ground are unchanged.

## Surface area

- [x] **UI** — in-tab presentation now covers the workspace chrome instead of being covered by it
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — presenting covers the tab chrome; no opt-in
- [ ] **None**

## Bug fix verification

### Red 1 — `apps/daemon/tests/project-file-range.test.ts` → **(A) intentional change; nothing lost.**

The spec pinned a contiguous JSON substring of the advertised capability list. What the daemon actually serves, captured from the real HTTP response:

```
var available=["content_measurement","scroll","snapshot","observability","selection","comment","inspect","draw","tweaks","palette","deck","presentation","edit"]
```

`deck` is still there. The list **gained** `presentation` — added by this branch (`050724c326`, `7103a3b7c7`) as an installed-rather-than-URL-negotiated bridge so presenting cannot renavigate the running document — and it sorts between `deck` and `edit`, landing inside the pinned run.

Checked at the receiver, not the sender: across a cross-process iframe those are different claims. Host-window probe in real Chrome recorded `od:preview:hello` arriving with all 13, the host negotiating back, `od:preview:capabilities-applied` returning 8 at rest with `deck` among them, and a next-slide click advancing the running document.

**New assertion.** `register()` is fail-closed (`if(!availableSet.has(capability)||modules[capability])return;`), so a module that ships unadvertised is dead code the host can never switch on. The helper asserts a set identity — every `register(...)` in the served document is advertised, every advertised capability has a module, and the converged transport carries the whole `PREVIEW_RUNTIME_CAPABILITIES` contract. Growing the union stays green when both halves are wired.

**Red-proofed:** dropping `'deck'` from `availableCapabilities` fails the set-identity line (`[…12]` vs `[…11]`).

### Red 2 — `e2e/ui/app-manual-edit.test.ts:777` → **(A) stale selector, and (B) a real regression behind it. Both fixed.**

**(A)** `iframe[title="present"]` matched nothing: the overlay owns no browsing context since `d0bd4a2ae7` made presenting promote the running document. A missed spot, not a new decision — `801bb6cd56` had already re-pointed the two Vitest specs. The invariant (OPEND-2156) is untouched; the frame is reached via the shared `ACTIVE_ARTIFACT_PREVIEW_SELECTOR`, and "the overlay owns no iframe" is now asserted explicitly.

**(B)** With the selector corrected the spec failed at the next step, for a real reason: the docked chrome hit-tested above the top 52px of the presented slide. Measured, settled state, reproduced across five runs — a real click there reached neither the document nor focus, while the same click at the slide's middle did both.

**The mechanism, because the obvious explanation is wrong.** `.viewer.is-tab-present .viewer-body` computes to `position: fixed; z-index: 1050`; the chrome is `position: relative; z-index: 120`. By the cascade the slide should already win. It does not, and raising it does not help:

```
viewer-body fixed/2000   → chrome still on top
viewer-body fixed/999999 → chrome still on top
viewer-body relative/2000 → chrome still on top
chrome z=1  → chrome on top       chrome z=0 → slide on top
```

The threshold sitting exactly at 0/1 is the signature of a trapping stacking context at `z-index: auto`. It is **`.app`**: `entrance.css:42` gives it `animation: od-fade-in 180ms … both`, `od-fade-in` animates `opacity`, and `animation-fill-mode: both` keeps that animation in effect for the element's life — so `.app` is permanently a stacking context. Everything inside it, the promoted `.viewer-body` included, is sorted *within* `.app`; its 1050 competes with `.app`'s children, never with the chrome, which is a sibling of `.app`'s ancestor in the root context.

Proven predictively, both directions: removing only `.app`'s animation fixes it; restoring it brings it back. Ancestor bumps agree — lifting `.app` or `.workspace-shell__body` fixes it, lifting anything inside `.app` does not. It also explains why the exit control works at all: `.present-overlay` is portaled to `<body>`, escaping `.app` entirely.

**The fix** lifts `.app`'s stacking context for the duration of the presentation, since the promoted document cannot be moved out of `.app` without re-mounting the iframe and dropping the running page. 1050 slots deliberately between `.present-backdrop` (1049) and `.present-overlay` (1060), both in the root context, so the ground stays under the slide and the exit stays above it — verified: after the fix the exit button still hit-tests as itself.

**Red-proofed:** with the rule removed the P0 fails at the focus step (`BODY` instead of `IFRAME`); with it, green.

## ⚠️ Separate high-priority defect found — NOT fixed here

**`LiveArtifactViewer`'s in-tab presentation appears to have no way out.** Filing separately per instruction; it is not in this PR.

- Its exit control (`FileViewer.tsx:2402`) is a child of `.viewer` at `z-index: 50`, **not** portaled to `<body>` like the main viewer's. Inside `.app`'s stacking context the promoted `.viewer-body` (1050) paints over it. Verified in the real browser against the real stylesheet: a `.present-exit-btn` authored exactly as that component authors it gets `position: absolute; z-index: 50`, a real 34×30 box at (1226, 108) — and `elementFromPoint` at its centre returns the presented `IFRAME`, not the button.
- Its only other escape is `document.addEventListener('keydown', …)` for Escape (`FileViewer.tsx:2337`) — the host listener that stops firing once focus is inside the sandboxed cross-origin frame. That is exactly the OPEND-2156 condition, and clicking a slide *does* put focus in the frame (measured).
- It has **no** `od:present-escape` listener; the only one is at `FileViewer.tsx:14681`, in the main viewer.

**This PR's fix does not help it** — both the button and the promoted body are inside `.app`, so lifting `.app` moves them together.

Honest limit: I could not drive the actual `LiveArtifactViewer` end to end, because creating a live artifact requires an agent tool grant that a UI test cannot mint. The stacking result above is measured in the real app against the real stylesheet with the control as authored; the Escape path is read from source.

## Adjacent issues (not fixed here)

Clean sweeps: exactly **one** `buildPreviewRuntimeBootstrap` product call site repo-wide, 13:13 parity, buffered and streaming share it. Other preview routes never build a bootstrap. No product source still assumes an overlay-owned frame.

1. `presentationSrcDoc` (`FileViewer.tsx:11275`) is orphaned — its consumer was deleted in `d0bd4a2ae7`, yet it still runs `buildSrcdoc` on every presentation entry for a document that is never mounted.
2. `BASE_PREVIEW_BRIDGE_QUERY` still appends `odPreviewBridge=presentation` and it is inert — `urlFrameSrc` is never assigned to any iframe `src`, and the daemon filters the token out on the scoped route. Its comment names it as *the* delivery mechanism, which is wrong; the real trigger is `createDeckPresentationSetMessage` posted to the running frame.
3. `.present-overlay iframe` (`composio.css:366`) is dead CSS, as is `display:flex` on the overlay.
4. **The scoped-origin + streaming presentation path has no test at all — and that path is what this branch is named after.** Correct by construction (both branches go through the same `buildScopedRuntimeBootstrap`), but nothing covers it.

## Validation

Dedicated worktree on `de1eddd572` (branch head), Playwright workers pinned to 1, runs serialized.

- `apps/daemon` → `vitest run tests/project-file-range.test.ts` — **97 passed (97)**, 10.37s. Before: **1 failed | 96 passed**, 20.99s.
- `e2e` → `playwright test ui/app-manual-edit.test.ts --grep "deck presentation host exit remains usable"` — **1 passed**, 14.0s (37.1s wall). Red-proof with the CSS rule removed: **1 failed** at the focus step.
- `apps/web` → `vitest run tests/styles tests/components/FileWorkspace.test.tsx tests/components/FileViewer.test.tsx` — **481 passed | 3 skipped (484)**, 40 files, 22.47s.
- `pnpm guard` exit 0; `pnpm typecheck` exit 0.
- All browser probes (capability receipt, hit-test stacks, stacking levers, exit-button stacking) were temporary and removed before commit; `git status` clean apart from the three committed files.
