### PR TITLE
fix(web): tie the preview scroll snapshot to document replacement

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -324,6 +324,8 @@ import { MANUAL_EDIT_STYLE_PROPS, type ManualEditBridgeMessage, type ManualEditH
 import { isRenderableSketchJson, SketchPreview } from './SketchPreview';
 import {
   canArmPersistedManualEditDocument,
+  manualEditPatchStreamsIntoLiveDocument,
+  manualEditSaveRetainsPreviewDocument,
   shouldAdoptPersistedManualEditDocument,
   shouldFreezeManualEditDocumentIdentity,
 } from '../runtime/manual-edit-document-latch';
@@ -13794,12 +13796,20 @@ function HtmlViewer({
         return false;
       }
       const parentVersionId = await resolveManualEditParentVersionId(baseSource);
-      // A committed content patch can notify the file watcher as soon as the
-      // write lands. Capture the opaque iframe's exact scroll position before
-      // that write so neither the watcher nor our local source update can
-      // rebuild the preview from an initial 0/0 position. Style patches stream
-      // live through postMessage and never reload.
-      if (patch.kind !== 'set-style') {
+      // A save that replaces the preview document can notify the file watcher
+      // as soon as the write lands. Capture the opaque iframe's exact scroll
+      // position before that write, so neither the watcher nor our local source
+      // update can rebuild the preview from an initial 0/0 position.
+      //
+      // The condition is whether the document survives this save, NOT which
+      // kind of patch it is. Those used to coincide and no longer do: once the
+      // identity freeze has lifted, a style save replaces the document like any
+      // other, and skipping the snapshot loses the user's place.
+      if (!manualEditSaveRetainsPreviewDocument({
+        liveDocumentDiverged: manualEditLiveDocumentDivergedRef.current,
+        manualEditSessionActive,
+        patchStreamsIntoLiveDocument: manualEditPatchStreamsIntoLiveDocument(patch.kind),
+      })) {
         await capturePreviewScrollPosition();
       }
       const saved = await writeProjectTextFileDetailed(projectId, file.name, result.source, {
@@ -13949,6 +13959,18 @@ function HtmlViewer({
         return;
       }
       const parentVersionId = await resolveManualEditParentVersionId(latest.afterSource);
+      // Same replacement risk as a committed patch, so the same ordering rule:
+      // the snapshot has to precede the write. The watcher can publish the new
+      // source the moment the write lands, and a snapshot taken after that
+      // measures the replacement document at 0/0 and records the top of the
+      // page as the place to restore to.
+      if (!manualEditSaveRetainsPreviewDocument({
+        liveDocumentDiverged: manualEditLiveDocumentDivergedRef.current,
+        manualEditSessionActive,
+        patchStreamsIntoLiveDocument: manualEditPatchStreamsIntoLiveDocument(latest.patch.kind),
+      })) {
+        await capturePreviewScrollPosition();
+      }
       const saved = await writeProjectTextFileDetailed(projectId, file.name, latest.beforeSource, {
         artifactManifest: file.artifactManifest,
         versionSource: 'manual',
@@ -13960,9 +13982,6 @@ function HtmlViewer({
         finish('failed', 'save_failed');
         return;
       }
-      // Same srcDoc rebuild as a committed patch — keep the scroll position
-      // across the reload (#92).
-      await capturePreviewScrollPosition();
       setSource(latest.beforeSource);
       sourceRef.current = latest.beforeSource;
       setInlinedSource(null);
@@ -14013,6 +14032,18 @@ function HtmlViewer({
         return;
       }
       const parentVersionId = await resolveManualEditParentVersionId(latest.beforeSource);
+      // Same replacement risk as a committed patch, so the same ordering rule:
+      // the snapshot has to precede the write. The watcher can publish the new
+      // source the moment the write lands, and a snapshot taken after that
+      // measures the replacement document at 0/0 and records the top of the
+      // page as the place to restore to.
+      if (!manualEditSaveRetainsPreviewDocument({
+        liveDocumentDiverged: manualEditLiveDocumentDivergedRef.current,
+        manualEditSessionActive,
+        patchStreamsIntoLiveDocument: manualEditPatchStreamsIntoLiveDocument(latest.patch.kind),
+      })) {
+        await capturePreviewScrollPosition();
+      }
       const saved = await writeProjectTextFileDetailed(projectId, file.name, latest.afterSource, {
         artifactManifest: file.artifactManifest,
         versionSource: 'manual',
@@ -14024,9 +14055,6 @@ function HtmlViewer({
         finish('failed', 'save_failed');
         return;
       }
-      // Same srcDoc rebuild as a committed patch — keep the scroll position
-      // across the reload (#92).
-      await capturePreviewScrollPosition();
       setSource(latest.afterSource);
       sourceRef.current = latest.afterSource;
       setInlinedSource(null);

--- a/apps/web/src/runtime/manual-edit-document-latch.ts
+++ b/apps/web/src/runtime/manual-edit-document-latch.ts
@@ -105,3 +105,58 @@ export function shouldFreezeManualEditDocumentIdentity(input: {
     || input.manualEditSrcDocActive
     || input.canAdoptPersistedDocument;
 }
+
+/**
+ * Whether a patch reaches the document already on screen without a rebuild.
+ *
+ * Only `set-style` does. Styles stream in through `od-edit-preview-style` as
+ * the user drags a slider, so by the time the save is written the document is
+ * already showing the result and the write's watcher echo has nothing to add.
+ * Every other kind changes the source and depends on the document coming back
+ * — mirrored if the bridge can carry it, re-rendered if it cannot.
+ *
+ * This is deliberately NOT "does the patch have a mirror message". Several
+ * kinds have one and still take the rebuild path, and the mirror can be refused
+ * at any time. What is being named here is the narrower property the scroll
+ * decision below actually rests on.
+ */
+export function manualEditPatchStreamsIntoLiveDocument(kind: string): boolean {
+  return kind === 'set-style';
+}
+
+/**
+ * Whether the preview document on screen will survive this save.
+ *
+ * This is the question the pre-write scroll snapshot depends on, and for a long
+ * time the code asked a different one. It skipped the snapshot for `set-style`,
+ * reasoning that "style patches stream live through postMessage and never
+ * reload" — which was true while Manual Edit pinned one document for the length
+ * of a session.
+ *
+ * It is no longer true. The identity freeze lifts for the rest of the session
+ * as soon as one save cannot be mirrored into the live document, and from then
+ * on every revision replaces the document, style saves included. A premise that
+ * used to hold was retired by a different change, and the code resting on it
+ * kept the old answer: the user scrolls down, nudges a style, and the preview
+ * comes back at the top with nothing to restore from.
+ *
+ * So the condition is stated as what it always was about — replacement — and
+ * the patch kind enters only through the one property that bears on it. Outside
+ * a Manual Edit session nothing pins the document at all; inside one, the
+ * freeze is what retains it, and a session that has already diverged no longer
+ * has a freeze to offer.
+ *
+ * Retention is claimed only where it is certain, because the two errors are not
+ * symmetric: a capture that was not needed costs one round trip of up to 120ms
+ * in front of the write, while a capture that was needed and skipped loses the
+ * user's place with no way to recover it afterwards.
+ */
+export function manualEditSaveRetainsPreviewDocument(input: {
+  liveDocumentDiverged: boolean;
+  manualEditSessionActive: boolean;
+  patchStreamsIntoLiveDocument: boolean;
+}): boolean {
+  if (!input.manualEditSessionActive) return false;
+  if (input.liveDocumentDiverged) return false;
+  return input.patchStreamsIntoLiveDocument;
+}

--- a/apps/web/tests/components/FileViewer.manual-edit-style-scroll.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit-style-scroll.test.tsx
@@ -1,0 +1,458 @@
+// @vitest-environment jsdom
+//
+// Red spec for the scroll position lost by a style save.
+//
+// `applyManualEdit` snapshots the preview's scroll position before it writes,
+// so the document that comes back after the write can be rebuilt where the user
+// left it rather than at 0/0. It skips that snapshot for one patch kind:
+//
+//   apps/web/src/components/FileViewer.tsx
+//   // Style patches stream live through postMessage and never reload.
+//   if (patch.kind !== 'set-style') {
+//     await capturePreviewScrollPosition();
+//   }
+//
+// That comment was TRUE when it was written. Manual Edit used to pin one
+// preview document for the length of a session, so a style save really did
+// stream into the document already on screen and really never reloaded.
+//
+// #7828 changed it. The identity freeze now lifts for the rest of the session
+// the moment a save cannot be mirrored into the live document
+// (`shouldFreezeManualEditDocumentIdentity` returns false once
+// `liveDocumentDiverged` is set) — deliberately, so unmirrored saves become
+// visible. From that point on EVERY revision replaces the preview document,
+// style saves included. The premise the skip rests on stopped holding, and the
+// code that depends on it was not revisited.
+//
+// So the skip is no longer "this kind of patch never reloads". It is "this kind
+// of patch never reloads, unless something else in the session already decided
+// otherwise" — and in that case the user's scroll is gone. The condition that
+// matters is whether the document is about to be REPLACED, and it was never
+// about the patch kind at all. These tests pin that: the same `set-style` save
+// must capture in one state and must not in the other.
+//
+// Scope note: this is a mechanism read out of the code, not an attribution.
+// It produces the same symptom as a cluster of failures seen elsewhere, but
+// nothing here claims those failures were this.
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ComponentProps } from 'react';
+import { FileViewer as ProductFileViewer } from '../../src/components/FileViewer';
+import { emptyManualEditStyles, type ManualEditTarget } from '../../src/edit-mode/types';
+import type { ProjectFile } from '../../src/types';
+import {
+  installFileViewerPreviewRuntimeHarness,
+  prepareSettledFileViewerFixture,
+  setSyntheticPreviewFileSource,
+  syntheticPreviewFileSource,
+  uninstallFileViewerPreviewRuntimeHarness,
+  useSyntheticProjectScopedPreviewNavigation,
+} from '../helpers/file-viewer-preview-runtime';
+
+vi.mock('../../src/providers/registry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/providers/registry')>();
+  return {
+    ...actual,
+    fetchProjectFileText(
+      projectId: string,
+      name: string,
+      options?: Parameters<typeof actual.fetchProjectFileText>[2],
+    ) {
+      const source = syntheticPreviewFileSource(projectId, name);
+      return source === undefined
+        ? actual.fetchProjectFileText(projectId, name, options)
+        : Promise.resolve(source);
+    },
+  };
+});
+
+vi.mock('../../src/runtime/use-project-preview-session-navigation', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('../../src/runtime/use-project-preview-session-navigation')
+  >();
+  return {
+    ...actual,
+    useProjectScopedPreviewNavigation: (
+      options: Parameters<typeof actual.useProjectScopedPreviewNavigation>[0],
+    ) => useSyntheticProjectScopedPreviewNavigation(options),
+  };
+});
+
+function FileViewer(props: ComponentProps<typeof ProductFileViewer>) {
+  return <ProductFileViewer {...prepareSettledFileViewerFixture(props)} />;
+}
+
+beforeEach(() => {
+  installFileViewerPreviewRuntimeHarness();
+});
+
+afterEach(() => {
+  uninstallFileViewerPreviewRuntimeHarness();
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+const PROJECT_ID = 'project-1';
+const FILE_NAME = 'preview.html';
+
+const PAGE_SOURCE =
+  '<!doctype html><html><body>'
+  + '<main data-od-id="hero">Hero</main>'
+  + '<section data-od-id="panel">Panel</section>'
+  + '</body></html>';
+
+function textTarget(): ManualEditTarget {
+  return {
+    id: 'hero',
+    kind: 'text',
+    label: 'Hero',
+    tagName: 'main',
+    className: '',
+    text: 'Hero',
+    rect: { x: 24, y: 24, width: 160, height: 48 },
+    fields: { text: 'Hero' },
+    attributes: { 'data-od-id': 'hero' },
+    styles: emptyManualEditStyles(),
+    isLayoutContainer: false,
+    outerHtml: '<main data-od-id="hero">Hero</main>',
+  };
+}
+
+function htmlPreviewFile(size = 1024, mtime = 1710000000): ProjectFile {
+  return {
+    name: FILE_NAME,
+    path: FILE_NAME,
+    type: 'file',
+    size,
+    mtime,
+    mime: 'text/html',
+    kind: 'html',
+    artifactManifest: {
+      version: 1,
+      kind: 'html',
+      title: 'Preview',
+      entry: FILE_NAME,
+      renderer: 'html',
+      exports: ['html'],
+    },
+  };
+}
+
+function liveFrame(): HTMLIFrameElement {
+  return screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+}
+
+describe('FileViewer manual edit — scroll across a style save', () => {
+  /**
+   * `documentApplies` is the bridge's answer to a mirror request, and it is what
+   * decides whether this session's preview document is retained or replaced:
+   * a refusal sets `liveDocumentDiverged`, which lifts the identity freeze for
+   * the rest of the session.
+   */
+  async function openManualEdit(documentApplies: boolean) {
+    let currentFile = htmlPreviewFile();
+    const writes: string[] = [];
+    /**
+     * The host's preview postMessages AND its writes, in the order they
+     * happened. Order is the whole point: a snapshot taken after the write has
+     * already lost the race with the file watcher.
+     */
+    const posted: { type: string }[] = [];
+
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof Request ? input.url : String(input);
+      if (url.includes(`/api/projects/${PROJECT_ID}/files`) && init?.method === 'POST') {
+        posted.push({ type: '__write__' });
+        const body = typeof init.body === 'string' ? init.body : '';
+        try {
+          const parsed = JSON.parse(body) as { content?: string };
+          if (typeof parsed.content === 'string') {
+            writes.push(parsed.content);
+            setSyntheticPreviewFileSource(PROJECT_ID, FILE_NAME, parsed.content);
+            currentFile = htmlPreviewFile(parsed.content.length, currentFile.mtime + 1);
+          }
+        } catch {
+          /* not a file write */
+        }
+        return new Response(JSON.stringify({ file: currentFile }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(PAGE_SOURCE, { status: 200, headers: { 'Content-Type': 'text/html' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const view = render(
+      <FileViewer
+        projectId={PROJECT_ID}
+        projectKind="prototype"
+        file={htmlPreviewFile()}
+        liveHtml={PAGE_SOURCE}
+      />,
+    );
+
+    const frame = await waitFor(() => {
+      const node = liveFrame();
+      if (!node.contentWindow) throw new Error('Preview frame not ready');
+      return node;
+    });
+
+    const bridged = new WeakSet<Window>();
+    /**
+     * Stand in for the injected bridge on whichever document is on screen, and
+     * record what the host posts into it. Every replacement mints a new
+     * document, so this re-installs the same way the real bridge boots.
+     */
+    function installBridge() {
+      const win = liveFrame().contentWindow;
+      if (!win || bridged.has(win)) return;
+      bridged.add(win);
+      const spy = vi.spyOn(win, 'postMessage');
+      const previous = spy.getMockImplementation();
+      spy.mockImplementation(((message: unknown, ...rest: unknown[]) => {
+        (previous as ((...args: unknown[]) => void) | undefined)?.(message, ...rest);
+        const data = message as { requestId?: unknown; id?: unknown; type?: unknown } | null;
+        if (typeof data?.type === 'string') posted.push({ type: data.type });
+        if (typeof data?.requestId !== 'string') return;
+        // A scroll capture is answered by the document, not by the edit bridge.
+        if (data.type === 'od:preview-scroll-capture') {
+          window.dispatchEvent(new MessageEvent('message', {
+            data: {
+              type: 'od:preview-scroll',
+              requestId: data.requestId,
+              frameLeft: 0,
+              frameTop: 640,
+              canvasLeft: 0,
+              canvasTop: 640,
+            },
+            source: win,
+          }));
+          return;
+        }
+        window.dispatchEvent(new MessageEvent('message', {
+          data: {
+            type: 'od-edit-preview:applied',
+            requestId: data.requestId,
+            id: data.id ?? '',
+            applied: documentApplies,
+          },
+          source: win,
+        }));
+      }) as Window['postMessage']);
+    }
+
+    const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage');
+    fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
+    const captureRequest = postMessage.mock.calls
+      .map(([value]) => value)
+      .find((value) => (
+        typeof value === 'object'
+        && value !== null
+        && (value as { type?: unknown }).type === 'od:preview-runtime-state-capture'
+      )) as { id: string } | undefined;
+    if (captureRequest) {
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          data: {
+            type: 'od:preview-runtime-state-captured',
+            id: captureRequest.id,
+            state: { version: 1, hash: '', htmlAttrs: {}, bodyAttrs: {}, entries: [] },
+          },
+          source: frame.contentWindow,
+        }));
+      });
+    }
+    await waitFor(() => {
+      expect(screen.getByTestId('manual-edit-mode-toggle').getAttribute('aria-pressed')).toBe('true');
+    });
+    installBridge();
+
+    async function settle() {
+      await act(async () => { await new Promise((resolve) => { setTimeout(resolve, 80); }); });
+      view.rerender(
+        <FileViewer projectId={PROJECT_ID} projectKind="prototype" file={currentFile} />,
+      );
+      await act(async () => { await new Promise((resolve) => { setTimeout(resolve, 80); }); });
+      installBridge();
+    }
+
+    function selectTarget(target: ManualEditTarget) {
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          data: { type: 'od-edit-select', target },
+          source: liveFrame().contentWindow,
+        }));
+      });
+      return waitFor(() => {
+        expect(document.querySelector('.manual-edit-right')).not.toBeNull();
+      });
+    }
+
+    /** The user scrolls the preview; the document reports where it is. */
+    function reportScroll(top: number) {
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          data: {
+            type: 'od:preview-scroll',
+            frameLeft: 0,
+            frameTop: top,
+            canvasLeft: 0,
+            canvasTop: top,
+          },
+          source: liveFrame().contentWindow,
+        }));
+      });
+    }
+
+    /** Save new panel text — the ordinary way to reach a non-style save. */
+    async function saveTextThroughPanel(value: string) {
+      const textarea = document.querySelector('.manual-edit-right textarea') as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value } });
+      fireEvent.click(screen.getByText('Save'));
+      await waitFor(() => {
+        expect(writes.some((written) => written.includes(value))).toBe(true);
+      });
+      await settle();
+    }
+
+    /**
+     * Drag an element, then Save. Dragging routes through the same pending-style
+     * pipeline the inspector uses, so this is a `set-style` save on the ordinary
+     * path.
+     */
+    async function saveStyleThroughDrag(transform: string) {
+      const before = writes.length;
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          data: {
+            type: 'od-edit-drag-commit',
+            id: 'hero',
+            transform,
+            display: 'block',
+          },
+          source: liveFrame().contentWindow,
+        }));
+      });
+      await act(async () => { await new Promise((resolve) => { setTimeout(resolve, 20); }); });
+      fireEvent.click(screen.getByText('Save'));
+      await waitFor(() => {
+        expect(writes.length).toBeGreaterThan(before);
+      });
+      await settle();
+    }
+
+    async function undo() {
+      const before = writes.length;
+      fireEvent.click(screen.getByLabelText('Undo'));
+      await waitFor(() => {
+        expect(writes.length).toBeGreaterThan(before);
+      });
+      await settle();
+    }
+
+    function capturedScrollBeforeWrite(): boolean {
+      const capture = posted.findIndex((m) => m.type === 'od:preview-scroll-capture');
+      const write = posted.findIndex((m) => m.type === '__write__');
+      return capture !== -1 && write !== -1 && capture < write;
+    }
+
+    function forgetPostedMessages() {
+      posted.length = 0;
+    }
+
+    return {
+      capturedScrollBeforeWrite,
+      forgetPostedMessages,
+      reportScroll,
+      saveStyleThroughDrag,
+      saveTextThroughPanel,
+      selectTarget,
+      undo,
+      writes,
+    };
+  }
+
+  /**
+   * The defect. The session has already diverged, so the identity freeze is
+   * lifted and this style save WILL replace the document — and the scroll
+   * position is never snapshotted, so the replacement comes back at the top.
+   */
+  it('captures the scroll before a style save that will replace the document', async () => {
+    const view = await openManualEdit(false);
+    await view.selectTarget(textTarget());
+
+    // One save the document cannot mirror lifts the freeze for the session.
+    await view.saveTextThroughPanel('Hero EDIT1');
+    // Prove the probe can see a capture at all before relying on its absence:
+    // a content save on this same harness does snapshot the scroll.
+    expect(view.capturedScrollBeforeWrite()).toBe(true);
+
+    // A successful panel save closes the inspector; the user picks the element
+    // again to keep editing it.
+    await view.selectTarget(textTarget());
+    view.reportScroll(640);
+    view.forgetPostedMessages();
+    await view.saveStyleThroughDrag('translate(12px, 8px)');
+
+    expect(view.capturedScrollBeforeWrite()).toBe(true);
+  }, 30_000);
+
+  /**
+   * The other direction, and the reason this cannot be fixed by capturing
+   * unconditionally: while the freeze holds, the style really does stream into
+   * the document already on screen and nothing is replaced. Paying for a
+   * capture round trip there would put 120ms on the wire in front of every
+   * style save for nothing.
+   *
+   * Together with the case above this is what makes the dependency explicit —
+   * the same `set-style` patch answers differently in the two states, so the
+   * decision is demonstrably about replacement and not about the patch kind.
+   */
+  it('does not capture the scroll for a style save that keeps the document', async () => {
+    const view = await openManualEdit(true);
+    await view.selectTarget(textTarget());
+
+    view.reportScroll(640);
+    view.forgetPostedMessages();
+    await view.saveStyleThroughDrag('translate(12px, 8px)');
+
+    expect(view.writes.length).toBeGreaterThan(0);
+    expect(view.capturedScrollBeforeWrite()).toBe(false);
+  }, 30_000);
+
+  /**
+   * The same retired premise, one function over.
+   *
+   * Undo and Redo write the previous source and then snapshot the scroll:
+   *
+   *   // Same srcDoc rebuild as a committed patch — keep the scroll position
+   *   // across the reload (#92).
+   *   await capturePreviewScrollPosition();
+   *
+   * `applyManualEdit` documents at length why that order is wrong — "a
+   * committed content patch can notify the file watcher as soon as the write
+   * lands" — and captures BEFORE writing for exactly that reason. Undo was
+   * written when the freeze made the ordering moot, because during a Manual
+   * Edit session nothing was going to replace the document anyway. Once the
+   * freeze lifts, the watcher can land the replacement between the write and
+   * the snapshot, and the snapshot then measures the fresh document at 0/0 —
+   * recording the top of the page as the place to restore to.
+   */
+  it('captures the scroll before an undo writes', async () => {
+    const view = await openManualEdit(false);
+    await view.selectTarget(textTarget());
+    await view.saveTextThroughPanel('Hero EDIT1');
+    await view.selectTarget(textTarget());
+
+    view.reportScroll(640);
+    view.forgetPostedMessages();
+    await view.undo();
+
+    expect(view.capturedScrollBeforeWrite()).toBe(true);
+  }, 30_000);
+});

