### PR TITLE
fix(preview): stop handing a comment to the element beside it

### DIFF
--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -816,6 +816,9 @@ const URL_PREVIEW_SELECTION_BRIDGE = `<script data-od-url-selection-bridge>
   var postTargetsTimer = null;
   var activeCommentElementId = null;
   var activeCommentSelector = null;
+  // What the stored comment says about the element it was left on. Without it a
+  // positional anchor is believed on sight; see commentTargetMatchesWitness.
+  var activeCommentWitness = null;
   var activeTargetPending = false;
   function postReady(){
     window.parent.postMessage({ type: 'od:url-selection-bridge-ready', href: window.location.href }, '*');
@@ -1023,10 +1026,32 @@ const URL_PREVIEW_SELECTION_BRIDGE = `<script data-od-url-selection-bridge>
       });
     }, 120);
   }
-  function findCommentTargetByIdentity(elementId, selector){
+  // A comment stores where it was left, and for an element the author gave no
+  // id to that is a bare structural path -- 'body > p:nth-of-type(4)'. That
+  // path names a POSITION, not an element, so anything added ahead of the
+  // commented one hands the comment to its neighbour: an agent turn that
+  // inserts a paragraph is enough. The anchor lives on the server, so the move
+  // outlives the session that caused it, and on a shared project the person who
+  // wrote the comment is not there to see it happen.
+  //
+  // So a positional match has to be corroborated before it is believed. The
+  // witness is what the comment already carries about the element it was left
+  // on; when it disagrees, the honest answer is that the anchor is lost, not
+  // that some other element will do. An attribute match needs no witness --
+  // 'data-od-id' names an element rather than a place.
+  function commentTargetMatchesWitness(el, witness){
+    if (!el || !witness) return true;
+    var expectedLabel = witness.label ? String(witness.label).split('.')[0].toLowerCase() : '';
+    if (expectedLabel && el.tagName && el.tagName.toLowerCase() !== expectedLabel) return false;
+    if (typeof witness.text !== 'string' || !witness.text) return true;
+    var actual = (el.textContent || '').replace(/\\s+/g, ' ').trim().slice(0, 160);
+    return actual === witness.text;
+  }
+  function findCommentTargetByIdentity(elementId, selector, witness){
     var el = null;
     if (selector) {
       try { el = document.querySelector(String(selector)); } catch (_) { el = null; }
+      if (el && !commentTargetMatchesWitness(el, witness)) el = null;
     }
     if (!el && elementId) {
       try {
@@ -1038,7 +1063,7 @@ const URL_PREVIEW_SELECTION_BRIDGE = `<script data-od-url-selection-bridge>
   }
   function postActiveCommentTarget(){
     if (!active() || !activeCommentElementId) return;
-    var el = findCommentTargetByIdentity(activeCommentElementId, activeCommentSelector);
+    var el = findCommentTargetByIdentity(activeCommentElementId, activeCommentSelector, activeCommentWitness);
     if (!el) return;
     var payload = targetFrom(el, commentEnabled && mode === 'picker');
     if (payload) window.parent.postMessage(Object.assign({}, payload, { type: 'od:comment-active-target-update' }), '*');
@@ -1310,6 +1335,7 @@ const URL_PREVIEW_SELECTION_BRIDGE = `<script data-od-url-selection-bridge>
         hoveredId = null;
         activeCommentElementId = null;
         activeCommentSelector = null;
+        activeCommentWitness = null;
       }
       if (!commentEnabled || mode !== 'pod') {
         drawing = false;
@@ -1321,6 +1347,9 @@ const URL_PREVIEW_SELECTION_BRIDGE = `<script data-od-url-selection-bridge>
     if (data.type === 'od:comment-active-target') {
       activeCommentElementId = data.elementId ? String(data.elementId) : null;
       activeCommentSelector = data.selector ? String(data.selector) : null;
+      activeCommentWitness = (data.text || data.label)
+        ? { text: data.text ? String(data.text) : '', label: data.label ? String(data.label) : '' }
+        : null;
       schedulePostActiveCommentTarget();
     }
   });

--- a/apps/daemon/tests/comment-anchor-across-save.test.ts
+++ b/apps/daemon/tests/comment-anchor-across-save.test.ts
@@ -32,23 +32,51 @@
 // than reimplemented here.
 
 import http from 'node:http';
+import { createRequire } from 'node:module';
 import { randomUUID } from 'node:crypto';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { startServer } from '../src/server.js';
 
 /**
+ * `apps/daemon` compiles with `lib: ["ES2022"]` and no DOM, on purpose: a
+ * backend package should not get `Document`, `Element` and `DOMParser` as
+ * ambient globals. This spec still needs to parse HTML, so it reaches for jsdom
+ * explicitly the way `mcp-brief-app.test.ts` already does in this package, and
+ * names only the members it actually touches rather than widening the whole
+ * package's type surface.
+ *
+ * The `@vitest-environment jsdom` pragma above stays: the bridge functions are
+ * lifted out of the served HTML and evaluated here, so they still expect the
+ * ambient browser globals a real page would give them at runtime.
+ */
+const require = createRequire(import.meta.url);
+const { JSDOM } = require('jsdom') as {
+  JSDOM: new (html: string) => { window: { document: DomDocument } };
+};
+
+type DomElement = {
+  tagName: string;
+  textContent: string | null;
+};
+
+type DomDocument = {
+  documentElement: { outerHTML: string };
+  querySelectorAll(selector: string): ArrayLike<DomElement>;
+};
+
+/**
  * `domSelectorFor` and `findCommentTargetByIdentity`, lifted verbatim out of
  * the bridge in the HTML the daemon served. Reimplementing them here would only
  * prove that a copy agrees with itself.
  */
-function bridgeAnchoring(servedHtml: string, doc: Document): {
-  domSelectorFor: (el: Element) => string | null;
+function bridgeAnchoring(servedHtml: string, doc: DomDocument): {
+  domSelectorFor: (el: DomElement) => string | null;
   findCommentTargetByIdentity: (
     elementId: string,
     selector: string,
     witness?: { text?: string; label?: string },
-  ) => Element | null;
+  ) => DomElement | null;
 } {
   const grab = (name: string): string => {
     const start = servedHtml.indexOf(`function ${name}(`);
@@ -72,7 +100,7 @@ function bridgeAnchoring(servedHtml: string, doc: Document): {
   )(doc) as ReturnType<typeof bridgeAnchoring>;
 }
 
-function identify(el: Element | null): string | null {
+function identify(el: DomElement | null): string | null {
   if (!el) return null;
   return `${el.tagName.toLowerCase()}:${(el.textContent ?? '').replace(/\s+/gu, ' ').trim()}`;
 }
@@ -165,7 +193,7 @@ describe('preview comment anchors across an ordinary save', () => {
 
   /** What a save writes: the source parsed and re-serialized, as the patch path does. */
   function reserialize(html: string): string {
-    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const doc = new JSDOM(html).window.document;
     return `<!doctype html>\n${doc.documentElement.outerHTML}`;
   }
 
@@ -181,7 +209,7 @@ describe('preview comment anchors across an ordinary save', () => {
     await writeFile(name, AUTHORED);
 
     const before = await servedPreview(name);
-    const beforeDoc = new DOMParser().parseFromString(before, 'text/html');
+    const beforeDoc = new JSDOM(before).window.document;
     const anchoring = bridgeAnchoring(before, beforeDoc);
 
     const target = Array.from(beforeDoc.querySelectorAll('p')).find(
@@ -194,7 +222,7 @@ describe('preview comment anchors across an ordinary save', () => {
     await writeFile(name, reserialize(AUTHORED));
 
     const after = await servedPreview(name);
-    const afterDoc = new DOMParser().parseFromString(after, 'text/html');
+    const afterDoc = new JSDOM(after).window.document;
     const resolved = bridgeAnchoring(after, afterDoc).findCommentTargetByIdentity(
       `dom:${selector}`,
       selector!,
@@ -224,7 +252,7 @@ describe('preview comment anchors across an ordinary save', () => {
     await writeFile(name, AUTHORED);
 
     const before = await servedPreview(name);
-    const beforeDoc = new DOMParser().parseFromString(before, 'text/html');
+    const beforeDoc = new JSDOM(before).window.document;
     const anchoring = bridgeAnchoring(before, beforeDoc);
 
     // The user leaves a comment on the last paragraph.
@@ -247,7 +275,7 @@ describe('preview comment anchors across an ordinary save', () => {
     );
 
     const after = await servedPreview(name);
-    const afterDoc = new DOMParser().parseFromString(after, 'text/html');
+    const afterDoc = new JSDOM(after).window.document;
     // Resolve through the product's own resolver, handing it the witness the
     // comment already stores.
     const resolved = bridgeAnchoring(after, afterDoc).findCommentTargetByIdentity(

--- a/apps/daemon/tests/comment-anchor-across-save.test.ts
+++ b/apps/daemon/tests/comment-anchor-across-save.test.ts
@@ -1,0 +1,266 @@
+// @vitest-environment jsdom
+//
+// Red spec for a comment that ends up on a different element than the one it
+// was left on.
+//
+// A preview comment stores where it was left. `targetFrom` in the selection
+// bridge takes `data-od-id` (or `data-screen-label`) when the author provided
+// one, and otherwise falls back to `domSelectorFor` — a purely structural path,
+// `body > div:nth-of-type(1) > p:nth-of-type(2)`. Most generated artifacts
+// carry no `data-od-id`, so most comments are anchored structurally.
+//
+// `findCommentTargetByIdentity` resolves that anchor with a bare
+// `document.querySelector(selector)`. There is no check that what came back is
+// the element the comment was left on — not its tag, not its text, nothing. Any
+// element the selector happens to match is accepted.
+//
+// Saving is what moves them. Manual Edit writes by parsing and re-serializing,
+// and the HTML parser is not a pass-through: it closes a `<p>` before a block
+// child and leaves the stray `</p>` behind as an empty paragraph. That empty
+// paragraph is a new `p` sibling, so every later `p:nth-of-type(n)` in that
+// parent now names the paragraph before it. A comment left on the third
+// paragraph silently becomes a comment on the second.
+//
+// This one outlives the session that caused it. The anchor is stored on the
+// server, so closing the tab and coming back tomorrow shows the same comment on
+// the same wrong element, and on a shared project the person who wrote it is
+// not there to notice.
+//
+// Everything here is driven through the real product: a real daemon, a real
+// project, a real file write, the real preview transport, and the anchoring
+// functions taken out of the bridge source the daemon actually served rather
+// than reimplemented here.
+
+import http from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+/**
+ * `domSelectorFor` and `findCommentTargetByIdentity`, lifted verbatim out of
+ * the bridge in the HTML the daemon served. Reimplementing them here would only
+ * prove that a copy agrees with itself.
+ */
+function bridgeAnchoring(servedHtml: string, doc: Document): {
+  domSelectorFor: (el: Element) => string | null;
+  findCommentTargetByIdentity: (
+    elementId: string,
+    selector: string,
+    witness?: { text?: string; label?: string },
+  ) => Element | null;
+} {
+  const grab = (name: string): string => {
+    const start = servedHtml.indexOf(`function ${name}(`);
+    if (start < 0) throw new Error(`bridge does not define ${name}`);
+    let depth = 0;
+    for (let i = servedHtml.indexOf('{', start); i < servedHtml.length; i += 1) {
+      if (servedHtml[i] === '{') depth += 1;
+      else if (servedHtml[i] === '}') {
+        depth -= 1;
+        if (depth === 0) return servedHtml.slice(start, i + 1);
+      }
+    }
+    throw new Error(`unterminated ${name}`);
+  };
+  // eslint-disable-next-line no-new-func
+  return new Function(
+    'document',
+    `${grab('domSelectorFor')}\n${grab('commentTargetMatchesWitness')}\n`
+      + `${grab('findCommentTargetByIdentity')}\n`
+      + 'return { domSelectorFor: domSelectorFor, findCommentTargetByIdentity: findCommentTargetByIdentity };',
+  )(doc) as ReturnType<typeof bridgeAnchoring>;
+}
+
+function identify(el: Element | null): string | null {
+  if (!el) return null;
+  return `${el.tagName.toLowerCase()}:${(el.textContent ?? '').replace(/\s+/gu, ' ').trim()}`;
+}
+
+/**
+ * Authored HTML with a paragraph wrapped around a block element — one of the
+ * most common things a generator emits, and something the parser rewrites.
+ */
+const AUTHORED =
+  '<!doctype html><html><body>'
+  + '<p>Intro<div>Body copy</div></p>'
+  + '<p>Second paragraph</p>'
+  + '<p>Third paragraph</p>'
+  + '</body></html>';
+
+describe('preview comment anchors across an ordinary save', () => {
+  let server: http.Server;
+  let baseUrl: string;
+  let projectId: string;
+
+  beforeAll(async () => {
+    const started = (await startServer({ port: 0, returnServer: true })) as {
+      url: string;
+      server: http.Server;
+    };
+    baseUrl = started.url;
+    server = started.server;
+    projectId = `comment-anchor-${randomUUID()}`;
+    const created = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id: projectId, name: 'Comment anchor across save' }),
+    });
+    expect(created.ok).toBe(true);
+  });
+
+  afterAll(async () => {
+    await fetch(`${baseUrl}/api/projects/${projectId}`, { method: 'DELETE' }).catch(() => {});
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  async function writeFile(name: string, content: string): Promise<void> {
+    const written = await fetch(`${baseUrl}/api/projects/${projectId}/files`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name, content }),
+    });
+    expect(written.ok).toBe(true);
+  }
+
+  /**
+   * The document as the browser receives it, through the scoped-origin
+   * transport the viewer actually uses. `fetch` refuses to send a caller
+   * supplied `Host`, and that header is where the transport reads the preview
+   * scope from, so this has to go over `node:http`.
+   */
+  async function servedPreview(name: string): Promise<string> {
+    const urls = await fetch(
+      `${baseUrl}/api/projects/${projectId}/preview-url?file=${encodeURIComponent(name)}`,
+    );
+    expect(urls.ok).toBe(true);
+    const body = (await urls.json()) as {
+      url: string;
+      scopedOrigin?: { normalUrl: string };
+    };
+    expect(body.scopedOrigin?.normalUrl, 'the daemon must offer a scoped origin').toBeTruthy();
+    const scoped = new URL(body.scopedOrigin!.normalUrl);
+    const daemon = new URL(baseUrl);
+    return new Promise<string>((resolve, reject) => {
+      const request = http.request(
+        {
+          host: daemon.hostname,
+          port: daemon.port,
+          // Ask for the comment bridge the way the viewer does with comment
+          // mode on; it is lazy, so a plain fetch does not carry it.
+          path: `${scoped.pathname}?odPreviewBridge=comment`,
+          method: 'GET',
+          headers: { Host: scoped.host },
+        },
+        (response) => {
+          const chunks: Buffer[] = [];
+          response.on('data', (chunk: Buffer) => chunks.push(chunk));
+          response.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+        },
+      );
+      request.on('error', reject);
+      request.end();
+    });
+  }
+
+  /** What a save writes: the source parsed and re-serialized, as the patch path does. */
+  function reserialize(html: string): string {
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    return `<!doctype html>\n${doc.documentElement.outerHTML}`;
+  }
+
+  /**
+   * The control, and the reason the original suspicion was wrong: a Manual Edit
+   * save re-serializes the source, but the DOM a browser builds is unchanged by
+   * that — the parser had already inserted the implicit paragraph the first time
+   * it read the authored bytes. Re-serialization only writes down what the DOM
+   * already was, so a structural anchor is not disturbed by it.
+   */
+  it('keeps a comment where a save only re-serializes the source', async () => {
+    const name = 'reserialized.html';
+    await writeFile(name, AUTHORED);
+
+    const before = await servedPreview(name);
+    const beforeDoc = new DOMParser().parseFromString(before, 'text/html');
+    const anchoring = bridgeAnchoring(before, beforeDoc);
+
+    const target = Array.from(beforeDoc.querySelectorAll('p')).find(
+      (el) => (el.textContent ?? '').trim() === 'Third paragraph',
+    )!;
+    const selector = anchoring.domSelectorFor(target);
+    expect(selector, 'the bridge must be able to anchor this element').toBeTruthy();
+    const commentedOn = identify(target);
+
+    await writeFile(name, reserialize(AUTHORED));
+
+    const after = await servedPreview(name);
+    const afterDoc = new DOMParser().parseFromString(after, 'text/html');
+    const resolved = bridgeAnchoring(after, afterDoc).findCommentTargetByIdentity(
+      `dom:${selector}`,
+      selector!,
+      {
+        text: (target.textContent ?? '').replace(/\s+/gu, ' ').trim().slice(0, 160),
+        label: target.tagName.toLowerCase(),
+      },
+    );
+    expect(identify(resolved), `anchor ${selector}`).toBe(commentedOn);
+  }, 60_000);
+
+  /**
+   * The defect. The anchor is a bare `:nth-of-type` path and
+   * `findCommentTargetByIdentity` resolves it with `document.querySelector` and
+   * no check of any kind — not the tag, not the text. Anything the path happens
+   * to match is accepted as the commented element.
+   *
+   * So any edit that adds a sibling of the same tag ahead of the commented one
+   * hands the comment to its neighbour. This is not an exotic edit: it is what
+   * the agent does on almost every turn, and what a user does by adding a
+   * paragraph. Nothing warns anyone, the anchor is stored on the server, and on
+   * a shared project the person who wrote the comment is not there to see it
+   * move.
+   */
+  it('does not hand a comment to a different element when the file is edited', async () => {
+    const name = 'edited.html';
+    await writeFile(name, AUTHORED);
+
+    const before = await servedPreview(name);
+    const beforeDoc = new DOMParser().parseFromString(before, 'text/html');
+    const anchoring = bridgeAnchoring(before, beforeDoc);
+
+    // The user leaves a comment on the last paragraph.
+    const target = Array.from(beforeDoc.querySelectorAll('p')).find(
+      (el) => (el.textContent ?? '').trim() === 'Third paragraph',
+    )!;
+    const selector = anchoring.domSelectorFor(target);
+    expect(selector, 'the bridge must be able to anchor this element').toBeTruthy();
+    const commentedOn = identify(target);
+    // What the stored comment already carries about where it was left.
+    const witness = {
+      text: (target.textContent ?? '').replace(/\s+/gu, ' ').trim().slice(0, 160),
+      label: target.tagName.toLowerCase(),
+    };
+
+    // The agent adds a paragraph above it, the way an ordinary turn does.
+    await writeFile(
+      name,
+      AUTHORED.replace('<p>Second paragraph</p>', '<p>Inserted by the agent</p><p>Second paragraph</p>'),
+    );
+
+    const after = await servedPreview(name);
+    const afterDoc = new DOMParser().parseFromString(after, 'text/html');
+    // Resolve through the product's own resolver, handing it the witness the
+    // comment already stores.
+    const resolved = bridgeAnchoring(after, afterDoc).findCommentTargetByIdentity(
+      `dom:${selector}`,
+      selector!,
+      witness,
+    );
+
+    // Either the comment still points at the paragraph it was left on, or it
+    // points at nothing and the product can say the anchor was lost. What it
+    // must never do is silently hand it to a different paragraph.
+    if (resolved !== null) {
+      expect(identify(resolved), `anchor ${selector}`).toBe(commentedOn);
+    }
+  }, 60_000);
+});

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -12958,10 +12958,19 @@ function HtmlViewer({
       type: 'od:comment-active-target',
       elementId: activeCommentTarget.elementId,
       selector: activeCommentTarget.selector,
+      // What this comment recorded about the element it was left on. A
+      // structural anchor names a position rather than an element, so the
+      // document has to corroborate the match before the overlay is placed —
+      // otherwise an edit that inserts a sibling hands the comment to its
+      // neighbour without anyone being told.
+      text: activeCommentTarget.text,
+      label: activeCommentTarget.label,
     }, '*');
   }, [
     activeCommentTarget?.elementId,
+    activeCommentTarget?.label,
     activeCommentTarget?.selector,
+    activeCommentTarget?.text,
     activeCommentTarget?.selectionKind,
     boardMode,
     previewRuntimeConvergenceActive,

--- a/packages/preview-runtime/src/srcdoc.ts
+++ b/packages/preview-runtime/src/srcdoc.ts
@@ -2163,6 +2163,9 @@ function meaningfulDomFallbackTarget(el) {
   var postActiveTargetPending = false;
   var activeCommentElementId = null;
   var activeCommentSelector = null;
+  // What the stored comment says about the element it was left on. Without it a
+  // positional anchor is believed on sight; see commentTargetMatchesWitness.
+  var activeCommentWitness = null;
   function previewScrollElement(){
     return document.querySelector('.design-canvas') || document.scrollingElement || document.documentElement;
   }
@@ -2214,10 +2217,32 @@ function meaningfulDomFallbackTarget(el) {
   function requestPreviewScrollRestore(){
     window.parent.postMessage({ type: 'od:preview-scroll-request' }, '*');
   }
-  function findCommentTargetByIdentity(elementId, selector){
+  // A comment stores where it was left, and for an element the author gave no
+  // id to that is a bare structural path -- 'body > p:nth-of-type(4)'. That
+  // path names a POSITION, not an element, so anything added ahead of the
+  // commented one hands the comment to its neighbour: an agent turn that
+  // inserts a paragraph is enough. The anchor lives on the server, so the move
+  // outlives the session that caused it, and on a shared project the person who
+  // wrote the comment is not there to see it happen.
+  //
+  // So a positional match has to be corroborated before it is believed. The
+  // witness is what the comment already carries about the element it was left
+  // on; when it disagrees, the honest answer is that the anchor is lost, not
+  // that some other element will do. An attribute match needs no witness --
+  // 'data-od-id' names an element rather than a place.
+  function commentTargetMatchesWitness(el, witness){
+    if (!el || !witness) return true;
+    var expectedLabel = witness.label ? String(witness.label).split('.')[0].toLowerCase() : '';
+    if (expectedLabel && el.tagName && el.tagName.toLowerCase() !== expectedLabel) return false;
+    if (typeof witness.text !== 'string' || !witness.text) return true;
+    var actual = (el.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 160);
+    return actual === witness.text;
+  }
+  function findCommentTargetByIdentity(elementId, selector, witness){
     var el = null;
     if (selector) {
       try { el = document.querySelector(String(selector)); } catch (_) { el = null; }
+      if (el && !commentTargetMatchesWitness(el, witness)) el = null;
     }
     if (!el && elementId) {
       try {
@@ -2229,7 +2254,7 @@ function meaningfulDomFallbackTarget(el) {
   }
   function postActiveCommentTarget(){
     if (!active() || !activeCommentElementId) return;
-    var el = findCommentTargetByIdentity(activeCommentElementId, activeCommentSelector);
+    var el = findCommentTargetByIdentity(activeCommentElementId, activeCommentSelector, activeCommentWitness);
     if (!el) return;
     var payload = targetFrom(el, commentEnabled && mode === 'picker' && !inspectEnabled);
     if (payload) window.parent.postMessage(Object.assign({}, payload, { type: 'od:comment-active-target-update' }), '*');
@@ -2648,6 +2673,7 @@ function meaningfulDomFallbackTarget(el) {
         hoveredId = null;
         activeCommentElementId = null;
         activeCommentSelector = null;
+        activeCommentWitness = null;
       }
       if (!commentEnabled || mode !== 'pod') {
         drawing = false;
@@ -2667,6 +2693,9 @@ function meaningfulDomFallbackTarget(el) {
     if (data.type === 'od:comment-active-target') {
       activeCommentElementId = data.elementId ? String(data.elementId) : null;
       activeCommentSelector = data.selector ? String(data.selector) : null;
+      activeCommentWitness = (data.text || data.label)
+        ? { text: data.text ? String(data.text) : '', label: data.label ? String(data.label) : '' }
+        : null;
       schedulePostActiveCommentTarget();
       return;
     }


### PR DESCRIPTION
> [!IMPORTANT]
> **This defect is on `main` and ships today — it is not introduced by this branch.** Verified at `origin/main` `9180cfd`: `domSelectorFor` (`:824`), the `dom:` fallback (`:904`), the unverified `findCommentTargetByIdentity` (`:966`) and the witness-less `od:comment-active-target` (`:1261`) are all present and identical.
>
> **#7854 carries this fix against `main`**, where it can be validated and released without waiting for preview convergence. Red on `main`, green with the fix, controls green both ways.
>
> **This PR should be reduced to what is branch-only once #7854 lands**: `packages/preview-runtime/src/srcdoc.ts` is a second copy of the same bridge that does not exist on `main`, and it still needs the same corroboration. The daemon and web halves here are the same change as #7854 and will arrive on this branch through the next merge from `main`.

## Why

Confirmed — but **not by the mechanism I claimed on #7850, and I was wrong there.** Both halves matter, so both are written down.

### What I claimed, and why it was wrong

The ring walk on #7850 said comments are keyed by element id and that a *renumbering save* would re-anchor them. Driven through the real product, that does not happen, and it cannot:

- A comment anchors to `data-od-id` / `data-screen-label` when the author provided one. Those are attributes, immune to the ordinal renumbering #7850 is about.
- Otherwise it anchors to `domSelectorFor` — a structural `body > p:nth-of-type(4)` path over the **parsed DOM**.
- A Manual Edit save re-serializes the source, and the DOM a browser builds is unchanged by that. The parser had already inserted the implicit paragraph the first time it read the authored bytes; re-serializing only writes down what the DOM already was.

The first test in this PR is that control, and it passes on unmodified product code. I asserted a mechanism from reading rather than running, and it did not survive being run.

### What is actually broken

The conclusion was right for a different and much broader reason. `findCommentTargetByIdentity` resolves the stored anchor with a bare `document.querySelector(selector)` and **accepts whatever comes back** — no check of the tag, no check of the text, nothing.

A structural path names a *position*, not an element. So any edit that adds a same-tag sibling ahead of the commented one hands the comment to its neighbour. That is not an exotic edit — it is what an agent turn does on almost every pass, and what a user does by adding a paragraph.

Measured through the real transport, real project, real file writes:

```
comment left on  body > p:nth-of-type(4)  = p "Third paragraph"
agent inserts one paragraph above
same anchor now resolves to               = p "Second paragraph"
```

The trigger is not Manual Edit at all. It is **any** edit to the file, which makes this wider than the surface it was found next to.

## What users will see

A comment stays on the paragraph it was left on after the file is edited. Where the element it was left on is genuinely gone, the comment reports its anchor as lost instead of quietly attaching itself to a neighbouring element.

## Surface area

- [x] **UI** — no new surface; comments stop being reassigned to the wrong element
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [x] **API / contract** — `od:comment-active-target` now carries the anchor's `text`/`label` witness (additive; a message without it keeps the previous behaviour)
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [x] **Default behavior change** — an anchor that cannot be corroborated now resolves to nothing rather than to a wrong element
- [ ] None

## Why it is the resolver's responsibility

Worth stating, because the neighbouring fix (#7850) solved a similar-looking problem in the host and reusing that path here would have been wrong. The comment's anchor is server-side state; the host is not the one that knows the document changed, and neither is the daemon. The only place that can tell is **where the anchor is resolved against a document** — so that is where the check lives. No server state is threaded into the host's session cleanup.

The witness costs nothing extra: `targetFrom` already records the element's tag and text when the comment is created, and the stored comment already carries them. They were simply never consulted on the way back in.

`data-od-id` matches are deliberately left uncorroborated — an attribute names an element rather than a place, so requiring a text match there would break comments on elements whose copy was legitimately edited.

## Reproduction and verification

`apps/daemon/tests/comment-anchor-across-save.test.ts` — a real daemon, a real project, real file writes, and the preview fetched over the real scoped-origin transport (`node:http` with the `Host` header, since `fetch` will not send one).

The anchoring functions are **lifted verbatim out of the bridge source the daemon actually served**, not reimplemented — a copy agreeing with itself would prove nothing.

Two cases, both directions:

```
✓ keeps a comment where a save only re-serializes the source   (control — passes unmodified too)
× does not hand a comment to a different element when the file is edited
```

Neutralizing the corroboration puts the second back to red while the control stays green.

## Validation

Run in an isolated worktree at `de1eddd`:

- `pnpm guard` — exit 0
- `pnpm --filter @open-design/web typecheck` — exit 0
- `pnpm --filter @open-design/daemon build` — exit 0
- `packages/preview-runtime` — 6 passed
- `apps/web` `FileViewer.test.tsx` — 290 passed
- `apps/daemon` full suite — 9985 passed, 7 failed

**On those 7:** the daemon suite has substantial pre-existing timeout flakiness (individual files at 271s, tests failing on 20s and 30s timeouts, a different set each run). Re-running the failing files at the branch point gave **6 failures**; the same subset with this change gave **3**, and the failure sets differ in both directions. The only preview-adjacent one — `binds a scoped preview origin to one project root and blocks daemon APIs` — fails **identically at the branch point**, so it is pre-existing. Nothing in either set is attributable to this change.

## Adjacent, not fixed here

- **Saved comment markers.** This PR corroborates the *active* target path (`od:comment-active-target`). The saved-marker overlay resolves anchors through its own path and wants the same witness; it needs its own red spec.
- **Inspect overrides** (`<style data-od-inspect-overrides>`, persisted in the artifact source, keyed by element id) — the second item from the #7850 ring walk, still unexamined. Given how this one turned out, its stated mechanism should be run before it is believed.

Base is `fix/streaming-html-preview-bridge`, not `main`. Not for merge yet.

