### PR TITLE
feat(web): land the 600 default weight app-wide and retire the Home stand-in rules (OPEND-2553 PR-C2)

### DIFF
--- a/apps/web/src/collab/PresenceBar.module.css
+++ b/apps/web/src/collab/PresenceBar.module.css
@@ -118,7 +118,7 @@
 
 .popoverHeader strong {
   font-size: 13px;
-  font-weight: 780;
+  font-weight: 700;
 }
 
 .popoverHeader span {
@@ -197,7 +197,7 @@
   min-width: 0;
   color: var(--text, #111827);
   font-size: 13px;
-  font-weight: 740;
+  font-weight: 700;
 }
 
 .memberName:first-child {
@@ -213,7 +213,7 @@
   background: color-mix(in srgb, var(--accent, #c85f3d) 12%, transparent);
   color: var(--text-muted, #64748b);
   font-size: 10px;
-  font-weight: 650;
+  font-weight: 600;
 }
 
 .memberMeta {

--- a/apps/web/src/components/AmrArtifactUpgradeDialog.module.css
+++ b/apps/web/src/components/AmrArtifactUpgradeDialog.module.css
@@ -109,7 +109,7 @@
   min-width: 0;
   color: inherit;
   font-size: 12.5px;
-  font-weight: 650;
+  font-weight: 600;
   line-height: 1.35;
   overflow-wrap: break-word;
 }
@@ -128,7 +128,7 @@
 .offerTimerLabel {
   color: color-mix(in srgb, #f8f3ec 70%, transparent);
   font-size: 9.5px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1;
   white-space: nowrap;
 }
@@ -137,7 +137,7 @@
   font-family: var(--mono);
   font-size: 11.5px;
   font-variant-numeric: tabular-nums;
-  font-weight: 650;
+  font-weight: 600;
   letter-spacing: -0.02em;
   line-height: 1.1;
   unicode-bidi: isolate;
@@ -149,7 +149,7 @@
   margin: 0 0 10px;
   color: var(--text-strong);
   font-size: 27px;
-  font-weight: 650;
+  font-weight: 600;
   letter-spacing: -0.035em;
   line-height: 1.12;
   overflow-wrap: break-word;

--- a/apps/web/src/components/AmrArtifactUpgradeHomeCard.module.css
+++ b/apps/web/src/components/AmrArtifactUpgradeHomeCard.module.css
@@ -42,7 +42,7 @@
   margin: 0 0 3px;
   color: var(--text-strong);
   font-size: 13.5px;
-  font-weight: 650;
+  font-weight: 600;
   letter-spacing: -0.01em;
   line-height: 1.35;
 }

--- a/apps/web/src/components/AmrBalanceDialog.module.css
+++ b/apps/web/src/components/AmrBalanceDialog.module.css
@@ -202,7 +202,7 @@
   border: none;
   background: var(--accent);
   color: #fff;
-  font-weight: 500;
+  font-weight: 600;
   box-shadow:
     inset 0 1px 0 color-mix(in srgb, #fff 12%, transparent),
     0 8px 20px color-mix(in srgb, var(--accent) 20%, transparent);

--- a/apps/web/src/components/BrandPreviewCard.module.css
+++ b/apps/web/src/components/BrandPreviewCard.module.css
@@ -749,7 +749,7 @@
 }
 
 .fontWeights {
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text-muted);
 }
 
@@ -1055,7 +1055,7 @@
 .shotCap {
   display: block;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.25;
   color: var(--text-strong);
 }
@@ -1782,7 +1782,7 @@
   background: var(--bg-panel);
   color: var(--text);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   font-family: inherit;
   cursor: pointer;
   transition: border-color var(--dur-quick) var(--ease-out),

--- a/apps/web/src/components/BrandReadyPrompt.module.css
+++ b/apps/web/src/components/BrandReadyPrompt.module.css
@@ -71,7 +71,7 @@
   color: var(--accent, #0969da);
   font: inherit;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   cursor: pointer;
 }
 .cta:hover {
@@ -167,7 +167,7 @@
   color: var(--text, #1f2328);
   font: inherit;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   cursor: pointer;
   transition:
     background 140ms cubic-bezier(0.23, 1, 0.32, 1),

--- a/apps/web/src/components/BrandReferencePicker.module.css
+++ b/apps/web/src/components/BrandReferencePicker.module.css
@@ -171,7 +171,7 @@
   background: var(--bg-elevated);
   color: var(--text);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   cursor: pointer;
   transition: border-color var(--dur-quick) var(--ease-out),
     background-color var(--dur-quick) var(--ease-out),
@@ -279,7 +279,7 @@
   background: var(--bg-subtle);
   color: var(--text-muted);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   cursor: pointer;
   transition: border-color var(--dur-quick) var(--ease-out),
     background-color var(--dur-quick) var(--ease-out),
@@ -537,7 +537,7 @@
   padding: 9px 12px;
   border-radius: var(--radius-sm);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
 }
 
 .statusBusy {
@@ -584,7 +584,7 @@
   background: var(--bg-elevated);
   color: var(--text);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   cursor: pointer;
   transition: border-color var(--dur-quick) var(--ease-out),
     background-color var(--dur-quick) var(--ease-out);

--- a/apps/web/src/components/DeepSeekV4FlashCampaign.module.css
+++ b/apps/web/src/components/DeepSeekV4FlashCampaign.module.css
@@ -88,7 +88,7 @@
   padding: 6px 9px;
   color: #78ea57;
   font-size: 8px;
-  font-weight: 750;
+  font-weight: 700;
   line-height: 1;
   letter-spacing: .06em;
   background: #11120f;
@@ -106,7 +106,7 @@
   color: #15220f;
   font-family: Inter, Arial, sans-serif;
   font-size: 78px;
-  font-weight: 650;
+  font-weight: 600;
   line-height: .82;
   letter-spacing: -.07em;
 }
@@ -126,7 +126,7 @@
   margin-top: 22px;
   color: #42533d;
   font-size: 13px;
-  font-weight: 400;
+  font-weight: 500;
   line-height: 1.55;
   letter-spacing: -.012em;
 }
@@ -142,7 +142,7 @@
   margin: 0 0 9px;
   color: #11120f;
   font-size: 30px;
-  font-weight: 680;
+  font-weight: 600;
   line-height: 1.08;
   letter-spacing: -.04em;
 }
@@ -186,7 +186,7 @@
   height: 26px;
   color: #fff;
   font-size: 8px;
-  font-weight: 800;
+  font-weight: 700;
   letter-spacing: -.02em;
   background: #20231f;
   border-radius: 6px;
@@ -264,7 +264,7 @@
   color: #fff;
   font-size: 7px;
   font-style: normal;
-  font-weight: 800;
+  font-weight: 700;
   letter-spacing: -.03em;
 }
 
@@ -312,7 +312,7 @@
   padding: 0 18px;
   color: #14210f;
   font-size: 13px;
-  font-weight: 750;
+  font-weight: 700;
   cursor: pointer;
   background: #78ea57;
   border: 0;
@@ -382,7 +382,7 @@
   margin: 3px 44px 8px 0;
   color: var(--brand-text);
   font-size: 12px;
-  font-weight: 750;
+  font-weight: 700;
   letter-spacing: 0.04em;
 }
 
@@ -391,7 +391,7 @@
   margin: 0;
   color: var(--text-strong);
   font-size: 29px;
-  font-weight: 680;
+  font-weight: 600;
   line-height: 1.14;
   letter-spacing: -0.035em;
   text-wrap: balance;
@@ -461,7 +461,7 @@
   padding: 4px 8px;
   border-radius: var(--radius-pill);
   font-size: 11px;
-  font-weight: 750;
+  font-weight: 700;
   white-space: nowrap;
 }
 
@@ -490,7 +490,7 @@
   color: var(--brand-text);
   background: var(--brand);
   font-size: 10px;
-  font-weight: 800;
+  font-weight: 700;
   white-space: nowrap;
 }
 
@@ -523,7 +523,7 @@
   border-color: var(--accent);
   color: var(--brand);
   background: var(--accent);
-  font-weight: 800;
+  font-weight: 700;
 }
 
 .panel .primaryAction:hover {
@@ -537,7 +537,7 @@
   border-color: transparent;
   color: var(--text-muted);
   background: transparent;
-  font-weight: 650;
+  font-weight: 600;
 }
 
 .panel .laterAction:hover {

--- a/apps/web/src/components/DesignSystemsTab.module.css
+++ b/apps/web/src/components/DesignSystemsTab.module.css
@@ -200,7 +200,7 @@
   background: var(--bg-subtle);
   color: var(--text-muted);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   font-family: inherit;
   cursor: pointer;
   transition: border-color var(--dur-quick) var(--ease-out),
@@ -281,7 +281,7 @@
   background: transparent;
   color: var(--text-muted);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   font-family: inherit;
   cursor: pointer;
   transition: background-color var(--dur-quick) var(--ease-out),
@@ -409,7 +409,7 @@
   color: var(--text);
   font-family: inherit;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   text-align: left;
   cursor: pointer;
 }
@@ -742,7 +742,7 @@
   background: var(--bg-panel);
   color: var(--text-muted);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   font-family: inherit;
   cursor: pointer;
   transition: border-color var(--dur-quick) var(--ease-out),
@@ -1588,7 +1588,7 @@
   padding: 6px 12px;
   border-radius: var(--radius-sm);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
 }
 
 .teamActionButton {
@@ -1615,7 +1615,7 @@
   padding: 5px 10px;
   border-radius: var(--radius-sm);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text-muted);
 }
 
@@ -1648,7 +1648,7 @@
   background: var(--bg-subtle);
   color: var(--text-muted);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   font-family: inherit;
   cursor: pointer;
   transition: border-color var(--dur-quick) var(--ease-out),

--- a/apps/web/src/components/ExperienceSurvey.module.css
+++ b/apps/web/src/components/ExperienceSurvey.module.css
@@ -176,7 +176,7 @@
 .cell.picked {
   background: var(--brand, #87ea5c);
   color: var(--brand-text, #0d5400);
-  font-weight: 650;
+  font-weight: 600;
   box-shadow: none;
 }
 
@@ -350,7 +350,7 @@
 .thanksTitle {
   margin: 0;
   font-size: var(--font-size-13, 13px);
-  font-weight: 650;
+  font-weight: 600;
   color: var(--text-strong, #202020);
 }
 

--- a/apps/web/src/components/FigmaHelpModal.module.css
+++ b/apps/web/src/components/FigmaHelpModal.module.css
@@ -31,7 +31,7 @@
   margin: 0 0 14px;
   color: var(--text-strong);
   font-size: 16px;
-  font-weight: 650;
+  font-weight: 600;
 }
 
 .close {

--- a/apps/web/src/components/GoPlanSunsetDialog.module.css
+++ b/apps/web/src/components/GoPlanSunsetDialog.module.css
@@ -72,7 +72,7 @@
   margin: 0 0 14px;
   color: #11120f;
   font-size: 30px;
-  font-weight: 680;
+  font-weight: 600;
   line-height: 1.08;
   letter-spacing: -0.04em;
 }
@@ -97,7 +97,7 @@
   margin: 0 0 6px;
   color: #30352d;
   font-size: 11px;
-  font-weight: 650;
+  font-weight: 600;
   line-height: 1.45;
 }
 
@@ -137,7 +137,7 @@
   align-items: center;
   color: #2a3027;
   font-size: 12.5px;
-  font-weight: 650;
+  font-weight: 600;
   line-height: 1.3;
 }
 

