### PR TITLE
fix(web): stop editing the element beside the one the user picked

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -13219,6 +13219,42 @@ function HtmlViewer({
     return ok;
   }
 
+  /**
+   * Drop every element identity this Manual Edit session is holding.
+   *
+   * `data-od-source-path` is a positional ordinal, so it identifies an element
+   * only while the document's shape holds still. A save that re-serializes
+   * through the HTML parser can add or remove an element — an implicit `</p>`
+   * before a block child, the `<tbody>` a table never wrote — and every ordinal
+   * after it shifts. The document on screen was mirrored rather than replaced,
+   * so it still answers to the old numbers while the source now answers to new
+   * ones; anything the host kept from before the save addresses the wrong
+   * element from here on.
+   *
+   * Marking the live document diverged is what makes it recoverable: the
+   * identity freeze lifts, the document is replaced, and the ids come back from
+   * the same source the next patch will be applied to. History goes too — its
+   * entries carry pre-save ids, and an undo that silently retargets is worse
+   * than an undo that is not offered.
+   */
+  function forgetManualEditElementIdentities(): void {
+    manualEditLiveDocumentDivergedRef.current = true;
+    manualEditPersistedDocumentRef.current = null;
+    selectedManualEditTargetIdRef.current = null;
+    manualEditSelectionDraftRef.current = null;
+    manualEditLiveStylesRef.current.clear();
+    manualEditPendingStyleRef.current = null;
+    clearManualEditStyleTimer();
+    manualEditTextSessionIdRef.current = null;
+    manualEditTextSessionStartSequenceRef.current = null;
+    setSelectedManualEditTarget(null);
+    setManualEditTargets([]);
+    setManualEditHoverTarget(null);
+    setManualEditPanelPosition(null);
+    setManualEditHistory([]);
+    setManualEditUndone([]);
+  }
+
   function cancelManualEditStyleDraft() {
     const pending = manualEditPendingStyleRef.current;
     if (!pending) return;
@@ -13826,6 +13862,15 @@ function HtmlViewer({
         afterSource: result.source,
         createdAt: Date.now(),
       };
+      // This save moved the ordinals it addresses elements by, so every id this
+      // session is still holding now points at a neighbour: the selection, the
+      // targets broadcast by the document, the live style map, the pending
+      // style, and the ids inside history. Reusing any of them writes to the
+      // wrong element with nothing on screen to suggest it, which is the one
+      // outcome worth losing an undo stack over.
+      if (result.identitiesRenumbered) {
+        forgetManualEditElementIdentities();
+      }
       setSource(result.source);
       sourceRef.current = result.source;
       setInlinedSource(null);

--- a/apps/web/src/edit-mode/source-patches.ts
+++ b/apps/web/src/edit-mode/source-patches.ts
@@ -106,34 +106,118 @@ export interface ManualEditPatchResult {
   ok: boolean;
   source: string;
   error?: string;
+  /**
+   * Whether this save moved the identities of elements it did not edit.
+   *
+   * Manual Edit addresses an element by `data-od-source-path`, a positional
+   * ordinal counted through the source in document order. That is an identity
+   * only while the document's shape holds still, and writing does not hold it
+   * still: the patch is applied by parsing and re-serializing, and an HTML
+   * parser is not a pass-through. It closes a `<p>` before a block child and
+   * leaves the stray `</p>` as an empty one, it materializes the `<tbody>` a
+   * table never wrote, it re-parents what was misplaced. Each of those adds or
+   * removes a discovery tag, and every ordinal after it shifts by one.
+   *
+   * The session cannot tell on its own. The document on screen was mirrored
+   * rather than replaced, so it still carries the ids it was served with, and
+   * the host's selection, history and live style map hold pre-save ids too. The
+   * next patch resolves one of those against the renumbered source and writes
+   * to the neighbouring element — the user picks one heading and another one
+   * changes, with nothing on screen to suggest it.
+   *
+   * So the save reports it, and the caller must treat every id it is holding as
+   * dead. This is the honest boundary: the ordinals cannot be kept stable
+   * without giving up the streaming annotator the daemon serves through, but a
+   * renumbering that is announced can no longer be silently written through.
+   */
+  identitiesRenumbered: boolean;
+}
+
+/**
+ * The tag carried by each source ordinal, in order. Two documents that agree
+ * here address the same elements by the same ids; the first index where they
+ * disagree is where every later id started pointing somewhere else.
+ */
+function sourcePathIdentitySignature(doc: Document): string[] {
+  return Array.from(doc.querySelectorAll(`[${MANUAL_EDIT_SOURCE_PATH_ATTR}]`)).map(
+    (el) => `${el.getAttribute(MANUAL_EDIT_SOURCE_PATH_ATTR)}:${el.tagName.toLowerCase()}`,
+  );
+}
+
+/**
+ * Whether the ids in `saved` still address what they addressed in `before`.
+ *
+ * Compared against the document the patch was applied to rather than against
+ * the raw input, so an element the patch itself removed or replaced is the only
+ * legitimate difference the caller has to reason about.
+ */
+function identitiesRenumberedBySave(before: readonly string[], saved: string): boolean {
+  const reparsed = parseSource(saved);
+  if (!reparsed) return true;
+  const after = sourcePathIdentitySignature(reparsed);
+  if (after.length !== before.length) return true;
+  return after.some((entry, index) => entry !== before[index]);
+}
+
+/** Serialize the patched document and report whether it moved any identity. */
+function finishPatch(
+  doc: Document,
+  originalSource: string,
+  identitiesBefore: readonly string[],
+): ManualEditPatchResult {
+  const saved = serializeSource(doc, originalSource);
+  return {
+    ok: true,
+    source: saved,
+    identitiesRenumbered: identitiesRenumberedBySave(identitiesBefore, saved),
+  };
 }
 
 export function applyManualEditPatch(source: string, patch: ManualEditPatch): ManualEditPatchResult {
-  if (patch.kind === 'set-full-source') return { ok: true, source: patch.source };
+  // A whole-source replacement makes no claim about identities at all: the
+  // document it produces is not the one the ids were counted through.
+  if (patch.kind === 'set-full-source') {
+    return { ok: true, source: patch.source, identitiesRenumbered: true };
+  }
 
   const doc = parseSource(source);
-  if (!doc) return { ok: false, source, error: 'Could not parse source.' };
+  if (!doc) {
+    return { ok: false, source, error: 'Could not parse source.', identitiesRenumbered: false };
+  }
+  const identitiesBefore = sourcePathIdentitySignature(doc);
 
   if (patch.kind === 'set-token') {
     const changed = setCssToken(doc, patch.token, patch.value);
-    return changed
-      ? { ok: true, source: serializeSource(doc, source) }
-      : { ok: false, source, error: `Token not found: ${patch.token}` };
+    if (!changed) {
+      return {
+        ok: false,
+        source,
+        error: `Token not found: ${patch.token}`,
+        identitiesRenumbered: false,
+      };
+    }
+    return finishPatch(doc, source, identitiesBefore);
   }
 
   const el = findEditableElement(doc, patch.id);
   if (!el) {
     const dynamic = applyDynamicBrandKitPatch(doc, patch);
-    return dynamic.ok
-      ? { ok: true, source: serializeSource(doc, source) }
-      : { ok: false, source, error: `Target not found: ${patch.id}` };
+    if (!dynamic.ok) {
+      return {
+        ok: false,
+        source,
+        error: `Target not found: ${patch.id}`,
+        identitiesRenumbered: false,
+      };
+    }
+    return finishPatch(doc, source, identitiesBefore);
   }
 
   if (patch.kind === 'set-text') {
     if (hasElementChildren(el)) {
       const soleText = findSoleMeaningfulTextNode(el);
       if (!soleText) {
-        return { ok: false, source, error: 'This element contains nested markup. Use the HTML tab instead.' };
+        return { ok: false, source, error: 'This element contains nested markup. Use the HTML tab instead.', identitiesRenumbered: false };
       }
       soleText.nodeValue = patch.value;
     } else {
@@ -149,7 +233,7 @@ export function applyManualEditPatch(source: string, patch: ManualEditPatch): Ma
         // outright — see findSoleMeaningfulTextNode for the safety bound.
         const soleText = findSoleMeaningfulTextNode(el);
         if (!soleText) {
-          return { ok: false, source, error: 'This link contains nested markup. Use the HTML tab to change its label.' };
+          return { ok: false, source, error: 'This link contains nested markup. Use the HTML tab to change its label.', identitiesRenumbered: false };
         }
         soleText.nodeValue = patch.text;
       }
@@ -171,19 +255,20 @@ export function applyManualEditPatch(source: string, patch: ManualEditPatch): Ma
         ok: false,
         source,
         error: 'error' in replaced ? replaced.error : 'Could not replace element HTML.',
+        identitiesRenumbered: false,
       };
     }
   } else if (patch.kind === 'remove-element') {
     if (!el.parentElement) {
-      return { ok: false, source, error: 'Cannot remove the root element.' };
+      return { ok: false, source, error: 'Cannot remove the root element.', identitiesRenumbered: false };
     }
     if (el.parentElement === doc.body && isLastRenderableBodyChild(doc, el)) {
-      return { ok: false, source, error: 'Cannot remove the last rendered element in the document.' };
+      return { ok: false, source, error: 'Cannot remove the last rendered element in the document.', identitiesRenumbered: false };
     }
     el.remove();
   }
 
-  return { ok: true, source: serializeSource(doc, source) };
+  return finishPatch(doc, source, identitiesBefore);
 }
 
 export function readManualEditFields(source: string, id: string): ManualEditFields {

--- a/apps/web/tests/components/FileViewer.manual-edit-identity-refresh.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit-identity-refresh.test.tsx
@@ -1,0 +1,315 @@
+// @vitest-environment jsdom
+//
+// Red spec for the document that keeps answering to ids a save has retired.
+//
+// Manual Edit addresses an element by `data-od-source-path`, a positional
+// ordinal counted through the source. Writing re-serializes the document
+// through the HTML parser, which can add or remove an element — an implicit
+// `</p>` before a block child, the `<tbody>` a table never wrote — and every
+// ordinal after that point shifts by one.
+//
+// Whether that becomes a wrong-element edit depends on what happens to the
+// document on screen. If the save is mirrored into it, the document is RETAINED
+// and still carries the ids it was served with, while the source it will be
+// patched against now answers to different ones. The user's next click travels
+// back with a retired id and the host writes to the element beside the one they
+// picked, with nothing on screen to suggest it.
+//
+// So a save that renumbers has to give the document up. That is what these
+// tests pin, in both directions: renumbered means replaced, and unchanged means
+// retained — because replacing on every save would throw away the live
+// document's canvas, timers and scroll for nothing.
+//
+// Provenance: this was found from two `edit-landed-on-clicked-element` failures
+// in a 500-artifact patrol, on `div` and `h3` targets, both with the document's
+// own witnesses reporting continuity preserved and zero navigations — that is,
+// with the document retained, which is the state this defect needs.
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ComponentProps } from 'react';
+import { annotateManualEditSourceOrdinals } from '@open-design/preview-runtime/manual-edit-source';
+import { FileViewer as ProductFileViewer } from '../../src/components/FileViewer';
+import { emptyManualEditStyles, type ManualEditTarget } from '../../src/edit-mode/types';
+import type { ProjectFile } from '../../src/types';
+import {
+  installFileViewerPreviewRuntimeHarness,
+  prepareSettledFileViewerFixture,
+  setSyntheticPreviewFileSource,
+  syntheticPreviewFileSource,
+  uninstallFileViewerPreviewRuntimeHarness,
+  useSyntheticProjectScopedPreviewNavigation,
+} from '../helpers/file-viewer-preview-runtime';
+
+vi.mock('../../src/providers/registry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/providers/registry')>();
+  return {
+    ...actual,
+    fetchProjectFileText(
+      projectId: string,
+      name: string,
+      options?: Parameters<typeof actual.fetchProjectFileText>[2],
+    ) {
+      const source = syntheticPreviewFileSource(projectId, name);
+      return source === undefined
+        ? actual.fetchProjectFileText(projectId, name, options)
+        : Promise.resolve(source);
+    },
+  };
+});
+
+vi.mock('../../src/runtime/use-project-preview-session-navigation', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('../../src/runtime/use-project-preview-session-navigation')
+  >();
+  return {
+    ...actual,
+    useProjectScopedPreviewNavigation: (
+      options: Parameters<typeof actual.useProjectScopedPreviewNavigation>[0],
+    ) => useSyntheticProjectScopedPreviewNavigation(options),
+  };
+});
+
+function FileViewer(props: ComponentProps<typeof ProductFileViewer>) {
+  return <ProductFileViewer {...prepareSettledFileViewerFixture(props)} />;
+}
+
+beforeEach(() => {
+  installFileViewerPreviewRuntimeHarness();
+});
+
+afterEach(() => {
+  uninstallFileViewerPreviewRuntimeHarness();
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+const PROJECT_ID = 'project-1';
+const FILE_NAME = 'preview.html';
+
+/** The parser rewrites this on the way in: `<p>` closes before the `<div>`. */
+const RENUMBERS_ON_SAVE =
+  '<!doctype html><html><body>'
+  + '<p>Intro<div data-od-id="body-copy">Body copy</div></p>'
+  + '<h3>Pricing</h3><h3>Support</h3>'
+  + '</body></html>';
+
+/** Nothing for the parser to rewrite. */
+const STABLE_ON_SAVE =
+  '<!doctype html><html><body>'
+  + '<div data-od-id="body-copy">Body copy</div>'
+  + '<h3>Pricing</h3><h3>Support</h3>'
+  + '</body></html>';
+
+function bodyCopyTarget(): ManualEditTarget {
+  return {
+    id: 'body-copy',
+    kind: 'text',
+    label: 'Body copy',
+    tagName: 'div',
+    className: '',
+    text: 'Body copy',
+    rect: { x: 24, y: 24, width: 160, height: 48 },
+    fields: { text: 'Body copy' },
+    attributes: { 'data-od-id': 'body-copy' },
+    styles: emptyManualEditStyles(),
+    isLayoutContainer: false,
+    outerHtml: '<div data-od-id="body-copy">Body copy</div>',
+  };
+}
+
+function htmlPreviewFile(size = 1024, mtime = 1710000000): ProjectFile {
+  return {
+    name: FILE_NAME,
+    path: FILE_NAME,
+    type: 'file',
+    size,
+    mtime,
+    mime: 'text/html',
+    kind: 'html',
+    artifactManifest: {
+      version: 1,
+      kind: 'html',
+      title: 'Preview',
+      entry: FILE_NAME,
+      renderer: 'html',
+      exports: ['html'],
+    },
+  };
+}
+
+function liveSessionId(): string {
+  const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+  const session = frame.dataset.odSessionId;
+  if (!session) throw new Error('Preview frame has no scoped session');
+  return session;
+}
+
+/** The ordinal each editable element answers to in the served document. */
+function servedIds(html: string): string[] {
+  const doc = new DOMParser().parseFromString(annotateManualEditSourceOrdinals(html), 'text/html');
+  return Array.from(doc.querySelectorAll('[data-od-source-path]')).map(
+    (el) => `${el.getAttribute('data-od-source-path')}:${el.tagName.toLowerCase()}`,
+  );
+}
+
+describe('FileViewer manual edit — a save that retires element ids', () => {
+  async function openManualEdit(pageSource: string) {
+    let currentFile = htmlPreviewFile();
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof Request ? input.url : String(input);
+      if (url.includes(`/api/projects/${PROJECT_ID}/files`) && init?.method === 'POST') {
+        const body = typeof init.body === 'string' ? init.body : '';
+        try {
+          const parsed = JSON.parse(body) as { content?: string };
+          if (typeof parsed.content === 'string') {
+            setSyntheticPreviewFileSource(PROJECT_ID, FILE_NAME, parsed.content);
+            currentFile = htmlPreviewFile(parsed.content.length, currentFile.mtime + 1);
+          }
+        } catch {
+          /* not a file write */
+        }
+        return new Response(JSON.stringify({ file: currentFile }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(pageSource, { status: 200, headers: { 'Content-Type': 'text/html' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const view = render(
+      <FileViewer
+        projectId={PROJECT_ID}
+        projectKind="prototype"
+        file={htmlPreviewFile()}
+        liveHtml={pageSource}
+      />,
+    );
+
+    const frame = await waitFor(() => {
+      const node = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      if (!node.contentWindow) throw new Error('Preview frame not ready');
+      return node;
+    });
+
+    const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage');
+    fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
+    const captureRequest = postMessage.mock.calls
+      .map(([value]) => value)
+      .find((value) => (
+        typeof value === 'object'
+        && value !== null
+        && (value as { type?: unknown }).type === 'od:preview-runtime-state-capture'
+      )) as { id: string } | undefined;
+    if (captureRequest) {
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          data: {
+            type: 'od:preview-runtime-state-captured',
+            id: captureRequest.id,
+            state: { version: 1, hash: '', htmlAttrs: {}, bodyAttrs: {}, entries: [] },
+          },
+          source: frame.contentWindow,
+        }));
+      });
+    }
+    await waitFor(() => {
+      expect(screen.getByTestId('manual-edit-mode-toggle').getAttribute('aria-pressed')).toBe('true');
+    });
+
+    const bridged = new WeakSet<Window>();
+    /** The injected bridge, applying every mirror — so the document is retained
+     *  unless the product itself decides to give it up. */
+    function installBridge() {
+      const win = (screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement).contentWindow;
+      if (!win || bridged.has(win)) return;
+      bridged.add(win);
+      const spy = vi.spyOn(win, 'postMessage');
+      const previous = spy.getMockImplementation();
+      spy.mockImplementation(((message: unknown, ...rest: unknown[]) => {
+        (previous as ((...args: unknown[]) => void) | undefined)?.(message, ...rest);
+        const data = message as { requestId?: unknown; id?: unknown } | null;
+        if (typeof data?.requestId !== 'string') return;
+        window.dispatchEvent(new MessageEvent('message', {
+          data: {
+            type: 'od-edit-preview:applied',
+            requestId: data.requestId,
+            id: data.id ?? '',
+            applied: true,
+          },
+          source: win,
+        }));
+      }) as Window['postMessage']);
+    }
+    installBridge();
+
+    async function settle() {
+      await act(async () => { await new Promise((resolve) => { setTimeout(resolve, 80); }); });
+      view.rerender(
+        <FileViewer projectId={PROJECT_ID} projectKind="prototype" file={currentFile} />,
+      );
+      await act(async () => { await new Promise((resolve) => { setTimeout(resolve, 80); }); });
+      installBridge();
+    }
+
+    async function saveTextThroughPanel(target: ManualEditTarget, value: string) {
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          data: { type: 'od-edit-select', target },
+          source: (screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement).contentWindow,
+        }));
+      });
+      await waitFor(() => {
+        expect(document.querySelector('.manual-edit-right')).not.toBeNull();
+      });
+      const textarea = document.querySelector('.manual-edit-right textarea') as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value } });
+      fireEvent.click(screen.getByText('Save'));
+      await waitFor(() => {
+        expect(syntheticPreviewFileSource(PROJECT_ID, FILE_NAME) ?? '').toContain(value);
+      });
+      await settle();
+    }
+
+    return { saveTextThroughPanel };
+  }
+
+  /**
+   * The defect. The save renumbers, the mirror lands, the document is kept —
+   * and it keeps answering to ids that no longer mean what they meant.
+   */
+  it('replaces the document when the save retired its element ids', async () => {
+    // The premise, checked rather than assumed: this document really does
+    // renumber, so the test is not passing on a document that never moved.
+    const beforeIds = servedIds(RENUMBERS_ON_SAVE);
+    const { saveTextThroughPanel } = await openManualEdit(RENUMBERS_ON_SAVE);
+    const before = liveSessionId();
+
+    await saveTextThroughPanel(bodyCopyTarget(), 'Body copy rewritten');
+
+    const persisted = syntheticPreviewFileSource(PROJECT_ID, FILE_NAME) ?? '';
+    expect(servedIds(persisted)).not.toEqual(beforeIds);
+    expect(liveSessionId()).not.toBe(before);
+  }, 30_000);
+
+  /**
+   * The other direction, and the reason this cannot be fixed by replacing on
+   * every save: a document whose ids survived keeps its browsing context, with
+   * the canvas, timers and scroll the retained runtime exists to preserve.
+   */
+  it('keeps the document when the save left its element ids alone', async () => {
+    const beforeIds = servedIds(STABLE_ON_SAVE);
+    const { saveTextThroughPanel } = await openManualEdit(STABLE_ON_SAVE);
+    const before = liveSessionId();
+
+    await saveTextThroughPanel(bodyCopyTarget(), 'Body copy rewritten');
+
+    const persisted = syntheticPreviewFileSource(PROJECT_ID, FILE_NAME) ?? '';
+    expect(servedIds(persisted)).toEqual(beforeIds);
+    expect(liveSessionId()).toBe(before);
+  }, 30_000);
+});

