### PR TITLE
fix(ci): dispatch prerelease packaged smoke, and stop the card calling it queued

### DIFF
--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -1601,7 +1601,29 @@ jobs:
     needs:
       - metadata
       - publish
-    if: ${{ inputs.enable_smoke && needs.publish.result == 'success' && needs.publish.outputs.version_metadata_url != '' }}
+    # `always() && !cancelled()` is load-bearing, not decoration.
+    #
+    # `build_linux` is skipped on every run (the repository has no
+    # ENABLE_STABLE_LINUX variable), and GitHub applies a skip "to all jobs in
+    # the dependency chain from the point of failure or skip onwards" unless a
+    # job uses a conditional expression that causes it to continue. That break
+    # is per job and is NOT inherited: `publish` carries the same prefix and so
+    # runs, but its own dependents are still downstream of build_linux's skip.
+    # Without a break of its own this job never evaluates the conditions below
+    # at all — GitHub's implicit `success()` skips it first.
+    #
+    # That is how release-prerelease-smoke.yml went 0-for-N. In run
+    # 34149795952 publish succeeded, version_metadata_url was published, and
+    # enable_smoke arrived as true; the job was still skipped with zero steps.
+    # The explicit publish gate below is what actually decides whether smoke is
+    # dispatched, and it is unchanged.
+    if: >-
+      ${{
+        always() && !cancelled() &&
+        inputs.enable_smoke &&
+        needs.publish.result == 'success' &&
+        needs.publish.outputs.version_metadata_url != ''
+      }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}

--- a/tools/pack/tests/release-workflows.test.ts
+++ b/tools/pack/tests/release-workflows.test.ts
@@ -29,6 +29,89 @@ function countOccurrences(content: string, needle: string): number {
   return content.split(needle).length - 1;
 }
 