--- a/apps/web/src/components/LibraryPreviewModal.module.css
+++ b/apps/web/src/components/LibraryPreviewModal.module.css
@@ -312,7 +312,7 @@
   border: none;
   padding: 6px 10px;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   cursor: pointer;
   color: var(--accent);
   text-decoration: none;

--- a/apps/web/src/components/ManualEditTextToolbar.module.css
+++ b/apps/web/src/components/ManualEditTextToolbar.module.css
@@ -60,7 +60,7 @@
   color: #2563eb;
 }
 
-.buttonBold { font-weight: 800; }
+.buttonBold { font-weight: 700; }
 .buttonItalic { font-style: italic; font-family: Georgia, 'Times New Roman', serif; }
 .buttonUnderline { text-decoration: underline; text-underline-offset: 3px; }
 .buttonStrike { text-decoration: line-through; }

--- a/apps/web/src/components/MemoryHooksPanel.module.css
+++ b/apps/web/src/components/MemoryHooksPanel.module.css
@@ -84,7 +84,7 @@
 
 .rowLabel {
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
 }
 
 .rowDesc {

--- a/apps/web/src/components/MemoryProfilePanel.module.css
+++ b/apps/web/src/components/MemoryProfilePanel.module.css
@@ -85,7 +85,7 @@
 
 .savedPill {
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--green);
 }
 

--- a/apps/web/src/components/NextStepActions.module.css
+++ b/apps/web/src/components/NextStepActions.module.css
@@ -55,7 +55,7 @@
   gap: 5px;
   padding: 4px 12px;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--accent-strong);
   background: var(--accent-tint);
   border: 1px solid color-mix(in srgb, var(--accent) 40%, var(--border));

--- a/apps/web/src/components/OdCard.module.css
+++ b/apps/web/src/components/OdCard.module.css
@@ -125,7 +125,7 @@
 }
 
 .appliedSummary {
-  font-weight: 500;
+  font-weight: 600;
 }
 
 .appliedRefs {
@@ -418,7 +418,7 @@
 .ruleFieldLabel textarea {
   width: 100%;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: normal;
   text-transform: none;
   color: var(--text);
@@ -458,5 +458,5 @@
 }
 
 .ruleSavedLabel {
-  font-weight: 500;
+  font-weight: 600;
 }

--- a/apps/web/src/components/OnboardingModelSource.module.css
+++ b/apps/web/src/components/OnboardingModelSource.module.css
@@ -100,7 +100,7 @@
 .optionTitle {
   display: block;
   font-size: 14px;
-  font-weight: 650;
+  font-weight: 600;
   letter-spacing: -0.01em;
 }
 

--- a/apps/web/src/components/ProjectReferenceModal.module.css
+++ b/apps/web/src/components/ProjectReferenceModal.module.css
@@ -35,7 +35,7 @@
   margin: 0;
   color: var(--text-strong);
   font-size: 16px;
-  font-weight: 650;
+  font-weight: 600;
 }
 
 .close {

--- a/apps/web/src/components/RecommendedStartRegion.module.css
+++ b/apps/web/src/components/RecommendedStartRegion.module.css
@@ -203,7 +203,7 @@
   flex: 0 0 auto;
   padding: 6px 10px;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text-muted);
   background: transparent;
   border: none;

--- a/apps/web/src/components/TeamSlotPlaceholder.module.css
+++ b/apps/web/src/components/TeamSlotPlaceholder.module.css
@@ -49,7 +49,7 @@
   margin-top: 4px;
   padding: 3px 10px;
   font-size: 11.5px;
-  font-weight: 500;
+  font-weight: 600;
   border-radius: 999px;
   color: var(--text-muted);
   background: color-mix(in srgb, var(--text-muted) 12%, transparent);

--- a/apps/web/src/components/UpdateDialog.module.css
+++ b/apps/web/src/components/UpdateDialog.module.css
@@ -85,7 +85,7 @@
   margin: 0;
   color: var(--text-strong);
   font-size: 18px;
-  font-weight: 650;
+  font-weight: 600;
   letter-spacing: -0.015em;
 }
 
@@ -161,7 +161,7 @@
   border-radius: 9px;
   font: inherit;
   font-size: 13px;
-  font-weight: 550;
+  font-weight: 600;
   cursor: pointer;
 }
 