--- a/apps/web/tests/edit-mode/source-patch-identity.test.ts
+++ b/apps/web/tests/edit-mode/source-patch-identity.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+//
+// Red spec for an edit that lands on a different element than the user picked.
+//
+// Manual Edit identifies an element by `data-od-source-path`, a POSITIONAL
+// ordinal — `source-0`, `source-1`, … — assigned by walking the source in order
+// and counting discovery tags (`ManualEditSourceAnnotator`). The daemon stamps
+// those onto the HTML it serves, the runtime reads one back as the patch id
+// (`stableId`), and the host resolves it against the source it is about to
+// patch (`findEditableElement`).
+//
+// The numbering is only an identity while the document's shape holds still.
+// `applyManualEditPatch` writes by parsing the source and re-serializing it,
+// and an HTML parser is not a pass-through: it closes a `<p>` before a block
+// child and leaves the stray `</p>` behind as an empty one, it materializes the
+// `<tbody>` a table never wrote, it re-parents what was misplaced. Every one of
+// those adds or removes a discovery tag, and every ordinal after the change
+// point shifts by one.
+//
+// Nothing tells the rest of the session. The document on screen was mirrored
+// rather than replaced, so it still carries the ids it was served with; the
+// host's selection, its history entries and its live style map all still hold
+// pre-save ids. The next patch resolves one of those against the renumbered
+// source and quietly writes to the neighbouring element. The user clicked one
+// heading and a different heading changed.
+//
+// The shapes below are ordinary authored HTML, not adversarial: a `<p>` around
+// a block element and a `<table>` written without `<tbody>` are two of the most
+// common things a generator emits.
+
+import { describe, expect, it } from 'vitest';
+import { annotateManualEditSourceOrdinals } from '@open-design/preview-runtime/manual-edit-source';
+import { applyManualEditPatch } from '../../src/edit-mode/source-patches';
+
+/**
+ * The editable elements of the document as the user's browser receives it:
+ * annotated the way the daemon annotates it, then parsed the way a browser
+ * parses it. This is where the ids the host later patches by come from.
+ */
+function servedElements(html: string): { id: string; tag: string; text: string }[] {
+  const doc = new DOMParser().parseFromString(annotateManualEditSourceOrdinals(html), 'text/html');
+  return Array.from(doc.querySelectorAll('[data-od-source-path]')).map((el) => ({
+    id: el.getAttribute('data-od-source-path')!,
+    tag: el.tagName.toLowerCase(),
+    text: (el.textContent ?? '').replace(/\s+/gu, ' ').trim(),
+  }));
+}
+
+function idOfText(html: string, text: string): string {
+  const match = servedElements(html).find((element) => element.text === text);
+  if (!match) throw new Error(`no served element carries ${JSON.stringify(text)}`);
+  return match.id;
+}
+
+function textOfId(html: string, id: string): string | undefined {
+  return servedElements(html).find((element) => element.id === id)?.text;
+}
+
+/** Authored HTML the browser's parser rewrites on the way in. */
+const P_AROUND_BLOCK =
+  '<!doctype html><html><body>'
+  + '<p>Intro<div>Body copy</div></p>'
+  + '<h3>Pricing</h3>'
+  + '<h3>Support</h3>'
+  + '</body></html>';
+
+const TABLE_WITHOUT_TBODY =
+  '<!doctype html><html><body>'
+  + '<div>Body copy</div>'
+  + '<table><tr><td>Starter</td></tr></table>'
+  + '<h3>Pricing</h3>'
+  + '<h3>Support</h3>'
+  + '</body></html>';
+
+/** Nothing for the parser to rewrite — the control. */
+const ALREADY_NORMALIZED =
+  '<!doctype html><html><body>'
+  + '<div>Body copy</div>'
+  + '<h3>Pricing</h3>'
+  + '<h3>Support</h3>'
+  + '</body></html>';
+
+describe('Manual Edit element identity across a save', () => {
+  /**
+   * The ordinals really do move, on ordinary authored HTML. This is the fact
+   * everything else rests on, so it is pinned directly rather than inferred.
+   */
+  it.each([
+    ['a paragraph wrapped around a block element', P_AROUND_BLOCK],
+    ['a table written without a tbody', TABLE_WITHOUT_TBODY],
+  ])('reports a save that renumbered the document: %s', (_label, source) => {
+    const saved = applyManualEditPatch(source, {
+      id: idOfText(source, 'Body copy'),
+      kind: 'set-text',
+      value: 'Body copy rewritten',
+    });
+
+    expect(saved.ok).toBe(true);
+    expect(saved.identitiesRenumbered).toBe(true);
+  });
+
+  /**
+   * And the flag has to be earned, or a caller that trusts it learns nothing:
+   * a document the parser has nothing to rewrite keeps every id it had.
+   */
+  it('reports no renumbering when the document was already normalized', () => {
+    const before = servedElements(ALREADY_NORMALIZED);
+    const editedId = idOfText(ALREADY_NORMALIZED, 'Body copy');
+    const saved = applyManualEditPatch(ALREADY_NORMALIZED, {
+      id: editedId,
+      kind: 'set-text',
+      value: 'Body copy rewritten',
+    });
+
+    expect(saved.ok).toBe(true);
+    expect(saved.identitiesRenumbered).toBe(false);
+    for (const element of before) {
+      if (element.id === editedId) continue;
+      expect(textOfId(saved.source, element.id), `${element.tag} ${element.id}`).toBe(element.text);
+    }
+  });
+
+  /**
+   * The contract the host depends on, stated as the thing that must never
+   * happen: a save that says it renumbered nothing must not have renumbered
+   * anything. A false negative here is the silent wrong-element edit.
+   */
+  it.each([
+    ['a paragraph wrapped around a block element', P_AROUND_BLOCK],
+    ['a table written without a tbody', TABLE_WITHOUT_TBODY],
+    ['an already-normalized document', ALREADY_NORMALIZED],
+  ])('never claims stability it does not have: %s', (_label, source) => {
+    const before = servedElements(source);
+    const editedId = idOfText(source, 'Body copy');
+    const saved = applyManualEditPatch(source, {
+      id: editedId,
+      kind: 'set-text',
+      value: 'Body copy rewritten',
+    });
+    expect(saved.ok).toBe(true);
+    if (saved.identitiesRenumbered) return;
+
+    for (const element of before) {
+      if (element.id === editedId) continue;
+      expect(textOfId(saved.source, element.id), `${element.tag} ${element.id}`).toBe(element.text);
+    }
+  });
+});