--- a/apps/web/tests/runtime/manual-edit-save-retains-document.test.ts
+++ b/apps/web/tests/runtime/manual-edit-save-retains-document.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  manualEditPatchStreamsIntoLiveDocument,
+  manualEditSaveRetainsPreviewDocument,
+} from '../../src/runtime/manual-edit-document-latch';
+
+/**
+ * These two decide whether the pre-write scroll snapshot is taken, and the
+ * point of splitting them out is that the decision stopped being a property of
+ * the patch kind. The table below is the whole claim: `set-style` — the one
+ * kind the old code skipped unconditionally — answers differently depending on
+ * whether the session still has a freeze to offer.
+ *
+ * The asymmetry is deliberate and worth stating. A snapshot taken when it was
+ * not needed costs one round trip of up to 120ms in front of the write. A
+ * snapshot skipped when it was needed loses the user's scroll position with
+ * nothing to recover it from. Retention is therefore claimed only where it is
+ * certain.
+ */
+describe('manualEditPatchStreamsIntoLiveDocument', () => {
+  it('is true only for the kind applied to the live DOM without a rebuild', () => {
+    expect(manualEditPatchStreamsIntoLiveDocument('set-style')).toBe(true);
+    for (const kind of [
+      'set-text',
+      'set-link',
+      'set-image',
+      'remove-element',
+      'set-outer-html',
+      'set-token',
+      'set-attributes',
+      'set-full-source',
+    ]) {
+      expect(manualEditPatchStreamsIntoLiveDocument(kind)).toBe(false);
+    }
+  });
+});
+
+describe('manualEditSaveRetainsPreviewDocument', () => {
+  it('retains a streaming patch while the session freeze still holds', () => {
+    expect(manualEditSaveRetainsPreviewDocument({
+      liveDocumentDiverged: false,
+      manualEditSessionActive: true,
+      patchStreamsIntoLiveDocument: true,
+    })).toBe(true);
+  });
+
+  it('does not retain the same patch once the session has diverged', () => {
+    // The regression this whole change is about: the freeze is gone, so the
+    // style save replaces the document like any other and the scroll must be
+    // captured first.
+    expect(manualEditSaveRetainsPreviewDocument({
+      liveDocumentDiverged: true,
+      manualEditSessionActive: true,
+      patchStreamsIntoLiveDocument: true,
+    })).toBe(false);
+  });
+
+  it('does not retain a patch that depends on the document coming back', () => {
+    expect(manualEditSaveRetainsPreviewDocument({
+      liveDocumentDiverged: false,
+      manualEditSessionActive: true,
+      patchStreamsIntoLiveDocument: false,
+    })).toBe(false);
+  });
+
+  it('retains nothing outside a Manual Edit session', () => {
+    // Nothing pins the document there at all; the write's watcher echo mints a
+    // new revision and replaces it.
+    expect(manualEditSaveRetainsPreviewDocument({
+      liveDocumentDiverged: false,
+      manualEditSessionActive: false,
+      patchStreamsIntoLiveDocument: true,
+    })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

`applyManualEdit` snapshots the preview's scroll position before it writes, so the document that comes back can be rebuilt where the user left it. It skipped that snapshot for one patch kind:

```
// Style patches stream live through postMessage and never reload.
if (patch.kind !== 'set-style') {
  await capturePreviewScrollPosition();
}
```

**That comment was true when it was written.** Manual Edit used to pin one preview document for the length of a session, so a style save really did stream into the document already on screen and really never reloaded. This is not a comment that was always wrong.

#7828 retired the premise. The identity freeze now lifts for the rest of the session the moment one save cannot be mirrored into the live document (`shouldFreezeManualEditDocumentIdentity` returns `false` once `liveDocumentDiverged` is set) — deliberately, so that unmirrored saves become visible. From that point on **every** revision replaces the preview document, style saves included. The change that retired the premise did not revisit the code resting on it.

The result: scroll down a long page, save something the live document cannot mirror (`set-token`, `set-attributes`, `set-full-source`, or any refused mirror), then nudge a style in the inspector — the preview comes back at the top, with no snapshot to restore from.

Found while walking the ring around a different #7828 fallout (#7844); this is a mechanism read out of the code, not an incident report.

## What users will see

Nudging a style in the Manual Edit inspector no longer jumps the preview back to the top of the document. Same for Undo and Redo. Nothing new appears on screen — the change is that the place you were looking at survives the save.

## Surface area

- [x] **UI** — no new surface; fixes scroll preservation in the Manual Edit preview
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change
- [ ] None

No screenshots: the observable is a `od:preview-scroll-capture` round trip that either precedes the write or does not. The specs assert on that ordering.

## What the fix does

The old code asked "which patch kind is this?". The new code asks the question the snapshot always depended on — **will this save replace the document?** — and lets the patch kind in only through the one property that bears on it:

```ts
manualEditPatchStreamsIntoLiveDocument(kind)      // true only for set-style
manualEditSaveRetainsPreviewDocument({ manualEditSessionActive, liveDocumentDiverged, patchStreamsIntoLiveDocument })
```

| state | `set-style` | everything else |
|---|---|---|
| no Manual Edit session | capture | capture |
| session, freeze holding | **skip** | capture |
| session, already diverged | **capture** ← the fix | capture |

The same `set-style` patch answers differently in the two session states, which is what makes the dependency legible: the next person reads "does the document survive this save", not "is this a style patch".

Retention is claimed only where it is certain, because the two errors are not symmetric — a needless capture costs one round trip of up to 120ms in front of the write, while a missing one loses the user's place with no way to recover it afterwards.

**Undo and Redo carried the same retired premise one function over.** They captured *after* writing:

```
// Same srcDoc rebuild as a committed patch — keep the scroll position
// across the reload (#92).
await capturePreviewScrollPosition();
```

`applyManualEdit` documents at length why that order is wrong ("a committed content patch can notify the file watcher as soon as the write lands") and captures first. Undo was written when the freeze made the ordering moot; with the freeze gone the watcher can land the replacement between the write and the snapshot, and the snapshot then measures the *fresh* document at 0/0 — recording the top of the page as the place to restore to. Both now capture before the write, through the same predicate.

## Bug fix verification

- Test path: `apps/web/tests/components/FileViewer.manual-edit-style-scroll.test.tsx`
- Red at the branch point (`de1eddd`), green on this branch: **yes**

Removing the implementation puts both defect cases back to red while the third stays green:

```
× captures the scroll before a style save that will replace the document
× captures the scroll before an undo writes
✓ does not capture the scroll for a style save that keeps the document
```

That third case is the over-fix guard: it fails if the fix degenerates into capturing unconditionally, which would put a round trip in front of every style save for nothing.

**Two things worth flagging about the specs themselves:**

- Before relying on the *absence* of a capture as a signal, the first case asserts a capture *is* observable on this same harness for a content save. A probe that cannot see the thing it is looking for would have made both defect cases pass vacuously.
- Both cases first went red for the wrong reason — my own driver threw, once because the panel closes after a successful save. Neither was a product signal. Only re-running against unmodified product code separated the two, and the assertion now used ("the capture precedes the write", ordered against a log that records writes too) is the one that survived that.

## Ring walk: who else depends on "this patch will not replace the document"?

I walked every `patch.kind` conditional in `FileViewer.tsx` and every scroll-capture call site.

**Found, and fixed here:** Undo/Redo capturing after the write (above). Same retired premise, different function.

**Checked and cleared:**

- `FileViewer.tsx:1586` (`manualEditHistoryStyleSnapshot`) and `13879-13881` (draft-dirty gating) are `patch.kind` conditionals, but neither encodes anything about document persistence — the first picks style patches for a history snapshot, the second decides whether the inspector draft is dirty.
- The other `patch.kind` branches (`13620-13665`, `13848-13886`) are the mirror dispatch and post-save inspector sync in `syncRetainedManualEditDocument` / `applyManualEdit`. They dispatch *on* the kind rather than assuming anything about replacement.
- Every other `capturePreviewScrollPosition()` call site (mode transitions, reload) already precedes the transition it protects.

**Related but not this PR** — `manualEditHoverTarget` holds geometry from the replaced document and paints the hover affordance at the old element's coordinates. It is the same family (state that assumes the document persists) but not the same premise, and it is already listed as found-not-fixed on #7844.

## Known residual, deliberately not fixed here

The **first** style save of a session that diverges is still uncovered. At capture time the freeze is still nominally holding, so the snapshot is skipped; the divergence is only discovered afterwards, in `syncRetainedManualEditDocument`, when the `set-style` proof fails (its target no longer exists in the persisted bytes, or the live style map disagrees). Closing it means capturing at the moment `liveDocumentDiverged` flips.

I did not add that branch, because I could not drive the state to make it go red without reaching past the product's own surface — and an implementation whose removal leaves every test green is one I should not be shipping. Recording it here with its precise trigger instead.

## Validation

Run in an isolated worktree at `de1eddd`:

- `pnpm guard` — exit 0
- `pnpm --filter @open-design/web typecheck` — exit 0
- `cd apps/web && ./node_modules/.bin/vitest run tests/components/FileViewer tests/runtime tests/edit-mode` — **107 files / 1434 tests passed**
- `cd apps/web && ./node_modules/.bin/vitest run tests/runtime/manual-edit-save-retains-document.test.ts` — 5 passed

## Scope note

This is **not** an attribution. It produces the same symptom as a cluster of scroll-preservation failures observed elsewhere, but that evidence no longer exists and those cases remain undetermined. What this PR claims is narrower and independent: a real mechanism, read out of the code, that loses the user's scroll position, reproducible on demand and now fixed.

Base is `fix/streaming-html-preview-bridge`, not `main`. Not for merge yet.