--- a/apps/web/src/styles/base.css
+++ b/apps/web/src/styles/base.css
@@ -31,6 +31,10 @@ body {
   color: var(--text);
   background: var(--bg-app);
   font-size: var(--font-size-14, 14px);
+  /* The product UI uses a consolidated 500 / 600 / 700 ladder. Unspecified
+     text defaults to 600; 400 is reserved for font metadata such as the
+     static JiduMono face above. */
+  font-weight: 600;
   line-height: 125%;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -160,7 +160,7 @@
   padding: 8px 0;
   font-size: 13px;
   color: var(--text-muted);
-  font-weight: 500;
+  font-weight: 600;
 }
 .chat-header-tab:hover { color: var(--text); background: transparent; border-color: transparent; }
 .chat-header-tab.active {
@@ -517,7 +517,7 @@
 .msg-time {
   color: var(--text-faint);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
@@ -763,7 +763,7 @@
 }
 .msg-plugin-chip__title {
   color: var(--text);
-  font-weight: 500;
+  font-weight: 600;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2134,13 +2134,6 @@
    the button's hover tooltip. viewer/routines.css loads later and owns the
    shared geometry for both states; these are the base-layer values for hosts
    that rule doesn't reach. */
-/* Typography ladder stand-in for the project composer — same reason as the
-   block at the top of home/home-hero.css: the app-wide 600 default ships with
-   the entry refresh, and the composer inherits it locally until then. */
-.composer,
-:where(.composer) button {
-  font-weight: 600;
-}
 .composer-send.stop {
   width: 32px;
   min-width: 32px;

--- a/apps/web/src/styles/design-system-flow.css
+++ b/apps/web/src/styles/design-system-flow.css
@@ -182,7 +182,7 @@
   margin-bottom: 18px;
   color: var(--text-muted);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
 }
 .ds-setup-field > span {
   color: var(--text-strong);
@@ -231,7 +231,7 @@
   color: var(--text-muted);
   font-family: var(--sans);
   font-size: 14px;
-  font-weight: 500;
+  font-weight: 600;
 }
 .ds-resource-card {
   margin-top: 12px;
@@ -274,7 +274,7 @@
   margin-top: 2px;
   color: var(--text-muted);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
 }
 .ds-resource-row > p {
   grid-column: 1 / -1;
@@ -427,7 +427,7 @@
   color: var(--text-strong);
   background: var(--bg-panel);
   box-shadow: var(--shadow-xs);
-  font: 13px/1.5 "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font: 500 13px/1.5 "SFMono-Regular", Consolas, "Liberation Mono", monospace;
 }
 .ds-design-md-preview {
   min-width: 0;
@@ -1494,7 +1494,7 @@ a.ds-source-link-open:focus-visible {
   border-radius: var(--radius-large, 8px);
   background: var(--bg-panel);
   color: var(--text-muted);
-  font: 11px/1.35 var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+  font: 500 11px/1.35 var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1658,7 +1658,7 @@ a.ds-source-link-open:focus-visible {
   border-radius: var(--radius-large, 8px);
   background: var(--bg-panel);
   color: var(--text);
-  font: 11px/1.35 var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+  font: 500 11px/1.35 var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1703,7 +1703,7 @@ a.ds-source-link-open:focus-visible {
   background: var(--bg-subtle);
   color: var(--text-muted);
   white-space: pre-wrap;
-  font: 12px/1.45 var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+  font: 500 12px/1.45 var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
 }
 .ds-warning-card span {
   flex: 1;
@@ -1761,7 +1761,7 @@ a.ds-source-link-open:focus-visible {
   background: var(--bg-panel);
   color: var(--text);
   white-space: pre-wrap;
-  font: 12.5px/1.5 var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+  font: 500 12.5px/1.5 var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
 }
 .ds-review-sections {
   display: grid;
@@ -1815,7 +1815,7 @@ a.ds-source-link-open:focus-visible {
   white-space: pre-wrap;
   margin: 0;
   color: var(--text);
-  font: 13px/1.55 var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+  font: 500 13px/1.55 var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
 }
 .ds-body-editor {
   display: grid;
@@ -2109,7 +2109,7 @@ a.ds-source-link-open:focus-visible {
   background: var(--bg-elevated);
   color: var(--text);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
 }
 .ds-user-empty {
   padding: 18px;
@@ -2350,7 +2350,7 @@ a.ds-source-link-open:focus-visible {
    Design Files tab, this tab scrolls with the strip — no sticky pinning, so
    overflowed tabs never slide underneath it. */
 .ws-tab.design-system-tab {
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text);
 }
 .ws-tab.design-system-tab.active {
@@ -2394,7 +2394,7 @@ a.ds-source-link-open:focus-visible {
   background: var(--text);
   color: var(--bg);
   border-color: var(--text);
-  font-weight: 500;
+  font-weight: 600;
 }
 .ws-tab-action.share:hover:not(:disabled) {
   background: #000;
@@ -2640,7 +2640,7 @@ a.ds-source-link-open:focus-visible {
   color: var(--text);
   font-family: var(--serif);
   font-size: 48px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.04;
   letter-spacing: 0;
 }
@@ -2900,7 +2900,7 @@ a.ds-source-link-open:focus-visible {
   font-family: var(--serif);
   font-size: clamp(28px, 4vw, 48px);
   line-height: 1.08;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
 }
 .ds-project-head p {
@@ -3602,7 +3602,7 @@ a.ds-source-link-open:focus-visible {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-weight: 500;
+  font-weight: 600;
 }
 .ds-project-file-row svg:last-child {
   color: var(--text-faint);
@@ -3664,7 +3664,7 @@ a.ds-source-link-open:focus-visible {
   margin: 0 0 2px 2px;
   color: var(--text-muted);
   font-size: 14px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
 }
 .ds-project-review-item {

--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -29,19 +29,6 @@
    viewport's true center, reading as an oversized blank band above it. Drop
    it back to match the bottom padding so the hero's own box is symmetric and
    the flex centering does all of the vertical balancing. */
-/* Typography ladder stand-in. The refreshed entry surfaces set the app's
-   default text to `body { font-weight: 600 }` and `button { font-weight: 600 }`
-   (base.css / primitives.css); that app-wide normalization lands with the
-   rest of the entry refresh, not with the hero. Until then the hero inherits
-   the same ladder locally so its staged chips, controls and rows read at the
-   weight they were designed at. `:where()` keeps the button rule at element
-   specificity, exactly where primitives.css's own sits, so a control that
-   names its weight still wins. Drop this block when the global one lands. */
-.home-hero,
-:where(.home-hero) button {
-  font-weight: 600;
-}
-
 .home-view--centered .home-hero {
   padding-top: var(--spacing-4);
 }

--- a/apps/web/src/styles/home/plugin-marketplace-demo.css
+++ b/apps/web/src/styles/home/plugin-marketplace-demo.css
@@ -528,7 +528,7 @@
   background: color-mix(in srgb, var(--accent) 12%, transparent);
   color: var(--accent);
   font-size: 12px;
-  font-weight: 550;
+  font-weight: 600;
   line-height: 1.5;
 }
 
@@ -564,7 +564,7 @@
   color: var(--text-muted);
   font-size: 12px;
   font-style: normal;
-  font-weight: 500;
+  font-weight: 600;
 }
 
 .plugin-marketplace__row-action {
@@ -581,7 +581,7 @@
   color: var(--accent);
   font: inherit;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   cursor: pointer;
 }
 
@@ -864,7 +864,7 @@
   background: color-mix(in srgb, var(--text) 5%, transparent);
   color: var(--text-muted);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
 }
 
 .plugin-marketplace__empty {
@@ -1420,7 +1420,7 @@
   color: var(--text-muted);
   font: inherit;
   font-size: 14px;
-  font-weight: 500;
+  font-weight: 600;
   cursor: pointer;
   box-shadow: none;
 }

--- a/apps/web/src/styles/home/plugins-home.css
+++ b/apps/web/src/styles/home/plugins-home.css
@@ -529,7 +529,7 @@
   background: var(--bg-subtle);
   color: var(--text-muted);
   font-size: 10.5px;
-  font-weight: 650;
+  font-weight: 600;
   letter-spacing: 0.01em;
   line-height: 1.3;
   white-space: nowrap;
@@ -816,7 +816,7 @@
   position: relative;
   font-size: 18px;
   line-height: 1.18;
-  font-weight: 500;
+  font-weight: 600;
   color: white;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
   z-index: 1;
@@ -1070,7 +1070,7 @@
   background: var(--bg-panel);
   color: var(--text-muted);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   font-family: inherit;
   cursor: pointer;
   white-space: nowrap;
@@ -1101,7 +1101,7 @@
   padding: 6px 12px;
   border-radius: var(--radius-sm);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   cursor: pointer;
   transition: background-color 120ms var(--ease-out), border-color 120ms var(--ease-out),
     color 120ms var(--ease-out);

--- a/apps/web/src/styles/home/plus-menu.css
+++ b/apps/web/src/styles/home/plus-menu.css
@@ -11,19 +11,6 @@
   position: relative;
   display: inline-flex;
 }
-/* Typography ladder stand-in for the popup — same reason as the block at the
-   top of home/home-hero.css: the app-wide `body` / `button { font-weight: 600 }`
-   default ships with the rest of the entry refresh, and until then each entry
-   surface inherits it locally. The popup is portaled to document.body, so the
-   hero's and the composer's scoped ladders never reach it and its rows fell
-   back to the 400/500 the app still defaults to. `:where()` keeps the button
-   rule at element specificity, exactly where primitives.css's own sits, so a
-   control that names its weight still wins. Drop this block when the global
-   ladder lands. */
-.plus-menu__popup,
-:where(.plus-menu__popup) button {
-  font-weight: 600;
-}
 .plus-menu__trigger {
   position: relative;
   /* The base `button.icon-btn` only sets padding/font-size, so the inline SVG

--- a/apps/web/src/styles/home/tasks.css
+++ b/apps/web/src/styles/home/tasks.css
@@ -876,7 +876,7 @@
 
 .automation-modal__title-input::placeholder {
   color: var(--text-faint);
-  font-weight: 500;
+  font-weight: 600;
 }
 
 .automation-modal__title-input:focus {
@@ -959,7 +959,7 @@
   background: color-mix(in srgb, var(--bg-panel) 72%, transparent);
   resize: none;
   color: var(--text);
-  font: 13.5px/1.55 var(--font, system-ui);
+  font: 500 13.5px/1.55 var(--font, system-ui);
 }
 
 .automation-modal__prompt::placeholder {
@@ -1248,7 +1248,7 @@
 
 .automation-pill__tz {
   color: var(--text-muted);
-  font-weight: 500;
+  font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/apps/web/src/styles/primitives.css
+++ b/apps/web/src/styles/primitives.css
@@ -8,7 +8,7 @@ button {
   height: 36px;
   padding: 0 var(--spacing-16, 16px);
   font-size: var(--font-size-14, 14px);
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1;
   white-space: nowrap;
   color: var(--text);
@@ -141,7 +141,7 @@ button:disabled {
   box-shadow: var(--shadow-sm);
   color: var(--vibrancy-label);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.2;
   contain: layout paint style;
   pointer-events: none;

--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -473,7 +473,7 @@ html.od-radial-open .workspace-shell {
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
 }
 /* Hairline between the home icon and the sidebar toggle in the pinned pill. */
@@ -867,7 +867,7 @@ html.od-radial-open .workspace-shell {
   padding: 0 12px;
   border-radius: var(--radius);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1;
   white-space: nowrap;
   cursor: pointer;
@@ -2013,7 +2013,7 @@ body:has(.artifact-version-panel) .ws-tabs-file-actions-before {
   overflow: hidden;
   color: var(--text-strong);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.15;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -2036,7 +2036,7 @@ body:has(.artifact-version-panel) .ws-tabs-file-actions-before {
 .avatar-amr-row__stat-label {
   flex: 0 0 auto;
   font-size: 11px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text-muted);
 }
 .avatar-amr-row__stat-value {
@@ -2062,7 +2062,7 @@ body:has(.artifact-version-panel) .ws-tabs-file-actions-before {
   background: var(--accent);
   color: #fff;
   font-size: 11px;
-  font-weight: 650;
+  font-weight: 600;
   letter-spacing: 0.02em;
   line-height: 1;
   /* The actual fix for the vertically-stacked label. */
@@ -2294,7 +2294,7 @@ a.avatar-item:visited {
 .env-pill-dot[data-mode="api"] {
   background: linear-gradient(135deg, #1c1b1a 0%, #4b4948 100%);
 }
-.env-pill-label { font-weight: 500; font-size: 12px; }
+.env-pill-label { font-weight: 600; font-size: 12px; }
 .env-pill-meta {
   font-size: 12px; color: var(--text-muted);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0;

--- a/apps/web/src/styles/viewer/code.css
+++ b/apps/web/src/styles/viewer/code.css
@@ -139,7 +139,7 @@
 .markdown-rendered h6 {
   margin: 32px 0 12px;
   color: var(--text-strong);
-  font-weight: 760;
+  font-weight: 700;
   letter-spacing: 0;
   line-height: 1.18;
 }
@@ -428,7 +428,7 @@
   outline: none;
   background: transparent;
   color: var(--text);
-  font: 13px/1.7 var(--mono);
+  font: 500 13px/1.7 var(--mono);
   padding: 24px 28px 40px;
   tab-size: 2;
 }
@@ -979,7 +979,7 @@
   background: var(--green);
   animation: pulse 1.2s ease-in-out infinite;
 }
-.assistant-label { font-weight: 500; color: var(--text-muted); font-size: 11px; }
+.assistant-label { font-weight: 600; color: var(--text-muted); font-size: 11px; }
 
 .assistant-flow {
   display: flex;
@@ -1018,7 +1018,7 @@
 .prose-block .md-h {
   margin: 24px 0 10px;
   line-height: 1.3;
-  font-weight: 650;
+  font-weight: 600;
   color: var(--text-strong, var(--text));
   letter-spacing: -0.02em;
 }
@@ -1041,7 +1041,7 @@
 .prose-block .md-ol li::marker {
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
-  font-weight: 500;
+  font-weight: 600;
 }
 /* GFM task list — checkbox glyph replaces the bullet marker. */
 .prose-block .md-task-list {
@@ -1091,7 +1091,7 @@
   font-family: var(--mono);
   font-size: 0.86em;
   color: var(--text);
-  font-weight: 450;
+  font-weight: 600;
 }
 .prose-block .md-code-block {
   position: relative;
@@ -1114,7 +1114,7 @@
 .prose-block .md-code-lang {
   font-family: var(--mono);
   font-size: 11px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text-muted);
   text-transform: lowercase;
   letter-spacing: 0.02em;
@@ -1396,7 +1396,7 @@
 .thinking-status.op-status-running { color: var(--purple); border-color: var(--purple); background: none; }
 .thinking-status-active { color: var(--purple); }
 .thinking-label {
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text-muted);
   font-size: 13px;
 }
@@ -1494,7 +1494,7 @@
   font-size: 12px;
   color: var(--text-muted);
 }
-.status-label { letter-spacing: 0.02em; font-weight: 500; }
+.status-label { letter-spacing: 0.02em; font-weight: 600; }
 .status-detail {
   min-width: 0;
   max-width: 100%;
@@ -1583,7 +1583,7 @@
 .action-card-status.op-status-ok { color: var(--green); }
 .action-card-status.op-status-error { color: var(--red); }
 .action-card-toggle .summary {
-  font-weight: 500;
+  font-weight: 600;
   font-size: 13px;
   color: var(--text-muted);
   flex: 1; min-width: 0;
@@ -1599,7 +1599,7 @@
 }
 .task-activity .action-card-toggle .summary {
   flex: 0 1 auto;
-  font-weight: 400;
+  font-weight: 600;
 }
 .task-activity-elapsed {
   color: var(--text-muted);
@@ -1745,7 +1745,7 @@
   transition: transform 120ms var(--ease-out);
 }
 .op-title {
-  font-weight: 500;
+  font-weight: 600;
   font-size: 13px;
   color: var(--text-muted);
 }

--- a/apps/web/src/styles/viewer/composio.css
+++ b/apps/web/src/styles/viewer/composio.css
@@ -256,7 +256,7 @@
 }
 .deploy-result-url {
   min-width: 0;
-  font-weight: 500;
+  font-weight: 600;
   overflow-wrap: anywhere;
 }
 .deploy-result-actions {
@@ -520,7 +520,7 @@
 }
 .system-reminder-toggle:hover { background: rgba(0, 0, 0, 0.03); }
 .system-reminder-icon { color: var(--text-muted); }
-.system-reminder-label { font-weight: 500; color: var(--text); }
+.system-reminder-label { font-weight: 600; color: var(--text); }
 .system-reminder-preview {
   flex: 1;
   color: var(--text-muted);
@@ -570,7 +570,7 @@
   animation: pulse 1.4s ease-in-out infinite;
 }
 .op-waiting-label {
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text);
 }
 .op-waiting-detail {
@@ -714,7 +714,7 @@
   margin: 6px 10px 6px 0;
   padding: 2px 12px;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   border: 1px solid var(--green-border);
   padding: 2px 10px;
   border: 1px solid var(--border-strong);
@@ -843,7 +843,7 @@
 }
 .qf-label {
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text);
   display: flex;
   align-items: center;
@@ -904,7 +904,7 @@ button.qf-chip-other:disabled { cursor: default; opacity: 0.6; }
 .qf-chip-desc {
   color: var(--text-muted);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
 }
 .qf-chip-on .qf-chip-desc {
   color: inherit;
@@ -920,7 +920,7 @@ button.qf-chip-other:disabled { cursor: default; opacity: 0.6; }
   border-color: var(--border-strong);
   background: color-mix(in srgb, var(--bg-subtle) 45%, var(--bg-panel));
   color: var(--accent-hover);
-  font-weight: 500;
+  font-weight: 600;
 }
 .question-form-locked .qf-chip { cursor: not-allowed; }
 .qf-input,
@@ -1360,7 +1360,7 @@ button.qf-chip-other:disabled { cursor: default; opacity: 0.6; }
 .qf-visual-custom-label {
   color: var(--text-muted);
   font-size: 11px;
-  font-weight: 550;
+  font-weight: 600;
   line-height: 1.3;
 }
 .qf-visual-dialog-foot {
@@ -1750,7 +1750,7 @@ button.qf-chip-other:disabled { cursor: default; opacity: 0.6; }
 .question-form-summary-visual-label {
   color: var(--text-muted);
   font-size: 10px;
-  font-weight: 550;
+  font-weight: 600;
 }
 .question-form-summary-visual-cards {
   display: flex;
@@ -1776,7 +1776,7 @@ button.qf-chip-other:disabled { cursor: default; opacity: 0.6; }
   padding: 4px 5px 5px;
   color: var(--text);
   font-size: 10px;
-  font-weight: 550;
+  font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1800,7 +1800,7 @@ button.qf-chip-other:disabled { cursor: default; opacity: 0.6; }
 .question-form-summary-item strong {
   overflow: hidden;
   color: var(--text);
-  font-weight: 550;
+  font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -2147,7 +2147,7 @@ button.qf-chip-other:disabled { cursor: default; opacity: 0.6; }
   border-radius: var(--radius-pill);
   padding: 6px 16px;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text-muted);
   cursor: pointer;
 }
@@ -2846,7 +2846,7 @@ button.qf-chip-other:disabled { cursor: default; opacity: 0.6; }
   letter-spacing: 0.06em;
   color: var(--text-muted);
   margin-right: 6px;
-  font-weight: 500;
+  font-weight: 600;
 }
 .filter-pill {
   background: var(--bg-panel);
@@ -2931,7 +2931,7 @@ button.filter-pill:hover:not(:disabled) .filter-pill-count,
   right: 10px;
   padding: 5px 12px;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   color: white;
   background: rgba(28, 27, 26, 0.78);
   border-radius: var(--radius-pill);
@@ -3172,7 +3172,7 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
 .chat-history-menu-count {
   color: var(--text-faint);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1;
   margin-left: 6px;
 }
@@ -3506,7 +3506,7 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   animation: pulse 1.2s ease-in-out infinite;
 }
 .assistant-footer .assistant-label {
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text-faint);
   font-size: 12px;
 }

--- a/apps/web/src/styles/viewer/core.css
+++ b/apps/web/src/styles/viewer/core.css
@@ -227,7 +227,7 @@
 .viewer-module-pointer__cta {
   margin: 4px 0 0;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text);
 }
 .viewer-module-pointer__entries {
@@ -571,7 +571,7 @@
   background: var(--bg-panel);
   border-color: var(--border);
   color: var(--text-strong);
-  font-weight: 500;
+  font-weight: 600;
 }
 .viewer-meta { font-size: 12px; color: var(--text-muted); }
 .ghost-link {
@@ -956,7 +956,7 @@
 }
 .live-artifact-refresh-value.muted {
   color: var(--text-muted);
-  font-weight: 500;
+  font-weight: 600;
 }
 .live-artifact-refresh-sub {
   font-size: 12px;
@@ -1154,7 +1154,7 @@
 }
 .live-artifact-refresh-tile-title {
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1383,7 +1383,7 @@
   background-color: transparent;
   color: var(--text);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.2;
   box-shadow: none;
 }
@@ -1444,7 +1444,7 @@
   background: transparent;
   color: var(--text-muted);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1;
   text-align: left;
 }
@@ -1731,7 +1731,7 @@
   overflow: hidden;
   color: var(--text);
   font-size: 12px;
-  font-weight: 650;
+  font-weight: 600;
   line-height: 1.25;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1810,7 +1810,7 @@
 }
 .annotation-style-row span {
   color: var(--text-muted);
-  font-weight: 500;
+  font-weight: 600;
 }
 .annotation-style-row strong {
   display: inline-flex;
@@ -3017,7 +3017,7 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   background: var(--bg-subtle);
   color: var(--text-muted);
   font-size: 11px;
-  font-weight: 650;
+  font-weight: 600;
   letter-spacing: 0;
   overflow: hidden;
   white-space: nowrap;

--- a/apps/web/src/styles/viewer/library.css
+++ b/apps/web/src/styles/viewer/library.css
@@ -388,7 +388,7 @@
 }
 .slash-popover-hint {
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   text-transform: none;
   letter-spacing: 0;
   color: var(--text-muted);
@@ -544,7 +544,7 @@
   background: transparent;
   padding: 14px 16px;
   font-size: 16px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text);
   border-bottom: 1px solid var(--border-soft);
 }
@@ -726,7 +726,7 @@
   min-width: 0;
 }
 .library-filter-select-label {
-  font-weight: 500;
+  font-weight: 600;
   flex: 0 0 auto;
 }
 .library-filter-select select {
@@ -771,7 +771,7 @@
   border-color: var(--text);
   background-color: var(--bg-subtle);
   color: var(--text);
-  font-weight: 500;
+  font-weight: 600;
 }
 
 .library-content {
@@ -798,7 +798,7 @@
 }
 
 .library-group-count {
-  font-weight: 500;
+  font-weight: 600;
   font-size: 12px;
   opacity: 0.6;
 }
@@ -857,7 +857,7 @@
   border-radius: var(--radius-xs);
   background: var(--accent-tint);
   color: var(--accent);
-  font-weight: 500;
+  font-weight: 600;
 }
 
 .library-card-desc {
@@ -1862,7 +1862,7 @@
   text-overflow: ellipsis;
   color: var(--text-muted);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.2;
   white-space: nowrap;
 }

--- a/apps/web/src/styles/viewer/memory.css
+++ b/apps/web/src/styles/viewer/memory.css
@@ -32,7 +32,7 @@
 }
 .memory-path-copied-badge {
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--success-fg, #16a34a);
   background: var(--success-bg, #dcfce7);
   padding: 1px 6px;
@@ -213,7 +213,7 @@
   color: var(--text-success, #1f7a4d);
   border: 1px solid rgba(34, 139, 90, 0.32);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
 }
 
 /* Library install UI */
@@ -265,7 +265,7 @@
 .library-section-count {
   margin-left: 6px;
   color: var(--text-muted);
-  font-weight: 500;
+  font-weight: 600;
 }
 
 .library-add-btn {
@@ -537,7 +537,7 @@
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  font-weight: 500;
+  font-weight: 600;
 }
 .library-source-badge.installed {
   background: color-mix(in srgb, var(--accent) 12%, transparent);
@@ -750,7 +750,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--manual-edit-field-text);
-  font-weight: 500;
+  font-weight: 600;
 }
 .manual-edit-measure-list {
   display: flex;
@@ -789,7 +789,7 @@
 .manual-edit-param-row span {
   color: var(--manual-edit-field-muted);
   font-size: var(--font-size-12, 12px);
-  font-weight: 500;
+  font-weight: 600;
   line-height: 125%;
 }
 .manual-edit-param-row code {
@@ -936,7 +936,7 @@
   color: var(--text-strong);
   font: inherit;
   font-size: var(--font-size-14, 14px);
-  font-weight: 500;
+  font-weight: 600;
   cursor: pointer;
   transition: background-color var(--duration-ultra-fast, 50ms) var(--curve-easy-ease, ease),
     border-color var(--duration-ultra-fast, 50ms) var(--curve-easy-ease, ease),
@@ -976,7 +976,7 @@
   max-width: 44%;
   padding-right: var(--spacing-8);
   overflow: hidden;
-  font-weight: 500;
+  font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1066,7 +1066,7 @@
   display: flex; align-items: center; justify-content: space-between;
   background: transparent; border: none; padding: 0 var(--spacing-2);
   font-size: var(--font-size-13, 13px); color: var(--text-muted); cursor: pointer;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 125%;
 }
 .cc-quad-head em { color: var(--text); font-style: normal; }
@@ -1079,7 +1079,7 @@
   color: var(--manual-edit-field-text);
   padding: 0 var(--spacing-8); height: 40px; font-size: var(--font-size-13, 13px); gap: var(--spacing-2);
 }
-.cc-quad-axis { color: var(--manual-edit-field-muted); font-style: normal; font-size: var(--font-size-12, 12px); flex: 0 0 auto; font-weight: 500; }
+.cc-quad-axis { color: var(--manual-edit-field-muted); font-style: normal; font-size: var(--font-size-12, 12px); flex: 0 0 auto; font-weight: 600; }
 .cc-step-quad {
   flex-basis: 12px;
   width: 12px;
@@ -1110,7 +1110,7 @@
 }
 .cc-suggest-head {
   display: flex; align-items: baseline; gap: var(--spacing-6);
-  font-size: var(--font-size-12, 12px); font-weight: 500;
+  font-size: var(--font-size-12, 12px); font-weight: 600;
   color: var(--manual-edit-field-muted);
 }
 .cc-suggest-head em { font-style: normal; color: var(--manual-edit-field-text); }
@@ -1144,7 +1144,7 @@
 .cc-suggest-token {
   flex: 0 1 auto; min-width: 0;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-  color: var(--manual-edit-field-muted); font-weight: 500;
+  color: var(--manual-edit-field-muted); font-weight: 600;
 }
 .cc-suggest-val {
   flex: 0 0 auto;
@@ -1379,7 +1379,7 @@
   background: var(--bg-subtle);
   font: inherit;
   font-size: var(--font-size-14, 14px);
-  font-weight: 500;
+  font-weight: 600;
   transition: background-color var(--duration-ultra-fast, 50ms) var(--curve-easy-ease, ease),
     border-color var(--duration-ultra-fast, 50ms) var(--curve-easy-ease, ease),
     color var(--duration-ultra-fast, 50ms) var(--curve-easy-ease, ease),

--- a/apps/web/src/styles/viewer/pets.css
+++ b/apps/web/src/styles/viewer/pets.css
@@ -527,7 +527,7 @@
   line-height: 1;
 }
 .composer-pet-label {
-  font-weight: 500;
+  font-weight: 600;
 }
 .composer-pet-menu {
   position: absolute;
@@ -1032,7 +1032,7 @@
   min-width: 0;
 }
 .composer-tools-row-body strong {
-  font-weight: 500;
+  font-weight: 600;
   font-size: 12px;
 }
 .composer-tools-row-meta {
@@ -1261,7 +1261,7 @@
 }
 .composer-ds-picker-item-title {
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text);
 }
 .composer-ds-picker-item-summary {

--- a/apps/web/src/styles/viewer/plugin-inputs.css
+++ b/apps/web/src/styles/viewer/plugin-inputs.css
@@ -134,7 +134,7 @@
 }
 .settings-skills .skills-file-entry-directory {
   color: var(--text);
-  font-weight: 500;
+  font-weight: 600;
 }
 .settings-skills .skills-file-size {
   margin-left: auto;
@@ -195,7 +195,7 @@
 
   background: transparent;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.5;
   color: var(--text-muted);
   cursor: pointer;
@@ -353,7 +353,7 @@
 
 .mcp-json-helper-toggle-text {
 	font-size: 12px;
-	font-weight: 500;
+	font-weight: 600;
 	line-height: 1.5;
 
 	color: inherit;

--- a/apps/web/src/styles/viewer/plugin-rail.css
+++ b/apps/web/src/styles/viewer/plugin-rail.css
@@ -45,7 +45,7 @@
   align-items: center;
   gap: 6px;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   border-radius: var(--radius-pill);
   padding: 5px 11px;
   cursor: pointer;
@@ -198,7 +198,7 @@
 .inline-plugins-rail--strip .inline-plugins-rail__title {
   overflow: hidden;
   text-overflow: ellipsis;
-  font-weight: 500;
+  font-weight: 600;
 }
 /* Description + trust are hidden inside the strip rail — they live
    in the marketplace detail page. Keeping the strip compact is the
@@ -317,7 +317,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--text);
-  font-weight: 500;
+  font-weight: 600;
 }
 .context-chip-strip__remove {
   appearance: none;
@@ -428,7 +428,7 @@ select.plugin-inputs-form__input {
   text-transform: none;
   letter-spacing: 0;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text);
 }
 .plugin-inputs-form__file-shell {
@@ -530,7 +530,7 @@ select.plugin-inputs-form__input {
 .composer-shell .context-chip-strip__label {
   max-width: 168px;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
 }
 .composer-shell .context-chip-strip__remove {
   width: 18px;

--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -362,11 +362,11 @@
   }
 }
 .od-toast-message {
-  font-weight: 500;
+  font-weight: 600;
 }
 .od-toast.od-toast-browser-snapshot .od-toast-message {
   font-size: 13.5px;
-  font-weight: 650;
+  font-weight: 600;
 }
 .od-toast.od-toast-browser-snapshot.tone-success .od-toast-icon {
   display: none;
@@ -375,7 +375,7 @@
   margin-top: 4px;
   font-size: 12px;
   opacity: 0.85;
-  font-weight: 500;
+  font-weight: 600;
 }
 .od-toast-code {
   margin: 8px 0 0;
@@ -582,7 +582,7 @@
   border-radius: var(--radius);
   padding: 6px 12px;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text-muted);
   cursor: pointer;
   transition: all 120ms var(--ease-out);
@@ -777,7 +777,7 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-weight: 500;
+  font-weight: 600;
 }
 .routines-history-link:hover {
   background: var(--text);
@@ -830,7 +830,7 @@
   background: transparent;
   padding: 3px 12px;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   border-radius: var(--radius-sm);
   color: var(--text-muted);
   cursor: pointer;
@@ -857,7 +857,7 @@
   background: var(--bg-panel);
   color: var(--text-muted);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   cursor: pointer;
   transition: border-color 140ms var(--ease-out), background 140ms var(--ease-out), color 140ms var(--ease-out);
 }
@@ -906,7 +906,7 @@
 .model-picker .ds-picker-popover { min-width: 320px; }
 .model-picker .ds-picker-list { padding: 6px; }
 .model-picker .ds-picker-item { padding: 8px 10px; }
-.model-picker .ds-picker-item-title { font-size: 13px; font-weight: 500; }
+.model-picker .ds-picker-item-title { font-size: 13px; font-weight: 600; }
 .model-picker .ds-picker-item-sub { font-size: 12px; }
 .model-picker .ds-picker-item .ds-picker-item-badge {
   font-size: 12px;
@@ -1412,7 +1412,7 @@
 }
 .workspace-shell .workspace-tab__label {
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
 }
 .workspace-shell .workspace-tab.is-active .workspace-tab__label {
   font-size: var(--font-size-13, 13px);
@@ -1627,7 +1627,7 @@
   font-size: 12px;
   line-height: 1.25;
   color: var(--text-muted);
-  font-weight: 500;
+  font-weight: 600;
 }
 .app .msg .role > span:first-child,
 .app .msg .role .role-name {
@@ -1650,7 +1650,7 @@
 .app .msg-time {
   font-size: 12px;
   color: var(--text-soft);
-  font-weight: 500;
+  font-weight: 600;
 }
 .app .msg.user .user-text {
   padding: 8px 12px;
@@ -1693,7 +1693,7 @@
   gap: 8px;
   padding: 6px 14px;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
 }
 .app .assistant-footer {
   padding: 4px 0;
@@ -1720,7 +1720,7 @@
   box-shadow: none;
 }
 .app .assistant-footer .assistant-label {
-  font-weight: 500;
+  font-weight: 600;
   font-size: 12px;
   color: var(--text-faint);
 }
@@ -2118,7 +2118,7 @@
   color: var(--text);
   font-size: 24px;
   line-height: 1;
-  font-weight: 500;
+  font-weight: 600;
 }
 .app .chat-design-artifact-more-count {
   font-size: 12px;
@@ -3016,7 +3016,7 @@
 }
 .app .df-row-name {
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text-strong);
 }
 .app .df-row-name-wrap {
@@ -3461,7 +3461,7 @@
   color: var(--text-muted);
   font: inherit;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -3708,7 +3708,7 @@
 }
 .project-ds-picker-option-title {
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text-strong, var(--text));
   min-width: 0;
   overflow: hidden;

--- a/apps/web/src/styles/viewer/templates-plugins.css
+++ b/apps/web/src/styles/viewer/templates-plugins.css
@@ -711,7 +711,7 @@
 }
 .xai-oauth-warning em {
   font-style: normal;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text-muted);
 }
 
@@ -1175,7 +1175,7 @@
   color: var(--text-muted);
   letter-spacing: 0.02em;
   text-transform: uppercase;
-  font-weight: 500;
+  font-weight: 600;
 }
 .plugin-details-modal__byline .plugin-details-modal__author-name {
   font-size: 13px;
@@ -1258,7 +1258,7 @@
   padding: 4px 10px;
   border-radius: var(--radius-pill);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   cursor: pointer;
   white-space: nowrap;
   max-width: 220px;
@@ -1332,7 +1332,7 @@
   background: var(--bg-panel);
   color: var(--text-muted);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   text-decoration: none;
   flex-shrink: 0;
   transition: color 120ms var(--ease-out), border-color 120ms var(--ease-out), background 120ms var(--ease-out);
@@ -1389,7 +1389,7 @@
 }
 .plugin-details-modal__section-count {
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0;
   text-transform: none;
   color: var(--text-muted);
@@ -1500,7 +1500,7 @@
   border-radius: var(--radius-pill);
   background: var(--bg-subtle);
   color: var(--text-muted);
-  font-weight: 500;
+  font-weight: 600;
 }
 .plugin-details-modal__badge.is-required {
   background: rgba(200, 60, 60, 0.1);
@@ -1583,7 +1583,7 @@
 }
 .plugin-details-modal__ctx-count {
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   text-transform: none;
   letter-spacing: 0;
   background: var(--bg-subtle);
@@ -1754,7 +1754,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text);
   transition: color 120ms var(--ease-out);
 }
@@ -1770,7 +1770,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-pill);
   padding: 1px 7px;
-  font-weight: 500;
+  font-weight: 600;
 }
 .settings-skills .skills-row-summary-source {
   color: var(--accent);
@@ -1812,7 +1812,7 @@
 .plugin-details-modal__stage-id {
   font-size: 13px;
   color: var(--text);
-  font-weight: 500;
+  font-weight: 600;
 }
 .plugin-details-modal__stage-atoms {
   display: flex;
@@ -1896,7 +1896,7 @@
 }
 .plugin-details-modal__source dt {
   color: var(--text-muted);
-  font-weight: 500;
+  font-weight: 600;
 }
 .plugin-details-modal__source dd {
   margin: 0;
@@ -1913,7 +1913,7 @@
   padding: 1px 8px;
   border-radius: var(--radius-pill);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   background: var(--bg-subtle);
   color: var(--text-muted);
   border: 1px solid var(--border);
@@ -1931,7 +1931,7 @@
   gap: 5px;
   color: var(--text-muted);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
 }
 .plugins-view__version-select select {
   width: min(240px, 100%);
@@ -2018,7 +2018,7 @@
   padding: 7px 14px;
   border-radius: var(--radius-sm, 6px);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   cursor: pointer;
 }
 .plugin-details-modal__secondary:hover {
@@ -2156,7 +2156,7 @@
   margin: 0;
   color: var(--text);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   overflow-wrap: anywhere;
 }
 .plugin-share-confirm__facts code {

--- a/apps/web/src/styles/viewer/theater.css
+++ b/apps/web/src/styles/viewer/theater.css
@@ -406,7 +406,7 @@
   color: var(--text-strong);
   content: attr(data-tooltip);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.2;
   opacity: 0;
   pointer-events: none;
@@ -1170,7 +1170,7 @@
 }
 .speaker-notes-panel-meta {
   color: var(--text-muted);
-  font-weight: 400;
+  font-weight: 600;
   text-transform: none;
   letter-spacing: 0;
 }

--- a/apps/web/src/styles/viewer/tools.css
+++ b/apps/web/src/styles/viewer/tools.css
@@ -68,7 +68,7 @@
   letter-spacing: 0.06em;
   color: var(--text-soft);
   margin-bottom: 6px;
-  font-weight: 500;
+  font-weight: 600;
 }
 .produced-files-list {
   display: flex;
@@ -243,7 +243,7 @@
   background: var(--bg-panel);
   color: var(--text);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   cursor: pointer;
 }
 .plugin-action-button:hover:not(:disabled) {
@@ -687,7 +687,7 @@
 .present-menu-copy small {
   color: var(--text-muted);
   font-size: 11px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.2;
 }
 
@@ -1342,5 +1342,5 @@
   color: var(--text-muted);
   background: var(--bg-subtle);
   border-color: var(--border);
-  font-weight: 500;
+  font-weight: 600;
 }

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -171,7 +171,7 @@
   border-radius: var(--radius-sm);
   background: var(--bg-panel);
   color: var(--text);
-  font: 11.5px/1.6 var(--mono);
+  font: 500 11.5px/1.6 var(--mono);
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
@@ -350,7 +350,7 @@
   align-items: center;
   padding: 2px 9px;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   background: transparent;
@@ -584,7 +584,7 @@
 }
 .settings-about-toggle-copy .hint {
   font-size: 12px;
-  font-weight: 400;
+  font-weight: 600;
   line-height: 1.45;
 }
 .diagnostics-export-row {
@@ -1011,7 +1011,7 @@
 .section-head h3 { margin: 0; font-size: 13px; font-weight: 600; letter-spacing: 0.01em; }
 .section-head .hint { margin-top: 2px; }
 .field { display: flex; flex-direction: column; gap: 4px; }
-.field-label { font-size: 12px; font-weight: 500; color: var(--text-muted); }
+.field-label { font-size: 12px; font-weight: 600; color: var(--text-muted); }
 .memory-model-inline__select {
   width: 100%;
   min-width: 0;
@@ -1130,7 +1130,7 @@
   padding: 0 var(--spacing-42) 0 var(--spacing-16);
   font: inherit;
   font-size: var(--font-size-14);
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.25;
   outline: 0;
   cursor: pointer;
@@ -1291,7 +1291,7 @@
   background: var(--accent-tint);
   border-color: var(--accent);
   color: var(--accent);
-  font-weight: 500;
+  font-weight: 600;
 }
 .settings-language-tile.active .settings-language-tile-title { color: var(--accent); }
 .settings-language-tile.active:hover { background: var(--accent-soft); }
@@ -1762,7 +1762,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
   background: var(--bg-panel);
   color: var(--text);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
 }
 .agent-card-installed .agent-card-test-btn:hover:not(:disabled) {
   background: color-mix(in srgb, var(--accent-tint) 58%, transparent);
@@ -1877,7 +1877,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
 }
 .agent-card-link {
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text-muted);
   text-decoration: none;
   transition: color 120ms var(--ease-out);
@@ -1893,7 +1893,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
    color change — to keep visual weight low. */
 .agent-card-link--muted {
   color: var(--text-muted);
-  font-weight: 500;
+  font-weight: 600;
 }
 .agent-card-link--muted:hover {
   color: var(--text);
@@ -2014,7 +2014,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
 .agent-card-name-divider,
 .agent-card-tagline {
   color: var(--text-muted);
-  font-weight: 500;
+  font-weight: 600;
 }
 .agent-card-tagline {
   flex: 1 1 auto;
@@ -2042,7 +2042,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
   margin-top: 4px;
   color: var(--text-muted);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   font-variant-numeric: tabular-nums;
   line-height: 1.35;
   white-space: nowrap;
@@ -2122,7 +2122,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
   min-width: 0;
   color: var(--text-soft);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -2230,7 +2230,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
   overflow: hidden;
   color: var(--text-muted);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -2468,7 +2468,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
   color: var(--text);
   box-shadow: var(--shadow-md);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.45;
   letter-spacing: 0;
   white-space: normal;
@@ -2531,7 +2531,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
 .settings-section-byok .field-label-link {
   color: var(--selected);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
 }
 .settings-section-byok .field-label-link:hover,
 .settings-section-byok .field-label-link:focus-visible {
@@ -2567,7 +2567,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
   box-shadow: none;
   color: var(--text);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   transform: translateY(-50%);
 }
 .settings-section-byok .settings-byok-key-toggle:hover:not(:disabled),
@@ -2592,7 +2592,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
   background: var(--bg-panel);
   color: var(--selected);
   font-size: 14px;
-  font-weight: 500;
+  font-weight: 600;
   white-space: nowrap;
   text-decoration: none;
 }
@@ -2614,7 +2614,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
   margin-left: 8px;
   color: var(--red);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.35;
 }
 .settings-byok-connection-test {
@@ -2654,7 +2654,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
 .settings-memory-summary-value {
   color: var(--text-muted);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
 }
 .agent-card-config .field,
 .agent-model-row .field { gap: 4px; }
@@ -2702,7 +2702,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
   background: transparent;
   color: var(--text-muted);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
 }
 .agent-model-source-badge.fallback::before {
   content: '·';
@@ -2841,7 +2841,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
   flex: 0 0 auto;
   color: var(--text-faint);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
 }
 .model-select-searchable__company-name {
   display: inline-flex;
@@ -2976,7 +2976,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
   color: var(--model-tag-color);
   box-shadow: inset 0 1px 0 color-mix(in srgb, var(--bg-panel) 72%, white 28%);
   font-size: 10.5px;
-  font-weight: 680;
+  font-weight: 600;
   line-height: 1.05;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -3279,7 +3279,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
   background: var(--accent);
   animation: pulse 1.2s ease-in-out infinite;
 }
-.activity-title { font-weight: 500; }
+.activity-title { font-weight: 600; }
 .activity-stats {
   margin-left: auto;
   color: var(--text-muted);
@@ -3310,7 +3310,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
   padding: 1px 6px;
   border-radius: var(--radius-xs);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0.02em;
   background: var(--bg-subtle);
   color: var(--text-muted);
@@ -3473,7 +3473,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
   background: transparent;
   font-size: 12.5px;
   color: var(--text-muted);
-  font-weight: 500;
+  font-weight: 600;
   border: 1px solid transparent;
   border-radius: var(--radius-pill);
   position: relative;
@@ -3531,7 +3531,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
 .newproj-title {
   margin: 0;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -3705,7 +3705,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
   display: block;
   padding: 7px 8px 8px;
   font-size: 11.5px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text);
   line-height: 1.3;
   overflow: hidden;
@@ -3726,7 +3726,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
 .newproj-label {
   font-size: 12px;
   color: var(--text-muted);
-  font-weight: 500;
+  font-weight: 600;
 }
 .newproj-media-options {
   display: flex;
@@ -3917,7 +3917,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
 }
 .skill-radio input { width: auto; margin-top: 2px; }
 .skill-radio-body { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-.skill-radio-name { font-weight: 500; font-size: 13px; }
+.skill-radio-name { font-weight: 600; font-size: 13px; }
 .skill-radio-desc { font-size: 12px; color: var(--text-muted); line-height: 1.4; }
 .newproj-empty {
   font-size: 12px; color: var(--text-muted);
@@ -3953,7 +3953,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
 }
 .audio-card-name {
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text);
   text-align: center;
   word-break: break-word;
@@ -4046,7 +4046,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
 .fidelity-label {
   text-align: center;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text);
 }
 
@@ -4096,7 +4096,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
 }
 .toggle-row-label {
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text);
 }
 .toggle-row-hint {
@@ -4329,7 +4329,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
 }
 .template-option-name {
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text);
 }
 .template-option-desc {
@@ -4348,7 +4348,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
 }
 .template-howto-title {
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text);
 }
 .template-howto-body {
@@ -4368,7 +4368,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
 .newproj-connectors-manage {
   padding: 2px 8px;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0.02em;
   color: var(--text-muted);
   background: transparent;
@@ -4417,7 +4417,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
   flex: none;
 }
 .newproj-connector-name {
-  font-weight: 500;
+  font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -4479,7 +4479,7 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
 }
 .newproj-connectors-empty-title {
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text);
 }
 .newproj-connectors-empty-body {
@@ -4490,6 +4490,6 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
 .newproj-connectors-empty-cta {
   margin-top: 4px;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--accent);
 }

--- a/apps/web/src/styles/workspace/connectors.css
+++ b/apps/web/src/styles/workspace/connectors.css
@@ -46,7 +46,7 @@
   align-items: center;
   gap: 6px;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.2;
   color: var(--text);
   overflow: hidden;
@@ -75,7 +75,7 @@
   color: var(--text-muted);
   transition: transform 160ms var(--ease-out);
 }
-.ds-picker-trigger.empty .ds-picker-title { color: var(--text-muted); font-weight: 500; }
+.ds-picker-trigger.empty .ds-picker-title { color: var(--text-muted); font-weight: 600; }
 
 /* Avatar — square with 2x2 swatch grid (or "none" diagonal slash). */
 .ds-avatar {
@@ -209,7 +209,7 @@
 .ds-picker-mode-btn {
   padding: 3px 12px !important;
   font-size: 12px !important;
-  font-weight: 500;
+  font-weight: 600;
   border: none !important;
   background: transparent !important;
   color: var(--text-muted) !important;
@@ -268,7 +268,7 @@
   align-items: center;
   gap: 6px;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.2;
   color: var(--text);
   overflow: hidden;
@@ -540,7 +540,7 @@
   padding: 6px 4px 8px;
   font-size: 12px;
   color: var(--text-muted);
-  font-weight: 500;
+  font-weight: 600;
   flex: 0 0 auto;
   white-space: nowrap;
   transition: none;
@@ -736,7 +736,7 @@
   margin: 0;
   font-size: 14px;
   color: var(--text);
-  font-weight: 500;
+  font-weight: 600;
   max-width: 480px;
   word-break: break-word;
 }
@@ -1081,7 +1081,7 @@
   border: 1px solid var(--border);
   color: var(--text-muted);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.3;
   white-space: nowrap;
   transform-origin: left center;
@@ -1217,7 +1217,7 @@ button.connector-action {
   gap: 6px;
   padding: 5px 12px;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   border-radius: var(--radius);
   transition: transform 120ms var(--ease-out), background 140ms var(--ease-out), border-color 140ms var(--ease-out);
 }
@@ -1444,7 +1444,7 @@ button.connector-action.is-loading {
   color: var(--text-muted);
   font: inherit;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0.005em;
   padding: 5px 12px;
   border-radius: var(--radius-pill);

--- a/apps/web/src/styles/workspace/design-browser.css
+++ b/apps/web/src/styles/workspace/design-browser.css
@@ -87,7 +87,7 @@
   color: var(--bg-panel);
   box-shadow: 0 8px 24px rgba(28, 27, 26, 0.18);
   font-size: 11px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.25;
   white-space: nowrap;
   pointer-events: none;
@@ -515,7 +515,7 @@
 }
 .db-browser-use-action-copy > span {
   font-size: 12.5px;
-  font-weight: 650;
+  font-weight: 600;
 }
 .db-browser-use-action-copy small {
   color: var(--text-muted);
@@ -585,7 +585,7 @@
   color: var(--bg-panel);
   box-shadow: 0 14px 34px rgba(28, 27, 26, 0.24);
   font-size: 12.5px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: -0.01em;
   white-space: nowrap;
   pointer-events: auto;
@@ -848,7 +848,7 @@
   gap: 8px;
   color: var(--accent);
   font-size: 11px;
-  font-weight: 650;
+  font-weight: 600;
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
@@ -919,7 +919,7 @@
   color: var(--text-muted);
   padding: 6px 13px;
   font-size: 12.5px;
-  font-weight: 550;
+  font-weight: 600;
   white-space: nowrap;
   cursor: pointer;
   transition:
@@ -1045,7 +1045,7 @@
   color: var(--text);
   padding: 7px 14px;
   font-size: 12.5px;
-  font-weight: 550;
+  font-weight: 600;
   cursor: pointer;
   transition:
     background 140ms cubic-bezier(0.23, 1, 0.32, 1),
@@ -1150,7 +1150,7 @@
 }
 .db-reference-title span {
   font-size: 14px;
-  font-weight: 650;
+  font-weight: 600;
   letter-spacing: -0.01em;
   color: var(--text-strong);
 }
@@ -1183,7 +1183,7 @@
   color: var(--text);
   padding: 5px 10px;
   font-size: 12px;
-  font-weight: 550;
+  font-weight: 600;
   cursor: pointer;
   transition:
     background 140ms cubic-bezier(0.23, 1, 0.32, 1),

--- a/apps/web/src/styles/workspace/drawer.css
+++ b/apps/web/src/styles/workspace/drawer.css
@@ -55,7 +55,7 @@
   flex-wrap: wrap;
   gap: 6px;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0.02em;
   text-transform: uppercase;
   color: var(--text-faint);
@@ -144,7 +144,7 @@
   padding: 4px 9px;
   border-radius: var(--radius);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   white-space: nowrap;
 }
 .connector-drawer-count {
@@ -191,7 +191,7 @@
   margin: 0;
   color: var(--text-muted);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
 }
 .connector-drawer-details dd {
   margin: 0;
@@ -406,7 +406,7 @@
   padding: 5px 16px;
   font-size: 12px;
   color: var(--text-muted);
-  font-weight: 500;
+  font-weight: 600;
   white-space: nowrap;
 }
 .subtab-pill button:hover:not(.active) { background: var(--bg-muted); border-color: transparent; color: var(--text); }
@@ -536,7 +536,7 @@
   color: var(--accent);
 }
 .design-card-status {
-  font-weight: 500;
+  font-weight: 600;
 }
 .design-card-status-running {
   color: var(--accent);
@@ -981,7 +981,7 @@
   justify-content: space-between;
   gap: 8px;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text-strong);
   padding-left: 2px;
   /* Prevent long status labels from pushing the count chip out of the column. */
@@ -1077,7 +1077,7 @@
 
 .design-kanban-card-name {
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text-strong);
   white-space: nowrap;
   overflow: hidden;
@@ -1094,7 +1094,7 @@
 }
 .design-kanban-card-meta .ds {
   color: var(--text-strong);
-  font-weight: 500;
+  font-weight: 600;
 }
 
 /* Honor user motion preferences for the new hover transform / transitions
@@ -1336,7 +1336,7 @@
 .ds-row.active { background: var(--accent-tint); border-color: var(--accent); }
 .ds-row-body { flex: 1; min-width: 0; }
 .ds-row-title {
-  font-weight: 500;
+  font-weight: 600;
   font-size: 14px;
   display: flex;
   align-items: center;
@@ -1771,7 +1771,7 @@
   white-space: nowrap;
   color: var(--text-faint);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
 }
 .ws-tab-meta::before {
   content: "/";
@@ -1877,7 +1877,7 @@
   margin: 0;
   color: var(--text);
   font-size: 18px;
-  font-weight: 650;
+  font-weight: 600;
   line-height: 1.15;
   letter-spacing: -0.01em;
 }
@@ -1926,7 +1926,7 @@
   background: transparent;
   color: var(--text-muted);
   font-size: 12.5px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.25;
   text-align: left;
   cursor: pointer;
@@ -1944,7 +1944,7 @@
   background: color-mix(in srgb, var(--bg-subtle) 86%, transparent);
   color: var(--text-faint);
   font-size: 11px;
-  font-weight: 650;
+  font-weight: 600;
   line-height: 1.2;
   text-align: center;
 }
@@ -2036,7 +2036,7 @@
   background: var(--bg-panel);
   color: var(--text-muted);
   font-size: 12.5px;
-  font-weight: 400;
+  font-weight: 600;
   line-height: 1;
   white-space: nowrap;
   cursor: pointer;
@@ -2058,7 +2058,7 @@
   border-color: var(--text-strong);
   background: var(--text-strong);
   color: var(--brand, #87ea5c);
-  font-weight: 550;
+  font-weight: 600;
 }
 .page-creator-subcat.active:hover {
   border-color: var(--text-strong);
@@ -2265,7 +2265,7 @@
 .page-creator-blank-title {
   color: var(--text);
   font-size: 14px;
-  font-weight: 650;
+  font-weight: 600;
   line-height: 1.2;
 }
 .page-creator-blank-hint {
@@ -2631,7 +2631,7 @@
   background: var(--text);
   color: var(--bg);
   border-color: var(--text);
-  font-weight: 500;
+  font-weight: 600;
 }
 .ws-tab-action.share:hover:not(:disabled) {
   background: #000;
@@ -2703,7 +2703,7 @@
   gap: 8px;
   padding: 8px 18px;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   border-radius: var(--radius-pill);
   cursor: pointer;
   box-shadow: 

--- a/apps/web/src/styles/workspace/mention-home.css
+++ b/apps/web/src/styles/workspace/mention-home.css
@@ -79,7 +79,7 @@
   color: var(--text-muted);
   font: inherit;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 18px;
   white-space: nowrap;
   cursor: pointer;
@@ -566,7 +566,7 @@
   padding: 8px 18px;
   border-radius: var(--radius-pill);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   cursor: pointer;
   border: 1px solid var(--border);
   background: var(--bg-subtle);
@@ -605,7 +605,7 @@
   padding: 8px 18px;
   border-radius: var(--radius-pill);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   cursor: pointer;
   border: 1px solid var(--border);
   background: var(--bg-subtle);
@@ -649,7 +649,7 @@
   padding: 1px 7px;
   border-radius: var(--radius-pill);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.5;
   letter-spacing: 0.01em;
   background: var(--bg-subtle);
@@ -959,7 +959,7 @@
   padding: 4px 10px;
   border-radius: var(--radius-pill);
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   letter-spacing: 0.005em;
   color: var(--text-muted);
   background: color-mix(in srgb, var(--bg-panel) 90%, transparent);
@@ -1511,7 +1511,7 @@
 .settings-nav-item strong {
   color: currentColor;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.3;
   overflow-wrap: anywhere;
 }
@@ -1724,7 +1724,7 @@
 }
 .seg-btn .seg-title {
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text);
   white-space: nowrap;
   overflow: hidden;
@@ -1787,7 +1787,7 @@
   border-radius: var(--radius-pill);
   padding: 4px 12px;
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text-muted);
   cursor: pointer;
   white-space: nowrap;
@@ -2464,7 +2464,7 @@
 }
 .orbit-next-run-value.muted {
   color: var(--text-muted);
-  font-weight: 500;
+  font-weight: 600;
 }
 
 @media (max-width: 620px) {
@@ -2525,7 +2525,7 @@
   border-radius: var(--radius-sm);
   background: color-mix(in srgb, #c47a2c 10%, var(--bg-panel));
   color: #8a5217;
-  font-weight: 500;
+  font-weight: 600;
 }
 .orbit-automation-sub-warning svg {
   color: #c47a2c;
@@ -2585,7 +2585,7 @@
   padding: 8px 32px 8px 12px;
   font: inherit;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text);
   background: var(--bg-subtle);
   border: 1px solid var(--border);
@@ -2679,7 +2679,7 @@
 }
 .orbit-receipt-timestamp.muted {
   color: var(--text-muted);
-  font-weight: 500;
+  font-weight: 600;
 }
 .orbit-trigger-pill {
   padding: 2px 10px;

--- a/apps/web/tests/styles/font-weight-normalization.test.ts
+++ b/apps/web/tests/styles/font-weight-normalization.test.ts
@@ -1,0 +1,140 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { extname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = fileURLToPath(new URL('../../../..', import.meta.url));
+const styleRoots = [
+  fileURLToPath(new URL('../../src', import.meta.url)),
+  fileURLToPath(new URL('../../../../packages/components/src', import.meta.url)),
+  fileURLToPath(new URL('../../../../apps/desktop/src', import.meta.url)),
+];
+
+/**
+ * Stylesheets owned by pull requests that were in flight when the ladder
+ * landed. They still carry pre-ladder weights and are normalised in their
+ * own PRs (entry layout / nav rail: #7832, design files: #7772). Remove an
+ * entry as soon as its file is clean; the second spec below fails when an
+ * entry has become unnecessary so the list cannot outlive its reason.
+ */
+const pendingNormalization = new Set([
+  'apps/web/src/styles/home/entry-layout.css',
+  'apps/web/src/components/EntryNavRail.module.css',
+  'apps/web/src/styles/workspace/design-files.css',
+]);
+
+function cssFiles(root: string): string[] {
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const path = `${root}/${entry.name}`;
+    if (entry.isDirectory()) return cssFiles(path);
+    return ['.css', '.scss', '.less'].includes(extname(entry.name)) ? [path] : [];
+  });
+}
+
+function withoutFontFaces(css: string): string {
+  return css
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/@font-face\s*\{[^}]*\}/g, '');
+}
+
+/**
+ * The product UI consolidates on a 500 / 600 / 700 ladder: 400 is reserved
+ * for font metadata, and the in-between values (450–680 other than 500/600,
+ * 720–800) that used to approximate emphasis are folded onto the nearest step.
+ */
+function isForbiddenWeight(weight: number): boolean {
+  const isIntermediateLow =
+    weight >= 450 && weight <= 680 && weight !== 500 && weight !== 600;
+  const isIntermediateHigh = weight >= 720 && weight <= 800;
+  return weight === 400 || isIntermediateLow || isIntermediateHigh;
+}
+
+function ladderViolations(file: string): string[] {
+  const violations: string[] = [];
+  const css = withoutFontFaces(readFileSync(file, 'utf8'));
+  for (const match of css.matchAll(/font-weight\s*:\s*(\d+)\b/g)) {
+    const weight = Number(match[1]);
+    if (isForbiddenWeight(weight)) {
+      violations.push(`${relative(repoRoot, file)}: ${weight}`);
+    }
+  }
+  for (const match of css.matchAll(/(?:^|[;{])\s*font\s*:\s*([^;}]+)/g)) {
+    const shorthand = match[1]!.trim();
+    if (shorthand === 'inherit') continue;
+
+    const explicitWeight = shorthand.match(/^(?:(?:normal|italic|oblique)\s+)?([1-9]00)\b/);
+    if (!explicitWeight) {
+      violations.push(`${relative(repoRoot, file)}: font shorthand implicit 400`);
+      continue;
+    }
+
+    const weight = Number(explicitWeight[1]);
+    if (isForbiddenWeight(weight)) {
+      violations.push(`${relative(repoRoot, file)}: font shorthand ${weight}`);
+    }
+  }
+  return violations;
+}
+
+describe('product UI font-weight normalization', () => {
+  const files = styleRoots.flatMap(cssFiles);
+  const isPending = (file: string) => pendingNormalization.has(relative(repoRoot, file));
+
+  it('defaults unspecified text and buttons to the 600 step', () => {
+    const baseCss = withoutFontFaces(
+      readFileSync(new URL('../../src/styles/base.css', import.meta.url), 'utf8'),
+    );
+    const primitivesCss = withoutFontFaces(
+      readFileSync(new URL('../../src/styles/primitives.css', import.meta.url), 'utf8'),
+    );
+    const buttonModuleCss = withoutFontFaces(
+      readFileSync(
+        new URL('../../../../packages/components/src/button.module.css', import.meta.url),
+        'utf8',
+      ),
+    );
+
+    expect(baseCss).toMatch(/(?:^|\})\s*body\s*\{[^}]*font-weight:\s*600;/);
+    expect(primitivesCss).toMatch(/(?:^|\})\s*button\s*\{[^}]*font-weight:\s*600;/);
+    expect(buttonModuleCss).toMatch(/\.button\s*\{[^}]*font-weight:\s*600;/);
+  });
+
+  it('carries no scoped stand-in for the app-wide default', () => {
+    // The hero, the project composer and the portaled "+" menu each used to
+    // re-declare the 600 default locally while the global one was pending.
+    const standIns = files.flatMap((file) => {
+      const css = readFileSync(file, 'utf8');
+      return /Typography ladder stand-in/.test(css) ||
+        /:where\(\.(?:home-hero|composer|plus-menu__popup)\)\s*button\s*\{[^}]*font-weight/.test(
+          css.replace(/\/\*[\s\S]*?\*\//g, ''),
+        )
+        ? [relative(repoRoot, file)]
+        : [];
+    });
+    expect(standIns).toEqual([]);
+  });
+
+  it('uses the consolidated weight ladder outside font metadata', () => {
+    const violations = files.filter((file) => !isPending(file)).flatMap(ladderViolations);
+    expect(violations).toEqual([]);
+  });
+
+  it('keeps the pending list limited to files that still need it', () => {
+    const stale = files.filter((file) => isPending(file) && ladderViolations(file).length === 0);
+    expect(stale.map((file) => relative(repoRoot, file))).toEqual([]);
+  });
+
+  it('preserves the real ranges registered by the bundled font files', () => {
+    const baseCss = readFileSync(new URL('../../src/styles/base.css', import.meta.url), 'utf8');
+
+    const albertFaces = [...baseCss.matchAll(/@font-face\s*\{[^}]*\}/g)].filter((match) =>
+      match[0].includes('font-family: "Albert Sans"'),
+    );
+
+    expect(albertFaces).toHaveLength(2);
+    for (const face of albertFaces) expect(face[0]).toMatch(/font-weight:\s*100 900;/);
+    expect(baseCss).toMatch(
+      /@font-face\s*\{[^}]*font-family:\s*"JiduMono Pro";[^}]*font-weight:\s*400;/s,
+    );
+  });
+});

