### PR TITLE
test(desktop): compare PPTX captures portably instead of per-platform

### DIFF
--- a/apps/desktop/src/main/deck-capture.ts
+++ b/apps/desktop/src/main/deck-capture.ts
@@ -1919,6 +1919,80 @@ export function pngBufferHasPaint(data: Buffer): boolean {
   return bgraBitmapHasPaint(nativeImage.createFromBuffer(data).toBitmap());
 }
 
+export type BgraBitmapComparison = {
+  maxChannelDelta: number;
+  meanChannelDelta: number;
+};
+
+/** Worst channel difference between one pixel of `a` and one pixel of `b`. */
+function bgraPixelDelta(a: Uint8Array, aOffset: number, b: Uint8Array, bOffset: number): number {
+  let worst = 0;
+  for (let channel = 0; channel < 4; channel += 1) {
+    const delta = Math.abs(a[aOffset + channel] - b[bOffset + channel]);
+    if (delta > worst) worst = delta;
+  }
+  return worst;
+}
+
+/**
+ * Compares a Chromium reference capture against the isolated capture the PPTX
+ * export produced from the same element, both BGRA of identical geometry.
+ *
+ * `meanChannelDelta` is a strict per-pixel, per-channel mean over the whole
+ * bitmap: a broad fidelity loss shows up there and has nowhere to hide.
+ *
+ * `maxChannelDelta` is deliberately not the strict global maximum. Isolating an
+ * element re-renders it, so a clip, mask, filter or text-clip boundary can land
+ * on a neighbouring pixel from the one the in-slide reference painted, and the
+ * capture rectangle's own rounding lands on the outermost frame. Neither is a
+ * fidelity loss, and both move with the host graphics stack — the same commit
+ * puts them in different places on Ubuntu and on Debian, which made a strict
+ * maximum a platform-calibrated assertion rather than a portable one. So each
+ * pixel is matched against the best candidate in the 3x3 neighbourhood of the
+ * exported bitmap, and the one-pixel frame is skipped. A genuine content or
+ * colour change has no matching neighbour and is still reported at its full
+ * magnitude.
+ *
+ * Bitmaps too small to have an interior are compared strictly, since there is
+ * no boundary allowance to make.
+ */
+export function compareBgraBitmaps(
+  reference: Uint8Array,
+  exported: Uint8Array,
+  width: number,
+  height: number,
+): BgraBitmapComparison {
+  let totalChannelDelta = 0;
+  for (let offset = 0; offset < reference.length; offset += 1) {
+    totalChannelDelta += Math.abs(reference[offset] - exported[offset]);
+  }
+  const meanChannelDelta = totalChannelDelta / (width * height * 4);
+
+  let maxChannelDelta = 0;
+  if (width < 3 || height < 3) {
+    for (let offset = 0; offset < reference.length; offset += 4) {
+      const strict = bgraPixelDelta(reference, offset, exported, offset);
+      if (strict > maxChannelDelta) maxChannelDelta = strict;
+    }
+    return { maxChannelDelta, meanChannelDelta };
+  }
+
+  for (let y = 1; y < height - 1; y += 1) {
+    for (let x = 1; x < width - 1; x += 1) {
+      const offset = (y * width + x) * 4;
+      let best = bgraPixelDelta(reference, offset, exported, offset);
+      for (let dy = -1; dy <= 1 && best > maxChannelDelta; dy += 1) {
+        for (let dx = -1; dx <= 1 && best > maxChannelDelta; dx += 1) {
+          const candidate = bgraPixelDelta(reference, offset, exported, ((y + dy) * width + (x + dx)) * 4);
+          if (candidate < best) best = candidate;
+        }
+      }
+      if (best > maxChannelDelta) maxChannelDelta = best;
+    }
+  }
+  return { maxChannelDelta, meanChannelDelta };
+}
+
 function injectBaseHref(doc: string, baseHref: string | undefined): string {
   if (!baseHref) return doc;
   const tag = `<base href="${escapeHtmlAttribute(baseHref)}">`;

--- a/apps/desktop/tests/main/pptx-layered-background.test.ts
+++ b/apps/desktop/tests/main/pptx-layered-background.test.ts
@@ -13,6 +13,7 @@ import {
   captureEditablePptxLayeredBackgrounds,
   captureUntilPainted,
   collectLayeredPptxBackgroundTargets,
+  compareBgraBitmaps,
   isolateLayeredPptxBackground,
   pngInspectionHasPaint,
   restoreLayeredPptxBackgroundIsolation,
@@ -68,6 +69,43 @@ function bgraBitmapHasPaint(bitmap) {
 }
 function pngBufferHasPaint(data) {
   return bgraBitmapHasPaint(nativeImage.createFromBuffer(data).toBitmap());
+}
+function bgraPixelDelta(a, aOffset, b, bOffset) {
+  let worst = 0;
+  for (let channel = 0; channel < 4; channel += 1) {
+    const delta = Math.abs(a[aOffset + channel] - b[bOffset + channel]);
+    if (delta > worst) worst = delta;
+  }
+  return worst;
+}
+function compareBgraBitmaps(reference, exported, width, height) {
+  let totalChannelDelta = 0;
+  for (let offset = 0; offset < reference.length; offset += 1) {
+    totalChannelDelta += Math.abs(reference[offset] - exported[offset]);
+  }
+  const meanChannelDelta = totalChannelDelta / (width * height * 4);
+  let maxChannelDelta = 0;
+  if (width < 3 || height < 3) {
+    for (let offset = 0; offset < reference.length; offset += 4) {
+      const strict = bgraPixelDelta(reference, offset, exported, offset);
+      if (strict > maxChannelDelta) maxChannelDelta = strict;
+    }
+    return { maxChannelDelta, meanChannelDelta };
+  }
+  for (let y = 1; y < height - 1; y += 1) {
+    for (let x = 1; x < width - 1; x += 1) {
+      const offset = (y * width + x) * 4;
+      let best = bgraPixelDelta(reference, offset, exported, offset);
+      for (let dy = -1; dy <= 1 && best > maxChannelDelta; dy += 1) {
+        for (let dx = -1; dx <= 1 && best > maxChannelDelta; dx += 1) {
+          const candidate = bgraPixelDelta(reference, offset, exported, ((y + dy) * width + (x + dx)) * 4);
+          if (candidate < best) best = candidate;
+        }
+      }
+      if (best > maxChannelDelta) maxChannelDelta = best;
+    }
+  }
+  return { maxChannelDelta, meanChannelDelta };
 }
 `;
 
@@ -228,6 +266,82 @@ async function runExport(
   const result = await runDomToPptx('.slide', layeredBackgrounds);
   expect(result.error).toBeUndefined();
 }
+
+/** Opaque BGRA canvas with a filled rectangle, so a shape can be moved by whole pixels. */
+function bgraCanvasWithRect(
+  width: number,
+  height: number,
+  rect: { x: number; y: number; w: number; h: number },
+  color: [number, number, number],
+): Uint8Array {
+  const bitmap = new Uint8Array(width * height * 4);
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const offset = (y * width + x) * 4;
+      const inside = x >= rect.x && x < rect.x + rect.w && y >= rect.y && y < rect.y + rect.h;
+      bitmap[offset] = inside ? color[0] : 0;
+      bitmap[offset + 1] = inside ? color[1] : 0;
+      bitmap[offset + 2] = inside ? color[2] : 0;
+      bitmap[offset + 3] = 255;
+    }
+  }
+  return bitmap;
+}
+
+describe('BGRA capture comparison', () => {
+  const size = { height: 24, width: 24 };
+  const rect = { h: 8, w: 8, x: 8, y: 8 };
+  const reference = bgraCanvasWithRect(size.width, size.height, rect, [200, 100, 50]);
+
+  test('reports no difference between identical bitmaps', () => {
+    const comparison = compareBgraBitmaps(reference, reference, size.width, size.height);
+
+    expect(comparison).toEqual({ maxChannelDelta: 0, meanChannelDelta: 0 });
+  });
+
+  test('absorbs a one-pixel boundary shift, the way an isolated re-render moves an edge', () => {
+    const shifted = bgraCanvasWithRect(size.width, size.height, { ...rect, x: rect.x + 1 }, [200, 100, 50]);
+
+    expect(compareBgraBitmaps(reference, shifted, size.width, size.height).maxChannelDelta).toBe(0);
+  });
+
+  test('still reports a shift the neighbourhood cannot explain', () => {
+    const shifted = bgraCanvasWithRect(size.width, size.height, { ...rect, x: rect.x + 3 }, [200, 100, 50]);
+
+    expect(compareBgraBitmaps(reference, shifted, size.width, size.height).maxChannelDelta).toBe(200);
+  });
+
+  test('still reports a colour change at full magnitude', () => {
+    const recoloured = bgraCanvasWithRect(size.width, size.height, rect, [200, 100, 250]);
+
+    expect(compareBgraBitmaps(reference, recoloured, size.width, size.height).maxChannelDelta).toBe(200);
+  });
+
+  test('still reports content that the export dropped entirely', () => {
+    const empty = bgraCanvasWithRect(size.width, size.height, { h: 0, w: 0, x: 0, y: 0 }, [200, 100, 50]);
+
+    expect(compareBgraBitmaps(reference, empty, size.width, size.height).maxChannelDelta).toBe(200);
+  });
+
+  test('skips the outer frame for the maximum but still counts it in the mean', () => {
+    const framed = Uint8Array.from(reference);
+    framed[0] = 255;
+    framed[1] = 255;
+    framed[2] = 255;
+
+    const comparison = compareBgraBitmaps(reference, framed, size.width, size.height);
+
+    expect(comparison.maxChannelDelta).toBe(0);
+    expect(comparison.meanChannelDelta).toBeGreaterThan(0);
+  });
+
+  test('compares bitmaps too small to have an interior strictly', () => {
+    const a = bgraCanvasWithRect(2, 2, { h: 1, w: 1, x: 0, y: 0 }, [200, 100, 50]);
+    const b = bgraCanvasWithRect(2, 2, { h: 1, w: 1, x: 1, y: 0 }, [200, 100, 50]);
+
+    expect(compareBgraBitmaps(a, b, 2, 2).maxChannelDelta).toBe(200);
+  });
+});
 
 describe('chromium empty-capture retry', () => {
   test('treats fully transparent inspections as unpainted', () => {
@@ -2425,22 +2539,12 @@ function comparePng(referenceData, exportedData) {
   if (referenceSize.width !== exportedSize.width || referenceSize.height !== exportedSize.height) {
     throw new Error('Cannot compare PNGs with different dimensions: ' + JSON.stringify({ referenceSize, exportedSize }));
   }
-  const referenceBitmap = reference.toBitmap();
-  const exportedBitmap = exported.toBitmap();
-  let maxChannelDelta = 0;
-  let totalChannelDelta = 0;
-  for (let offset = 0; offset < referenceBitmap.length; offset += 4) {
-    for (let channel = 0; channel < 4; channel += 1) {
-      const delta = Math.abs(referenceBitmap[offset + channel] - exportedBitmap[offset + channel]);
-      maxChannelDelta = Math.max(maxChannelDelta, delta);
-      totalChannelDelta += delta;
-    }
-  }
-  const pixels = referenceSize.width * referenceSize.height;
-  return {
-    maxChannelDelta,
-    meanChannelDelta: totalChannelDelta / (pixels * 4),
-  };
+  return compareBgraBitmaps(
+    reference.toBitmap(),
+    exported.toBitmap(),
+    referenceSize.width,
+    referenceSize.height,
+  );
 }
 
 function inspectPseudoLayerOrder(entries, mediaName) {


### PR DESCRIPTION
Fixes #7841

## Why

I hit this while preparing the Linux `.deb` packaging work (#7767, #6010, #6017): on Debian, `pnpm --filter @open-design/desktop test` is red on a clean checkout of `main`, with six failures in `pptx-layered-background.test.ts`. That leaves a contributor on any non-Ubuntu Linux unable to tell a real regression from a calibration gap — which is the actual pain here, since the suite is otherwise the local gate for `apps/desktop`.

`comparePng` reduced every BGRA comparison to a mean and one strict global maximum. For six assertions the maximum is the whole gate, and it is not portable. Same commit, same lockfile, same Electron 41.3.0, `desktop build` run first in both cases:

| Assertion | Debian | Ubuntu 24.04 | bound |
| --- | --- | --- | --- |
| text-clipped layered gradients | 255 ❌ | 0 ✅ | 224 |
| narrow clipped stripe backdrop | 18 ❌ | 0 ✅ | 16 |
| filtered layered pseudo | 245 ❌ | 0 ✅ | 160 |
| layered element clip path | 211 ❌ | 117 ✅ | 160 |
| ancestor clip path | 201 ❌ | 71 ✅ | 160 |
| ancestor prefixed mask | 205 ❌ | 0 ✅ | 160 |

The `meanChannelDelta` assertion passes on both platforms in all six cases.

As @lefarcen noted on the issue, the maximum is poor at telling a localized geometry difference from a broad fidelity loss. Instrumenting the comparison confirmed it is not antialiasing noise: hundreds of *fully opaque* pixels carry the content in the reference capture and plain white in the isolated export, or the reverse — 875, 546 and 1100 on three of the probes. Isolating an element re-renders it, so a clip, mask, filter or text-clip boundary lands on a neighbouring pixel from the one the in-slide reference painted, and the capture rectangle's own rounding lands on the outer frame. On the filtered-pseudo probe, 608 of the 876 divergent pixels were exactly the bottom row of a 608-wide image.

## What users will see

Nothing. Test-only change, plus one new exported helper in `deck-capture.ts`.

The contributor-facing effect: `pnpm --filter @open-design/desktop test` is now green on a clean checkout on Debian as well as Ubuntu.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## Bug fix verification

- Test path that reproduces the bug: `apps/desktop/tests/main/pptx-layered-background.test.ts`
- Did it go red on `main` and green on this branch? **Yes** — 6 failed / 49 passed on `main` at `b5c9723`, 62 passed on this branch, on the same Debian host. On Ubuntu 24.04 it was already green and stays green (62 passed).
- The six failures were not flaky: repeated runs reproduced the same numbers bit-for-bit, and they were identical on a commit predating my packaging work, so nothing in my branches caused them.

## What changed

`compareBgraBitmaps` moves into `deck-capture.ts` next to the other pure capture helpers, and is mirrored into the probe source string the same way `captureUntilPainted` and `bgraBitmapHasPaint` already are, so the probe and the unit tests exercise one implementation.

- `meanChannelDelta` stays a strict per-pixel, per-channel mean over the whole bitmap, outer frame included. A broad fidelity loss has nowhere to hide.
- `maxChannelDelta` matches each pixel against the best candidate in the 3×3 neighbourhood of the exported bitmap and skips the one-pixel frame. A genuine content or colour change has no matching neighbour and is still reported at full magnitude.
- Bitmaps too small to have an interior are compared strictly.

**No bound is raised.** Worst case per assertion after the change, Debian / Ubuntu:

| Assertion | Debian | Ubuntu | bound | headroom |
| --- | --- | --- | --- | --- |
| text-clipped layered gradients | 111 | 0 | 224 | 50% |
| narrow clipped stripe backdrop | 8 | 0 | 16 | 50% |
| filtered layered pseudo | 123 | 0 | 160 | 23% |
| layered element clip path | 72 | 76 | 160 | 53% |
| ancestor clip path | 73 | 51 | 160 | 54% |
| ancestor prefixed mask | 75 | 0 | 160 | 53% |

The two platforms trade places on the clip-path probe (72 vs 76) rather than one being systematically looser, which is the sign I was looking for that the metric measures the capture rather than the host graphics stack.

Seven unit tests cover the helper directly, so the gate is checked rather than assumed: identical bitmaps report nothing; a one-pixel shift is absorbed; a three-pixel shift is still reported at 200; a colour change and content the export dropped entirely are still reported at 200; a difference confined to the outer frame is invisible to the maximum but visible in the mean; and a 2×2 bitmap is compared strictly.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/desktop test` — 42 files, 428 passed, 1 skipped (Debian forky/sid, kernel 7.0.7, x86_64)
- `pnpm --filter @open-design/desktop test` restricted to the changed file, in a clean Ubuntu 24.04.4 container with Node 24.20.0 and pnpm 10.33.2 — 62 passed

The Ubuntu figures throughout come from that container, built to approximate the `ubuntu-latest` runner `ci.yml` uses for `workspace_unit`: `docker run ubuntu:24.04`, NodeSource Node 24, `pnpm install --frozen-lockfile`, `desktop build`, then the suite. Happy to re-run any of it or to fold the container recipe into a doc note if that would be useful.
