### PR TITLE
docs(prompts): align od-default task-type form localization with discovery

### DIFF
--- a/apps/daemon/tests/prompts/discovery-localization-drift.test.ts
+++ b/apps/daemon/tests/prompts/discovery-localization-drift.test.ts
@@ -18,12 +18,29 @@ const languageMatchRule =
 const localizationBullet =
   '- Localize every user-facing string in the form (\\`title\\`, \\`description\\`, the per-question \\`label\\`, \\`placeholder\\`, and option \\`label\\`s) to the user\'s chat language — write what a native speaker would naturally say, never a word-for-word translation (the Chinese title is 快速确认 · 30秒, not the literal 快速简报). Set the top-level \\`"lang"\\` field to the BCP-47 tag of that language (e.g. \\`"zh-CN"\\`, \\`"ja"\\`) so the host renders its built-in controls (the "Other" chip, the custom-answer field) in the same language. \\`id\\`, \\`type\\`, option \\`value\\`, and the stable branch values (\\`pick_direction\\`, \\`brand_spec\\`, \\`reference_match\\`) MUST stay in English because later branch rules match against them.';
 
+const odDefaultSkillPath = 'plugins/_official/scenarios/od-default/SKILL.md';
+
+// The example body deliberately keeps `"lang": "en"` (it is the English
+// reference form); these rules are what tell the model to replace it.
+const odDefaultLangTagRule =
+  'Set the top-level `"lang"`\nfield to the BCP-47 tag of that language (e.g. `"zh-CN"`, `"ja"`) so the host\nrenders its built-in controls in the same language.';
+
+const odDefaultExampleLocalizationRule =
+  'The example form below\nuses English text for reference; replace each user-facing string with its\nlocalized equivalent before emitting.';
+
 describe('discovery prompt localization rules', () => {
   it.each(promptPaths)('%s includes the localized form wording', (promptPath) => {
     const source = readFileSync(resolve(repoRoot, promptPath), 'utf8');
 
     expect(source).toContain(languageMatchRule);
     expect(source).toContain(localizationBullet);
+  });
+
+  it('od-default states the same lang-tag and localize-the-example rules', () => {
+    const source = readFileSync(resolve(repoRoot, odDefaultSkillPath), 'utf8');
+
+    expect(source).toContain(odDefaultLangTagRule);
+    expect(source).toContain(odDefaultExampleLocalizationRule);
   });
 });
 

--- a/plugins/_official/scenarios/od-default/SKILL.md
+++ b/plugins/_official/scenarios/od-default/SKILL.md
@@ -22,12 +22,16 @@ discovery stage does not by itself require a question form.
 Emit the form below only when two or more routes remain materially plausible
 and choosing the wrong one would change the delivery format. Localize every
 user-facing string to the user's chat language, but keep ids, types, option
