### PR TITLE
fix(live-artifact): keep an exit from a presented live artifact

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -2396,16 +2396,37 @@ export function LiveArtifactViewer({
           ) : null}
         </div>
       )}
-      {inTabPresent ? (
-        <button
-          type="button"
-          className="present-exit-btn"
-          onClick={() => setInTabPresent(false)}
-          title={t('common.exitFullscreen')}
-          aria-label={t('common.exitFullscreen')}
-        >
-          <Icon name="close" size={14} />
-        </button>
+      {/* Portaled to <body>, not rendered here, and that is the whole point.
+          `.app` is permanently a stacking context (it carries the entrance fade,
+          an opacity animation with `animation-fill-mode: both`), so everything
+          inside it is sorted within it — including the promoted `.viewer-body`
+          at z-index 1050. An exit control left in this subtree sits at z-index
+          50 in that same context and is painted over by the document it is
+          supposed to escape: it renders, it just is not what a click at its own
+          position lands on.
+
+          It has to work from the only state that matters. Once the user clicks
+          the artifact, focus moves into the sandboxed frame and the host's
+          Escape listener stops firing (OPEND-2156) — and unlike the file
+          viewer, a live artifact preview carries no Open Design bridge
+          (`/api/live-artifacts/:id/preview` serves the stored HTML as-is into a
+          frame sandboxed without `allow-same-origin`), so nothing can post
+          `od:present-escape` back either. Adding that listener here would be
+          dead code. The pointer path is the only escape there is, so it is the
+          one that must not be buried. */}
+      {inTabPresent && typeof document !== 'undefined' ? createPortal(
+        <div className="present-overlay" role="dialog" aria-label={t('fileViewer.present')}>
+          <button
+            type="button"
+            className="present-exit-btn"
+            onClick={() => setInTabPresent(false)}
+            title={t('common.exitFullscreen')}
+            aria-label={t('common.exitFullscreen')}
+          >
+            <Icon name="close" size={14} />
+          </button>
+        </div>,
+        document.body,
       ) : null}
       <div className="viewer-toolbar">
         <div className="viewer-toolbar-left">

--- a/e2e/ui/live-artifact-presentation-exit.test.ts
+++ b/e2e/ui/live-artifact-presentation-exit.test.ts
@@ -1,0 +1,177 @@
+import { expect, test } from '@/playwright/suite';
+import { applyStandardMocks, routeAgents } from '@/playwright/mock-factory';
+import type { Page } from '@playwright/test';
+import { T } from '@/timeouts';
+
+test.describe.configure({ timeout: T.xlong });
+
+const ARTIFACT_ID = 'live-artifact-exit-probe';
+const ARTIFACT_TITLE = 'Exit Probe Artifact';
+
+/**
+ * A live artifact preview is a plain URL document with no Open Design bridge
+ * injected (`/api/live-artifacts/:id/preview` serves the stored HTML as-is), and
+ * the iframe is sandboxed without `allow-same-origin`. So it is cross-origin to
+ * the host and cannot post anything back — including the `od:present-escape`
+ * signal the main file viewer relies on.
+ */
+const PREVIEW_HTML = `<!doctype html><html><head><meta charset="utf-8">
+<style>html,body{margin:0;height:100%}main{height:100%;display:flex;align-items:center;justify-content:center;font:600 40px system-ui}</style>
+</head><body><main><h1>Live Artifact Slide</h1></main></body></html>`;
+
+function liveArtifactSummary(projectId: string) {
+  return {
+    schemaVersion: 1 as const,
+    id: ARTIFACT_ID,
+    projectId,
+    title: ARTIFACT_TITLE,
+    slug: 'exit-probe-artifact',
+    status: 'active' as const,
+    pinned: false,
+    preview: { type: 'html' as const, entry: 'index.html' },
+    refreshStatus: 'succeeded' as const,
+    createdAt: new Date(Date.now() - 60_000).toISOString(),
+    updatedAt: new Date().toISOString(),
+    lastRefreshedAt: new Date().toISOString(),
+    hasDocument: true,
+  };
+}
+
+/**
+ * Stub only the live-artifact data source. Everything downstream — the tab
+ * strip, the LiveArtifactViewer, its Present menu, the promotion CSS — is the
+ * real product. A live artifact cannot be created through the UI: the create
+ * endpoint is behind an agent tool grant, so this is the closest a UI test can
+ * get to the real surface.
+ */
+async function routeLiveArtifact(page: Page, projectId: string) {
+  const summary = liveArtifactSummary(projectId);
+  await page.route('**/api/live-artifacts?*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ artifacts: [summary] }),
+    });
+  });
+  await page.route('**/api/live-artifacts/*/preview*', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'text/html; charset=utf-8', body: PREVIEW_HTML });
+  });
+  await page.route('**/api/live-artifacts/*/refreshes*', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ refreshes: [] }) });
+  });
+  await page.route(`**/api/live-artifacts/${ARTIFACT_ID}?*`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        artifact: {
+          ...summary,
+          document: {
+            format: 'html_template_v1',
+            templatePath: 'template.html',
+            generatedPreviewPath: 'index.html',
+            dataPath: 'data.json',
+            dataJson: {},
+          },
+        },
+      }),
+    });
+  });
+}
+
+async function createProject(page: Page, name: string): Promise<string> {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  const id = `pw-live-artifact-exit-${Date.now()}`;
+  const response = await page.request.post('/api/projects', {
+    data: { id, name, skillId: null, designSystemId: null },
+  });
+  expect(response.ok()).toBeTruthy();
+  return id;
+}
+
+/** Open the artifact the way a user does: from the Design Files panel. */
+async function openLiveArtifact(page: Page) {
+  await expect(page.getByTestId('file-workspace')).toBeVisible();
+  const row = page.getByTestId(`design-file-row-live:${ARTIFACT_ID}`);
+  if (await row.count() === 0) {
+    // The panel shows one category at a time; live artifacts get their own tab
+    // only when at least one exists.
+    await page.getByRole('button', { name: /live artifact/i }).first().click();
+  }
+  await row.click();
+  await expect(page.getByTestId('live-artifact-preview-frame')).toBeVisible();
+}
+
+async function enterPresentation(page: Page) {
+  await page.getByRole('button', { name: 'Present', exact: true }).click();
+  await page.getByRole('menuitem', { name: /^In this tab/i }).click();
+  await expect(page.locator('.live-artifact-viewer.is-tab-present')).toBeVisible();
+}
+
+test.beforeEach(async ({ page }) => {
+  await applyStandardMocks(page);
+  await routeAgents(page, [{ id: 'mock', name: 'Mock Agent', bin: 'mock-agent', available: true }]);
+});
+
+/**
+ * Presenting a live artifact must leave a way out that a pointer can reach.
+ *
+ * The exit control is the last resort by construction: once the user clicks the
+ * artifact, focus moves into the sandboxed cross-origin frame and Escape stops
+ * arriving at the host document (OPEND-2156). The live artifact preview also
+ * ships no Open Design bridge, so — unlike the file viewer — nothing can post
+ * `od:present-escape` back either. That leaves exactly one escape, and it has to
+ * actually be on top: not merely rendered, but the element a click at its own
+ * position lands on.
+ */
+test('[P0] presented live artifact keeps an exit control a pointer can reach', async ({ page }) => {
+  const projectId = await createProject(page, 'Live artifact exit stacking');
+  await routeLiveArtifact(page, projectId);
+  await page.goto(`/projects/${projectId}`, { waitUntil: 'domcontentloaded' });
+  await openLiveArtifact(page);
+
+  await enterPresentation(page);
+
+  const exit = page.locator('.present-exit-btn');
+  await expect(exit).toHaveCount(1);
+
+  const hit = await exit.evaluate((el) => {
+    const r = el.getBoundingClientRect();
+    const at = document.elementFromPoint(Math.round(r.x + r.width / 2), Math.round(r.y + r.height / 2));
+    return {
+      hasBox: r.width > 0 && r.height > 0,
+      isSelf: at === el || (at != null && el.contains(at)),
+      topMost: at ? `${at.tagName}.${String((at as HTMLElement).className || '').split(' ')[0]}` : null,
+    };
+  });
+  expect(hit.hasBox).toBe(true);
+  expect(hit, 'the exit control must be the element a click at its own position lands on').toMatchObject({ isSelf: true });
+});
+
+/**
+ * The exit must work from the state the user is actually in: having clicked the
+ * artifact, so focus is inside the sandboxed frame and no keyboard path is left.
+ * This is the invariant — an exit that does not depend on the host document
+ * holding focus — not the specific control that provides it.
+ */
+test('[P0] presented live artifact can be exited after the sandboxed frame takes focus', async ({ page }) => {
+  const projectId = await createProject(page, 'Live artifact exit escape');
+  await routeLiveArtifact(page, projectId);
+  await page.goto(`/projects/${projectId}`, { waitUntil: 'domcontentloaded' });
+  await openLiveArtifact(page);
+
+  await enterPresentation(page);
+
+  // Put focus where a presenting user puts it: inside the artifact.
+  const frameBox = await page.getByTestId('live-artifact-preview-frame').boundingBox();
+  expect(frameBox).not.toBeNull();
+  await page.mouse.click(
+    Math.round(frameBox!.x + frameBox!.width / 2),
+    Math.round(frameBox!.y + frameBox!.height / 2),
+  );
+  await expect.poll(() => page.evaluate(() => document.activeElement?.tagName)).toBe('IFRAME');
+
+  // Escape is gone now, by design of the sandbox. The pointer path must remain.
+  await page.locator('.present-exit-btn').click({ timeout: 10_000 });
+  await expect(page.locator('.live-artifact-viewer.is-tab-present')).toHaveCount(0);
+});


