### PR TITLE
fix(web): stop Manual Edit Save from silently doing nothing

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -327,6 +327,7 @@ import {
   shouldAdoptPersistedManualEditDocument,
   shouldFreezeManualEditDocumentIdentity,
 } from '../runtime/manual-edit-document-latch';
+import { manualEditTextSessionHasLiveDocument } from '../runtime/manual-edit-text-session';
 import {
   PRESENTATION_BACKDROP_DELAY_MS,
   presentationBackdropPhase,
@@ -9009,6 +9010,10 @@ function HtmlViewer({
   // resulting commit has been applied, so exit/dismiss/cancel never tear down
   // mid-round-trip and drop the final edit (the #3647 exit-path regression).
   const manualEditTextSessionIdRef = useRef<string | null>(null);
+  // The document that opened the inline edit. The session belief is only ever
+  // valid while this is still the document the host would post into; see
+  // `manualEditTextSessionHasLiveDocument`.
+  const manualEditTextSessionWindowRef = useRef<Window | null>(null);
   const manualEditTextSessionStartSequenceRef = useRef<number | null>(null);
   const manualEditTextFinishRef = useRef<((acknowledged?: boolean, sessionId?: string) => void) | null>(null);
   const manualEditTextCommitInFlightRef = useRef<Promise<unknown> | null>(null);
@@ -9099,6 +9104,7 @@ function HtmlViewer({
     manualEditLiveStylesRef.current.clear();
     manualEditPendingStyleRef.current = null;
     manualEditTextSessionIdRef.current = null;
+    manualEditTextSessionWindowRef.current = null;
     manualEditTextSessionStartSequenceRef.current = null;
     manualEditTextFinishRef.current = null;
     manualEditTextCommitInFlightRef.current = null;
@@ -12979,6 +12985,7 @@ function HtmlViewer({
       selectedManualEditTargetIdRef.current = null;
       manualEditSelectionDraftRef.current = null;
       manualEditTextSessionIdRef.current = null;
+      manualEditTextSessionWindowRef.current = null;
       manualEditTextSessionStartSequenceRef.current = null;
       manualEditTextFinishRef.current = null;
       manualEditTextCommitInFlightRef.current = null;
@@ -13086,11 +13093,16 @@ function HtmlViewer({
         const sessionId = String(data.id || '');
         if (data.active) {
           manualEditTextSessionIdRef.current = sessionId;
+          // Scope the belief to the document that opened it. Only that document
+          // can close the session, so a later teardown must not block on it once
+          // the document is gone.
+          manualEditTextSessionWindowRef.current = (ev.source as Window | null) ?? null;
           manualEditTextSessionStartSequenceRef.current = manualEditTextCommitSequenceRef.current;
           return;
         }
         if (manualEditTextSessionIdRef.current === sessionId) {
           manualEditTextSessionIdRef.current = null;
+          manualEditTextSessionWindowRef.current = null;
           manualEditTextSessionStartSequenceRef.current = null;
         }
         const pending = manualEditTextFinishRef.current;
@@ -13316,6 +13328,7 @@ function HtmlViewer({
           if ((acknowledged || relevantCommit)
             && manualEditTextSessionIdRef.current === sessionId) {
             manualEditTextSessionIdRef.current = null;
+            manualEditTextSessionWindowRef.current = null;
             manualEditTextSessionStartSequenceRef.current = null;
           }
           resolve(committed);
@@ -13336,7 +13349,25 @@ function HtmlViewer({
   // edit mode open with the error rather than tearing down through it (#4291).
   async function settlePendingManualEditCommit(commitActiveSession = true): Promise<boolean> {
     if (manualEditTextSessionIdRef.current) {
-      return finishManualEditTextSession(commitActiveSession);
+      if (manualEditTextSessionHasLiveDocument({
+        liveWindows: [
+          iframeRef.current?.contentWindow,
+          urlPreviewIframeRef.current?.contentWindow,
+          srcDocPreviewIframeRef.current?.contentWindow,
+        ],
+        sessionWindow: manualEditTextSessionWindowRef.current,
+      })) {
+        return finishManualEditTextSession(commitActiveSession);
+      }
+      // The document that owned the inline edit is gone, so no bridge will ever
+      // answer for it. Release the belief and settle on whatever that document
+      // already committed; blocking here would report "the pending edit failed"
+      // for an edit that was never pending, and every fail-closed caller —
+      // Save included — would abort without a write and without an error.
+      manualEditTextSessionIdRef.current = null;
+      manualEditTextSessionWindowRef.current = null;
+      manualEditTextSessionStartSequenceRef.current = null;
+      manualEditTextFinishRef.current = null;
     }
     const latestCommit = manualEditTextLatestCommitRef.current;
     if (latestCommit && latestCommit.result == null) {
@@ -13512,6 +13543,7 @@ function HtmlViewer({
     selectedManualEditTargetIdRef.current = null;
     manualEditSelectionDraftRef.current = null;
     manualEditTextSessionIdRef.current = null;
+    manualEditTextSessionWindowRef.current = null;
     manualEditTextSessionStartSequenceRef.current = null;
     setSelectedManualEditTarget(null);
     setManualEditPanelPosition(null);

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -329,6 +329,12 @@ import {
 } from '../runtime/manual-edit-document-latch';
 import { manualEditTextSessionHasLiveDocument } from '../runtime/manual-edit-text-session';
 import {
+  manualEditFlushAllowsTeardown,
+  manualEditFlushIsDurableFailure,
+  manualEditFlushOwesUserNotice,
+  type ManualEditFlushOutcome,
+} from '../runtime/manual-edit-flush';
+import {
   PRESENTATION_BACKDROP_DELAY_MS,
   presentationBackdropPhase,
 } from '../runtime/presentation-backdrop';
@@ -9020,7 +9026,7 @@ function HtmlViewer({
   const manualEditTextCommitSequenceRef = useRef(0);
   const manualEditTextFailedSessionIdsRef = useRef<Set<string>>(new Set());
   const manualEditTextLatestCommitRef = useRef<{
-    promise: Promise<unknown>;
+    promise: Promise<ManualEditFlushOutcome>;
     result: boolean | null;
     sequence: number;
     sessionId: string;
@@ -13073,14 +13079,16 @@ function HtmlViewer({
         };
         manualEditTextLatestCommitRef.current = record;
         void (async () => {
+          let outcome: ManualEditFlushOutcome = 'reported';
           try {
-            record.result = (await commit) !== false;
+            outcome = await commit;
           } catch {
-            record.result = false;
+            outcome = 'reported';
           }
+          record.result = manualEditFlushAllowsTeardown(outcome);
           if (record.result) {
             manualEditTextFailedSessionIdsRef.current.delete(sessionId);
-          } else {
+          } else if (manualEditFlushIsDurableFailure(outcome)) {
             manualEditTextFailedSessionIdsRef.current.add(sessionId);
           }
           if (manualEditTextCommitInFlightRef.current === commit) {
@@ -13214,21 +13222,54 @@ function HtmlViewer({
     previewStyleToIframe(id, styles, version);
   }
 
-  async function flushManualEditStyleSave(): Promise<boolean> {
+  /**
+   * Put a refusing flush on screen. Every site that declines to proceed on a
+   * flush outcome routes through here, so "the teardown refused" and "the user
+   * was told" can never come apart.
+   */
+  function noteManualEditFlushOutcome(outcome: ManualEditFlushOutcome): void {
+    if (!manualEditFlushOwesUserNotice(outcome)) return;
+    setManualEditError('Could not save yet — another change is still saving. Try again in a moment.');
+  }
+
+  /**
+   * Whether an earlier edit in this session never persisted, and say so if it
+   * did not.
+   *
+   * The witness in `manualEditTextFailedSessionIdsRef` outlives the message
+   * that explained it: the failure sets an error, and the next successful save
+   * clears the banner. From then on this gate refuses every exit and every
+   * reload with nothing on screen, and the only way out is to re-edit the exact
+   * element that failed — which the user cannot know without being told.
+   */
+  function noteManualEditUnpersistedSession(): boolean {
+    if (manualEditTextFailedSessionIdsRef.current.size === 0) return false;
+    // Only fill a gap. The failure's own message names the file and the status
+    // code and is strictly more useful than this one; the generic line is for
+    // the case where a later successful save has already cleared the banner and
+    // the witness is all that is left.
+    setManualEditError((current) => current
+      ?? 'An earlier edit could not be saved. Select that element and edit it again to retry.');
+    return true;
+  }
+
+  async function flushManualEditStyleSave(): Promise<ManualEditFlushOutcome> {
     const pending = manualEditPendingStyleRef.current;
-    if (!pending) return true;
-    if (manualEditSavingRef.current) return false;
-    const ok = await applyManualEdit(
+    if (!pending) return 'settled';
+    // No busy guard here on purpose: applyManualEdit owns that decision and
+    // reports it, where a guard here would refuse in silence.
+    const outcome = await applyManualEdit(
       { id: pending.id, kind: 'set-style', styles: pending.styles },
       pending.label,
     );
     // Keep the exact failed snapshot for retry. If another style change landed
     // while this save was in flight, it has already replaced/extended the ref
     // and must likewise remain pending.
-    if (ok && manualEditPendingStyleRef.current === pending) {
+    if (manualEditFlushAllowsTeardown(outcome)
+      && manualEditPendingStyleRef.current === pending) {
       manualEditPendingStyleRef.current = null;
     }
-    return ok;
+    return outcome;
   }
 
   function cancelManualEditStyleDraft() {
@@ -13270,11 +13311,14 @@ function HtmlViewer({
   // failed (applyManualEdit returned false / threw). Callers that tear down
   // edit state must honor a false result — keep edit mode open and preserve the
   // error so a failed save never looks like a successful one (#4291 review).
-  function finishManualEditTextSession(commit: boolean): Promise<boolean> {
+  function finishManualEditTextSession(commit: boolean): Promise<ManualEditFlushOutcome> {
     const win = iframeRef.current?.contentWindow;
     const sessionId = manualEditTextSessionIdRef.current;
-    if (!sessionId) return Promise.resolve(true);
-    if (!win) return Promise.resolve(false);
+    if (!sessionId) return Promise.resolve('settled');
+    // The session's document is alive (the caller checked) but the host has no
+    // browsing context to post into right now, so the bridge cannot be asked.
+    // Nothing failed and nothing committed: refuse the teardown, and say so.
+    if (!win) return Promise.resolve('blocked');
     const sessionStartSequence = manualEditTextSessionStartSequenceRef.current
       ?? manualEditTextCommitSequenceRef.current;
     const commitSequenceAtFinish = manualEditTextCommitSequenceRef.current;
@@ -13283,7 +13327,7 @@ function HtmlViewer({
       && commitAtFinish.sequence > sessionStartSequence
       ? commitAtFinish
       : null;
-    return new Promise<boolean>((resolve) => {
+    return new Promise<ManualEditFlushOutcome>((resolve) => {
       let settled = false;
       let timer: ReturnType<typeof setTimeout> | null = null;
       const settle = (acknowledged = false, acknowledgedSessionId?: string) => {
@@ -13304,21 +13348,29 @@ function HtmlViewer({
         const relevantCommit = currentSessionCommit ?? sameSessionCommitAtFinish;
         void (async () => {
           let committed = acknowledged;
+          // A refusal that never ran is not a failure. Only a real failure is
+          // recorded as one, and only a real failure has already explained
+          // itself to the user.
+          let commitOutcome: ManualEditFlushOutcome | null = null;
           try {
-            // applyManualEdit resolves false when the save fails (or the source
-            // changed externally); surface that so callers can abort teardown.
+            // applyManualEdit reports a non-settled outcome when the save fails
+            // (or the source changed externally); surface that so callers can
+            // abort teardown.
             if (relevantCommit) {
-              committed = relevantCommit.result
-                ?? (await relevantCommit.promise) !== false;
+              commitOutcome = relevantCommit.result === null
+                ? await relevantCommit.promise
+                : (relevantCommit.result ? 'settled' : 'reported');
+              committed = manualEditFlushAllowsTeardown(commitOutcome);
               relevantCommit.result = committed;
               if (committed) {
                 manualEditTextFailedSessionIdsRef.current.delete(relevantCommit.sessionId);
-              } else {
+              } else if (manualEditFlushIsDurableFailure(commitOutcome)) {
                 manualEditTextFailedSessionIdsRef.current.add(relevantCommit.sessionId);
               }
             }
           } catch {
             committed = false;
+            commitOutcome = 'reported';
           }
           // A timeout by itself does not prove that the iframe ended the
           // editing session. Keep the session live so every later teardown
@@ -13331,7 +13383,11 @@ function HtmlViewer({
             manualEditTextSessionWindowRef.current = null;
             manualEditTextSessionStartSequenceRef.current = null;
           }
-          resolve(committed);
+          if (committed) { resolve('settled'); return; }
+          // A commit that failed already reported itself. Anything else — most
+          // often the backstop firing because the document never answered —
+          // stopped the teardown without saying a word, and must not.
+          resolve(commitOutcome === 'reported' ? 'reported' : 'blocked');
         })();
       };
       manualEditTextFinishRef.current = settle;
@@ -13347,7 +13403,9 @@ function HtmlViewer({
   // otherwise an in-flight commit left by an iframe-driven finish (Enter /
   // click-another-target). Returns false on a failed commit so callers keep
   // edit mode open with the error rather than tearing down through it (#4291).
-  async function settlePendingManualEditCommit(commitActiveSession = true): Promise<boolean> {
+  async function settlePendingManualEditCommit(
+    commitActiveSession = true,
+  ): Promise<ManualEditFlushOutcome> {
     if (manualEditTextSessionIdRef.current) {
       if (manualEditTextSessionHasLiveDocument({
         liveWindows: [
@@ -13370,19 +13428,29 @@ function HtmlViewer({
       manualEditTextFinishRef.current = null;
     }
     const latestCommit = manualEditTextLatestCommitRef.current;
+    let latestOutcome: ManualEditFlushOutcome | null = null;
     if (latestCommit && latestCommit.result == null) {
       try {
-        latestCommit.result = (await latestCommit.promise) !== false;
+        latestOutcome = await latestCommit.promise;
       } catch {
-        latestCommit.result = false;
+        latestOutcome = 'reported';
       }
+      latestCommit.result = manualEditFlushAllowsTeardown(latestOutcome);
       if (latestCommit.result) {
         manualEditTextFailedSessionIdsRef.current.delete(latestCommit.sessionId);
-      } else {
+      } else if (manualEditFlushIsDurableFailure(latestOutcome)) {
         manualEditTextFailedSessionIdsRef.current.add(latestCommit.sessionId);
       }
     }
-    return manualEditTextFailedSessionIdsRef.current.size === 0;
+    // 'reported' promises the user is already looking at an explanation, so
+    // this gate has to actually put one there — the original failure message is
+    // long gone by the time a later successful save clears the banner.
+    if (noteManualEditUnpersistedSession()) return 'reported';
+    // A commit that could not run leaves pending work behind with nothing on
+    // screen; it must stop the teardown AND owe a notice.
+    return latestOutcome !== null && !manualEditFlushAllowsTeardown(latestOutcome)
+      ? 'blocked'
+      : 'settled';
   }
 
   function requestManualEditUrlStandbyRefresh(
@@ -13425,15 +13493,20 @@ function HtmlViewer({
   async function exitManualEditModeAfterFlush(): Promise<boolean> {
     // A failed text commit must keep edit mode open with its error visible,
     // rather than tearing down (which would clear the error) and looking saved.
-    if (!(await settlePendingManualEditCommit())) {
+    const settleOutcome = await settlePendingManualEditCommit();
+    if (!manualEditFlushAllowsTeardown(settleOutcome)) {
+      noteManualEditFlushOutcome(settleOutcome);
       return false;
     }
     // Finishing the currently active session may succeed while another text
     // session still has an unpersisted Enter commit. Only a successful retry
     // for that same session consumes its failure witness.
-    if (manualEditTextFailedSessionIdsRef.current.size > 0) return false;
-    const ok = await flushManualEditStyleSave();
-    if (!ok) return false;
+    if (noteManualEditUnpersistedSession()) return false;
+    const styleOutcome = await flushManualEditStyleSave();
+    if (!manualEditFlushAllowsTeardown(styleOutcome)) {
+      noteManualEditFlushOutcome(styleOutcome);
+      return false;
+    }
     setManualEditPanelPosition(null);
     // Manual Edit temporarily forces srcDoc so the host can inject its bridge.
     // Once Edit is closed, always release that transport latch. A persisted
@@ -13536,7 +13609,9 @@ function HtmlViewer({
     // If an inline edit is still live (e.g. clearing the selection from the
     // panel mid-edit), commit it first so it is not lost. Keep the selection
     // and the error if that commit fails.
-    if (!(await settlePendingManualEditCommit())) {
+    const settleOutcome = await settlePendingManualEditCommit();
+    if (!manualEditFlushAllowsTeardown(settleOutcome)) {
+      noteManualEditFlushOutcome(settleOutcome);
       return;
     }
     cancelManualEditStyleDraft();
@@ -13559,11 +13634,16 @@ function HtmlViewer({
   async function dismissManualEditPanel() {
     // Closing the panel must not swallow a failed text commit: keep it open
     // with the error if the pending edit could not be saved.
-    if (!(await settlePendingManualEditCommit())) {
+    const settleOutcome = await settlePendingManualEditCommit();
+    if (!manualEditFlushAllowsTeardown(settleOutcome)) {
+      noteManualEditFlushOutcome(settleOutcome);
       return;
     }
-    const ok = await flushManualEditStyleSave();
-    if (!ok) return;
+    const styleOutcome = await flushManualEditStyleSave();
+    if (!manualEditFlushAllowsTeardown(styleOutcome)) {
+      noteManualEditFlushOutcome(styleOutcome);
+      return;
+    }
     if (selectedManualEditTarget) void clearManualEditTargetSelection();
     else setManualEditPageStylesOpen(false);
   }
@@ -13612,17 +13692,27 @@ function HtmlViewer({
     const panelContentChanged = contentPatchBeforeText !== null;
     const textCommitSequenceBeforeSave = manualEditTextCommitSequenceRef.current;
     const hadTextCommitInFlight = Boolean(manualEditTextCommitInFlightRef.current);
-    if (!(await settlePendingManualEditCommit(!panelContentChanged))) return;
+    const settleOutcome = await settlePendingManualEditCommit(!panelContentChanged);
+    if (!manualEditFlushAllowsTeardown(settleOutcome)) {
+      noteManualEditFlushOutcome(settleOutcome);
+      return;
+    }
     const inlineTextCommitted =
       hadTextCommitInFlight ||
       manualEditTextCommitSequenceRef.current !== textCommitSequenceBeforeSave;
     if (selectedTarget && (panelContentChanged || !inlineTextCommitted)) {
       const base = sourceRef.current ?? '';
       const contentPatch = manualEditContentPatchForDraft(selectedTarget, manualEditDraft, base);
-      if (contentPatch && !(await applyManualEdit(contentPatch.patch, contentPatch.label))) return;
+      if (contentPatch) {
+        const contentOutcome = await applyManualEdit(contentPatch.patch, contentPatch.label);
+        if (!manualEditFlushAllowsTeardown(contentOutcome)) return;
+      }
     }
-    const ok = await flushManualEditStyleSave();
-    if (!ok) return;
+    const styleOutcome = await flushManualEditStyleSave();
+    if (!manualEditFlushAllowsTeardown(styleOutcome)) {
+      noteManualEditFlushOutcome(styleOutcome);
+      return;
+    }
     if (selectedManualEditTarget) void clearManualEditTargetSelection();
     else setManualEditPageStylesOpen(false);
   }
@@ -13761,11 +13851,11 @@ function HtmlViewer({
     const base = sourceRef.current ?? '';
     const currentOuterHtml = readManualEditOuterHtml(base, selectedManualEditTarget.id);
     if (snapshot.outerHtml && currentOuterHtml && snapshot.outerHtml !== currentOuterHtml) {
-      const ok = await applyManualEdit(
+      const outcome = await applyManualEdit(
         { id: selectedManualEditTarget.id, kind: 'set-outer-html', html: snapshot.outerHtml },
         'Reset element',
       );
-      if (!ok) return;
+      if (!manualEditFlushAllowsTeardown(outcome)) return;
     }
     const refreshedBase = sourceRef.current ?? base;
     setManualEditDraft({
@@ -13788,7 +13878,10 @@ function HtmlViewer({
     }
   }
 
-  async function applyManualEdit(patch: ManualEditPatch, label: string): Promise<boolean> {
+  async function applyManualEdit(
+    patch: ManualEditPatch,
+    label: string,
+  ): Promise<ManualEditFlushOutcome> {
     const startedAt = performance.now();
     let resultTracked = false;
     const finish = (
@@ -13800,12 +13893,17 @@ function HtmlViewer({
       fireArtifactEditResult('apply', patch, startedAt, result, errorCode);
     };
     if (manualEditSavingRef.current) {
+      // Transient: another write owns the editor for this moment. Nothing was
+      // lost and the pending work is still pending, but the user has to be told
+      // why their action did nothing.
       finish('failed', 'edit_busy');
-      return false;
+      noteManualEditFlushOutcome('blocked');
+      return 'blocked';
     }
     if (sourceRef.current == null) {
       finish('failed', 'source_unavailable');
-      return false;
+      setManualEditError('Could not save: the file contents are not loaded yet.');
+      return 'reported';
     }
     manualEditSavingRef.current = true;
     setManualEditSaving(true);
@@ -13816,14 +13914,15 @@ function HtmlViewer({
       if (!result.ok) {
         setManualEditError(result.error ?? 'Could not apply edit.');
         finish('failed', 'patch_invalid');
-        return false;
+        return 'reported';
       }
       if (!(await confirmManualEditHistorySource(
         baseSource,
         'The file changed outside manual edit mode. Refreshing before applying manual edits.',
       ))) {
+        // confirmManualEditHistorySource already put its message on screen.
         finish('failed', 'source_conflict');
-        return false;
+        return 'reported';
       }
       const parentVersionId = await resolveManualEditParentVersionId(baseSource);
       // A committed content patch can notify the file watcher as soon as the
@@ -13848,7 +13947,7 @@ function HtmlViewer({
           `Could not save the edited file${status ? ` (${status}${code ? ` ${code}` : ''})` : ''}: ${message}`,
         );
         finish('failed', 'save_failed');
-        return false;
+        return 'reported';
       }
       const entry: ManualEditHistoryEntry = {
         id: `${Date.now()}-${manualEditHistory.length}`,
@@ -13916,7 +14015,7 @@ function HtmlViewer({
       setManualEditError(null);
       finish('success');
       await onFileSaved?.();
-      return true;
+      return 'settled';
     } catch (error) {
       finish('failed', 'unknown');
       throw error;
@@ -15201,9 +15300,17 @@ function HtmlViewer({
       // user-requested reload must first persist pending work, but it must not
       // turn the tool off: the replacement document re-enables the exact same
       // capability set before promotion.
-      if (!(await settlePendingManualEditCommit())) return;
-      if (manualEditTextFailedSessionIdsRef.current.size > 0) return;
-      if (!(await flushManualEditStyleSave())) return;
+      const settleOutcome = await settlePendingManualEditCommit();
+      if (!manualEditFlushAllowsTeardown(settleOutcome)) {
+        noteManualEditFlushOutcome(settleOutcome);
+        return;
+      }
+      if (noteManualEditUnpersistedSession()) return;
+      const styleOutcome = await flushManualEditStyleSave();
+      if (!manualEditFlushAllowsTeardown(styleOutcome)) {
+        noteManualEditFlushOutcome(styleOutcome);
+        return;
+      }
     } else if (manualEditMode && !(await requestManualEditSafeExitRef.current())) {
       return;
     }

--- a/apps/web/src/runtime/manual-edit-flush.ts
+++ b/apps/web/src/runtime/manual-edit-flush.ts
@@ -1,0 +1,70 @@
+/**
+ * The outcome of flushing Manual Edit's pending work before something tears
+ * state down.
+ *
+ * Save, dismissing the panel, clearing the selection, leaving edit mode and
+ * reloading all begin the same way: settle the inline text edit, then flush the
+ * pending style save. Both steps used to answer with a bare `boolean` and every
+ * caller wrote `if (!ok) return;`. That single `false` stood for three
+ * different situations, and only one of them had told the user anything:
+ *
+ *   - nothing was pending, or everything pending committed;
+ *   - the flush could not run at all — another write already owned the editor,
+ *     or no document could be reached to answer for the inline edit. Nothing
+ *     was written and nothing was lost, but nothing was shown either;
+ *   - a pending save genuinely failed, and its error is already on screen.
+ *
+ * Collapsing the middle case into the third is what makes a click disappear.
+ * `saveManualEditPanelDraft` takes its early return before `applyManualEdit`
+ * ever runs, so the button never goes busy, no banner appears and no request is
+ * issued — the user clicks Save and the file does not change. The same
+ * collapse recorded a transient refusal as a permanent failure witness, which
+ * held the user inside Manual Edit with nothing to read.
+ *
+ * Naming the three states is the fix. The invariant every caller must preserve
+ * is deliberately weaker than "the save must succeed", because some of these
+ * states genuinely cannot complete a save:
+ *
+ *   **A teardown that refuses must leave the user something to read.**
+ *
+ * `settled` may proceed. `reported` must not, and has already explained itself.
+ * `blocked` must not either, and still owes the user an explanation — that debt
+ * is the whole reason this type exists.
+ */
+export type ManualEditFlushOutcome = 'settled' | 'blocked' | 'reported';
+
+/**
+ * Whether the caller may go on to tear down or replace Manual Edit state.
+ * Only a fully settled flush may: both other outcomes leave pending work
+ * behind, and tearing down through it is how an unsaved edit disappears.
+ */
+export function manualEditFlushAllowsTeardown(outcome: ManualEditFlushOutcome): boolean {
+  return outcome === 'settled';
+}
+
+/**
+ * Whether this outcome would leave the user with no explanation.
+ *
+ * `blocked` is the only outcome that stops a teardown without having said
+ * anything, so it is the only one that still owes a notice. Every site that
+ * refuses to proceed must consult this; a bare `return` on a blocked flush is
+ * the defect this type was introduced to remove.
+ */
+export function manualEditFlushOwesUserNotice(outcome: ManualEditFlushOutcome): boolean {
+  return outcome === 'blocked';
+}
+
+/**
+ * Whether this outcome is a durable failure witness for the edit that produced
+ * it.
+ *
+ * Only a real failure is. A `blocked` flush did not fail — it never ran,
+ * because something else held the editor for that moment — so recording it
+ * alongside genuine failures makes a transient refusal permanent. That is what
+ * left Manual Edit refusing to close: one inline commit arriving while another
+ * was still on the wire marked its session failed forever, and the exit path
+ * consults that mark on every attempt.
+ */
+export function manualEditFlushIsDurableFailure(outcome: ManualEditFlushOutcome): boolean {
+  return outcome === 'reported';
+}

--- a/apps/web/src/runtime/manual-edit-text-session.ts
+++ b/apps/web/src/runtime/manual-edit-text-session.ts
@@ -1,0 +1,59 @@
+/**
+ * Whether the host's inline-text-edit belief still has a document behind it.
+ *
+ * An inline text edit is state of ONE preview document. The injected bridge
+ * opens it (`od-edit-text-session {active:true}`), holds it in that document's
+ * `activeTextEdit`, and closes it from inside that same document. The host
+ * mirrors it in `manualEditTextSessionIdRef` so every teardown — Save, closing
+ * the panel, clearing the selection, leaving edit mode — can flush the pending
+ * edit before tearing anything down. That mirror is fail-closed on purpose: a
+ * settle that cannot confirm the commit refuses the teardown, so a failed save
+ * can never look like a successful one.
+ *
+ * The mirror is a belief about a document, and it does not expire with the
+ * document. When the preview document is replaced, the bridge in the
+ * replacement has no inline edit open and answers `od-edit-text-finish` with
+ * nothing at all — `finishActiveTextEdit` returns before it posts. The host is
+ * then holding a session belief that no document will ever close, and every
+ * fail-closed teardown blocks on it: the settle's 1500ms backstop resolves
+ * `false` and the caller takes its early return. For Save that early return is
+ * silent data loss. It happens before `applyManualEdit`, so the button never
+ * goes busy, no error is set, and no write is issued — the user clicks Save on
+ * a live-looking panel and the file does not change.
+ *
+ * Manual Edit used to pin one document for the length of a session, which is
+ * why this could not previously happen. It no longer does: the identity freeze
+ * lifts for the rest of the session as soon as a save cannot be mirrored into
+ * the live document, so every later revision replaces the document underneath
+ * an open Manual Edit.
+ *
+ * So the belief is scoped to the document that minted it — but only on POSITIVE
+ * evidence that the document is gone, never on a mismatch. The host's frame
+ * refs are legitimately unaligned at moments that have nothing to do with a
+ * replacement: a retained viewer keeps its document mounted while deactivated,
+ * and the current/standby pair swaps under promotion and navigation retries.
+ * Reading any of those as a dead document would drop a live session and let a
+ * fail-closed teardown proceed through a genuinely pending edit — the opposite
+ * bug, and a worse one. Evidence therefore means: this viewer has preview
+ * documents mounted, and the session's document is not among them. With no
+ * mounted document to compare against there is no evidence either way, and the
+ * original fail-closed behavior stands.
+ *
+ * A session whose document is gone is not a failure. There is nothing left to
+ * commit and nothing to fail, so it must not be reported as one. Any commit
+ * that document already posted is in flight as an ordinary HTTP write and is
+ * settled on its own, independently of this.
+ */
+export function manualEditTextSessionHasLiveDocument(input: {
+  liveWindows: readonly (Window | null | undefined)[];
+  sessionWindow: Window | null | undefined;
+}): boolean {
+  // A session recorded before this scoping existed carries no window. Treat it
+  // as live so the fail-closed teardown keeps its original behavior rather than
+  // being weakened by a missing witness.
+  if (!input.sessionWindow) return true;
+  const mounted = input.liveWindows.filter((value): value is Window => Boolean(value));
+  // No mounted preview document is no evidence, not counter-evidence.
+  if (mounted.length === 0) return true;
+  return mounted.includes(input.sessionWindow);
+}

--- a/apps/web/tests/components/FileViewer.manual-edit-silent-flush.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit-silent-flush.test.tsx
@@ -1,0 +1,447 @@
+// @vitest-environment jsdom
+//
+// Red spec for the remaining silent no-ops in the Manual Edit save path.
+//
+// Every Manual Edit teardown — Save, dismissing the panel, clearing the
+// selection, leaving edit mode, reloading — first flushes the pending work
+// through `settlePendingManualEditCommit()` and `flushManualEditStyleSave()`,
+// and both answer with a bare `boolean`. Callers uniformly do `if (!ok)
+// return;`.
+//
+// That boolean conflates three different situations, and only one of them has
+// told the user anything:
+//
+//   - nothing was pending, or everything pending committed  -> proceed
+//   - the flush could not run right now (another write owns the editor, or no
+//     document could be reached to answer for the inline edit) -> nothing was
+//     lost, nothing was written, and NOTHING WAS SHOWN
+//   - a pending save genuinely failed -> its error is already on screen
+//
+// The middle case is the defect. `applyManualEdit` returns `false` for
+// `edit_busy` and `source_unavailable` without calling `setManualEditError`,
+// `flushManualEditStyleSave` returns `false` outright when a write is already
+// in flight, and `finishManualEditTextSession` returns `false` when it has no
+// window to post into. Each one reaches `saveManualEditPanelDraft` as a bare
+// `return` taken before `applyManualEdit` ever runs: the button never goes
+// busy, no banner appears, no request is issued, and the file does not change.
+//
+// This is the same class as the replaced-document defect fixed alongside it,
+// and it is the root that one was an instance of. The invariant is the same
+// and it is deliberately weaker than "the save must succeed": whatever else
+// happens, clicking Save must not leave the user with an idle button, no
+// message, and an unchanged file. Some of these states genuinely cannot
+// complete the save — being told so is the whole requirement.
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ComponentProps } from 'react';
+import { FileViewer as ProductFileViewer } from '../../src/components/FileViewer';
+import { emptyManualEditStyles, type ManualEditTarget } from '../../src/edit-mode/types';
+import type { ProjectFile } from '../../src/types';
+import {
+  installFileViewerPreviewRuntimeHarness,
+  prepareSettledFileViewerFixture,
+  setSyntheticPreviewFileSource,
+  syntheticPreviewFileSource,
+  uninstallFileViewerPreviewRuntimeHarness,
+  useSyntheticProjectScopedPreviewNavigation,
+} from '../helpers/file-viewer-preview-runtime';
+
+vi.mock('../../src/providers/registry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/providers/registry')>();
+  return {
+    ...actual,
+    fetchProjectFileText(
+      projectId: string,
+      name: string,
+      options?: Parameters<typeof actual.fetchProjectFileText>[2],
+    ) {
+      const source = syntheticPreviewFileSource(projectId, name);
+      return source === undefined
+        ? actual.fetchProjectFileText(projectId, name, options)
+        : Promise.resolve(source);
+    },
+  };
+});
+
+vi.mock('../../src/runtime/use-project-preview-session-navigation', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('../../src/runtime/use-project-preview-session-navigation')
+  >();
+  return {
+    ...actual,
+    useProjectScopedPreviewNavigation: (
+      options: Parameters<typeof actual.useProjectScopedPreviewNavigation>[0],
+    ) => useSyntheticProjectScopedPreviewNavigation(options),
+  };
+});
+
+function FileViewer(props: ComponentProps<typeof ProductFileViewer>) {
+  return <ProductFileViewer {...prepareSettledFileViewerFixture(props)} />;
+}
+
+beforeEach(() => {
+  installFileViewerPreviewRuntimeHarness();
+});
+
+afterEach(() => {
+  uninstallFileViewerPreviewRuntimeHarness();
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+const PROJECT_ID = 'project-1';
+const FILE_NAME = 'preview.html';
+
+const PAGE_SOURCE =
+  '<!doctype html><html><body>'
+  + '<a data-od-id="cta" href="./tokens.css">View tokens<svg viewBox="0 0 24 24"></svg></a>'
+  + '<main data-od-id="hero">Hero</main>'
+  + '</body></html>';
+
+function textTarget(): ManualEditTarget {
+  return {
+    id: 'hero',
+    kind: 'text',
+    label: 'Hero',
+    tagName: 'main',
+    className: '',
+    text: 'Hero',
+    rect: { x: 24, y: 24, width: 160, height: 48 },
+    fields: { text: 'Hero' },
+    attributes: { 'data-od-id': 'hero' },
+    styles: emptyManualEditStyles(),
+    isLayoutContainer: false,
+    outerHtml: '<main data-od-id="hero">Hero</main>',
+  };
+}
+
+function htmlPreviewFile(size = 1024, mtime = 1710000000): ProjectFile {
+  return {
+    name: FILE_NAME,
+    path: FILE_NAME,
+    type: 'file',
+    size,
+    mtime,
+    mime: 'text/html',
+    kind: 'html',
+    artifactManifest: {
+      version: 1,
+      kind: 'html',
+      title: 'Preview',
+      entry: FILE_NAME,
+      renderer: 'html',
+      exports: ['html'],
+    },
+  };
+}
+
+function liveFrame(): HTMLIFrameElement {
+  return screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+}
+
+/**
+ * What the user can actually see after clicking Save. `silent` is the defect:
+ * no write reached the server and the panel says nothing about why.
+ */
+interface SaveVerdict {
+  /** Save was unclickable, which is at least an honest visible state. */
+  buttonDisabled: boolean;
+  errorShown: boolean;
+  silent: boolean;
+  /** A write carrying THIS click's text. A concurrent write landing from
+   *  somewhere else is not evidence that this click did anything. */
+  wrote: boolean;
+}
+
+describe('FileViewer manual edit — Save must never fail without saying so', () => {
+  async function openManualEdit() {
+    let currentFile = htmlPreviewFile();
+    /** Set to hold the next write open, modelling a save still in flight. */
+    let holdWrite: Promise<void> | null = null;
+    /** Set to make the next write come back as a server failure. */
+    let failNextWrite = false;
+    const writes: string[] = [];
+
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof Request ? input.url : String(input);
+      if (url.includes(`/api/projects/${PROJECT_ID}/files`) && init?.method === 'POST') {
+        if (holdWrite) await holdWrite;
+        if (failNextWrite) {
+          failNextWrite = false;
+          return new Response(JSON.stringify({ error: 'disk full' }), {
+            status: 500,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        const body = typeof init.body === 'string' ? init.body : '';
+        try {
+          const parsed = JSON.parse(body) as { content?: string };
+          if (typeof parsed.content === 'string') {
+            writes.push(parsed.content);
+            setSyntheticPreviewFileSource(PROJECT_ID, FILE_NAME, parsed.content);
+            currentFile = htmlPreviewFile(parsed.content.length, currentFile.mtime + 1);
+          }
+        } catch {
+          /* not a file write */
+        }
+        return new Response(JSON.stringify({ file: currentFile }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(PAGE_SOURCE, { status: 200, headers: { 'Content-Type': 'text/html' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <FileViewer
+        projectId={PROJECT_ID}
+        projectKind="prototype"
+        file={htmlPreviewFile()}
+        liveHtml={PAGE_SOURCE}
+      />,
+    );
+
+    const frame = await waitFor(() => {
+      const node = liveFrame();
+      if (!node.contentWindow) throw new Error('Preview frame not ready');
+      return node;
+    });
+
+    const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage');
+    fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
+    const captureRequest = postMessage.mock.calls
+      .map(([value]) => value)
+      .find((value) => (
+        typeof value === 'object'
+        && value !== null
+        && (value as { type?: unknown }).type === 'od:preview-runtime-state-capture'
+      )) as { id: string } | undefined;
+    if (captureRequest) {
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          data: {
+            type: 'od:preview-runtime-state-captured',
+            id: captureRequest.id,
+            state: { version: 1, hash: '', htmlAttrs: {}, bodyAttrs: {}, entries: [] },
+          },
+          source: frame.contentWindow,
+        }));
+      });
+    }
+    await waitFor(() => {
+      expect(screen.getByTestId('manual-edit-mode-toggle').getAttribute('aria-pressed')).toBe('true');
+    });
+
+    /**
+     * The injected bridge, in the state these tests need: it applies mirrors,
+     * and it closes an inline text edit when the host asks. A live document
+     * always answers `od-edit-text-finish`; the cases below are about the host
+     * never getting to ask, not about a document refusing.
+     */
+    const sessionWindow = liveFrame().contentWindow!;
+    const spy = vi.spyOn(sessionWindow, 'postMessage');
+    const previous = spy.getMockImplementation();
+    spy.mockImplementation(((message: unknown, ...rest: unknown[]) => {
+      (previous as ((...args: unknown[]) => void) | undefined)?.(message, ...rest);
+      const data = message as { requestId?: unknown; id?: unknown; type?: unknown } | null;
+      if (data?.type === 'od-edit-text-finish') {
+        window.dispatchEvent(new MessageEvent('message', {
+          data: { type: 'od-edit-text-session', id: 'hero', active: false, committed: false },
+          source: sessionWindow,
+        }));
+        return;
+      }
+      if (typeof data?.requestId !== 'string') return;
+      window.dispatchEvent(new MessageEvent('message', {
+        data: {
+          type: 'od-edit-preview:applied',
+          requestId: data.requestId,
+          id: data.id ?? '',
+          applied: true,
+        },
+        source: sessionWindow,
+      }));
+    }) as Window['postMessage']);
+
+    function selectTarget(target: ManualEditTarget) {
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          data: { type: 'od-edit-select', target },
+          source: sessionWindow,
+        }));
+      });
+      return waitFor(() => {
+        expect(document.querySelector('.manual-edit-right')).not.toBeNull();
+      });
+    }
+
+    /** Click Save with `value` typed into the panel, then report what the user sees. */
+    async function saveThroughPanel(value: string): Promise<SaveVerdict> {
+      const textarea = document.querySelector('.manual-edit-right textarea') as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value } });
+      const button = screen.getByText('Save') as HTMLButtonElement;
+      const buttonDisabled = button.disabled;
+      fireEvent.click(button);
+      // Comfortably past the product's own 1500ms settle backstop, so a slow
+      // path is never mistaken for a silent one.
+      await act(async () => { await new Promise((resolve) => { setTimeout(resolve, 2400); }); });
+      const wrote = writes.some((written) => written.includes(value));
+      const errorShown = document.querySelector('.manual-edit-error') !== null;
+      return {
+        buttonDisabled,
+        errorShown,
+        silent: !wrote && !errorShown && !buttonDisabled,
+        wrote,
+      };
+    }
+
+    function beginInlineTextEdit(id: string) {
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          data: { type: 'od-edit-text-session', id, active: true },
+          source: sessionWindow,
+        }));
+      });
+    }
+
+    /** Post a text commit from the document, as pressing Enter inline does. */
+    function commitInlineText(id: string, value: string) {
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          data: { type: 'od-edit-text-commit', id, value },
+          source: sessionWindow,
+        }));
+      });
+    }
+
+    /**
+     * Take the host's route into the live document away while leaving the
+     * document itself mounted and running. This is the instant during a
+     * document replacement when the old frame has been detached but the new
+     * one has not been adopted: the host holds a frame with no browsing
+     * context, so it can neither post to the bridge nor accept a reply.
+     */
+    function detachHostRouteToDocument() {
+      Object.defineProperty(frame, 'contentWindow', {
+        configurable: true,
+        get: () => null,
+      });
+    }
+
+    function failWriteOnce() {
+      failNextWrite = true;
+    }
+
+    function holdNextWrite() {
+      let release = () => {};
+      holdWrite = new Promise<void>((resolve) => { release = () => resolve(); });
+      return () => {
+        holdWrite = null;
+        release();
+      };
+    }
+
+    /** Click the toolbar toggle to leave edit mode; report whether it refused. */
+    async function leaveManualEditFails(): Promise<boolean> {
+      fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
+      await act(async () => { await new Promise((resolve) => { setTimeout(resolve, 2400); }); });
+      return screen.getByTestId('manual-edit-mode-toggle').getAttribute('aria-pressed') === 'true';
+    }
+
+    return {
+      beginInlineTextEdit,
+      commitInlineText,
+      detachHostRouteToDocument,
+      failWriteOnce,
+      holdNextWrite,
+      leaveManualEditFails,
+      saveThroughPanel,
+      selectTarget,
+    };
+  }
+
+  /**
+   * `finishManualEditTextSession` returns `false` when it has no window to post
+   * into, and that `false` is indistinguishable from a failed commit. Save
+   * takes its bare return.
+   */
+  it('says something when it cannot reach the document holding the inline edit', async () => {
+    const view = await openManualEdit();
+    await view.selectTarget(textTarget());
+    view.beginInlineTextEdit('hero');
+    view.detachHostRouteToDocument();
+
+    const verdict = await view.saveThroughPanel('Hero EDIT1');
+
+    expect(verdict.silent).toBe(false);
+  });
+
+  /**
+   * `applyManualEdit` refuses with `edit_busy` while another write is in
+   * flight, without setting an error — and the refusal is not discarded. The
+   * commit record stores it as a FAILED commit, which lands the session id in
+   * `manualEditTextFailedSessionIdsRef`, and `exitManualEditModeAfterFlush`
+   * refuses to leave edit mode for as long as that set is non-empty.
+   *
+   * So the user is held inside Manual Edit by a failure they were never told
+   * about. Reaching it needs no unusual timing beyond two inline commits close
+   * together — type in an element, press Enter, immediately edit another and
+   * press Enter again while the first write is still on the wire.
+   *
+   * Note the panel's Save button is NOT the way in: it disables itself while a
+   * write is in flight, so `edit_busy` cannot be reached by clicking it. That
+   * was checked before writing this case.
+   */
+  it('says something when a second inline commit is refused as busy', async () => {
+    const view = await openManualEdit();
+    await view.selectTarget(textTarget());
+
+    // Two DIFFERENT elements. A refusal recorded against the same element id
+    // as the write that succeeds is erased by that success, so the stuck state
+    // needs the second edit to be a different element — which is also what a
+    // user does: finish one, click the next, press Enter again.
+    const release = view.holdNextWrite();
+    view.commitInlineText('hero', 'Hero first');
+    view.commitInlineText('cta', 'View tokens second');
+    release();
+    await act(async () => { await new Promise((resolve) => { setTimeout(resolve, 400); }); });
+
+    const stuck = await view.leaveManualEditFails();
+    const errorShown = document.querySelector('.manual-edit-error') !== null;
+
+    expect(stuck && !errorShown).toBe(false);
+  });
+
+  /**
+   * The failure witness outlives the message that explained it.
+   *
+   * `manualEditTextFailedSessionIdsRef` records a commit that genuinely failed,
+   * and `exitManualEditModeAfterFlush` consults it on every attempt to leave.
+   * The error that explained the failure is transient: the next successful save
+   * clears the banner via `setManualEditError(null)`. From then on the witness
+   * gates the exit with nothing on screen, and the only way out is to re-edit
+   * the exact element that failed — which the user has no way to know.
+   */
+  it('says something when an earlier failed edit is still holding edit mode', async () => {
+    const view = await openManualEdit();
+    await view.selectTarget(textTarget());
+
+    view.failWriteOnce();
+    view.commitInlineText('cta', 'View tokens that failed');
+    await act(async () => { await new Promise((resolve) => { setTimeout(resolve, 400); }); });
+
+    // A later save succeeds and clears the banner the failure had put up.
+    view.commitInlineText('hero', 'Hero that saved');
+    await act(async () => { await new Promise((resolve) => { setTimeout(resolve, 400); }); });
+
+    const stuck = await view.leaveManualEditFails();
+    const errorShown = document.querySelector('.manual-edit-error') !== null;
+
+    expect(stuck && !errorShown).toBe(false);
+  });
+});

--- a/apps/web/tests/components/FileViewer.manual-edit-stale-text-session.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit-stale-text-session.test.tsx
@@ -1,0 +1,396 @@
+// @vitest-environment jsdom
+//
+// Red spec for a Manual Edit save that silently does nothing.
+//
+// Manual Edit keeps ONE piece of state about the preview document that is not
+// owned by the preview document: `manualEditTextSessionIdRef`. The host sets it
+// when the injected edit bridge reports `od-edit-text-session {active:true}`,
+// and clears it only when the bridge reports the session ended, when the file
+// changes, or when edit mode closes. Nothing clears it when the *document* is
+// replaced.
+//
+// Every Save routes through `settlePendingManualEditCommit()` first, and while
+// that ref is set the host posts `od-edit-text-finish` into the live frame and
+// waits for the bridge to acknowledge. The runtime answers that message from
+// `finishActiveTextEdit`, which returns immediately — sending nothing at all —
+// when the document it is running in has no inline edit open
+// (`packages/preview-runtime/src/manual-edit.ts`, `if (!activeTextEdit) return
+// false;`). A replaced document therefore never answers, the 1500ms backstop
+// resolves the settle as `false`, and `saveManualEditPanelDraft` takes its bare
+// `return`.
+//
+// That return is the whole defect. It happens before `applyManualEdit`, so
+// `manualEditSaving` is never set and the Save button never goes busy; it sets
+// no `manualEditError`, so no banner appears; and it issues no write, so the
+// file is byte-identical afterwards. The user clicks Save on a live-looking
+// panel and loses the edit with no signal of any kind.
+//
+// The precondition is reachable in the shipped product because Manual Edit no
+// longer pins one document for the length of a session. PR #7828 made the
+// identity freeze lift for the rest of the session as soon as a save cannot be
+// mirrored into the live document (`shouldFreezeManualEditDocumentIdentity`
+// returns false once `liveDocumentDiverged` is set) — deliberately, so that
+// unmirrored saves become visible. Once that freeze is lifted every subsequent
+// revision of the file replaces the preview document while Manual Edit is still
+// open, which is exactly the state these tests put the product in: a session
+// belief minted against a document that is no longer on screen.
+//
+// The invariant under test is the plain one, and it is deliberately not phrased
+// as "the settle must succeed": clicking Save either writes the file or tells
+// the user why it did not. A silent no-op is neither.
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ComponentProps } from 'react';
+import { FileViewer as ProductFileViewer } from '../../src/components/FileViewer';
+import { emptyManualEditStyles, type ManualEditTarget } from '../../src/edit-mode/types';
+import type { ProjectFile } from '../../src/types';
+import {
+  installFileViewerPreviewRuntimeHarness,
+  prepareSettledFileViewerFixture,
+  setSyntheticPreviewFileSource,
+  syntheticPreviewFileSource,
+  uninstallFileViewerPreviewRuntimeHarness,
+  useSyntheticProjectScopedPreviewNavigation,
+} from '../helpers/file-viewer-preview-runtime';
+
+vi.mock('../../src/providers/registry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/providers/registry')>();
+  return {
+    ...actual,
+    fetchProjectFileText(
+      projectId: string,
+      name: string,
+      options?: Parameters<typeof actual.fetchProjectFileText>[2],
+    ) {
+      const source = syntheticPreviewFileSource(projectId, name);
+      return source === undefined
+        ? actual.fetchProjectFileText(projectId, name, options)
+        : Promise.resolve(source);
+    },
+  };
+});
+
+vi.mock('../../src/runtime/use-project-preview-session-navigation', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('../../src/runtime/use-project-preview-session-navigation')
+  >();
+  return {
+    ...actual,
+    useProjectScopedPreviewNavigation: (
+      options: Parameters<typeof actual.useProjectScopedPreviewNavigation>[0],
+    ) => useSyntheticProjectScopedPreviewNavigation(options),
+  };
+});
+
+function FileViewer(props: ComponentProps<typeof ProductFileViewer>) {
+  return <ProductFileViewer {...prepareSettledFileViewerFixture(props)} />;
+}
+
+beforeEach(() => {
+  installFileViewerPreviewRuntimeHarness();
+});
+
+afterEach(() => {
+  uninstallFileViewerPreviewRuntimeHarness();
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+const PROJECT_ID = 'project-1';
+const FILE_NAME = 'preview.html';
+
+const PAGE_SOURCE =
+  '<!doctype html><html><body>'
+  + '<a data-od-id="cta" href="./tokens.css">View tokens<svg viewBox="0 0 24 24"></svg></a>'
+  + '<main data-od-id="hero">Hero</main>'
+  + '</body></html>';
+
+function linkTarget(): ManualEditTarget {
+  return {
+    id: 'cta',
+    kind: 'link',
+    label: 'View tokens',
+    tagName: 'a',
+    className: 'btn btn-primary',
+    text: 'View tokens',
+    rect: { x: 16, y: 358, width: 250, height: 40 },
+    fields: { text: 'View tokens', href: './tokens.css' },
+    attributes: { 'data-od-id': 'cta', href: './tokens.css' },
+    styles: emptyManualEditStyles(),
+    isLayoutContainer: false,
+    outerHtml: '<a data-od-id="cta" href="./tokens.css">View tokens<svg viewBox="0 0 24 24"></svg></a>',
+  };
+}
+
+function textTarget(): ManualEditTarget {
+  return {
+    id: 'hero',
+    kind: 'text',
+    label: 'Hero',
+    tagName: 'main',
+    className: '',
+    text: 'Hero',
+    rect: { x: 24, y: 24, width: 160, height: 48 },
+    fields: { text: 'Hero' },
+    attributes: { 'data-od-id': 'hero' },
+    styles: emptyManualEditStyles(),
+    isLayoutContainer: false,
+    outerHtml: '<main data-od-id="hero">Hero</main>',
+  };
+}
+
+function htmlPreviewFile(size = 1024, mtime = 1710000000): ProjectFile {
+  return {
+    name: FILE_NAME,
+    path: FILE_NAME,
+    type: 'file',
+    size,
+    mtime,
+    mime: 'text/html',
+    kind: 'html',
+    artifactManifest: {
+      version: 1,
+      kind: 'html',
+      title: 'Preview',
+      entry: FILE_NAME,
+      renderer: 'html',
+      exports: ['html'],
+    },
+  };
+}
+
+function liveFrame(): HTMLIFrameElement {
+  return screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+}
+
+function liveSessionId(): string {
+  const session = liveFrame().dataset.odSessionId;
+  if (!session) throw new Error('Preview frame has no scoped session');
+  return session;
+}
+
+describe('FileViewer manual edit — Save after the edited document was replaced', () => {
+  /**
+   * Drives the real product flow: mount the viewer on a settled HTML document
+   * and open Manual Edit. The preview window stands in for the injected edit
+   * bridge and answers mirror requests with `documentApplies`.
+   *
+   * The bridge double deliberately does NOT answer `od-edit-text-finish`. That
+   * is not a weakened double: a document with no inline edit open is exactly
+   * what the shipped runtime does with that message — `finishActiveTextEdit`
+   * returns before posting anything.
+   */
+  async function openManualEdit(documentApplies = true) {
+    let currentFile = htmlPreviewFile();
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof Request ? input.url : String(input);
+      if (url.includes(`/api/projects/${PROJECT_ID}/files`) && init?.method === 'POST') {
+        const body = typeof init.body === 'string' ? init.body : '';
+        try {
+          const parsed = JSON.parse(body) as { content?: string };
+          if (typeof parsed.content === 'string') {
+            setSyntheticPreviewFileSource(PROJECT_ID, FILE_NAME, parsed.content);
+            currentFile = htmlPreviewFile(parsed.content.length, currentFile.mtime + 1);
+          }
+        } catch {
+          /* not a file write */
+        }
+        return new Response(JSON.stringify({ file: currentFile }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(PAGE_SOURCE, { status: 200, headers: { 'Content-Type': 'text/html' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const view = render(
+      <FileViewer
+        projectId={PROJECT_ID}
+        projectKind="prototype"
+        file={htmlPreviewFile()}
+        liveHtml={PAGE_SOURCE}
+      />,
+    );
+
+    const frame = await waitFor(() => {
+      const node = liveFrame();
+      if (!node.contentWindow) throw new Error('Preview frame not ready');
+      return node;
+    });
+
+    const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage');
+    fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
+    const captureRequest = postMessage.mock.calls
+      .map(([value]) => value)
+      .find((value) => (
+        typeof value === 'object'
+        && value !== null
+        && (value as { type?: unknown }).type === 'od:preview-runtime-state-capture'
+      )) as { id: string } | undefined;
+    if (captureRequest) {
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          data: {
+            type: 'od:preview-runtime-state-captured',
+            id: captureRequest.id,
+            state: { version: 1, hash: '', htmlAttrs: {}, bodyAttrs: {}, entries: [] },
+          },
+          source: frame.contentWindow,
+        }));
+      });
+    }
+    await waitFor(() => {
+      expect(screen.getByTestId('manual-edit-mode-toggle').getAttribute('aria-pressed')).toBe('true');
+    });
+
+    /**
+     * Install the bridge double on whichever document is currently on screen.
+     * Every replacement mints a new frame, so this has to be re-installed the
+     * same way the real injected bridge boots inside each new document.
+     */
+    const bridged = new WeakSet<Window>();
+    function installBridge() {
+      const win = liveFrame().contentWindow!;
+      if (bridged.has(win)) return;
+      bridged.add(win);
+      const spy = vi.spyOn(win, 'postMessage');
+      const previous = spy.getMockImplementation();
+      spy.mockImplementation(((message: unknown, ...rest: unknown[]) => {
+        (previous as ((...args: unknown[]) => void) | undefined)?.(message, ...rest);
+        const data = message as { requestId?: unknown; id?: unknown } | null;
+        if (typeof data?.requestId !== 'string') return;
+        window.dispatchEvent(new MessageEvent('message', {
+          data: {
+            type: 'od-edit-preview:applied',
+            requestId: data.requestId,
+            id: data.id ?? '',
+            applied: documentApplies,
+          },
+          source: win,
+        }));
+      }) as Window['postMessage']);
+    }
+    installBridge();
+
+    async function settle() {
+      await act(async () => { await new Promise((resolve) => { setTimeout(resolve, 80); }); });
+      view.rerender(
+        <FileViewer projectId={PROJECT_ID} projectKind="prototype" file={currentFile} />,
+      );
+      await act(async () => { await new Promise((resolve) => { setTimeout(resolve, 80); }); });
+      installBridge();
+    }
+
+    /** Select a target and save new text through the properties panel. */
+    async function saveTextThroughPanel(target: ManualEditTarget, value: string) {
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          data: { type: 'od-edit-select', target },
+          source: liveFrame().contentWindow,
+        }));
+      });
+      await waitFor(() => {
+        expect(document.querySelector('.manual-edit-right')).not.toBeNull();
+      });
+      const textarea = document.querySelector('.manual-edit-right textarea') as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value } });
+      fireEvent.click(screen.getByText('Save'));
+      // The settle backstop inside the product is 1500ms; give the save more
+      // than that so a slow-but-correct path is never reported as a silent one.
+      await act(async () => { await new Promise((resolve) => { setTimeout(resolve, 2200); }); });
+      await settle();
+    }
+
+    /**
+     * The user clicks into a text element in the live document and starts
+     * typing. This is the message the injected bridge posts from `makeEditable`.
+     */
+    function beginInlineTextEdit(id: string) {
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          data: { type: 'od-edit-text-session', id, active: true },
+          source: liveFrame().contentWindow,
+        }));
+      });
+    }
+
+    /**
+     * A new revision of the file lands while Manual Edit is open. Once the
+     * identity freeze has lifted this replaces the preview document, which is
+     * the product behavior PR #7828 introduced on purpose.
+     */
+    async function deliverExternalRevision() {
+      currentFile = htmlPreviewFile(currentFile.size + 1, currentFile.mtime + 1);
+      await settle();
+    }
+
+    return {
+      beginInlineTextEdit,
+      deliverExternalRevision,
+      fetchMock,
+      saveTextThroughPanel,
+    };
+  }
+
+  /**
+   * The defect. The session belief outlives the document that minted it, the
+   * replacement document has nothing to acknowledge, and Save returns before it
+   * ever reaches `applyManualEdit`.
+   */
+  it('persists a panel save after the document that held the inline edit was replaced', async () => {
+    const { beginInlineTextEdit, deliverExternalRevision, saveTextThroughPanel } =
+      await openManualEdit(false);
+
+    // Lift the identity freeze the way the shipped product does: one save the
+    // live document cannot mirror.
+    await saveTextThroughPanel(linkTarget(), 'View tokens EDIT1');
+    expect(syntheticPreviewFileSource(PROJECT_ID, FILE_NAME)).toContain('View tokens EDIT1');
+
+    // The user clicks into the hero text and starts typing.
+    beginInlineTextEdit('hero');
+    const editedDocument = liveSessionId();
+
+    // A new revision replaces the document out from under that inline edit.
+    await deliverExternalRevision();
+    expect(liveSessionId()).not.toBe(editedDocument);
+
+    // The user now saves through the panel. This must reach the file.
+    await saveTextThroughPanel(textTarget(), 'Hero EDIT2');
+
+    expect(syntheticPreviewFileSource(PROJECT_ID, FILE_NAME)).toContain('Hero EDIT2');
+  }, 30_000);
+
+  /**
+   * The severity claim, pinned separately so a fix cannot satisfy the spec by
+   * swapping a silent no-op for a silent-but-different no-op: whatever happens,
+   * the user is never left looking at a Save button that is idle, unerrored and
+   * did nothing.
+   */
+  it('never leaves Save idle, unerrored and unwritten', async () => {
+    const { beginInlineTextEdit, deliverExternalRevision, fetchMock, saveTextThroughPanel } =
+      await openManualEdit(false);
+
+    await saveTextThroughPanel(linkTarget(), 'View tokens EDIT1');
+    beginInlineTextEdit('hero');
+    await deliverExternalRevision();
+
+    const writesBefore = fetchMock.mock.calls.filter(
+      ([, init]) => (init as RequestInit | undefined)?.method === 'POST',
+    ).length;
+
+    await saveTextThroughPanel(textTarget(), 'Hero EDIT2');
+
+    const writesAfter = fetchMock.mock.calls.filter(
+      ([, init]) => (init as RequestInit | undefined)?.method === 'POST',
+    ).length;
+    const errorShown = document.querySelector('.manual-edit-error') !== null
+      || document.body.textContent?.includes('Could not save') === true;
+
+    expect(writesAfter > writesBefore || errorShown).toBe(true);
+  }, 30_000);
+});

--- a/apps/web/tests/runtime/manual-edit-flush.test.ts
+++ b/apps/web/tests/runtime/manual-edit-flush.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  manualEditFlushAllowsTeardown,
+  manualEditFlushIsDurableFailure,
+  manualEditFlushOwesUserNotice,
+  type ManualEditFlushOutcome,
+} from '../../src/runtime/manual-edit-flush';
+
+/**
+ * The three predicates exist to keep three separate decisions from collapsing
+ * back into one boolean, so what is pinned here is that each decision reads the
+ * outcome differently — a table that would be satisfied by a single `=== true`
+ * would prove nothing.
+ *
+ * `blocked` is the outcome the type was introduced for, and it is the only one
+ * that answers differently to all three questions: it must stop the teardown,
+ * it still owes the user an explanation, and it must NOT be filed alongside
+ * genuine failures.
+ */
+const ALL: ManualEditFlushOutcome[] = ['settled', 'blocked', 'reported'];
+
+describe('manualEditFlushAllowsTeardown', () => {
+  it('lets only a fully settled flush proceed', () => {
+    expect(ALL.filter(manualEditFlushAllowsTeardown)).toEqual(['settled']);
+  });
+});
+
+describe('manualEditFlushOwesUserNotice', () => {
+  it('owes a notice only for a flush that stopped without explaining itself', () => {
+    // `reported` is excluded because it has already put its own error on
+    // screen; `settled` never stopped anything.
+    expect(ALL.filter(manualEditFlushOwesUserNotice)).toEqual(['blocked']);
+  });
+});
+
+describe('manualEditFlushIsDurableFailure', () => {
+  it('treats only a real failure as a lasting witness', () => {
+    expect(ALL.filter(manualEditFlushIsDurableFailure)).toEqual(['reported']);
+  });
+
+  it('does not file a blocked flush as a failure', () => {
+    // Filing it is what left Manual Edit refusing to close: a second inline
+    // commit arriving while the first was still on the wire was recorded as a
+    // permanent failure for its element, and the exit path consults that mark
+    // on every attempt.
+    expect(manualEditFlushIsDurableFailure('blocked')).toBe(false);
+    expect(manualEditFlushAllowsTeardown('blocked')).toBe(false);
+    expect(manualEditFlushOwesUserNotice('blocked')).toBe(true);
+  });
+});

--- a/apps/web/tests/runtime/manual-edit-text-session.test.ts
+++ b/apps/web/tests/runtime/manual-edit-text-session.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { manualEditTextSessionHasLiveDocument } from '../../src/runtime/manual-edit-text-session';
+
+/**
+ * The predicate decides whether a fail-closed teardown may block on the host's
+ * inline-text-session belief. Both directions cost a user something real, so
+ * both are pinned here:
+ *
+ * - Saying "live" when the document is gone is the silent save. No bridge will
+ *   ever answer, the settle times out, and Save returns before it writes
+ *   anything or sets an error.
+ * - Saying "gone" when the document is alive drops a genuinely pending inline
+ *   edit and lets teardown proceed straight through it.
+ *
+ * The second is why "the session window is not the active frame" is not enough
+ * on its own. A retained viewer keeps its document mounted while deactivated,
+ * and the current/standby pair swaps under promotion and navigation retries;
+ * the frame the host would post into is routinely not the frame that opened the
+ * session, with no replacement involved. Only the absence of the document from
+ * a non-empty set of mounted documents is evidence.
+ */
+const windowA = { name: 'document-a' } as unknown as Window;
+const windowB = { name: 'document-b' } as unknown as Window;
+
+describe('manualEditTextSessionHasLiveDocument', () => {
+  it('keeps the session while its document is still mounted', () => {
+    expect(manualEditTextSessionHasLiveDocument({
+      liveWindows: [windowA],
+      sessionWindow: windowA,
+    })).toBe(true);
+  });
+
+  it('keeps the session when its document is mounted but not the active frame', () => {
+    // The standby/current swap and the retained-viewer cycle both land here.
+    expect(manualEditTextSessionHasLiveDocument({
+      liveWindows: [windowB, windowA],
+      sessionWindow: windowA,
+    })).toBe(true);
+  });
+
+  it('releases the session once its document is absent from the mounted set', () => {
+    expect(manualEditTextSessionHasLiveDocument({
+      liveWindows: [windowB],
+      sessionWindow: windowA,
+    })).toBe(false);
+  });
+
+  it('keeps the session when no document is mounted to compare against', () => {
+    // No evidence is not counter-evidence: an unaligned or torn-down ref must
+    // not be read as a replacement.
+    expect(manualEditTextSessionHasLiveDocument({
+      liveWindows: [null, undefined],
+      sessionWindow: windowA,
+    })).toBe(true);
+    expect(manualEditTextSessionHasLiveDocument({
+      liveWindows: [],
+      sessionWindow: windowA,
+    })).toBe(true);
+  });
+
+  it('keeps a session recorded without an owning document', () => {
+    // Sessions minted before this scoping existed carry no witness; they keep
+    // the original fail-closed behavior rather than being weakened by it.
+    expect(manualEditTextSessionHasLiveDocument({
+      liveWindows: [windowB],
+      sessionWindow: null,
+    })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

Chasing a single-sample report from a 500-artifact sweep: *"1 of 16 trials — clicked Save, the button was enabled, no error appeared, and the file on disk was byte-for-byte unchanged."* The report had no mechanism attached, so this started as an attempt to falsify it. It did not falsify.

There is a real silent-save defect with exactly that signature, and it sits immediately next to #7828 — which is what made it reachable.

`manualEditTextSessionIdRef` is the host's mirror of an inline text edit. The bridge opens the session (`od-edit-text-session {active:true}`), holds it in that document's `activeTextEdit`, and closes it from inside that same document. Every teardown — Save, closing the panel, clearing the selection, leaving edit mode — flushes through `settlePendingManualEditCommit()` first, fail-closed on purpose so a failed text commit can never look like a successful save.

The mirror is a belief about a document, and it never expired with the document. When the preview document is replaced, `finishActiveTextEdit` in the replacement returns before posting anything (`packages/preview-runtime/src/manual-edit.ts`, `if (!activeTextEdit) return false;`). Nothing ever answers, the 1500ms backstop resolves `false`, and the caller takes its early return.

For Save that early return is the bug. It happens *before* `applyManualEdit`, so:

- `manualEditSaving` is never set — the button never goes busy and stays enabled
- no `manualEditError` is set — no banner, nothing in the console
- no request is issued — the write never reaches the daemon at all

Silent data loss, front-end side, one layer above the network.

**Why it is reachable now.** Manual Edit used to pin one document for the length of a session. #7828 deliberately made the identity freeze lift for the rest of the session as soon as a save cannot be mirrored into the live document (`shouldFreezeManualEditDocumentIdentity` returns false once `liveDocumentDiverged` is set), so that unmirrored saves become visible. Correct fix — but from that point on, every later revision of the file replaces the preview document while Manual Edit is still open. A session belief minted against the old document then survives into a document that cannot close it. The precondition simply did not exist before #7828.

## What users will see

Nothing new on screen. What changes is that clicking **Save** in the Manual Edit properties panel now writes the file in a case where it previously did nothing at all — no write, no error, no busy state. The path there is ordinary: edit a page, save something the live preview cannot mirror (`set-token`, `set-attributes`, `set-full-source`), click into a text element, and save again after the preview has refreshed.

## Surface area

- [x] **UI** — no new surface; fixes an existing control (Manual Edit → Save) that could silently no-op
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change
- [ ] None

No screenshots: there is no visual change. The observable is a file write that previously did not happen — the specs assert on the persisted bytes.

## Bug fix verification

- Test path: `apps/web/tests/components/FileViewer.manual-edit-stale-text-session.test.tsx`
- Red on the branch point (`de1eddd`), green with the fix: **yes**

Red output before the fix, driving the real product flow — Manual Edit open, one unmirrored save to lift the freeze, an inline text edit started, a revision replacing the document, then Save:

```
AssertionError: expected '<!doctype html>…' to contain 'Hero EDIT2'
+ <main data-od-id="hero">Hero</main>
```

Zero POSTs and no error banner — the second spec pins that pair directly, so a fix cannot pass by swapping one silent no-op for another.

Implementation was removed twice and the specs went red both times, so nothing here is vacuous.

Second commit: `apps/web/tests/components/FileViewer.manual-edit-silent-flush.test.tsx`,
three cases, all three red at the first commit and green after. Removing the implementation
puts all three back to red while the first commit's two specs stay green — a clean
differential rather than a blanket one.

**Two things the red-first discipline caught that I would otherwise have shipped wrong:**

- The `edit_busy` case first went red for the wrong reason — my own harness threw inside
  `liveFrame()` rather than the product failing. Fixing the harness turned it green on
  *unfixed* code. The real trigger needs two **different** elements: a refusal recorded
  against the same element as the write that succeeds is erased by that success. That is
  also what a user actually does.
- I first checked whether `edit_busy` was reachable by clicking Save, and it is **not** —
  the panel disables Save while a write is in flight. The reachable path is the inline
  bridge, which has no button to disable. Recorded here because a bug report claiming the
  Save button would have been wrong.

**A regression this caught, worth flagging for review.** The first version of the predicate compared the session's window against the active frame only. That broke `FileViewer.test.tsx > preserves pending inline text and style edits while retained` — verified green on the branch point, so it was mine, not pre-existing. A retained viewer keeps its document mounted while deactivated, and the current/standby pair swaps under promotion and navigation retries; the frame the host would post into is routinely *not* the frame that opened the session, with no replacement involved. Reading that as a dead document drops a genuinely pending edit — the opposite bug, and a worse one. The predicate now releases the session only on positive evidence: documents are mounted, and the session's is not among them. No mounted document is no evidence, and the original fail-closed behavior stands. `apps/web/tests/runtime/manual-edit-text-session.test.ts` pins both directions.

## Validation

Run in an isolated worktree at `de1eddd`:

- `pnpm guard` — exit 0
- `pnpm --filter @open-design/web typecheck` — exit 0
- `cd apps/web && ./node_modules/.bin/vitest run tests/components/FileViewer tests/runtime tests/edit-mode` — **106 files / 1428 tests passed**, 50.6s
- `cd apps/web && ./node_modules/.bin/vitest run tests/components/FileViewer.manual-edit-stale-text-session.test.tsx` — 2 passed, 20.5s
- `cd apps/web && ./node_modules/.bin/vitest run tests/runtime/manual-edit-text-session.test.ts` — 5 passed

Re-run after the second commit:

- `pnpm guard` — exit 0
- `pnpm --filter @open-design/web typecheck` — exit 0
- `cd apps/web && ./node_modules/.bin/vitest run tests/components/FileViewer tests/runtime tests/edit-mode` — **109 files / 1440 tests passed**

One honest note on that sweep: an earlier run of it reported 5 failures. Two were real —
my first version of the failure-witness notice clobbered the specific save error that
`FileViewer.test.tsx > keeps a settled Enter-commit failure` asserts on, so the notice now
only fills a gap. The other three passed in isolation and were this machine being loaded;
they are green in the run above.

## Second commit: the root the first one was an instance of

The three silent paths originally listed here as adjacent issues are now fixed in
`3c7d76f`, because they are not three bugs — they are one.

Both flush steps (`settlePendingManualEditCommit`, `flushManualEditStyleSave`) answered
with a bare `boolean`, and every caller wrote `if (!ok) return;`. That single `false`
stood for three situations, only one of which had told the user anything:

| | teardown may proceed | already explained itself | durable failure witness |
|---|---|---|---|
| `settled` | yes | — | no |
| `blocked` | no | **no** | no |
| `reported` | no | yes | yes |

`blocked` is the defect. `ManualEditFlushOutcome` (`apps/web/src/runtime/manual-edit-flush.ts`)
names the three, and three predicates keep the three decisions apart at their own call
sites rather than each site re-deriving them from a boolean. The invariant every caller
now reads: **a teardown that refuses must leave the user something to read.**

What that repaired, in order of severity:

1. **A transient refusal was filed as a permanent failure.** `applyManualEdit` returns
   `edit_busy` when another write owns the editor; the commit record stored that as a
   *failed* commit, which put the element id in `manualEditTextFailedSessionIdsRef`, which
   `exitManualEditModeAfterFlush` and `reloadHtmlPreview` consult on every attempt. Two
   inline commits close together — type, Enter, click the next element, Enter again — and
   the user is **locked inside Manual Edit for the rest of the session with nothing on
   screen**, escapable only by re-editing the exact element that failed. `blocked` is no
   longer a durable failure witness.
2. **The failure witness outlived the message that explained it.** Even for a *genuine*
   failure, the next successful save clears the banner via `setManualEditError(null)`, and
   the witness then gates every exit silently. That gate now states itself — but only fills
   a gap, so the original message (which names the file and status code) still wins when
   it is still on screen.
3. **`finishManualEditTextSession` returned `false` with no window to post into.** That is
   `blocked`, not a failure: nothing committed and nothing failed. It now says so.
4. **`applyManualEdit`'s `source_unavailable`** returned `false` silently; it now reports.

## Ring walk: what else #7828's unfreezing put at risk

Asked and answered, since the first commit's precondition was created by #7828 lifting the
identity freeze. I walked every consumer of `previewRuntimeRevisionIdentityRef` and every
per-document ref in `FileViewer.tsx`, looking for state that survives a document
replacement. Resets keyed on `file.name` or on leaving edit mode do not count — the
document is replaced while both are unchanged.

**Found, and fixed here:** `manualEditTextFailedSessionIdsRef` — the hard sibling of the
first commit's bug, and item 1 above. Confirmed independently by the walk before I had a
green fix.

**Found, not fixed — each wants its own red spec** (I am deliberately holding scope):

- **`capturePreviewScrollPosition` is skipped for `set-style` on a premise #7828 falsified.**
  `FileViewer.tsx:13802` skips the pre-write scroll capture because "style patches stream
  live through postMessage and never reload". Once the freeze has lifted, every `set-style`
  save bumps mtime and *does* replace the document. Nudging a style in the inspector after
  an unmirrored save jumps the preview to the top.
- **`manualEditHoverTarget`** holds geometry from the replaced document; the hover
  affordance stays painted at the old element's coordinates until the pointer moves.
- **`selectedManualEditTarget` is deliberately sticky** across an empty target broadcast
  (`FileViewer.tsx:13012`), and a replacement document that genuinely no longer contains the
  element is indistinguishable from that settling window. The inspector stays open on a
  gone element and Save then produces a patch the document refuses.
- **Latent:** the `set-style` branch of `syncRetainedManualEditDocument` proves the mirror
  from the host's own map rather than a document round-trip. Not user-visible today only
  because `liveDocumentDiverged` is already sticky-true whenever a replacement has happened.

**Checked and cleared** (so the negative is on the record): `manualEditLiveStylesRef`,
`inspectOverrides`/`inspectHydratedSourceRef`, deck slide state, the scroll refs as
*handles*, `dcViewportRef`, the whole content-measurement epoch machinery,
`presenterWindowRef`, `manualEditPersistedDocumentRef`, `manualEditPreviewMirrorSequenceRef`,
`manualEditPendingStyleRef`, `manualEditSelectionDraftRef`, history/draft/frozen-source
state, the navigation-generation refs, and the srcDoc/URL-standby refs (dead under
`previewRuntimeConvergenceActive`). These are replayed onto the new frame by
`replayPreviewBridgeModes`, re-armed by `onCurrentFrameChange`, derived from `source` rather
than the DOM, or unreachable.

## A note on the new strings

The four new messages are plain English literals, matching every other message on this
surface (`'Could not apply edit.'`, `'Could not save the edited file…'`). Adding i18n keys
for four of them while the rest stay literal would make the inconsistency worse, not better.
Flagging the copy itself for review.

## Adjacent issue: the Manual Edit error surface has no i18n at all

Separate from this PR and not fixed by it, recorded so it does not disappear as a footnote.

**Every** user-facing error string in the Manual Edit flow is a hard-coded English literal
in `FileViewer.tsx` — `'Could not apply edit.'`, `` `Could not save the edited file${…}` ``,
`'The file changed outside manual edit mode…'`, `'Could not save the undo result'`, and the
four added here. None of them goes through `apps/web/src/i18n`, so a user on any of the
other 18 locales hits English the moment a save fails. Everything *else* in the Manual Edit
panel — every label, tab, and control — is translated, which makes the gap specific to the
failure path: the one place a confused user most needs to read what happened.

Fixing it is a self-contained change (new keys in `i18n/types.ts` plus all 19 locale files,
and threading `t()` through the error call sites). It wants its own PR, and a decision on
whether the interpolated server messages should be translated or left verbatim.

## Scope note

This PR does **not** claim to be the cause of the original 1-in-16 observation — that sample carried no trace, and the frequency of the timing that produces it here has not been measured. What it does claim: a defect with exactly the reported signature (enabled button, no error, byte-identical file, request never sent) exists on this branch, is deterministically reproducible, and is now fixed.

Base is `fix/streaming-html-preview-bridge`, not `main`. Not for merge yet.