--- a/apps/web/tests/styles/plus-menu-typography.test.ts
+++ b/apps/web/tests/styles/plus-menu-typography.test.ts
@@ -20,23 +20,17 @@ function cssDeclarations(selector: string): string {
 }
 
 /**
- * The entry surfaces were designed on an app-wide 600 text weight that has
- * not shipped yet; until it does, `.home-hero` and `.composer` each carry the
- * ladder locally. The "+" menu popup renders through a portal on
- * document.body, outside both of those scopes, so it needs the same stand-in
- * or its rows read lighter than the trigger that opened them.
+ * The "+" menu popup renders through a portal on document.body, outside the
+ * hero and the composer. It reads at the app-wide 600 default from base.css /
+ * primitives.css (see font-weight-normalization.test.ts); the popup must not
+ * re-declare that ladder locally, nor name a lighter weight on its rows.
  */
 describe('ComposerPlusMenu popup typography', () => {
-  it('carries the 600 ladder on the portaled popup', () => {
-    expect(cssDeclarations('.plus-menu__popup')).toMatch(
-      /(?:^|[;\n])\s*font-weight:\s*600\s*;/,
+  it('inherits the app-wide ladder instead of carrying its own', () => {
+    expect(() => cssDeclarations(':where(.plus-menu__popup) button')).toThrow(
+      /Missing CSS block/,
     );
-  });
-
-  it('keeps the button rule at element specificity so named weights still win', () => {
-    expect(cssDeclarations(':where(.plus-menu__popup) button')).toMatch(
-      /(?:^|[;\n])\s*font-weight:\s*600\s*;/,
-    );
+    expect(plusMenuCss).not.toMatch(/Typography ladder stand-in/);
   });
 
   it('lets the rows inherit that weight instead of naming a lighter one', () => {

--- a/packages/components/src/button.module.css
+++ b/packages/components/src/button.module.css
@@ -9,7 +9,7 @@
   height: 36px;
   padding: 0 var(--spacing-16, 16px);
   font-size: var(--font-size-14, 14px);
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1;
   white-space: nowrap;
   color: var(--text);

--- a/packages/components/src/styles.css
+++ b/packages/components/src/styles.css
@@ -8,7 +8,7 @@ button {
   height: 36px;
   padding: 0 var(--spacing-16, 16px);
   font-size: var(--font-size-14, 14px);
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1;
   white-space: nowrap;
   color: var(--text);


### PR DESCRIPTION
Base: `feat/home-entry-refresh`. #7769 has merged into that branch (74cf9b174e) and this branch was rebased onto it, so the diff is this PR's own change only.

Plane: OPEND-2634 (final form of the Plus-menu weight fix that #7769 scoped locally) under OPEND-2553 PR-C2.

## Why

**Use case.** The Home-line Demo (#7635) was designed on an app-wide text weight of 600: `body { font-weight: 600 }`, `button { font-weight: 600 }`, and every stylesheet folded onto a consolidated 500 / 600 / 700 ladder. While the Home hero, composer and Plus menu were being ported (#7731, #7769), that app-wide default had not landed yet, so each of those surfaces carried a scoped stand-in (`.home-hero`, `.composer`, `.plus-menu__popup` + their `:where(...) button` twins) to read at the designed weight. This PR is the closing step of the OPEND-2553 first phase: land the default globally and delete the stand-ins.

**Pain.** With the default still 400 and the stand-ins scoped, the app read as two typographic systems: the entry surfaces at 600 and everything else (Community, Settings, the workspace chrome, dialogs) at 400/500. Any new portal or panel outside a stand-in scope silently fell back to the old weight, which is exactly how the Plus-menu popup bug (OPEND-2634) happened. The scoped rules also had to be kept in sync by hand across three files.

## What users will see

- All product text now reads at weight 600 by default, everywhere: Community cards and filters, the Settings navigation and provider cards, workspace tabs, dialogs, drawers, the memory / routines / connectors panels. Text that names its own weight (titles at 700, secondary labels at 500) is unchanged.
- Buttons default to 600 instead of 500 (shared `Button` primitive included).
- The Home hero, the project composer and the "+" menu look exactly as they did after #7769; they simply inherit the default now instead of carrying their own copy.
- Odd in-between weights (550, 640, 650, 680, 740–800) used across the app collapse onto 600 / 700, so emphasis reads consistently instead of varying per panel.
- A monospace `font:` shorthand block (design-system flow, code viewer, artifacts, tasks) now names its weight (500) explicitly instead of resetting to the browser's 400.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install) — the default text weight changes app-wide, not only on Home.
- [ ] **None** — internal refactor, docs, tests, or translation update only

CLI: not applicable, this is a stylesheet-only change with no daemon capability behind it.

## Screenshots

Before = head of #7769 (scoped stand-ins), after = this branch. Same seeded data, same 1440×900 viewport, light theme. The change is visible on every page, not only on Home.

Home (left rail expanded; rail button labels stay at 400 until #7832, see "Not ported"):

![Home before/after](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-c2/cmp-home.png)

Community (type filters, category chips, card metadata move 400/500 → 600):

![Community before/after](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-c2/cmp-community.png)

Settings → Models & providers (navigation, hints, provider taglines and versions move 400/500 → 600):

![Settings before/after](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-c2/cmp-settings.png)

Project chat (workspace tab label; the composer itself is unchanged because it already carried the 600 stand-in):

![Chat before/after](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-c2/cmp-chat.png)

## What was ported, and what was not

Method: three-way diff per CSS rule (`78baa5228` merge-base → `upstream/pr-7635-new` vs. this branch), matching rules by selector and occurrence. Only rules whose weight the Demo changed **and** that `main` had not changed since the merge-base were rewritten; values are the Demo's.

Ported (276 rule rewrites across 45 files + the global defaults):

- `base.css` `body { font-weight: 600 }` with the Demo's ladder comment; `primitives.css` both `button` rules 500 → 600; `packages/components` `button.module.css` / `styles.css` 500 → 600.
- The Demo's ladder normalization in every stylesheet the Demo touched that no concurrent PR owns: 500 → 600 uplifts, 550/640/650/680 → 600, 720–800 → 700, explicit 400 → 600, and the nine `font:` shorthands that now carry `500`.
- Stand-ins deleted: `home-hero.css` (`.home-hero, :where(.home-hero) button`), `plus-menu.css` (`.plus-menu__popup, :where(.plus-menu__popup) button`), `chat.css` (`.composer, :where(.composer) button`). Every other `font-weight: 600` those files carry also exists in the Demo, so they stay (verified rule-by-rule, see the selector maps in the validation notes).
- `chat.css` `.chat-header-tab`, `.msg-time`, `.msg-plugin-chip__title` 500 → 600 (Demo values).

Brought onto the ladder although the Demo never saw them (files added on `main` after the merge-base; the ported spec would otherwise fail on them):

- `ExperienceSurvey.module.css` 650 → 600 (×2).
- `GoPlanSunsetDialog.module.css` 680 → 600, 650 → 600 (×2). Its `300` stays: the ladder only forbids 400 and the in-between values.
- `DeepSeekV4FlashCampaign.module.css` "Go welcome" section: 750 → 700 (×2), 650 → 600, 680 → 600, 800 → 700 (×2), and the 400 fine print → 500 (the lightest ladder step, the Demo mapped explicit 400 on labels to 600 but this is a caption on a marketing card).

Not ported, on purpose:

- `apps/web/src/styles/home/entry-layout.css` (29 rewrites + 2 removals), `EntryNavRail.module.css` (2 × 640 → 600), `apps/web/src/styles/workspace/design-files.css` (8) — owned by #7832 (C1) and #7772. They are on an explicit `pendingNormalization` list in the new spec; the list is self-policing (a second assertion fails when an entry no longer has violations). Visible consequence until those land: the left-rail button labels stay at 400, the `.df-empty-*` CTA labels at 500, the model badge at 680.
- `apps/web/src/styles/home/recent-projects.css` (7 rewrites + 1 addition) — C1 restyles `RecentProjectsStrip`; its weights ride with that PR.
- Demo-only components and rules that belong to phase 2/3 or to the "not in any phase" list: `SiriOrb`, `UserActionCard`, `RotatingTitleWord`, the `MessageCenter` redesign, `WorkingDirPicker` extras, `chat-cards-next.css`, `composer-beam.css`, the `MarqueeLabel` / `.od-marquee` block in `primitives.css`, the new `design-files/*` modules, plus the Demo-only rules in `plugin-marketplace-demo.css`, `routines.css`, `recent-projects.css`.
- `theater.css` `.prompt-template-model` — the rule no longer exists on `main`.
- 24 rules already at the Demo's value through #7731 / #7769 (`.home-hero__*`, `.use-everywhere-*`, `.composer-*`) — nothing to do.

Observation for product (matches the Demo, not adjusted here): `<strong>` / `<b>` with the browser's default `font-weight: bolder` now compute to 900 on a 600 parent (e.g. the Community "Last 30 days" filter). The Demo renders the same 900.

## Bug fix verification

- Not a bug fix. The behaviour is pinned by `apps/web/tests/styles/font-weight-normalization.test.ts` (ported from the Demo and re-pinned to the current tree): the global default on `body` / `button` / the shared `Button`, the absence of the three scoped stand-ins, the ladder across `apps/web/src`, `packages/components/src` and `apps/desktop/src`, and the pending list staying minimal. `plus-menu-typography.test.ts` now asserts the popup inherits the ladder instead of carrying it.

## Validation

- `pnpm guard` ✅, `pnpm typecheck` ✅, `pnpm --filter @open-design/e2e typecheck` ✅.
- `pnpm --filter @open-design/web test`: 686 files, 7257 passed, 1 expected fail, 11 skipped ✅ (includes the new/updated style specs).
- Visual parity vs. the Demo: Demo (`upstream/pr-7635-new` @ `7c9b4dbfb`) and this branch each run through `pnpm tools-dev run web` with isolated `OD_DATA_DIR`; a Playwright script collects computed `font-weight` for every visible text node on Home, Community, Settings and a project chat, matched by tag + class + text.
  - Home / Community: 0 weight differences except the left-rail labels (`.entry-nav-rail__btn-label` 400 vs 600) and the rail menu close glyph — both `entry-layout.css`, deferred to #7832.
  - Settings: 0 differences except `.model-select-searchable__value-badge` (680 vs 600) — `entry-layout.css`, deferred to #7832.
  - Chat: 0 differences on the shared nodes; the design-files empty-state CTAs read 500 from `design-files.css`, deferred to #7772.
- Rebase note for reviewers: the base is the long-lived `feat/home-entry-refresh` branch (phase one no longer lands on `main` directly). Once #7769 merges there, this branch is rebased with `git rebase --onto upstream/feat/home-entry-refresh <#7769 head>` and force-pushed; the first line of this description is dropped at that point.