+type WorkflowJob = { needs: string[]; if: string };
+
+/**
+ * Minimal `jobs:` reader: job id -> its `needs` list and its job-level `if`.
+ *
+ * Deliberately not a YAML parser. These workflows are hand-written with a
+ * stable two-space job indentation, and the alternative is adding a YAML
+ * dependency to tools/pack purely for a topology assertion.
+ */
+function parseJobGraph(content: string): Map<string, WorkflowJob> {
+  const lines = content.split("\n");
+  const jobsIndex = lines.indexOf("jobs:");
+  expect(jobsIndex).toBeGreaterThanOrEqual(0);
+
+  const blocks = new Map<string, string[]>();
+  let current: string | null = null;
+  for (const line of lines.slice(jobsIndex + 1)) {
+    const header = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line);
+    if (header?.[1] != null) {
+      current = header[1];
+      blocks.set(current, []);
+      continue;
+    }
+    if (line.trim().length > 0 && /^\S/.test(line)) break;
+    if (current != null) blocks.get(current)?.push(line);
+  }
+
+  const jobs = new Map<string, WorkflowJob>();
+  for (const [name, block] of blocks) {
+    const job: WorkflowJob = { needs: [], if: "" };
+    for (let index = 0; index < block.length; index += 1) {
+      const line = block[index] ?? "";
+      const inlineNeeds = /^ {4}needs:\s*(.+)$/.exec(line);
+      if (inlineNeeds?.[1] != null) {
+        const value = inlineNeeds[1].split("#")[0]?.trim() ?? "";
+        job.needs = value.startsWith("[")
+          ? value.replace(/[[\]]/g, "").split(",").map((entry) => entry.trim()).filter(Boolean)
+          : [value].filter(Boolean);
+        continue;
+      }
+      if (/^ {4}needs:\s*$/.test(line)) {
+        for (const candidate of block.slice(index + 1)) {
+          const item = /^ {6}- ([A-Za-z0-9_-]+)/.exec(candidate);
+          if (item?.[1] == null) break;
+          job.needs.push(item[1]);
+        }
+        continue;
+      }
+      const conditionStart = /^ {4}if:\s*(.*)$/.exec(line);
+      if (conditionStart != null) {
+        let value = conditionStart[1] ?? "";
+        for (const candidate of block.slice(index + 1)) {
+          if (/^ {4}\S/.test(candidate)) break;
+          value += ` ${candidate.trim()}`;
+        }
+        job.if = value.trim();
+      }
+    }
+    jobs.set(name, job);
+  }
+  return jobs;
+}
+
+/** Every job `name` depends on, directly or through another job. */
+function transitiveNeeds(jobs: Map<string, WorkflowJob>, name: string): string[] {
+  const seen = new Set<string>();
+  const stack = [...(jobs.get(name)?.needs ?? [])];
+  while (stack.length > 0) {
+    const next = stack.pop();
+    if (next == null || seen.has(next) || !jobs.has(next)) continue;
+    seen.add(next);
+    stack.push(...(jobs.get(next)?.needs ?? []));
+  }
+  return [...seen];
+}
+
+/**
+ * Status-check functions that make a job evaluate its own `if` instead of
+ * inheriting a skip from somewhere up the chain. `success()` does not count:
+ * it is what GitHub already applies implicitly.
+ */
+const SKIP_CHAIN_BREAKERS = ["always(", "cancelled(", "failure("];
+
 describe("release workflows", () => {
   it("retains only the newest outer tools-pack cache for each release lane", async () => {
     const workflows = await Promise.all([
@@ -343,6 +426,62 @@ describe("release workflows", () => {
     expect(modeLine).toMatch(/\|\|\s*'core'\s*\}\}/);
   });
 
+  it("keeps a job that hand-checks an upstream result reachable past a skipped ancestor", async () => {
+    // GitHub, on `jobs.<job_id>.needs`: "If a job fails or is skipped, all jobs
+    // that need it are skipped unless the jobs use a conditional expression
+    // that causes the job to continue. If a run contains a series of jobs that
+    // need each other, a failure or skip applies to all jobs in the dependency
+    // chain from the point of failure or skip onwards."
+    //
+    // The break is per job and is NOT inherited. `always()` on `publish` lets
+    // PUBLISH run past a skipped `build_linux`; it does nothing for publish's
+    // own dependents, which are still downstream of the same skip. A job whose
+    // `if` hand-checks `needs.<x>.result` is by construction making its own
+    // decision about an upstream outcome — so it has to break the chain too,
+    // or GitHub's implicit `success()` skips it before that condition is ever
+    // evaluated.
+    //
+    // release-prerelease.yml's `dispatch_smoke` was exactly that shape, and
+    // `build_linux` is skipped on every single run because the repository has
+    // no ENABLE_STABLE_LINUX variable. Run 34149795952: publish succeeded,
+    // version_metadata_url was published, enable_smoke came through as true —
+    // and the job was skipped with zero steps, so release-prerelease-smoke.yml
+    // had never once run.
+    const files = [
+      "release-prerelease.yml",
+      "release-beta.yml",
+      "release-stable.yml",
+      "notify-release-feishu.yml",
+    ];
+    const contents = await Promise.all(
+      files.map((file) => readFile(new URL(`../../../.github/workflows/${file}`, import.meta.url), "utf8")),
+    );
+
+    const unreachable: string[] = [];
+    for (const [index, content] of contents.entries()) {
+      const jobs = parseJobGraph(content);
+      for (const [name, job] of jobs) {
+        if (!/needs\.[A-Za-z0-9_-]+\.result/.test(job.if)) continue;
+        if (SKIP_CHAIN_BREAKERS.some((breaker) => job.if.includes(breaker))) continue;
+        const skippableAncestors = transitiveNeeds(jobs, name).filter(
+          (ancestor) => (jobs.get(ancestor)?.if ?? "").length > 0,
+        );
+        if (skippableAncestors.length === 0) continue;
+        unreachable.push(`${files[index]}:${name} (skippable ancestors: ${skippableAncestors.sort().join(", ")})`);
+      }
+    }
+    expect(unreachable, "these jobs are skipped before their own condition is evaluated").toEqual([]);
+
+    // And specifically: the smoke dispatcher must stay reachable while
+    // build_linux stays opt-in.
+    const prerelease = parseJobGraph(contents[0] ?? "");
+    const dispatchSmoke = prerelease.get("dispatch_smoke");
+    expect(dispatchSmoke, "release-prerelease.yml must still dispatch packaged smoke").toBeDefined();
+    expect(transitiveNeeds(prerelease, "dispatch_smoke")).toContain("build_linux");
+    expect(prerelease.get("build_linux")?.if).toContain("vars.ENABLE_STABLE_LINUX");
+    expect(SKIP_CHAIN_BREAKERS.some((breaker) => (dispatchSmoke?.if ?? "").includes(breaker))).toBe(true);
+  });
+
   it("keeps every prerelease validation lane out of the release concurrency group", async () => {
     // release-prerelease.yml holds ONE repository-wide concurrency group with
     // cancel-in-progress: false. Anything that outlives `publish` inside it
@@ -379,10 +518,15 @@ describe("release workflows", () => {
     expect(prerelease).not.toContain("- dispatch_validation");
     expect(prerelease).not.toContain("- dispatch_smoke");
     // Smoke needs a package, so it waits for publish — but only long enough to
-    // POST the dispatch.
-    expect(prerelease).toContain(
-      "if: ${{ inputs.enable_smoke && needs.publish.result == 'success' && needs.publish.outputs.version_metadata_url != '' }}",
-    );
+    // POST the dispatch. Asserted as substance rather than as one literal
+    // line: the previous form pinned the exact string of a condition that
+    // never ran, which made the topology test agree with the bug. Reachability
+    // itself is covered by "keeps a job that hand-checks an upstream result
+    // reachable past a skipped ancestor" above.
+    const smokeCondition = parseJobGraph(prerelease).get("dispatch_smoke")?.if ?? "";
+    expect(smokeCondition).toContain("inputs.enable_smoke");
+    expect(smokeCondition).toContain("needs.publish.result == 'success'");
+    expect(smokeCondition).toContain("needs.publish.outputs.version_metadata_url != ''");
 
     // Two refs, tried in order, so a release branch cut before these lanes
     // existed still gets validated from the default branch.

--- a/tools/release/src/notifications/prerelease-card.ts
+++ b/tools/release/src/notifications/prerelease-card.ts
@@ -18,6 +18,12 @@ export type LaneStatus =
   | "failure"
   | "cancelled"
   | "skipped"
+  /**
+   * Expected, and never dispatched. Distinct from `pending` (a result is still
+   * coming) and from `skipped` (a switch said not to run it): this lane should
+   * have run, nothing will ever report on it, and somebody has to look.
+   */
+  | "never_started"
   | "unknown";
 
 export type PlatformKey = "mac_arm64" | "mac_x64" | "win_x64" | "linux_x64";
@@ -88,6 +94,7 @@ const STATUS_GLYPH: Record<LaneStatus, string> = {
   failure: "❌",
   cancelled: "⚠️",
   skipped: "⚪️",
+  never_started: "🚨",
   unknown: "⏳",
 };
 
@@ -98,6 +105,7 @@ const BUILD_STATUS_TEXT: Record<LaneStatus, string> = {
   failure: "构建失败",
   cancelled: "已取消",
   skipped: "本次未构建",
+  never_started: "未触发",
   unknown: "状态未知",
 };
 
@@ -108,11 +116,47 @@ const CHECK_STATUS_TEXT: Record<LaneStatus, string> = {
   failure: "未通过",
   cancelled: "已取消",
   skipped: "未运行",
+  never_started: "未触发（应运行，但没有被调起）",
   unknown: "状态未知",
 };
 
 export function isTerminal(status: LaneStatus): boolean {
-  return status === "success" || status === "failure" || status === "cancelled" || status === "skipped";
+  return (
+    status === "success" ||
+    status === "failure" ||
+    status === "cancelled" ||
+    status === "skipped" ||
+    status === "never_started"
+  );
+}
+
+/**
+ * What the card has learned about a lane it expected but has found no job for.
+ *
+ * `runFound` — a workflow run carrying this origin's marker exists.
+ * `runCompleted` — that run has finished, which is the only thing that proves a
+ *   job is genuinely absent rather than not yet created by the API.
+ * `discoveryExpired` — the dispatch window closed without a run ever appearing.
+ */
+export type LaneDiscovery = {
+  runFound: boolean;
+  runCompleted: boolean;
+  discoveryExpired: boolean;
+};
+
+/**
+ * Status for an expected lane the card has found no job for.
+ *
+ * The invariant: the same discovery window that lets the watcher stop waiting
+ * on a lane must also change what that lane SAYS. A lane whose run never
+ * appeared before that window closed was never dispatched, so "排队中" promises
+ * a result that can never arrive — worse than saying nothing, because a reader
+ * waits for it.
+ */
+export function undiscoveredLaneStatus(discovery: LaneDiscovery): LaneStatus {
+  if (discovery.runCompleted) return "skipped";
+  if (discovery.runFound) return "pending";
+  return discovery.discoveryExpired ? "never_started" : "pending";
 }
 
 /** A lane that a human has to look at. `skipped` is a decision, not a problem. */
@@ -152,13 +196,33 @@ export function failureCount(state: PrereleaseCardState): number {
   return failures;
 }
 
+/**
+ * Lanes that were expected and never dispatched.
+ *
+ * Counted separately from `failureCount` because the two say different things
+ * to a reader: a failure means a check ran and disagreed, a never-started lane
+ * means the pipeline did not do what it said it would. Both need a human, so
+ * both colour the card — but the card must not report one as the other.
+ */
+export function neverStartedCount(state: PrereleaseCardState): number {
+  let count = 0;
+  for (const platform of state.platforms) {
+    if (platform.build === "never_started") count += 1;
+    if (platform.smoke === "never_started") count += 1;
+  }
+  for (const test of state.tests) {
+    if (test.status === "never_started") count += 1;
+  }
+  return count;
+}
+
 export function headerTemplate(state: PrereleaseCardState): string {
   if (!anyPackagePublished(state)) {
     // Nothing shipped. Red whether the builds failed or the watcher gave up
     // waiting — either way there is no package and someone has to look.
     return state.platforms.every((platform) => !isTerminal(platform.build)) && !state.timedOut ? "blue" : "red";
   }
-  if (failureCount(state) > 0) return "orange";
+  if (failureCount(state) > 0 || neverStartedCount(state) > 0) return "orange";
   return state.finished && !state.timedOut ? "green" : "blue";
 }
 
@@ -171,7 +235,12 @@ export function headerTitle(state: PrereleaseCardState): string {
       : `🚀 ${name} · 构建中`;
   }
   const failures = failureCount(state);
+  const neverStarted = neverStartedCount(state);
+  // "未通过" is a claim that something ran and disagreed. Never say it about a
+  // lane that was never dispatched.
+  if (failures > 0 && neverStarted > 0) return `⚠️ ${name} · ${failures} 项未通过、${neverStarted} 项未触发`;
   if (failures > 0) return `⚠️ ${name} · ${failures} 项未通过`;
+  if (neverStarted > 0) return `⚠️ ${name} · ${neverStarted} 项未触发`;
   if (!state.finished || state.timedOut) return `🚀 ${name} · 进行中`;
   return `🚀 ${name}`;
 }

--- a/tools/release/src/notifications/prerelease-progress-card.ts
+++ b/tools/release/src/notifications/prerelease-progress-card.ts
@@ -29,6 +29,7 @@ import {
   readChangelogLines,
   renderPrereleaseCard,
   shouldPostFirstCard,
+  undiscoveredLaneStatus,
 } from "./prerelease-card.ts";
 import type {
   Changelog,
@@ -300,6 +301,16 @@ async function collect(previous: Watch): Promise<Watch> {
 }
 
 async function buildState(watch: Watch, startedAt: number, timedOut: boolean): Promise<PrereleaseCardState> {
+  // Computed once, up front, and used BOTH to decide what a lane says and to
+  // decide when the watcher may stop waiting for it. Deriving these twice is
+  // what let the card report a never-dispatched smoke lane as "排队中" while
+  // simultaneously concluding it had waited long enough to finish.
+  const testsDiscoveryExpired = watch.testsRun == null && Date.now() - startedAt > discoveryGraceMs;
+  const smokeDiscoveryExpired =
+    watch.smokeRun == null &&
+    watch.publishSucceededAt != null &&
+    Date.now() - watch.publishSucceededAt > discoveryGraceMs;
+
   const platforms: PlatformLane[] = [];
   for (const key of PLATFORM_ORDER) {
     const job = watch.originJobs.find((candidate) => jobMatches(String(candidate.name ?? ""), ORIGIN_BUILD_JOB[key]));
@@ -315,12 +326,17 @@ async function buildState(watch: Watch, startedAt: number, timedOut: boolean): P
       // no job there stays "skipped" rather than pretending to be pending.
       if (key === "linux_x64") smoke = "skipped";
       else if (smokeJob != null) smoke = statusOf(smokeJob);
-      // No job for this platform, and the run has FINISHED: it genuinely did
-      // not run. While the run is still going, a missing job just means the
-      // API has not created it yet.
-      else if (watch.smokeRun?.completed === true) smoke = "skipped";
-      else if (watch.smokeRun != null || watch.publish === "success") smoke = "pending";
-      else smoke = "skipped";
+      // No job for this platform. Only a COMPLETED run proves it genuinely did
+      // not run; while the run is still going, a missing job just means the API
+      // has not created it yet — and a run that never appeared at all before
+      // the discovery window closed was never dispatched.
+      else if (watch.smokeRun != null || watch.publish === "success") {
+        smoke = undiscoveredLaneStatus({
+          runFound: watch.smokeRun != null,
+          runCompleted: watch.smokeRun?.completed === true,
+          discoveryExpired: smokeDiscoveryExpired,
+        });
+      } else smoke = "skipped";
     }
     platforms.push({ key, label: PLATFORM_LABELS[key], build, downloadUrl, smoke });
   }
@@ -330,11 +346,16 @@ async function buildState(watch: Watch, startedAt: number, timedOut: boolean): P
     const family = watch.testsJobs.filter((job) => jobFamilyMatches(String(job.name ?? ""), entry.prefix));
     if (family.length === 0) {
       // Same rule as the smoke lanes: only a COMPLETED run proves a job is
-      // absent rather than not yet created.
+      // absent rather than not yet created, and a run that never appeared
+      // before the discovery window closed was never dispatched at all.
       return {
         key: entry.key,
         label: entry.label,
-        status: (watch.testsRun?.completed === true ? "skipped" : "pending") as LaneStatus,
+        status: undiscoveredLaneStatus({
+          runFound: watch.testsRun != null,
+          runCompleted: watch.testsRun?.completed === true,
+          discoveryExpired: testsDiscoveryExpired,
+        }),
       };
     }
     return { key: entry.key, label: entry.label, status: rollup(family.map(statusOf)) };
@@ -344,14 +365,14 @@ async function buildState(watch: Watch, startedAt: number, timedOut: boolean): P
   const testsDone = !expectTests
     ? true
     : watch.testsRun == null
-      ? Date.now() - startedAt > discoveryGraceMs
+      ? testsDiscoveryExpired
       : tests.every((test) => isTerminal(test.status));
   const smokeDone = !expectSmoke
     ? true
     : watch.publish !== "success"
       ? isTerminal(watch.publish)
       : watch.smokeRun == null
-        ? watch.publishSucceededAt != null && Date.now() - watch.publishSucceededAt > discoveryGraceMs
+        ? smokeDiscoveryExpired
         : platforms.every((platform) => isTerminal(platform.smoke));
 
   return {

--- a/tools/release/tests/prerelease-card.test.ts
+++ b/tools/release/tests/prerelease-card.test.ts
@@ -4,8 +4,10 @@ import {
   PLATFORM_LABELS,
   headerTemplate,
   headerTitle,
+  isTerminal,
   renderPrereleaseCard,
   shouldPostFirstCard,
+  undiscoveredLaneStatus,
 } from "../src/notifications/prerelease-card.ts";
 import type { LaneStatus, PlatformKey, PlatformLane, PrereleaseCardState } from "../src/notifications/prerelease-card.ts";
 
@@ -239,6 +241,99 @@ describe("prerelease progress card", () => {
     const nothing = state({ platforms: [platform("mac_arm64", "running")], timedOut: true });
     expect(headerTemplate(nothing)).toBe("red");
     expect(headerTitle(nothing)).toContain("等待产物超时");
+  });
+
+  // Regression cover for run 34149795952, the first real run of the split
+  // prerelease pipeline: `publish` succeeded and published version metadata,
+  // but `dispatch_smoke` was skipped, so release-prerelease-smoke.yml never
+  // ran at all. The card carried three ⏳ 排队中 packaged-smoke rows that could
+  // never resolve — a lie that reads as "a result is still coming".
+  describe("a lane that was expected but never dispatched", () => {
+    const neverDispatched = undiscoveredLaneStatus({
+      runFound: false,
+      runCompleted: false,
+      discoveryExpired: true,
+    });
+
+    function smokeState(smoke: LaneStatus, overrides: Partial<PrereleaseCardState> = {}): PrereleaseCardState {
+      return state({
+        platforms: [
+          platform("mac_arm64", "success", { smoke }),
+          platform("mac_x64", "success", { smoke }),
+          platform("win_x64", "success", { smoke }),
+        ],
+        expectSmoke: true,
+        finished: true,
+        ...overrides,
+      });
+    }
+
+    function checkBlock(input: PrereleaseCardState): string {
+      return texts(render(input)).find((text) => text.startsWith("**验证**")) ?? "";
+    }
+
+    it("is a terminal state, not a queue position", () => {
+      // Identical watcher inputs either side of the discovery window. Before it
+      // closes the lane genuinely is queued; after it closes with no run ever
+      // found, nothing is coming and the card must stop waiting on it.
+      const queued = undiscoveredLaneStatus({ runFound: false, runCompleted: false, discoveryExpired: false });
+      expect(queued).toBe("pending");
+      expect(isTerminal(queued)).toBe(false);
+
+      expect(neverDispatched).not.toBe("pending");
+      expect(isTerminal(neverDispatched)).toBe(true);
+    });
+
+    it("says 未触发 rather than 排队中", () => {
+      const checks = checkBlock(smokeState(neverDispatched));
+      expect(checks).not.toContain("排队中");
+      expect(checks).toContain("macOS (Apple Silicon) packaged smoke · 未触发");
+      expect(checks).toContain("Windows packaged smoke · 未触发");
+    });
+
+    it("is loud, because it is an anomaly rather than a decision", () => {
+      const card = render(smokeState(neverDispatched));
+      // A shipped package keeps the card out of the red, but a lane that should
+      // have run and did not must never read as an all-clear.
+      expect(card.header.template).toBe("orange");
+      expect(card.header.title?.content).toContain("未触发");
+      expect(card.header.title?.content).not.toBe("🚀 Open Design Prerelease 0.21.1-prerelease.3");
+    });
+
+    it("still reads 排队中 while the lane is genuinely queued", () => {
+      const checks = checkBlock(smokeState("pending", { finished: false }));
+      expect(checks).toContain("macOS (Apple Silicon) packaged smoke · 排队中");
+      expect(checks).not.toContain("未触发");
+    });
+
+    it("says nothing at all when the switch turned the lane off", () => {
+      // enable_smoke: false is a decision. It is not an anomaly and must not
+      // colour the card or add rows a reader would wait on.
+      const off = render(smokeState("skipped", { expectSmoke: false }));
+      expect(texts(off).some((text) => text.startsWith("**验证**"))).toBe(false);
+      expect(off.header.template).toBe("green");
+    });
+
+    it("applies the same rule to the code test lanes", () => {
+      // release-prerelease-tests.yml is dispatched from a job with no skipped
+      // ancestor, so it has not hit this in production — but the card must not
+      // depend on that luck.
+      const card = render(
+        state({
+          platforms: [platform("mac_arm64", "success")],
+          expectTests: true,
+          tests: [
+            { key: "functional_e2e", label: "P0 Functional E2E", status: neverDispatched },
+            { key: "verify", label: "Verify build", status: "success" },
+          ],
+          finished: true,
+        }),
+      );
+      const checks = texts(card).find((text) => text.startsWith("**验证**")) ?? "";
+      expect(checks).toContain("P0 Functional E2E · 未触发");
+      expect(checks).not.toContain("排队中");
+      expect(card.header.template).toBe("orange");
+    });
   });
 
   it("links every run it is watching", () => {


### PR DESCRIPTION
## Why

Two defects that the **first real run** of the split prerelease pipeline (#7842, backported as #7858) surfaced — found by reading [run 34149795952](https://github.com/nexu-io/open-design/actions/runs/34149795952), not by inspection. `release/v0.22.0` is cutting real prereleases through this path right now, so both are live.

**1. The packaged smoke has never run once.** `gh run list --workflow=release-prerelease-smoke.yml` returns empty. Meanwhile `release-prerelease-tests.yml` runs on every prerelease. In run 34149795952 the `Dispatch packaged smoke` job was **skipped with zero steps**.

Everything in its condition was true:

| term | actual | evidence |
| --- | --- | --- |
| `inputs.enable_smoke` | `true` | `enable_smoke: true` in the workflow_call **Inputs** group of every job's Set up job |
| `needs.publish.result == 'success'` | success | publish job conclusion |
| `needs.publish.outputs.version_metadata_url != ''` | `https://releases.open-design.ai/prerelease/versions/0.22.0-prerelease.15/metadata.json` | `Evaluate and set job outputs / Set output 'version_metadata_url'`, and the same value arrives in the caller's `notify` job env |

The condition was never evaluated. GitHub, on `jobs.<job_id>.needs`:

> If a job fails **or is skipped**, all jobs that need it are skipped unless the jobs use a conditional expression that causes the job to continue. **If a run contains a series of jobs that need each other, a failure or skip applies to all jobs in the dependency chain from the point of failure or skip onwards.**

`build_linux` is skipped on *every* run — the repository has no `ENABLE_STABLE_LINUX` variable (`gh api .../variables/ENABLE_STABLE_LINUX` → 404), so `vars.ENABLE_STABLE_LINUX == 'true'` can never hold. The skip propagates down the chain. **That break is per job and is not inherited:** `publish` carries `always() && !cancelled()` and therefore runs, but `dispatch_smoke` is downstream of the same skip with no break of its own, so the implicit `success()` skips it first.

This also explains the asymmetry: `dispatch_validation` needs only `metadata`, which has no skippable ancestor, so the tests lane was never in the chain. Its step-level `if: ${{ inputs.enable_tests }}` firing is what proves input forwarding was fine all along — the caller's `github.event_name != 'workflow_dispatch' || inputs.enable_smoke` shape is **not** at fault, and neither is job-level output propagation.

The repo already has this exact topology solved one file over: `release-stable.yml`'s `publish_docker_image` (`needs: [metadata, publish]`, hand-checks `needs.publish.result == 'success'`) leads with `always() && !cancelled()`. `dispatch_smoke` is the same shape minus the prefix.

**2. The card reported it as ⏳ 排队中.** Worse than not showing it: three packaged-smoke rows promised a result that could never arrive, and the release channel read them as "still coming". The watcher *already knew* — it computed that the discovery window had closed with no smoke run found, used that to stop waiting (`smokeDone`), and threw it away when deciding what the lane said. The lane model had no state between "a result is coming" (`pending`) and "a switch turned it off" (`skipped`).

## What users will see

Nobody touches a UI here; the audience is the release channel and whoever is on release duty.

- **Packaged smoke actually runs.** Every prerelease now dispatches `release-prerelease-smoke.yml`, so the mac arm64 / mac Intel / Windows packaged smoke results start appearing on the card instead of never arriving. This is the first time that lane has ever executed.
- **The card stops lying about lanes that never started.** A lane that was expected and never dispatched now reads `🚨 … · 未触发（应运行，但没有被调起）` instead of `⏳ … · 排队中`, the header goes orange with `⚠️ … · N 项未触发`, and the card no longer finishes green.
- The three cases stay visibly distinct: genuinely queued still says 排队中; switched off via `enable_smoke: false` still shows no row at all; never-dispatched is loud.
- The wording deliberately avoids "未通过" for a lane that never ran — that phrase claims a check executed and disagreed.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — packaged smoke now actually dispatches on every prerelease (it was silently never running), and the Feishu card renders a new lane state.
- [ ] **None**

## Screenshots

No UI surface. The user-visible artifact is the Feishu card text, covered by the assertions in `tools/release/tests/prerelease-card.test.ts` and quoted above.

## Bug fix verification

Red spec first, both defects, per AGENTS.md → Bug follow-up workflow.

**Defect 1 — `tools/pack/tests/release-workflows.test.ts` → "keeps a job that hand-checks an upstream result reachable past a skipped ancestor"**

Asserts the invariant, not the string: across `release-prerelease.yml`, `release-beta.yml`, `release-stable.yml` and `notify-release-feishu.yml`, a job whose `if` hand-checks `needs.<x>.result` and that has a skippable job in its transitive `needs` closure must carry a chain-breaking status function. Red before the fix, naming exactly one job in four workflows and zero false positives:

```
AssertionError: these jobs are skipped before their own condition is evaluated
+   "release-prerelease.yml:dispatch_smoke (skippable ancestors: build_linux, build_mac_intel, publish)"
```

**Defect 2 — `tools/release/tests/prerelease-card.test.ts` → "a lane that was expected but never dispatched"** (5 cases). Red before the fix, e.g.:

```
AssertionError: expected '**验证**（不阻塞发布）\n⏳ P0 Functional E2E · …' to contain 'P0 Functional E2E · 未触发'
+ ⏳ P0 Functional E2E · 排队中
```

Did the tests go red on `main` and green on this branch? **Yes.** The branch is cut from `origin/main` and the red runs above are on `main`'s workflow/source content.

**Removing the implementation puts them back to red** (tests untouched, only the source reverted): dropping `always() && !cancelled()` from `dispatch_smoke` → 1 failed; making `undiscoveredLaneStatus` return `"pending"` again → 4 failed. Neither test passes vacuously.

One note on the previous cover: the topology test used to pin `dispatch_smoke`'s exact `if` string, so it asserted the broken condition byte-for-byte and stayed green through the whole outage. It now asserts the substance of the gate (`enable_smoke`, `publish.result == 'success'`, non-empty `version_metadata_url` — all preserved) and leaves reachability to the invariant test.

## Adjacent issues

- The `-tests` lane has the **same** card hole (`family.length === 0` → `pending` forever if `testsRun` is never found). It has not fired in production only because `dispatch_validation` has no skippable ancestor. Fixed here rather than deferred, since it is the same helper and the same line of reasoning.
- `build_linux` being permanently skipped for want of an `ENABLE_STABLE_LINUX` variable is load-bearing for this bug but is its own question (is the Linux lane meant to be dead?). Not touched here.
- The watcher's `never_started` lanes are derived from a 20-minute discovery grace; a genuinely slow GitHub queue past that window would read as 未触发. That is the correct trade for a lane that is normally dispatched within seconds, but it is a tunable (`CARD_DISCOVERY_GRACE_MS`) worth revisiting if it ever misfires.

## Validation

- `pnpm guard` → exit 0
- `pnpm typecheck` → exit 0
- `actionlint` v1.7.12 (the version `ci.yml` pins) → exit 0, clean; the pre-change workflows were also clean, so no new findings
- `pnpm --filter @open-design/tools-release test` → 11 files, 99 passed
- `tools/pack` full suite → 41 files, 305 passed, 8 skipped
- `e2e/tests/packaged-smoke-workflow.test.ts` (workflow topology) → 81 passed, 1 skipped
- `e2e/tests/scripts/smoke-artifacts.test.ts` + `e2e/tests/packaged/smoke-namespace.test.ts` → 9 passed

Not run: a live prerelease. The fix's effect is a job that starts instead of being skipped, which only a real push to a release branch can demonstrate end to end — the reachability invariant is the standing guard.
