### PR TITLE
test(preview): cover presenting a deck the daemon has to stream

### DIFF
--- a/e2e/ui/app-manual-edit.test.ts
+++ b/e2e/ui/app-manual-edit.test.ts
@@ -6,6 +6,7 @@ import { clickDeckNextSlide, openAllProjectFiles } from '@/playwright/workspace'
 import type { Page } from '@playwright/test';
 import { pathToFileURL } from 'node:url';
 import { T } from '@/timeouts';
+import { PREVIEW_URL_GUARD_MAX_HTML_BYTES } from '@open-design/contracts/runtime/preview-guards';
 
 const STORAGE_KEY = 'open-design:config';
 test.describe.configure({ timeout: T.xlong });
@@ -801,6 +802,82 @@ test('[P0] deck presentation host exit remains usable after the sandboxed slide 
   expect(presenter.isClosed()).toBe(true);
 });
 
+/**
+ * The transport this branch is named after, end to end.
+ *
+ * Every other presentation spec uses a deck small enough for the daemon to
+ * buffer. A document over `PREVIEW_URL_GUARD_MAX_HTML_BYTES` takes a different
+ * branch: the scoped preview origin streams it and injects the runtime
+ * bootstrap on the way past, rather than assembling the response in memory.
+ * Nothing covered that combination — scoped origin *and* streaming *and*
+ * presentation — which is where both of this branch's red jobs turned out to
+ * live. That is not a coincidence worth leaving uncovered.
+ *
+ * Deliberately not covered here, because the daemon-side unit specs already
+ * own them and duplicating them through the UI would only make this slower and
+ * flakier: which capabilities the bootstrap advertises, and whether the
+ * presentation bridge is injected exactly once. This spec asserts only what the
+ * UI can actually observe — that the document really did arrive over the
+ * streaming path, and that presenting it works.
+ */
+test('[P0] a deck too large to buffer presents, advances and exits on the scoped origin', async ({ page }) => {
+  await routeMockAgents(page);
+  const projectId = await createEmptyProject(page, 'Streaming deck presentation');
+  await seedDeckArtifact(
+    page,
+    projectId,
+    'streaming-deck.html',
+    'Streaming Deck',
+    ['Slide One', 'Slide Two'],
+    { padBytes: PREVIEW_URL_GUARD_MAX_HTML_BYTES + 4096 },
+  );
+  await page.goto(`/projects/${projectId}/files/streaming-deck.html`);
+  await openDesignFile(page, 'streaming-deck.html');
+
+  const frame = artifactPreviewFrame(page);
+  await expect(frame.getByRole('heading', { name: 'Slide One' })).toBeVisible();
+
+  // Prove the transport rather than assuming it: the document has to have come
+  // from the scoped preview origin (`n-<session>` / `p-<session>`), and to be
+  // over the threshold that makes the daemon stream it instead of buffering.
+  // `location.origin` is "null" in this sandbox, so read the URL itself.
+  const served = await frame.locator('body').evaluate(() => ({
+    href: location.href,
+    bytes: document.documentElement.outerHTML.length,
+  }));
+  expect(served.href).toMatch(/^https?:\/\/[np]-[^./]+\.localhost(?::\d+)?\//u);
+  expect(served.bytes).toBeGreaterThan(PREVIEW_URL_GUARD_MAX_HTML_BYTES);
+
+  await page.getByRole('button', { name: 'Present', exact: true }).click();
+  const popupPromise = page.waitForEvent('popup');
+  await page.getByRole('menuitem', { name: /^In this tab/i }).click();
+  const presenter = await popupPromise;
+
+  const overlay = page.locator('.present-overlay');
+  await expect(overlay).toBeVisible();
+  await expect(frame.getByRole('heading', { name: 'Slide One' })).toBeVisible();
+
+  // Advance while presenting. It has to come from inside the document: the
+  // product hides both host slide controls in this mode — the inline one lives
+  // in `.viewer-toolbar` (`display: none` under `.is-tab-present`) and the
+  // floating one is gated on `!inTabPresent`. So this is the real presenter
+  // gesture, and it exercises the streamed document's own deck runtime.
+  const frameBox = await artifactPreview(page).boundingBox();
+  expect(frameBox).not.toBeNull();
+  await page.mouse.click(
+    Math.round(frameBox!.x + frameBox!.width / 2),
+    Math.round(frameBox!.y + frameBox!.height / 2),
+  );
+  await page.keyboard.press('ArrowRight');
+  await expect(frame.getByRole('heading', { name: 'Slide Two' })).toBeVisible();
+
+  const presenterClosed = presenter.waitForEvent('close');
+  await overlay.getByRole('button', { name: 'Exit presentation' }).click();
+  await expect(overlay).toHaveCount(0);
+  await presenterClosed;
+  expect(presenter.isClosed()).toBe(true);
+});
+
 test('[P1] deck thumbnail rail keeps complete 16:9 slides separated and aligned', async ({ page }) => {
   await routeMockAgents(page);
   const projectId = await createEmptyProject(page, 'Deck thumbnail rail layout');
@@ -1119,6 +1196,13 @@ async function seedDeckArtifact(
     stopsSlideMessagePropagation?: boolean;
     handlesKeyboard?: boolean;
     frameworkDeck?: boolean;
+    /**
+     * Pad the document past `PREVIEW_URL_GUARD_MAX_HTML_BYTES` so the daemon
+     * serves it through the streaming branch of the scoped preview origin
+     * instead of buffering it. The padding is an HTML comment, so it changes
+     * the transport without changing what the deck renders.
+     */
+    padBytes?: number;
   } = {},
 ) {
   const slideHtml = slides
@@ -1186,7 +1270,8 @@ async function seedDeckArtifact(
     {
       data: {
         name: fileName,
-        content: `<!doctype html><html><body>${deckChrome}${deckHtml}${protocolText}${slideScript}</body></html>`,
+        content: `<!doctype html><html><body>${deckChrome}${deckHtml}${protocolText}${slideScript}`
+          + `${options.padBytes ? `<!-- ${'x'.repeat(options.padBytes)} -->` : ''}</body></html>`,
         artifactManifest: {
           version: 1,
           kind: 'deck',


### PR DESCRIPTION
## Why

This branch converges preview onto a cross-process real-URL runtime, and we are building release confidence on that. The scoped preview origin takes a **different branch** for a document over `PREVIEW_URL_GUARD_MAX_HTML_BYTES`: it streams the response and injects the runtime bootstrap on the way past, instead of assembling it in memory.

Every existing presentation spec uses a deck small enough to buffer. So the combination this branch is *named after* — scoped origin **and** streaming **and** presentation — had no coverage at all.

That gap is not academic. Both red jobs on this branch (fixed in #7833) lived on exactly that path: one was a capability-list drift, the other a stacking regression that made the top of a presented slide unclickable. Two independent defects on the one path nothing walks is not a coincidence.

## What users will see

Nothing — a test.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — tests only

## What it covers

`[P0] a deck too large to buffer presents, advances and exits on the scoped origin`

Walks the real path, not an approximation of it:

1. Seeds a deck padded past `PREVIEW_URL_GUARD_MAX_HTML_BYTES` (a new `padBytes` option on the existing deck fixture — an HTML comment, so the transport changes and the rendering does not).
2. **Proves the transport rather than assuming it** — the document must have come from the scoped preview origin (`n-`/`p-<session>.localhost`) and must measure over the threshold. `location.origin` is `"null"` in that sandbox, so the URL itself is read.
3. Presents in place.
4. Advances a slide.
5. Exits, and the presenter window closes.

**Advancing has to come from inside the presented document, and that is the point rather than a workaround.** The product hides both host slide controls in this mode — the inline one lives in `.viewer-toolbar`, which `.is-tab-present` sets to `display: none`, and the floating one is gated on `!inTabPresent` (`FileViewer.tsx:16511`). The only presenter gesture left is the one that exercises the streamed document's own deck runtime, which is what we want walked.

## Not covered — stated rather than approximated

- **Which capabilities the bootstrap advertises on this path**, and **single injection of the presentation bridge.** The daemon specs already own both (`project-file-range.test.ts`, `project-preview-deck-presentation.test.ts`); duplicating them through the UI would only be slower and flakier. What is still uncovered at the daemon level specifically is the *streaming* scoped bootstrap — `project-preview-deck-presentation.test.ts` covers buffered-scoped and streamed-via-token, but not both at once. This spec covers that combination from the UI side; a daemon-level sibling would be a cheaper place to assert the byte-level contract.
- **The `p-` powered variant under streaming.** This spec accepts either origin prefix but in practice exercises the normal one.

## Bug fix verification

Not a bug fix — coverage. But it was checked for the failure mode that matters for a new test, which is passing for the wrong reason:

**Falsification:** with the padding removed, the document measures **201,059 bytes** against the **2,097,152** threshold and the transport assertion fails. So the spec genuinely discriminates the streaming path from the buffered one rather than going green either way.

## Validation

Runs serialized (other agents on this machine); Playwright workers pinned to 1.

- `e2e` → `playwright test ui/app-manual-edit.test.ts --grep "too large to buffer"` — **1 passed**, 26.2 s (54.6 s wall).
- Falsification run (padding removed) — **1 failed** at the byte-threshold assertion, as quoted above.
- `pnpm --filter @open-design/e2e typecheck` exit 0; `pnpm guard` exit 0.