-values, and the ordered `taskType` options stable. Set `defaultValue` to the
-stable value of the route you recommend so the user can submit unchanged; the
-example below recommends `prototype`, but replace it with the inferred route
-value before emission. You may add at most two other unanswered questions, and
-only when their answers are also required before useful work can begin; never
-restore a fixed discovery checklist.
+values, and the ordered `taskType` options stable. Set the top-level `"lang"`
+field to the BCP-47 tag of that language (e.g. `"zh-CN"`, `"ja"`) so the host
+renders its built-in controls in the same language. The example form below
+uses English text for reference; replace each user-facing string with its
+localized equivalent before emitting. Set `defaultValue` to the stable value
+of the route you recommend so the user can submit unchanged; the example below
+recommends `prototype`, but replace it with the inferred route value before
+emission. You may add at most two other unanswered questions, and only when
+their answers are also required before useful work can begin; never restore a
+fixed discovery checklist.
 
 ```html
 <question-form id="task-type" title="Choose the task type">


### PR DESCRIPTION
Part of #2705

<!-- Not using `Fixes` on purpose: #2705's original symptom was already
     substantially addressed by #6223, and @lefarcen asked to keep the issue
     open pending final runtime verification. This PR closes only the
     code-visible mismatch he confirmed. -->

## Why

Follow-up requested by @lefarcen in https://github.com/nexu-io/open-design/issues/2705#issuecomment-5536309213 — after I flagged that #6223 had already landed the missing localization rule in `od-default`:

> The remaining code-visible mismatch is real too: `od-default` still hardcodes `"lang": "en"` in its example form, while `apps/daemon/src/prompts/discovery.ts` also requires the emitted form to use the user's BCP-47 language tag for host-rendered controls. If you'd like to send the small follow-up PR to align those wordings and extend `discovery-localization-drift.test.ts` to cover `od-default`, that would be useful.

The pain: `plugins/_official/scenarios/od-default/SKILL.md` owns the conditional `task-type` form (the discovery prompt explicitly delegates it — `apps/daemon/src/prompts/discovery.ts:48`). Its localization rule stops at "localize every user-facing string ... but keep ids, types, option values stable". The discovery prompt's own rule says two more things that `od-default` never inherited:

1. set the top-level `"lang"` field to the BCP-47 tag of the user's language, so host-rendered controls follow the same language (`discovery.ts:83`);
2. the example form is English *for reference* — replace each user-facing string with its localized equivalent before emitting (`discovery.ts:45`).

Because those two sentences were missing, a model following `od-default` literally can localize the labels and still emit `"lang": "en"`, which is exactly the mixed-language card #2705 reported. This is prompt wording, not code, so it is a drift risk rather than a hard bug — hence the test.

## What users will see

For a non-English chat, the `task-type` routing card can now be expected to carry the user's own `lang` tag rather than always `en`, so any host chrome rendered from that field matches the localized labels instead of staying English. No change for English chats, and no change to routing: `id`, `type`, and the `taskType` option `value`s stay English exactly as before.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal refactor, docs, tests, or translation update only

Judgement call, flagging it rather than hiding it: nothing here is a new surface or a new extension point — it is prompt prose in an existing bundled scenario plus a test. It does influence emitted model output for non-English chats (that is the point), but it only states explicitly what the neighbouring discovery rule already required, so I did not read it as a **Default behavior change** in the sense the box describes (default model / setting / schema / auto-network). Happy to re-tick if you'd rather scope it that way.

## Screenshots

N/A — no UI surface. The change is model-facing prompt text; the resulting card is rendered by the model at runtime, not by code I can screenshot deterministically.

## Bug fix verification

- Test path that reproduces the drift: `apps/daemon/tests/prompts/discovery-localization-drift.test.ts` → `discovery prompt localization rules > od-default states the same lang-tag and localize-the-example rules`
- Did the test go red before the source change and green after? **yes** — added the assertions first, on an otherwise untouched `upstream/main` (`d18ada9e35`):

```
# with the new test only, SKILL.md unchanged
 ❯ tests/prompts/discovery-localization-drift.test.ts:42:20
     42|     expect(source).toContain(odDefaultLangTagRule);
 Test Files  1 failed (1)
      Tests  1 failed | 23 passed (24)

# after the SKILL.md wording change
 Test Files  1 passed (1)
      Tests  24 passed (24)
```

The assertions match the exact wrapped sentences (the same `\n`-embedded-phrase style this file already uses for the SKILL.md checks further down), so a reworded copy in either prompt trips the test rather than drifting silently.

**Deliberately *not* changed: the example body still reads `"lang": "en"`.** That block is the English reference form, and `discovery-localization-drift.test.ts:44` asserts it. The fix is the instruction telling the model to replace it before emission — mirroring how the discovery prompt keeps `"lang": "en"` in its own example alongside the same rule. Please don't read the surviving `"lang": "en"` as a missed edit.

I also kept the wording as close to `discovery.ts` as accuracy allowed, with one deliberate trim: discovery's version names the host controls as `(the "Other" chip, the custom-answer field)`. The `task-type` form is `"allowCustom": false`, so it has no custom-answer field — quoting that parenthetical verbatim would have been wrong here, so the sentence stops at "its built-in controls".

## Validation

Node 24.14.0 / pnpm 10.33.2, fresh `pnpm install` in a worktree on `upstream/main` (`d18ada9e35`):

- `pnpm typecheck` — **exit 0** (all packages)
- `pnpm guard` — **exit 0** (design-system parity checks all passed)
- `pnpm --filter @open-design/daemon exec vitest run tests/prompts` — **13 files / 212 tests passed**
- `pnpm --filter @open-design/daemon exec vitest run tests/app-config.test.ts tests/plugins-atom-bodies.test.ts tests/plugins-bundled-scenarios-roster.test.ts tests/plugins-local-skill.test.ts` — **4 files / 121 tests passed** (the other daemon suites that read `od-default`)
- `pnpm --filter @open-design/contracts exec vitest run` — **55 files / 508 tests passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJ93MXjVGwbuKWMuYqrCm1