### PR DESCRIPTION
## Why

Presenting a live artifact in this tab was a dead end: the user could get in and could not get out. Found while fixing the two red jobs on this branch (#7833) — a stacking defect there led to auditing every other presentation surface, and this one turned out worse than the one being fixed.

All three escapes were gone at the same time, and each for its own reason:

1. **The exit control is painted over.** It is authored as a child of `.viewer` at `z-index: 50` (`FileViewer.tsx:2399`), while the promoted `.viewer-body` sits at `z-index: 1050`. It renders with a real box — it simply is not the element a click at its own position lands on.
2. **Escape cannot arrive.** The handler is `document.addEventListener('keydown', …)` on the host (`FileViewer.tsx:2337`), and focus moves into the sandboxed cross-origin frame the moment the user clicks the artifact. That is exactly the condition OPEND-2156 established.
3. **Nothing can forward Escape either.** There is no `od:present-escape` listener — and there could not usefully be one. `/api/live-artifacts/:id/preview` serves the stored HTML as-is, into a frame sandboxed without `allow-same-origin`. That document carries no Open Design bridge, so it can post nothing back.

Why `z-index: 50` loses to `1050` inside the same `.viewer`, when both are in the same subtree: `.app` carries the entrance fade (`entrance.css:42` — `animation: od-fade-in … both`), which animates `opacity` with `animation-fill-mode: both`. That keeps the animation in effect for the element's life, so **`.app` is permanently a stacking context** and everything inside it is sorted within it. The file viewer escapes this only because its overlay is portaled to `<body>`.

## What users will see

**Presenting a live artifact can now be exited.** The close control in the top-right corner is clickable while presenting — before, it was drawn underneath the artifact and clicking it did nothing, and with focus inside the artifact Escape did nothing either, leaving no way back short of reloading.

## Surface area

- [x] **UI** — the exit control on a presented live artifact is reachable
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — presenting a live artifact is now exitable
- [ ] **None**

## The fix

Reuses the mechanism the file viewer already proves, rather than inventing a second one: the exit control is portaled into a `.present-overlay` on `<body>` at `z-index: 1060`, escaping `.app`'s stacking context.

**Both halves of that mechanism were checked against this component's context before being copied**, not assumed:
- The **portal** applies — it is a pure host-side rendering choice, independent of the frame.
- The **`od:present-escape` listener does not** apply. The live artifact preview ships no bridge, so that signal can never be sent; adding the listener would have been dead code. It is deliberately not copied.

## Bug fix verification

Two specs, both red first, both driven through the real UI — real tab strip, real Design Files panel, real `LiveArtifactViewer`, real Present menu, real promotion CSS. Only the live-artifact **data source** is stubbed, because creating a live artifact goes through an endpoint behind an agent tool grant that a UI test cannot mint. That limit is stated here rather than papered over.

`e2e/ui/live-artifact-presentation-exit.test.ts`

| Spec | Red (before) | Green (after) |
|---|---|---|
| `[P0] presented live artifact keeps an exit control a pointer can reach` | `isSelf: false` — `elementFromPoint` at the control's own centre returns the presented frame, not the control | passes |
| `[P0] presented live artifact can be exited after the sandboxed frame takes focus` | focus reaches `IFRAME` (assertion passes), then `locator.click` times out at 10 s on the buried control | passes |

The second spec is the one that matters: it asserts the invariant — **an exit that does not depend on the host document holding focus** — from the exact state a presenting user is in, having clicked the artifact. It deliberately does not assert *which* control provides it.

The first spec's red is what upgrades "I read the source" into executable evidence: it fails on a hit test against the real stylesheet in a real presentation, not on a grep.

## Validation

Runs serialized (other agents on this machine); Playwright workers pinned to 1.

- `e2e` → `playwright test ui/live-artifact-presentation-exit.test.ts` — **2 passed**, 4.7 s + 3.3 s (29.9 s wall). Before the fix, same specs, same command: **2 failed**, for the two reasons in the table.
- `apps/web` → `vitest run tests/components/FileViewer.test.tsx tests/components/ProjectView.deleteConversation.test.tsx tests/runtime/srcdoc-bridge-empty-targets.test.ts` — **318 passed (318)**.
  Baseline check: the full 714-file suite reported 11 failures under heavy parallel load, so those three files were re-run alone against the pristine `de1eddd572` file (**318 passed**) and again with this change applied (**318 passed**) — identical, so the full-suite failures are load-induced flakes and not attributable here.
- `pnpm guard` exit 0; `pnpm typecheck` exit 0; `pnpm --filter @open-design/e2e typecheck` exit 0.

## Not in scope

The `.app` stacking-context finding is fixed for the *file viewer's* presentation separately in #7833 (which lifts `.app` above the workspace chrome). That fix does not help this surface — the buried control and the promoted body are both inside `.app`, so lifting `.app` moves them together. The two are independent.