--- a/apps/web/tests/edit-mode/source-patches.test.ts
+++ b/apps/web/tests/edit-mode/source-patches.test.ts
@@ -193,7 +193,9 @@ describe('manual edit source patches', () => {
     const source = '<!doctype html><html><body><h1 data-od-id="hero-title">Snapshot</h1></body></html>';
     const result = applyManualEditPatch(baseSource, { kind: 'set-full-source', source });
 
-    expect(result).toEqual({ ok: true, source });
+    // A whole-source replacement is not a patch against the numbering the ids
+    // were counted through, so it never claims identity stability.
+    expect(result).toEqual({ ok: true, source, identitiesRenumbered: true });
   });
 
   it('updates CSS tokens in style tags', () => {


### PR DESCRIPTION
## Why

A 500-artifact patrol reported `edit-landed-on-clicked-element` twice, on separate shards, both in the concurrency-2 control arm, both with witnesses fully populated. **Reproduced, root-caused, and it is a real silent wrong-element write.**

Manual Edit addresses an element by `data-od-source-path` — a **positional ordinal** counted through the source in document order by `ManualEditSourceAnnotator`. The daemon stamps it on the HTML it serves, the runtime reads one back as the patch id (`stableId`), and the host resolves it against the source it is about to patch (`findEditableElement`).

That is an identity only while the document's shape holds still, and saving does not hold it still. `applyManualEditPatch` writes by parsing and re-serializing, and an HTML parser is not a pass-through:

```
<p>Intro<div>Body copy</div></p><h3>Pricing</h3><h3>Support</h3>
```

goes in with `p=0 div=1 h3=2 h3=3` and comes back out as `<p>Intro</p><div>…</div><p></p><h3>…` — the parser closed the `<p>` before the block child and left the stray `</p>` behind as an empty one. Now `h3 "Pricing"` is `source-3` and `h3 "Support"` is `source-4`. A `<table>` written without `<tbody>` does the same thing.

Nothing told the rest of the session. The save was mirrored into the document rather than replacing it, so **the document kept answering to the ids it was served with while the source answered to new ones.** The host's selection, broadcast targets, live style map, pending style and history all still held pre-save ids. The next click travelled back with a retired id and the host wrote to the neighbouring element.

Measured, from the second edit of one session:

```
BEFORE   source-1 div "Body copy"   source-2 h3 "Gamma"   source-3 h3 "Delta"
save 1   source-1 div "EDIT-ONE"    source-2 p ""         source-3 h3 "Gamma"   source-4 h3 "Delta"
save 2   meant "Delta" (source-3) → "Gamma" became EDIT-TWO; "Delta" untouched
```

The user picked Delta and Gamma changed.

## What users will see

Editing two elements in one Manual Edit session no longer writes the second edit to a different element. On documents whose markup the browser rewrites — a `<p>` around a block element, a `<table>` without `<tbody>` — the preview now refreshes after the first save so later clicks address the document that is actually on disk.

## Surface area

- [x] **UI** — no new surface; fixes wrong-element writes in Manual Edit
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [x] **Default behavior change** — a save that renumbers now drops the Manual Edit undo stack and re-renders the preview (see below)
- [ ] None

## What the fix does

`applyManualEditPatch` now reports `identitiesRenumbered`, by comparing the ordinal→tag signature of the document it patched against the same signature re-derived from the bytes it produced. A save that moved identities makes the host call `forgetManualEditElementIdentities()`: drop the selection, the broadcast targets, the live style map, the pending style, the text session and history, and mark the live document diverged so it is replaced and the ids come back from the same source the next patch will be applied to.

The ordinals cannot be made stable without giving up the streaming annotator the daemon serves through — it never parses, by design, so it cannot know what the parser will do to the markup later. What *can* be fixed is that a renumbering is no longer silent, and a retired id is never written through.

**History is cleared on a renumbering save, and that is a real cost.** Its entries carry pre-save ids, so an undo would retarget exactly the way the second edit did. An undo that is not offered is better than one that silently rewrites the wrong element. The user sees their undo stack disappear with no explanation, which is worth knowing about before this ships.

**Clearing is not the only option, and the next person should not assume it is.** The old→new ordinal correspondence is already available at the moment it is needed: `identitiesRenumberedBySave` compares the before and after signatures, and the first index where they diverge plus the length delta is exactly the remapping. History entries could be re-keyed through it instead of discarded, and so could the selection. Deliberately not done here — remapping is only sound if the signature diff is unambiguous, and establishing that wants its own red spec rather than being bolted onto this one.

## Reproduction and verification

- Pure: `apps/web/tests/edit-mode/source-patch-identity.test.ts`
- Host: `apps/web/tests/components/FileViewer.manual-edit-identity-refresh.test.tsx`

Red at the branch point, green on this branch. Neutralizing the detection puts **5 cases** back to red while the three "already normalized / ids survived" controls stay green:

```
× reports a save that renumbered the document: a paragraph wrapped around a block element
× reports a save that renumbered the document: a table written without a tbody
× never claims stability it does not have: (both shapes)
× replaces the document when the save retired its element ids
✓ reports no renumbering when the document was already normalized
✓ keeps the document when the save left its element ids alone
```

Those controls are the over-fix guard: replacing the document on *every* save would throw away the live document's canvas, timers and scroll for nothing, and the pure control fails if `identitiesRenumbered` degenerates into a constant.

`tests/edit-mode/source-patches.test.ts` needed one update: `replaces full source for snapshot-based undo history` asserts the whole result object. It now asserts the new field too rather than being loosened — `set-full-source` reports `identitiesRenumbered: true`, because a whole-source replacement is not a patch against the numbering the ids were counted through.

## On the patrol's two cases specifically

Worth separating, because the invariant's name is stronger than what it observed. The probe records a pre-save `data-od-source-path`, drives one edit, and re-reads text at that path. For a **single** edit the write lands correctly — what the probe detected is that the path stopped pointing at the same element, i.e. the identity moved underneath it. That is a true positive about identity instability and it is what led here.

The user-visible loss is one step further on: the **second** action of the session — another edit, or an undo — resolves a retired id and writes to the neighbouring element. That part is reproduced directly above, with no instrument involved.

Both patrol cases reported `continuity: preserved` and zero navigations, i.e. the document was retained. That is precisely the state this defect needs, and it is also what ruled out the first hypothesis I was pointed at (staleness across a document *replacement*): there was no replacement.

## Ring walk: who else holds an id across a save?

Everything inside the Manual Edit session is handled by `forgetManualEditElementIdentities`. Two surfaces outside it hold the same kind of id and are **not** fixed here — each needs its own red spec and its own persistence story:

- **Inspect overrides.** `<style data-od-inspect-overrides>` is persisted *in the artifact source*, keyed by element id. A Manual Edit save that renumbers leaves those rules pointing at different elements, so persisted styling silently moves to a neighbour. Inspect is force-closed when Manual Edit opens, which limits the window but does not close it — the block outlives the session.
- ~~**Comments.** `comment.elementId` anchors comments to element ids server-side. A renumbering save re-anchors existing comments to different elements.~~ **This was wrong — corrected in #7853.** Driven through the real product, a renumbering save does *not* move comment anchors and cannot: comments anchor either to `data-od-id` (an attribute, immune to renumbering) or to a structural path over the *parsed DOM*, and the parsed DOM is unchanged by re-serialization. I asserted that mechanism from reading rather than running it.

  The conclusion happened to be right for a different and much broader reason, which #7853 fixes: the anchor is resolved with a bare `querySelector` and no check that the element is the one the comment was left on, so **any** edit that inserts a same-tag sibling ahead of it — an ordinary agent turn — hands the comment to its neighbour.

## Validation

Run in an isolated worktree at `de1eddd`:

- `pnpm guard` — exit 0
- `pnpm --filter @open-design/web typecheck` — exit 0
- `cd apps/web && ./node_modules/.bin/vitest run tests/components tests/edit-mode tests/runtime` — **490 files / 5304 passed**, 1 expected fail, 11 skipped

Base is `fix/streaming-html-preview-bridge`, not `main`. Not for merge yet.


