### PR TITLE
fix(preview): stop handing a comment to the element beside it

### DIFF
--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -756,6 +756,9 @@ const URL_PREVIEW_SELECTION_BRIDGE = `<script data-od-url-selection-bridge>
   var postTargetsTimer = null;
   var activeCommentElementId = null;
   var activeCommentSelector = null;
+  // What the stored comment says about the element it was left on. Without it a
+  // positional anchor is believed on sight; see commentTargetMatchesWitness.
+  var activeCommentWitness = null;
   var activeTargetPending = false;
   function postReady(){
     window.parent.postMessage({ type: 'od:url-selection-bridge-ready', href: window.location.href }, '*');
@@ -963,10 +966,32 @@ const URL_PREVIEW_SELECTION_BRIDGE = `<script data-od-url-selection-bridge>
       });
     }, 120);
   }
-  function findCommentTargetByIdentity(elementId, selector){
+  // A comment stores where it was left, and for an element the author gave no
+  // id to that is a bare structural path -- 'body > p:nth-of-type(4)'. That
+  // path names a POSITION, not an element, so anything added ahead of the
+  // commented one hands the comment to its neighbour: an agent turn that
+  // inserts a paragraph is enough. The anchor lives on the server, so the move
+  // outlives the session that caused it, and on a shared project the person who
+  // wrote the comment is not there to see it happen.
+  //
+  // So a positional match has to be corroborated before it is believed. The
+  // witness is what the comment already carries about the element it was left
+  // on; when it disagrees, the honest answer is that the anchor is lost, not
+  // that some other element will do. An attribute match needs no witness --
+  // 'data-od-id' names an element rather than a place.
+  function commentTargetMatchesWitness(el, witness){
+    if (!el || !witness) return true;
+    var expectedLabel = witness.label ? String(witness.label).split('.')[0].toLowerCase() : '';
+    if (expectedLabel && el.tagName && el.tagName.toLowerCase() !== expectedLabel) return false;
+    if (typeof witness.text !== 'string' || !witness.text) return true;
+    var actual = (el.textContent || '').replace(/\\s+/g, ' ').trim().slice(0, 160);
+    return actual === witness.text;
+  }
+  function findCommentTargetByIdentity(elementId, selector, witness){
     var el = null;
     if (selector) {
       try { el = document.querySelector(String(selector)); } catch (_) { el = null; }
+      if (el && !commentTargetMatchesWitness(el, witness)) el = null;
     }
     if (!el && elementId) {
       try {
@@ -978,7 +1003,7 @@ const URL_PREVIEW_SELECTION_BRIDGE = `<script data-od-url-selection-bridge>
   }
   function postActiveCommentTarget(){
     if (!active() || !activeCommentElementId) return;
-    var el = findCommentTargetByIdentity(activeCommentElementId, activeCommentSelector);
+    var el = findCommentTargetByIdentity(activeCommentElementId, activeCommentSelector, activeCommentWitness);
     if (!el) return;
     var payload = targetFrom(el, commentEnabled && mode === 'picker');
     if (payload) window.parent.postMessage(Object.assign({}, payload, { type: 'od:comment-active-target-update' }), '*');
@@ -1250,6 +1275,7 @@ const URL_PREVIEW_SELECTION_BRIDGE = `<script data-od-url-selection-bridge>
         hoveredId = null;
         activeCommentElementId = null;
         activeCommentSelector = null;
+        activeCommentWitness = null;
       }
       if (!commentEnabled || mode !== 'pod') {
         drawing = false;
@@ -1261,6 +1287,9 @@ const URL_PREVIEW_SELECTION_BRIDGE = `<script data-od-url-selection-bridge>
     if (data.type === 'od:comment-active-target') {
       activeCommentElementId = data.elementId ? String(data.elementId) : null;
       activeCommentSelector = data.selector ? String(data.selector) : null;
+      activeCommentWitness = (data.text || data.label)
+        ? { text: data.text ? String(data.text) : '', label: data.label ? String(data.label) : '' }
+        : null;
       schedulePostActiveCommentTarget();
     }
   });

--- a/apps/daemon/tests/comment-anchor-across-save.test.ts
+++ b/apps/daemon/tests/comment-anchor-across-save.test.ts
@@ -1,0 +1,246 @@
+// @vitest-environment jsdom
+//
+// Red spec for a comment that ends up on a different element than the one it
+// was left on.
+//
+// A preview comment stores where it was left. `targetFrom` in the selection
+// bridge takes `data-od-id` (or `data-screen-label`) when the author provided
+// one, and otherwise falls back to `domSelectorFor` — a purely structural path,
+// `body > div:nth-of-type(1) > p:nth-of-type(2)`. Most generated artifacts
+// carry no `data-od-id`, so most comments are anchored structurally.
+//
+// `findCommentTargetByIdentity` resolves that anchor with a bare
+// `document.querySelector(selector)`. There is no check that what came back is
+// the element the comment was left on — not its tag, not its text, nothing. Any
+// element the selector happens to match is accepted.
+//
+// Saving is what moves them. Manual Edit writes by parsing and re-serializing,
+// and the HTML parser is not a pass-through: it closes a `<p>` before a block
+// child and leaves the stray `</p>` behind as an empty paragraph. That empty
+// paragraph is a new `p` sibling, so every later `p:nth-of-type(n)` in that
+// parent now names the paragraph before it. A comment left on the third
+// paragraph silently becomes a comment on the second.
+//
+// This one outlives the session that caused it. The anchor is stored on the
+// server, so closing the tab and coming back tomorrow shows the same comment on
+// the same wrong element, and on a shared project the person who wrote it is
+// not there to notice.
+//
+// Everything here is driven through the real product: a real daemon, a real
+// project, a real file write, the real preview transport, and the anchoring
+// functions taken out of the bridge source the daemon actually served rather
+// than reimplemented here.
+
+import http from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+/**
+ * `domSelectorFor` and `findCommentTargetByIdentity`, lifted verbatim out of
+ * the bridge in the HTML the daemon served. Reimplementing them here would only
+ * prove that a copy agrees with itself.
+ */
+function bridgeAnchoring(servedHtml: string, doc: Document): {
+  domSelectorFor: (el: Element) => string | null;
+  findCommentTargetByIdentity: (
+    elementId: string,
+    selector: string,
+    witness?: { text?: string; label?: string },
+  ) => Element | null;
+} {
+  const grabOptional = (name: string): string | null => {
+    try {
+      return grab(name);
+    } catch {
+      return null;
+    }
+  };
+  const grab = (name: string): string => {
+    const start = servedHtml.indexOf(`function ${name}(`);
+    if (start < 0) throw new Error(`bridge does not define ${name}`);
+    let depth = 0;
+    for (let i = servedHtml.indexOf('{', start); i < servedHtml.length; i += 1) {
+      if (servedHtml[i] === '{') depth += 1;
+      else if (servedHtml[i] === '}') {
+        depth -= 1;
+        if (depth === 0) return servedHtml.slice(start, i + 1);
+      }
+    }
+    throw new Error(`unterminated ${name}`);
+  };
+  // eslint-disable-next-line no-new-func
+  return new Function(
+    'document',
+    // The corroboration helper is the fix; before it exists the resolver must
+    // still be runnable, so its absence produces a clean failing assertion
+    // rather than an extraction error that says nothing about the product.
+    `${grab('domSelectorFor')}\n`
+      + `${grabOptional('commentTargetMatchesWitness') ?? 'function commentTargetMatchesWitness(){ return true; }'}\n`
+      + `${grab('findCommentTargetByIdentity')}\n`
+      + 'return { domSelectorFor: domSelectorFor, findCommentTargetByIdentity: findCommentTargetByIdentity };',
+  )(doc) as ReturnType<typeof bridgeAnchoring>;
+}
+
+function identify(el: Element | null): string | null {
+  if (!el) return null;
+  return `${el.tagName.toLowerCase()}:${(el.textContent ?? '').replace(/\s+/gu, ' ').trim()}`;
+}
+
+/**
+ * Authored HTML with a paragraph wrapped around a block element — one of the
+ * most common things a generator emits, and something the parser rewrites.
+ */
+const AUTHORED =
+  '<!doctype html><html><body>'
+  + '<p>Intro<div>Body copy</div></p>'
+  + '<p>Second paragraph</p>'
+  + '<p>Third paragraph</p>'
+  + '</body></html>';
+
+describe('preview comment anchors across an ordinary save', () => {
+  let server: http.Server;
+  let baseUrl: string;
+  let projectId: string;
+
+  beforeAll(async () => {
+    const started = (await startServer({ port: 0, returnServer: true })) as {
+      url: string;
+      server: http.Server;
+    };
+    baseUrl = started.url;
+    server = started.server;
+    projectId = `comment-anchor-${randomUUID()}`;
+    const created = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id: projectId, name: 'Comment anchor across save' }),
+    });
+    expect(created.ok).toBe(true);
+  });
+
+  afterAll(async () => {
+    await fetch(`${baseUrl}/api/projects/${projectId}`, { method: 'DELETE' }).catch(() => {});
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  async function writeFile(name: string, content: string): Promise<void> {
+    const written = await fetch(`${baseUrl}/api/projects/${projectId}/files`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name, content }),
+    });
+    expect(written.ok).toBe(true);
+  }
+
+  /**
+   * The document as the browser receives it. The viewer loads the preview from
+   * the raw route with its own bridge query (`BASE_PREVIEW_BRIDGE_QUERY` in
+   * FileViewer), and the comment bridge is conditional on exactly that — a
+   * plain fetch does not carry it.
+   */
+  async function servedPreview(name: string): Promise<string> {
+    const response = await fetch(
+      `${baseUrl}/api/projects/${projectId}/raw/${encodeURIComponent(name)}`
+      + '?odPreviewBridge=scroll&odPreviewBridge=selection'
+      + '&odPreviewBridge=snapshot&odPreviewBridge=observability',
+    );
+    expect(response.ok).toBe(true);
+    return response.text();
+  }
+
+  /** What a save writes: the source parsed and re-serialized, as the patch path does. */
+  function reserialize(html: string): string {
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    return `<!doctype html>\n${doc.documentElement.outerHTML}`;
+  }
+
+  it('keeps a comment where a save only re-serializes the source', async () => {
+    const name = 'reserialized.html';
+    await writeFile(name, AUTHORED);
+
+    const before = await servedPreview(name);
+    const beforeDoc = new DOMParser().parseFromString(before, 'text/html');
+    const anchoring = bridgeAnchoring(before, beforeDoc);
+
+    const target = Array.from(beforeDoc.querySelectorAll('p')).find(
+      (el) => (el.textContent ?? '').trim() === 'Third paragraph',
+    )!;
+    const selector = anchoring.domSelectorFor(target);
+    expect(selector, 'the bridge must be able to anchor this element').toBeTruthy();
+    const commentedOn = identify(target);
+
+    await writeFile(name, reserialize(AUTHORED));
+
+    const after = await servedPreview(name);
+    const afterDoc = new DOMParser().parseFromString(after, 'text/html');
+    const resolved = bridgeAnchoring(after, afterDoc).findCommentTargetByIdentity(
+      `dom:${selector}`,
+      selector!,
+      {
+        text: (target.textContent ?? '').replace(/\s+/gu, ' ').trim().slice(0, 160),
+        label: target.tagName.toLowerCase(),
+      },
+    );
+    expect(identify(resolved), `anchor ${selector}`).toBe(commentedOn);
+  }, 60_000);
+
+  /**
+   * The defect. The anchor is a bare `:nth-of-type` path and
+   * `findCommentTargetByIdentity` resolves it with `document.querySelector` and
+   * no check of any kind — not the tag, not the text. Anything the path happens
+   * to match is accepted as the commented element.
+   *
+   * So any edit that adds a sibling of the same tag ahead of the commented one
+   * hands the comment to its neighbour. This is not an exotic edit: it is what
+   * the agent does on almost every turn, and what a user does by adding a
+   * paragraph. Nothing warns anyone, the anchor is stored on the server, and on
+   * a shared project the person who wrote the comment is not there to see it
+   * move.
+   */
+  it('does not hand a comment to a different element when the file is edited', async () => {
+    const name = 'edited.html';
+    await writeFile(name, AUTHORED);
+
+    const before = await servedPreview(name);
+    const beforeDoc = new DOMParser().parseFromString(before, 'text/html');
+    const anchoring = bridgeAnchoring(before, beforeDoc);
+
+    // The user leaves a comment on the last paragraph.
+    const target = Array.from(beforeDoc.querySelectorAll('p')).find(
+      (el) => (el.textContent ?? '').trim() === 'Third paragraph',
+    )!;
+    const selector = anchoring.domSelectorFor(target);
+    expect(selector, 'the bridge must be able to anchor this element').toBeTruthy();
+    const commentedOn = identify(target);
+    // What the stored comment already carries about where it was left.
+    const witness = {
+      text: (target.textContent ?? '').replace(/\s+/gu, ' ').trim().slice(0, 160),
+      label: target.tagName.toLowerCase(),
+    };
+
+    // The agent adds a paragraph above it, the way an ordinary turn does.
+    await writeFile(
+      name,
+      AUTHORED.replace('<p>Second paragraph</p>', '<p>Inserted by the agent</p><p>Second paragraph</p>'),
+    );
+
+    const after = await servedPreview(name);
+    const afterDoc = new DOMParser().parseFromString(after, 'text/html');
+    // Resolve through the product's own resolver, handing it the witness the
+    // comment already stores.
+    const resolved = bridgeAnchoring(after, afterDoc).findCommentTargetByIdentity(
+      `dom:${selector}`,
+      selector!,
+      witness,
+    );
+
+    // Either the comment still points at the paragraph it was left on, or it
+    // points at nothing and the product can say the anchor was lost. What it
+    // must never do is silently hand it to a different paragraph.
+    if (resolved !== null) {
+      expect(identify(resolved), `anchor ${selector}`).toBe(commentedOn);
+    }
+  }, 60_000);
+});

--- a/apps/daemon/tests/comment-anchor-across-save.test.ts
+++ b/apps/daemon/tests/comment-anchor-across-save.test.ts
@@ -32,23 +32,51 @@
 // than reimplemented here.
 
 import http from 'node:http';
+import { createRequire } from 'node:module';
 import { randomUUID } from 'node:crypto';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { startServer } from '../src/server.js';
 
 /**
+ * `apps/daemon` compiles with `lib: ["ES2022"]` and no DOM, on purpose: a
+ * backend package should not get `Document`, `Element` and `DOMParser` as
+ * ambient globals. This spec still needs to parse HTML, so it reaches for jsdom
+ * explicitly the way `mcp-brief-app.test.ts` already does in this package, and
+ * names only the members it actually touches rather than widening the whole
+ * package's type surface.
+ *
+ * The `@vitest-environment jsdom` pragma above stays: the bridge functions are
+ * lifted out of the served HTML and evaluated here, so they still expect the
+ * ambient browser globals a real page would give them at runtime.
+ */
+const require = createRequire(import.meta.url);
+const { JSDOM } = require('jsdom') as {
+  JSDOM: new (html: string) => { window: { document: DomDocument } };
+};
+
+type DomElement = {
+  tagName: string;
+  textContent: string | null;
+};
+
+type DomDocument = {
+  documentElement: { outerHTML: string };
+  querySelectorAll(selector: string): ArrayLike<DomElement>;
+};
+
+/**
  * `domSelectorFor` and `findCommentTargetByIdentity`, lifted verbatim out of
  * the bridge in the HTML the daemon served. Reimplementing them here would only
  * prove that a copy agrees with itself.
  */
-function bridgeAnchoring(servedHtml: string, doc: Document): {
-  domSelectorFor: (el: Element) => string | null;
+function bridgeAnchoring(servedHtml: string, doc: DomDocument): {
+  domSelectorFor: (el: DomElement) => string | null;
   findCommentTargetByIdentity: (
     elementId: string,
     selector: string,
     witness?: { text?: string; label?: string },
-  ) => Element | null;
+  ) => DomElement | null;
 } {
   const grabOptional = (name: string): string | null => {
     try {
@@ -83,7 +111,7 @@ function bridgeAnchoring(servedHtml: string, doc: Document): {
   )(doc) as ReturnType<typeof bridgeAnchoring>;
 }
 
-function identify(el: Element | null): string | null {
+function identify(el: DomElement | null): string | null {
   if (!el) return null;
   return `${el.tagName.toLowerCase()}:${(el.textContent ?? '').replace(/\s+/gu, ' ').trim()}`;
 }
@@ -152,7 +180,7 @@ describe('preview comment anchors across an ordinary save', () => {
 
   /** What a save writes: the source parsed and re-serialized, as the patch path does. */
   function reserialize(html: string): string {
-    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const doc = new JSDOM(html).window.document;
     return `<!doctype html>\n${doc.documentElement.outerHTML}`;
   }
 
@@ -161,7 +189,7 @@ describe('preview comment anchors across an ordinary save', () => {
     await writeFile(name, AUTHORED);
 
     const before = await servedPreview(name);
-    const beforeDoc = new DOMParser().parseFromString(before, 'text/html');
+    const beforeDoc = new JSDOM(before).window.document;
     const anchoring = bridgeAnchoring(before, beforeDoc);
 
     const target = Array.from(beforeDoc.querySelectorAll('p')).find(
@@ -174,7 +202,7 @@ describe('preview comment anchors across an ordinary save', () => {
     await writeFile(name, reserialize(AUTHORED));
 
     const after = await servedPreview(name);
-    const afterDoc = new DOMParser().parseFromString(after, 'text/html');
+    const afterDoc = new JSDOM(after).window.document;
     const resolved = bridgeAnchoring(after, afterDoc).findCommentTargetByIdentity(
       `dom:${selector}`,
       selector!,
@@ -204,7 +232,7 @@ describe('preview comment anchors across an ordinary save', () => {
     await writeFile(name, AUTHORED);
 
     const before = await servedPreview(name);
-    const beforeDoc = new DOMParser().parseFromString(before, 'text/html');
+    const beforeDoc = new JSDOM(before).window.document;
     const anchoring = bridgeAnchoring(before, beforeDoc);
 
     // The user leaves a comment on the last paragraph.
@@ -227,7 +255,7 @@ describe('preview comment anchors across an ordinary save', () => {
     );
 
     const after = await servedPreview(name);
-    const afterDoc = new DOMParser().parseFromString(after, 'text/html');
+    const afterDoc = new JSDOM(after).window.document;
     // Resolve through the product's own resolver, handing it the witness the
     // comment already stores.
     const resolved = bridgeAnchoring(after, afterDoc).findCommentTargetByIdentity(

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -12469,8 +12469,15 @@ function HtmlViewer({
       type: 'od:comment-active-target',
       elementId: activeCommentTarget.elementId,
       selector: activeCommentTarget.selector,
+      // What this comment recorded about the element it was left on. A
+      // structural anchor names a position rather than an element, so the
+      // document has to corroborate the match before the overlay is placed —
+      // otherwise an edit that inserts a sibling hands the comment to its
+      // neighbour without anyone being told.
+      text: activeCommentTarget.text,
+      label: activeCommentTarget.label,
     }, '*');
-  }, [activeCommentTarget?.elementId, activeCommentTarget?.selector, activeCommentTarget?.selectionKind, boardMode, workspaceActive]);
+  }, [activeCommentTarget?.elementId, activeCommentTarget?.label, activeCommentTarget?.selector, activeCommentTarget?.selectionKind, activeCommentTarget?.text, boardMode, workspaceActive]);
 
   useEffect(() => {
     if (!manualEditMode) {


### PR DESCRIPTION
## Why

**This ships today.** It is not introduced by any in-flight branch — the defective code is on `main` right now, and every agent turn that edits a file can trigger it.

A preview comment stores where it was left. For an element the author gave no `data-od-id`, that is a bare structural path — `body > p:nth-of-type(4)` — produced by `domSelectorFor` (`apps/daemon/src/routes/project/index.ts:824`) via the `dom:` fallback (`:904`). `findCommentTargetByIdentity` (`:966`) resolves it with a plain `document.querySelector` and **accepts whatever comes back**. Nothing checks that it is the element the comment was left on: not the tag, not the text.

A path names a *position*, not an element. So any edit that adds a same-tag sibling ahead of the commented one hands the comment to its neighbour. That is not an exotic edit — it is what an agent turn does on almost every pass, and what a user does by adding a paragraph.

Measured through the real preview transport, on a real daemon with a real project and real file writes:

```
comment left on  body > p:nth-of-type(4)  = p "Third paragraph"
an edit inserts one paragraph above
the same anchor now resolves to           = p "Second paragraph"
```

Three things make this worse than an in-session glitch:

1. **It is on disk.** The anchor is server-side, so closing the tab and coming back tomorrow shows the same comment on the same wrong element.
2. **It is a collaboration surface.** On a shared project the comment belongs to someone who is not there and will never learn it moved.
3. **Nothing says anything.** No warning, no "anchor lost" state — the wrong element simply looks like the right one.

Found while walking the ring around a Manual Edit identity bug (#7850) on the preview-convergence branch. It turned out to have nothing to do with Manual Edit or with that branch, so it is filed here against `main` where it belongs rather than sitting under an unmerged branch.

## What users will see

A comment stays on the paragraph it was left on after the file is edited. Where the element it was left on is genuinely gone, the comment reports its anchor as lost instead of quietly attaching itself to a neighbouring element.

## Surface area

- [x] **UI** — no new surface; comments stop being reassigned to the wrong element
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [x] **API / contract** — `od:comment-active-target` now carries the anchor's `text`/`label` witness (additive; a message without it keeps the previous behaviour)
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [x] **Default behavior change** — an anchor that cannot be corroborated now resolves to nothing rather than to a wrong element
- [ ] None

## The fix, and why it belongs in the resolver

The comment already records the tag and the text of the element it was left on — `targetFrom` writes them when the comment is created and the stored comment carries them. They were simply never consulted on the way back in. A positional match is now corroborated against that witness, and an uncorroborated anchor is reported as lost.

Responsibility sits with **whoever resolves an anchor against a document**. Neither the host nor the daemon knows the document changed; the resolver is the only place that can tell, so no state is threaded anywhere else to make this work.

`data-od-id` matches are deliberately left uncorroborated — an attribute names an element rather than a place, so requiring a text match there would break comments on elements whose copy was legitimately edited.

## Reproduction and verification

`apps/daemon/tests/comment-anchor-across-save.test.ts` — a real daemon, a real project, real file writes, and the preview fetched from the raw route with the viewer's own bridge query (`BASE_PREVIEW_BRIDGE_QUERY`).

The anchoring functions are **lifted verbatim out of the bridge source the daemon actually served**, not reimplemented — a copy agreeing with itself would prove nothing. The corroboration helper is extracted optionally, so the pre-fix state produces a clean failing assertion rather than an extraction error that says nothing about the product.

Two cases, both directions:

```
✓ keeps a comment where a save only re-serializes the source   (control — passes before the fix too)
× does not hand a comment to a different element when the file is edited
```

Red on `main` at `9180cfd`, green with this change. Neutralizing the corroboration puts the second back to red while the control stays green.

That control is load-bearing, and it is there because it falsified my first hypothesis: I had assumed a *re-serializing* save moves comment anchors. It does not and cannot — the parsed DOM is unchanged by re-serialization, because the parser had already normalized the markup the first time it read the authored bytes. The conclusion survived; the mechanism I first proposed did not.

## Validation

Run in an isolated worktree at `main` (`9180cfd`):

- `pnpm guard` — exit 0
- `pnpm --filter @open-design/web typecheck` — exit 0
- `pnpm --filter @open-design/daemon build` — exit 0
- `apps/web` `FileViewer.test.tsx` — 315 passed
- `apps/daemon` every comment suite plus `project-file-range` — **180 passed**, 6 files
- `apps/daemon` `comment-anchor-across-save` — 2 passed

## Adjacent, not fixed here

- **Saved comment markers.** This corroborates the *active* target path (`od:comment-active-target`). The saved-marker overlay resolves anchors through its own path and wants the same witness; it needs its own red spec.
- **`data-od-id` is not always available.** The deeper issue is that the fallback anchor is positional at all. Corroboration turns a silent wrong answer into an honest "lost", which is the right first move, but a durable anchor (content hash, or a persisted id) would keep the comment attached instead. That is a design change, not a bug fix.

A sibling PR (#7853) carries the same fix for the second copy of this bridge that exists only on `fix/streaming-html-preview-bridge` (`packages/preview-runtime/src/srcdoc.ts`, a file that does not exist on `main`). If this lands first, that one reduces to just the extra copy.
