### PR TITLE
fix(contracts): scan components-manifest CSS structurally instead of by regex

### DIFF
--- a/design-systems/agentic/components.manifest.json
+++ b/design-systems/agentic/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/airbnb/components.manifest.json
+++ b/design-systems/airbnb/components.manifest.json
@@ -379,7 +379,10 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--accent-hover",
+        "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
@@ -388,8 +391,10 @@
         "--font-display",
         "--motion-fast",
         "--radius-lg",
+        "--radius-pill",
         "--radius-sm",
         "--space-2",
+        "--space-3",
         "--surface",
         "--text-base",
         "--text-sm"
@@ -431,12 +436,17 @@
         "--danger",
         "--ease-standard",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
+        "--font-display",
         "--motion-fast",
         "--muted",
         "--radius-sm",
         "--space-2",
         "--surface",
-        "--text-base"
+        "--text-base",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -470,9 +480,17 @@
       "tokenReferences": [
         "--accent",
         "--accent-on",
+        "--elev-ring",
         "--fg",
+        "--font-display",
         "--radius-md",
-        "--surface-warm"
+        "--radius-pill",
+        "--space-2",
+        "--space-3",
+        "--success",
+        "--surface",
+        "--surface-warm",
+        "--text-xs"
       ]
     },
     {
@@ -508,7 +526,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--fg",
+        "--font-mono",
+        "--radius-sm",
+        "--surface-warm",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -547,11 +572,15 @@
         "p"
       ],
       "tokenReferences": [
+        "--fg",
         "--font-display",
         "--leading-tight",
         "--muted",
+        "--text-2xl",
+        "--text-base",
         "--text-sm",
         "--text-xl",
+        "--text-xs",
         "--tracking-display"
       ]
     },
@@ -587,13 +616,22 @@
         "section"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--font-display",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-2",
-        "--space-4"
+        "--space-3",
+        "--space-4",
+        "--space-6",
+        "--text-lg",
+        "--tracking-display"
       ]
     }
   ],

--- a/design-systems/airtable/components.manifest.json
+++ b/design-systems/airtable/components.manifest.json
@@ -289,9 +289,12 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
+        "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-sm",
@@ -325,9 +328,17 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--text-base",
         "--text-sm",
         "--text-xs"
       ]
@@ -351,7 +362,15 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--ease-standard",
+        "--elev-raised",
+        "--motion-base",
+        "--radius-md",
+        "--radius-sm",
         "--space-2",
+        "--space-3",
+        "--space-6",
+        "--surface",
         "--text-sm"
       ]
     },
@@ -376,6 +395,7 @@
         "--fg-2",
         "--radius-pill",
         "--space-2",
+        "--success",
         "--text-xs"
       ]
     },
@@ -392,6 +412,7 @@
         "a"
       ],
       "tokenReferences": [
+        "--accent",
         "--accent-hover"
       ]
     },
@@ -406,7 +427,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--fg-2",
+        "--font-mono",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -453,10 +481,15 @@
       "tokenReferences": [
         "--accent",
         "--fg",
+        "--fg-2",
         "--font-display",
         "--leading-tight",
         "--muted",
         "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -492,8 +525,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
-        "--space-4"
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/ant/components.manifest.json
+++ b/design-systems/ant/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/apple/components.manifest.json
+++ b/design-systems/apple/components.manifest.json
@@ -311,9 +311,20 @@
         "--accent-active",
         "--accent-hover",
         "--accent-on",
+        "--border",
+        "--ease-standard",
+        "--elev-ring",
+        "--fg",
         "--focus-ring",
+        "--font-body",
         "--meta",
-        "--surface"
+        "--motion-fast",
+        "--radius-pill",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--text-base",
+        "--text-sm"
       ]
     },
     {
@@ -342,10 +353,12 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--bg",
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--meta",
         "--motion-fast",
@@ -353,6 +366,7 @@
         "--radius-sm",
         "--space-2",
         "--text-base",
+        "--text-sm",
         "--text-xs"
       ]
     },
@@ -371,7 +385,18 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--elev-raised"
+        "--bg",
+        "--border",
+        "--border-soft",
+        "--ease-standard",
+        "--elev-raised",
+        "--motion-base",
+        "--radius-lg",
+        "--space-3",
+        "--space-4",
+        "--space-6",
+        "--space-8",
+        "--surface-warm"
       ]
     },
     {
@@ -396,6 +421,7 @@
         "--radius-pill",
         "--space-2",
         "--space-3",
+        "--success",
         "--text-xs"
       ]
     },
@@ -414,7 +440,11 @@
         "a"
       ],
       "tokenReferences": [
-        "--accent-active"
+        "--accent-active",
+        "--ease-standard",
+        "--fg",
+        "--motion-fast",
+        "--text-sm"
       ]
     },
     {
@@ -478,11 +508,18 @@
         "p"
       ],
       "tokenReferences": [
+        "--accent",
         "--fg",
+        "--fg-2",
         "--font-display",
+        "--leading-tight",
         "--muted",
         "--text-2xl",
+        "--text-3xl",
+        "--text-lg",
         "--text-sm",
+        "--text-xl",
+        "--text-xs",
         "--tracking-display"
       ]
     },
@@ -519,12 +556,24 @@
         "section"
       ],
       "tokenReferences": [
+        "--bg",
+        "--border-soft",
         "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--ease-standard",
+        "--fg",
+        "--font-display",
+        "--motion-fast",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
-        "--space-6"
+        "--space-4",
+        "--space-6",
+        "--text-base",
+        "--text-sm"
       ]
     }
   ],

--- a/design-systems/application/components.manifest.json
+++ b/design-systems/application/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/arc/components.manifest.json
+++ b/design-systems/arc/components.manifest.json
@@ -270,10 +270,16 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--ease-standard",
         "--elev-ring",
         "--fg",
         "--focus-ring",
-        "--space-3"
+        "--font-body",
+        "--motion-fast",
+        "--radius-md",
+        "--space-2",
+        "--space-3",
+        "--text-base"
       ]
     },
     {
@@ -301,15 +307,20 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--ease-standard",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--muted",
         "--radius-md",
         "--space-2",
-        "--text-base"
+        "--text-base",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -354,6 +365,7 @@
         "--accent",
         "--radius-pill",
         "--space-2",
+        "--success",
         "--text-xs"
       ]
     },
@@ -370,7 +382,10 @@
         "a"
       ],
       "tokenReferences": [
-        "--accent-hover"
+        "--accent",
+        "--accent-hover",
+        "--ease-standard",
+        "--motion-fast"
       ]
     },
     {
@@ -384,7 +399,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--fg-2",
+        "--font-mono",
+        "--radius-sm",
+        "--surface-warm",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -427,10 +449,19 @@
         "p"
       ],
       "tokenReferences": [
+        "--fg-2",
+        "--font-body",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
-        "--text-3xl"
+        "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -462,7 +493,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/artistic/components.manifest.json
+++ b/design-systems/artistic/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/atelier-zero/components.manifest.json
+++ b/design-systems/atelier-zero/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/bento/components.manifest.json
+++ b/design-systems/bento/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/binance/components.manifest.json
+++ b/design-systems/binance/components.manifest.json
@@ -311,9 +311,17 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--accent-active",
         "--accent-hover",
+        "--accent-on",
+        "--ease-standard",
         "--focus-ring",
-        "--radius-pill"
+        "--font-body",
+        "--motion-base",
+        "--motion-fast",
+        "--radius-pill",
+        "--space-2",
+        "--text-base"
       ]
     },
     {
@@ -345,14 +353,18 @@
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
+        "--meta",
         "--motion-base",
         "--motion-fast",
         "--muted",
         "--radius-sm",
         "--space-2",
         "--surface-warm",
-        "--text-base"
+        "--text-base",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -375,12 +387,14 @@
         "--accent",
         "--accent-active",
         "--border",
+        "--border-soft",
         "--ease-standard",
         "--elev-raised",
         "--motion-base",
         "--radius-md",
         "--radius-pill",
         "--space-3",
+        "--space-4",
         "--space-6",
         "--surface"
       ]
@@ -405,9 +419,12 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--danger",
         "--radius-pill",
         "--space-2",
+        "--success",
         "--text-xs"
       ]
     },
@@ -424,7 +441,11 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--accent",
+        "--ease-standard",
+        "--motion-fast"
+      ]
     },
     {
       "id": "keyboard",
@@ -495,8 +516,10 @@
         "--leading-tight",
         "--muted",
         "--text-3xl",
+        "--text-4xl",
         "--text-lg",
         "--text-sm",
+        "--text-xs",
         "--tracking-display"
       ]
     },
@@ -533,11 +556,17 @@
         "section"
       ],
       "tokenReferences": [
+        "--accent",
         "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
         "--space-4",
+        "--space-5",
         "--space-6"
       ]
     }

--- a/design-systems/bmw-m/components.manifest.json
+++ b/design-systems/bmw-m/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -407,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/bmw/components.manifest.json
+++ b/design-systems/bmw/components.manifest.json
@@ -281,9 +281,11 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-sm",
@@ -317,9 +319,17 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--bg",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--text-base",
         "--text-xs"
       ]
     },
@@ -342,12 +352,15 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--focus-ring",
+        "--font-display",
         "--radius-md",
         "--space-2",
         "--space-4",
         "--space-6",
         "--surface",
+        "--text-2xl",
         "--text-sm"
       ]
     },
@@ -433,7 +446,11 @@
         "--leading-tight",
         "--muted",
         "--text-2xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -467,7 +484,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
         "--space-4",
+        "--space-5",
         "--space-6"
       ]
     }

--- a/design-systems/bold/components.manifest.json
+++ b/design-systems/bold/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/brutalism/components.manifest.json
+++ b/design-systems/brutalism/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/bugatti/components.manifest.json
+++ b/design-systems/bugatti/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -407,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/cafe/components.manifest.json
+++ b/design-systems/cafe/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/cal/components.manifest.json
+++ b/design-systems/cal/components.manifest.json
@@ -267,11 +267,14 @@
       ],
       "tokenReferences": [
         "--ease-standard",
+        "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-sm",
         "--space-2",
+        "--surface",
         "--text-sm"
       ]
     },
@@ -301,9 +304,17 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--bg",
+        "--border",
+        "--ease-standard",
+        "--fg",
         "--fg-2",
         "--focus-ring",
+        "--font-body",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
         "--text-sm",
         "--text-xs"
       ]
@@ -324,7 +335,15 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--ease-standard",
+        "--elev-raised",
+        "--fg-2",
+        "--motion-base",
+        "--radius-md",
+        "--space-3",
+        "--space-6",
+        "--surface"
       ]
     },
     {
@@ -344,7 +363,12 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--success"
+        "--font-body",
+        "--muted",
+        "--radius-pill",
+        "--space-2",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -363,7 +387,8 @@
       ],
       "tokenReferences": [
         "--accent",
-        "--accent-hover"
+        "--accent-hover",
+        "--fg-2"
       ]
     },
     {
@@ -377,7 +402,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--elev-ring",
+        "--font-mono",
+        "--muted",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -423,9 +455,14 @@
         "--fg",
         "--font-body",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -461,7 +498,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/canva/components.manifest.json
+++ b/design-systems/canva/components.manifest.json
@@ -282,7 +282,13 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-on",
+        "--bg",
+        "--border",
         "--ease-standard",
+        "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-sm",
@@ -317,9 +323,18 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--bg",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
+        "--meta",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--text-base",
         "--text-sm",
         "--text-xs"
       ]
@@ -344,7 +359,17 @@
         "card-thumb-mint"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--bg",
+        "--border",
+        "--ease-standard",
+        "--motion-fast",
+        "--radius-md",
+        "--radius-sm",
+        "--space-2",
+        "--space-3",
+        "--space-6"
+      ]
     },
     {
       "id": "badges",
@@ -363,7 +388,10 @@
         "chip-mint"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--radius-pill",
+        "--text-xs"
+      ]
     },
     {
       "id": "links",
@@ -445,10 +473,16 @@
         "--accent",
         "--fg",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-2xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -482,7 +516,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/cisco/components.manifest.json
+++ b/design-systems/cisco/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -407,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/claude/components.manifest.json
+++ b/design-systems/claude/components.manifest.json
@@ -264,7 +264,10 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--accent-hover",
+        "--accent-on",
         "--ease-standard",
         "--fg-2",
         "--focus-ring",
@@ -304,13 +307,16 @@
         "--border-soft",
         "--ease-standard",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--font-body",
         "--meta",
         "--motion-fast",
         "--radius-md",
         "--space-2",
         "--surface",
-        "--text-sm"
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -350,7 +356,13 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--success"
+        "--font-body",
+        "--muted",
+        "--radius-pill",
+        "--space-2",
+        "--space-3",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -366,7 +378,8 @@
         "a"
       ],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--fg-2"
       ]
     },
     {
@@ -380,7 +393,13 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border-soft",
+        "--font-mono",
+        "--muted",
+        "--surface-warm",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -425,10 +444,15 @@
       "tokenReferences": [
         "--font-body",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--meta",
         "--muted",
         "--text-2xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -464,7 +488,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/clay/components.manifest.json
+++ b/design-systems/clay/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/claymorphism/components.manifest.json
+++ b/design-systems/claymorphism/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/clean/components.manifest.json
+++ b/design-systems/clean/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/clickhouse/components.manifest.json
+++ b/design-systems/clickhouse/components.manifest.json
@@ -305,14 +305,17 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-sm",
         "--space-2",
         "--space-8",
+        "--success",
         "--surface",
         "--text-base"
       ]
@@ -343,16 +346,21 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--meta",
         "--motion-fast",
+        "--muted",
         "--radius-sm",
         "--space-2",
+        "--space-3",
         "--surface",
-        "--text-sm"
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -371,6 +379,7 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--border-soft",
         "--radius-md",
@@ -395,6 +404,7 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--border-soft",
         "--muted",
@@ -438,7 +448,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--fg-2",
+        "--font-mono",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -485,7 +502,12 @@
         "--font-display",
         "--leading-tight",
         "--muted",
-        "--text-2xl"
+        "--text-2xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--tracking-display"
       ]
     },
     {
@@ -521,8 +543,13 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
-        "--space-5"
+        "--space-4",
+        "--space-5",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/cloudflare-kumo/components.manifest.json
+++ b/design-systems/cloudflare-kumo/components.manifest.json
@@ -282,16 +282,21 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
+        "--border-soft",
         "--danger",
         "--fg",
+        "--focus-ring",
         "--motion-base",
+        "--muted",
         "--radius-lg",
         "--radius-pill",
         "--space-2",
         "--space-3",
-        "--surface"
+        "--surface",
+        "--surface-warm"
       ]
     },
     {
@@ -320,10 +325,14 @@
         "--border",
         "--danger",
         "--fg",
+        "--focus-ring",
+        "--muted",
         "--radius-lg",
         "--space-2",
         "--space-3",
-        "--surface"
+        "--surface",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -343,8 +352,12 @@
       "elements": [],
       "tokenReferences": [
         "--border-soft",
+        "--elev-raised",
+        "--elev-ring",
+        "--radius-lg",
         "--space-4",
-        "--space-5"
+        "--space-5",
+        "--surface"
       ]
     },
     {
@@ -369,7 +382,9 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--focus-ring"
+      ]
     },
     {
       "id": "keyboard",
@@ -422,9 +437,12 @@
         "p"
       ],
       "tokenReferences": [
+        "--fg-2",
         "--font-display",
         "--leading-tight",
         "--muted",
+        "--text-3xl",
+        "--text-base",
         "--text-lg",
         "--text-sm",
         "--tracking-display"
@@ -454,6 +472,9 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
+        "--container-gutter-phone",
+        "--container-max",
         "--space-2",
         "--space-4"
       ]

--- a/design-systems/cohere/components.manifest.json
+++ b/design-systems/cohere/components.manifest.json
@@ -261,8 +261,15 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--ease-standard",
+        "--fg",
         "--fg-2",
-        "--focus-ring"
+        "--focus-ring",
+        "--font-body",
+        "--motion-fast",
+        "--radius-pill",
+        "--space-2",
+        "--text-base"
       ]
     },
     {
@@ -290,8 +297,16 @@
         "label"
       ],
       "tokenReferences": [
+        "--bg",
+        "--border",
+        "--ease-standard",
+        "--fg",
         "--focus-ring",
+        "--font-body",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
         "--text-sm",
         "--text-xs"
       ]
@@ -307,7 +322,13 @@
         "card"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--bg",
+        "--border-soft",
+        "--radius-md",
+        "--space-3",
+        "--space-6"
+      ]
     },
     {
       "id": "badges",
@@ -329,6 +350,7 @@
         "--muted",
         "--radius-pill",
         "--space-2",
+        "--success",
         "--text-xs"
       ]
     },
@@ -345,6 +367,7 @@
         "a"
       ],
       "tokenReferences": [
+        "--accent",
         "--fg"
       ]
     },
@@ -411,9 +434,11 @@
       "tokenReferences": [
         "--font-body",
         "--font-display",
+        "--font-mono",
         "--leading-body",
         "--leading-tight",
         "--muted",
+        "--text-2xl",
         "--text-4xl",
         "--text-lg",
         "--text-sm",
@@ -452,7 +477,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/coinbase/components.manifest.json
+++ b/design-systems/coinbase/components.manifest.json
@@ -315,9 +315,12 @@
         "--accent-hover",
         "--accent-on",
         "--ease-standard",
+        "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--space-2",
+        "--surface",
         "--text-base"
       ]
     },
@@ -348,9 +351,16 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--text-base",
         "--text-sm"
       ]
     },
@@ -372,11 +382,16 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--bg",
         "--border",
+        "--radius-lg",
         "--radius-md",
         "--radius-pill",
         "--space-3",
-        "--space-6"
+        "--space-4",
+        "--space-6",
+        "--space-8",
+        "--surface"
       ]
     },
     {
@@ -398,9 +413,11 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
         "--muted",
         "--radius-pill",
         "--space-2",
+        "--success",
         "--surface"
       ]
     },
@@ -418,7 +435,10 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--accent",
+        "--focus-ring"
+      ]
     },
     {
       "id": "keyboard",
@@ -485,8 +505,12 @@
         "p"
       ],
       "tokenReferences": [
+        "--fg",
         "--font-body",
+        "--font-display",
+        "--leading-tight",
         "--muted",
+        "--text-2xl",
         "--text-4xl",
         "--text-lg",
         "--text-sm",
@@ -529,14 +553,20 @@
         "section"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
         "--fg",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
-        "--space-5"
+        "--space-4",
+        "--space-5",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/colorful/components.manifest.json
+++ b/design-systems/colorful/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/composio/components.manifest.json
+++ b/design-systems/composio/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -407,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/contemporary/components.manifest.json
+++ b/design-systems/contemporary/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/corporate/components.manifest.json
+++ b/design-systems/corporate/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/cosmic/components.manifest.json
+++ b/design-systems/cosmic/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/creative/components.manifest.json
+++ b/design-systems/creative/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/cursor/components.manifest.json
+++ b/design-systems/cursor/components.manifest.json
@@ -296,12 +296,23 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--danger",
+        "--ease-standard",
+        "--fg",
         "--focus-ring",
+        "--font-display",
+        "--motion-base",
+        "--motion-fast",
         "--muted",
-        "--radius-pill"
+        "--radius-pill",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--surface-warm",
+        "--text-sm"
       ]
     },
     {
@@ -329,11 +340,20 @@
         "label"
       ],
       "tokenReferences": [
+        "--bg",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
         "--font-body",
         "--font-display",
+        "--meta",
+        "--motion-base",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--text-base",
         "--text-sm"
       ]
     },
@@ -352,7 +372,16 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--elev-raised"
+        "--bg",
+        "--border",
+        "--ease-standard",
+        "--elev-raised",
+        "--motion-base",
+        "--radius-md",
+        "--radius-sm",
+        "--space-3",
+        "--space-5",
+        "--surface"
       ]
     },
     {
@@ -378,10 +407,14 @@
       "tokenReferences": [
         "--fg",
         "--font-display",
+        "--meta",
         "--muted",
         "--radius-pill",
         "--space-2",
         "--space-3",
+        "--success",
+        "--surface",
+        "--text-sm",
         "--text-xs"
       ]
     },
@@ -398,7 +431,8 @@
         "a"
       ],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--meta"
       ]
     },
     {
@@ -461,10 +495,17 @@
         "p"
       ],
       "tokenReferences": [
+        "--font-body",
         "--font-display",
         "--leading-tight",
         "--muted",
-        "--text-3xl"
+        "--text-2xl",
+        "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -498,7 +539,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/dashboard/components.manifest.json
+++ b/design-systems/dashboard/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/default/components.manifest.json
+++ b/design-systems/default/components.manifest.json
@@ -266,7 +266,10 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--accent-hover",
+        "--accent-on",
         "--border",
         "--ease-standard",
         "--fg",
@@ -274,6 +277,7 @@
         "--motion-fast",
         "--radius-sm",
         "--space-2",
+        "--surface",
         "--text-sm"
       ]
     },
@@ -302,15 +306,18 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--motion-fast",
         "--muted",
         "--radius-sm",
         "--space-2",
         "--surface",
-        "--text-sm"
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -349,7 +356,11 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--success"
+        "--muted",
+        "--radius-pill",
+        "--space-2",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -364,7 +375,9 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--accent"
+      ]
     },
     {
       "id": "keyboard",
@@ -377,7 +390,13 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--font-mono",
+        "--muted",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -424,6 +443,9 @@
         "--leading-tight",
         "--muted",
         "--text-2xl",
+        "--text-3xl",
+        "--text-lg",
+        "--text-sm",
         "--text-xs",
         "--tracking-display"
       ]
@@ -459,7 +481,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/discord/components.manifest.json
+++ b/design-systems/discord/components.manifest.json
@@ -239,8 +239,16 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
         "--accent-hover",
-        "--focus-ring"
+        "--accent-on",
+        "--ease-standard",
+        "--focus-ring",
+        "--font-body",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--text-base"
       ]
     },
     {
@@ -263,8 +271,16 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
+        "--ease-standard",
+        "--fg",
         "--fg-2",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--surface-warm",
+        "--text-base",
         "--text-sm"
       ]
     },
@@ -354,8 +370,13 @@
         "--leading-tight",
         "--meta",
         "--muted",
+        "--text-2xl",
         "--text-3xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -386,6 +407,10 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
         "--space-4"
       ]
     }

--- a/design-systems/dithered/components.manifest.json
+++ b/design-systems/dithered/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/doodle/components.manifest.json
+++ b/design-systems/doodle/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/dramatic/components.manifest.json
+++ b/design-systems/dramatic/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/duolingo/components.manifest.json
+++ b/design-systems/duolingo/components.manifest.json
@@ -297,12 +297,17 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
+        "--bg",
+        "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-display",
         "--meta",
         "--motion-fast",
+        "--muted",
         "--radius-md",
         "--space-2",
         "--space-6",
@@ -337,11 +342,22 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--bg",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
         "--font-display",
         "--meta",
-        "--text-sm"
+        "--motion-fast",
+        "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--space-4",
+        "--text-base",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -365,19 +381,22 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
         "--accent-on",
         "--bg",
         "--border",
         "--danger",
         "--ease-standard",
         "--elev-raised",
+        "--fg",
         "--font-display",
         "--motion-fast",
         "--radius-md",
         "--radius-pill",
         "--space-3",
         "--space-6",
-        "--text-xl"
+        "--text-xl",
+        "--warn"
       ]
     },
     {
@@ -398,12 +417,17 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent-on",
+        "--border",
         "--fg",
         "--font-display",
+        "--muted",
         "--radius-pill",
         "--space-1",
         "--space-2",
         "--space-3",
+        "--success",
+        "--surface",
         "--text-xs",
         "--warn"
       ]
@@ -420,7 +444,9 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--accent-active"
+      ]
     },
     {
       "id": "keyboard",
@@ -433,7 +459,15 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--bg",
+        "--border",
+        "--font-mono",
+        "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -476,12 +510,22 @@
         "p"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--fg",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
+        "--radius-pill",
+        "--space-1",
+        "--space-3",
         "--text-2xl",
-        "--text-sm"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -518,9 +562,13 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-2",
         "--space-3",
-        "--space-4"
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/editorial/components.manifest.json
+++ b/design-systems/editorial/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/elegant/components.manifest.json
+++ b/design-systems/elegant/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/elevenlabs/components.manifest.json
+++ b/design-systems/elevenlabs/components.manifest.json
@@ -258,10 +258,12 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--bg",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-pill",
@@ -293,16 +295,19 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--bg",
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--muted",
         "--radius-md",
         "--space-2",
-        "--text-sm"
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -341,7 +346,11 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--success"
+        "--muted",
+        "--radius-pill",
+        "--space-2",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -357,6 +366,7 @@
         "a"
       ],
       "tokenReferences": [
+        "--fg",
         "--muted"
       ]
     },
@@ -371,7 +381,13 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--font-mono",
+        "--muted",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -413,9 +429,14 @@
         "--fg-2",
         "--font-body",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-2xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -451,7 +472,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/energetic/components.manifest.json
+++ b/design-systems/energetic/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/enterprise/components.manifest.json
+++ b/design-systems/enterprise/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/expo/components.manifest.json
+++ b/design-systems/expo/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -407,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/expressive/components.manifest.json
+++ b/design-systems/expressive/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/fantasy/components.manifest.json
+++ b/design-systems/fantasy/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/ferrari/components.manifest.json
+++ b/design-systems/ferrari/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -407,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/figma/components.manifest.json
+++ b/design-systems/figma/components.manifest.json
@@ -232,7 +232,15 @@
         "button"
       ],
       "tokenReferences": [
-        "--fg"
+        "--accent-on",
+        "--bg",
+        "--ease-standard",
+        "--fg",
+        "--font-display",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--text-base"
       ]
     },
     {
@@ -335,7 +343,12 @@
       "tokenReferences": [
         "--font-display",
         "--leading-tight",
-        "--text-3xl"
+        "--muted",
+        "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-xl",
+        "--tracking-display"
       ]
     },
     {
@@ -367,7 +380,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/flat/components.manifest.json
+++ b/design-systems/flat/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/framer/components.manifest.json
+++ b/design-systems/framer/components.manifest.json
@@ -277,7 +277,15 @@
         "button"
       ],
       "tokenReferences": [
-        "--fg"
+        "--ease-standard",
+        "--fg",
+        "--focus-ring",
+        "--font-body",
+        "--motion-base",
+        "--motion-fast",
+        "--radius-pill",
+        "--space-2",
+        "--text-base"
       ]
     },
     {
@@ -306,17 +314,21 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--border-soft",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
+        "--meta",
         "--motion-fast",
         "--muted",
         "--radius-sm",
         "--space-2",
         "--surface",
         "--text-base",
+        "--text-sm",
         "--text-xs"
       ]
     },
@@ -335,7 +347,17 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--elev-raised"
+        "--accent",
+        "--ease-standard",
+        "--elev-raised",
+        "--elev-ring",
+        "--font-mono",
+        "--motion-base",
+        "--radius-md",
+        "--space-3",
+        "--space-6",
+        "--surface",
+        "--text-xs"
       ]
     },
     {
@@ -356,6 +378,8 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
+        "--border",
         "--muted",
         "--radius-pill",
         "--space-2",
@@ -443,9 +467,14 @@
         "--fg-2",
         "--font-body",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--tracking-display"
       ]
     },
@@ -481,7 +510,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
         "--space-4",
+        "--space-5",
         "--space-6"
       ]
     }

--- a/design-systems/friendly/components.manifest.json
+++ b/design-systems/friendly/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/futuristic/components.manifest.json
+++ b/design-systems/futuristic/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/github/components.manifest.json
+++ b/design-systems/github/components.manifest.json
@@ -255,10 +255,12 @@
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-sm",
         "--space-2",
+        "--success",
         "--surface",
         "--text-sm"
       ]
@@ -291,6 +293,7 @@
         "--focus-ring",
         "--font-body",
         "--motion-fast",
+        "--muted",
         "--radius-sm",
         "--space-2",
         "--text-sm"
@@ -377,9 +380,12 @@
         "--font-display",
         "--leading-tight",
         "--muted",
+        "--text-4xl",
+        "--text-lg",
         "--text-sm",
         "--text-xl",
-        "--text-xs"
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -410,7 +416,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-3"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4"
       ]
     }
   ],

--- a/design-systems/glassmorphism/components.manifest.json
+++ b/design-systems/glassmorphism/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/gradient/components.manifest.json
+++ b/design-systems/gradient/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/hashicorp/components.manifest.json
+++ b/design-systems/hashicorp/components.manifest.json
@@ -273,13 +273,20 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
         "--bg",
         "--border",
+        "--ease-standard",
         "--elev-raised",
+        "--fg",
         "--fg-2",
         "--focus-ring",
-        "--radius-sm"
+        "--font-body",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--text-base"
       ]
     },
     {
@@ -307,9 +314,18 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
+        "--ease-standard",
+        "--fg",
         "--fg-2",
+        "--focus-ring",
         "--font-body",
         "--meta",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--text-base",
         "--text-sm",
         "--text-xs"
       ]
@@ -325,7 +341,13 @@
         "card"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border-soft",
+        "--elev-raised",
+        "--radius-md",
+        "--space-6",
+        "--surface"
+      ]
     },
     {
       "id": "badges",
@@ -346,6 +368,7 @@
         "--font-body",
         "--radius-pill",
         "--space-2",
+        "--success",
         "--text-sm"
       ]
     },
@@ -361,7 +384,11 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--accent-hover",
+        "--ease-standard",
+        "--motion-fast"
+      ]
     },
     {
       "id": "keyboard",
@@ -374,7 +401,13 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--fg-2",
+        "--font-mono",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -418,11 +451,18 @@
       ],
       "tokenReferences": [
         "--fg",
+        "--fg-2",
         "--font-display",
         "--leading-tight",
         "--muted",
         "--text-2xl",
-        "--text-3xl"
+        "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -456,7 +496,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/hud/components.manifest.json
+++ b/design-systems/hud/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/huggingface/components.manifest.json
+++ b/design-systems/huggingface/components.manifest.json
@@ -264,8 +264,11 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
         "--accent-hover",
+        "--accent-on",
         "--ease-standard",
+        "--fg",
         "--fg-2",
         "--focus-ring",
         "--font-display",
@@ -300,10 +303,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
         "--font-display",
+        "--motion-fast",
         "--muted",
+        "--radius-md",
+        "--space-2",
+        "--surface",
         "--text-sm",
         "--text-xs"
       ]
@@ -321,7 +331,11 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--border",
+        "--radius-md",
+        "--space-3",
+        "--surface"
       ]
     },
     {
@@ -340,7 +354,14 @@
         "badge-success"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border-soft",
+        "--font-display",
+        "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--text-xs"
+      ]
     },
     {
       "id": "links",
@@ -354,7 +375,9 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--fg"
+      ]
     },
     {
       "id": "keyboard",
@@ -367,7 +390,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--border-soft",
+        "--font-display",
+        "--muted",
+        "--radius-sm",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -410,10 +440,16 @@
         "p"
       ],
       "tokenReferences": [
+        "--fg-2",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-2xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -449,7 +485,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/ibm/components.manifest.json
+++ b/design-systems/ibm/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -407,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/intercom/components.manifest.json
+++ b/design-systems/intercom/components.manifest.json
@@ -299,9 +299,16 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
+        "--ease-standard",
         "--fg",
-        "--focus-ring"
+        "--focus-ring",
+        "--font-body",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--text-base"
       ]
     },
     {
@@ -333,10 +340,20 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
         "--meta",
-        "--text-sm"
+        "--motion-fast",
+        "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--text-base",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -358,12 +375,14 @@
         "--accent",
         "--border",
         "--ease-standard",
+        "--elev-raised",
         "--font-mono",
         "--motion-base",
         "--radius-lg",
         "--space-3",
         "--space-6",
         "--surface-warm",
+        "--text-2xl",
         "--text-xs"
       ]
     },
@@ -388,9 +407,11 @@
       "tokenReferences": [
         "--accent",
         "--font-mono",
+        "--muted",
         "--radius-pill",
         "--space-2",
         "--space-3",
+        "--success",
         "--text-xs"
       ]
     },
@@ -407,7 +428,9 @@
         "a"
       ],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--border",
+        "--fg"
       ]
     },
     {
@@ -421,7 +444,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--font-mono",
+        "--muted",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -467,9 +497,17 @@
       "tokenReferences": [
         "--fg",
         "--font-display",
+        "--font-mono",
         "--leading-tight",
         "--muted",
-        "--text-3xl"
+        "--text-2xl",
+        "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -507,8 +545,13 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-2",
+        "--space-3",
         "--space-4",
+        "--space-5",
         "--space-6"
       ]
     }

--- a/design-systems/kami/components.manifest.json
+++ b/design-systems/kami/components.manifest.json
@@ -299,9 +299,11 @@
         "--accent",
         "--accent-on",
         "--ease-standard",
+        "--elev-raised",
         "--elev-ring",
         "--elev-ring-accent",
         "--fg-2",
+        "--focus-ring",
         "--font-display",
         "--motion-base",
         "--radius-md",
@@ -341,6 +343,7 @@
       "tokenReferences": [
         "--border",
         "--ease-standard",
+        "--elev-raised",
         "--motion-base",
         "--radius-md",
         "--space-3",
@@ -369,6 +372,7 @@
         "--font-display",
         "--radius-sm",
         "--radius-xs",
+        "--tag-bg-faint",
         "--tag-bg-soft",
         "--tag-bg-strong",
         "--text-sm",
@@ -387,7 +391,9 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--accent"
+      ]
     },
     {
       "id": "keyboard",
@@ -432,11 +438,17 @@
       ],
       "tokenReferences": [
         "--font-display",
+        "--leading-display",
         "--leading-tight",
+        "--meta",
         "--muted",
         "--space-6",
         "--text-2xl",
-        "--text-sm"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--tracking-display",
+        "--tracking-eyebrow"
       ]
     },
     {
@@ -468,8 +480,12 @@
         "--container-gutter-tablet",
         "--container-max",
         "--font-display",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
         "--space-4",
+        "--space-6",
         "--text-base",
         "--tracking-label"
       ]

--- a/design-systems/kraken/components.manifest.json
+++ b/design-systems/kraken/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -407,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/lamborghini/components.manifest.json
+++ b/design-systems/lamborghini/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -407,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/levels/components.manifest.json
+++ b/design-systems/levels/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/linear-app/components.manifest.json
+++ b/design-systems/linear-app/components.manifest.json
@@ -236,8 +236,10 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--ease-standard",
+        "--focus-ring",
         "--font-display",
         "--motion-fast",
         "--radius-sm",
@@ -265,8 +267,16 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
+        "--border",
+        "--ease-standard",
         "--fg-2",
+        "--font-body",
         "--meta",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--text-base",
         "--text-sm"
       ]
     },
@@ -282,7 +292,13 @@
         "card"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--ease-standard",
+        "--motion-base",
+        "--radius-md",
+        "--space-6"
+      ]
     },
     {
       "id": "badges",
@@ -363,7 +379,12 @@
         "--meta",
         "--muted",
         "--text-2xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -395,7 +416,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/lingo/components.manifest.json
+++ b/design-systems/lingo/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/loom/components.manifest.json
+++ b/design-systems/loom/components.manifest.json
@@ -279,10 +279,14 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--accent-hover",
+        "--accent-on",
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--leading-tight",
         "--motion-fast",
@@ -318,18 +322,23 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--bg",
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--leading-tight",
         "--meta",
         "--motion-fast",
+        "--muted",
         "--radius-sm",
         "--space-2",
         "--space-3",
-        "--text-base"
+        "--text-base",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -373,6 +382,7 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--danger",
         "--muted",
         "--radius-pill",
         "--space-2",
@@ -393,7 +403,8 @@
         "a"
       ],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--accent-hover"
       ]
     },
     {
@@ -457,11 +468,18 @@
         "p"
       ],
       "tokenReferences": [
+        "--accent",
         "--fg",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-2xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
         "--tracking-display"
       ]
     },
@@ -497,8 +515,13 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-2",
-        "--space-4"
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/lovable/components.manifest.json
+++ b/design-systems/lovable/components.manifest.json
@@ -265,8 +265,10 @@
       ],
       "tokenReferences": [
         "--ease-standard",
+        "--fg",
         "--focus-ring",
         "--font-body",
+        "--meta",
         "--motion-fast",
         "--radius-sm",
         "--space-2",
@@ -302,7 +304,20 @@
         "textarea"
       ],
       "tokenReferences": [
+        "--border",
+        "--ease-standard",
+        "--fg",
+        "--focus-ring",
+        "--font-body",
+        "--leading-body",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--space-3",
+        "--space-4",
+        "--surface",
+        "--text-base",
         "--text-sm"
       ]
     },
@@ -318,7 +333,16 @@
         "card"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--ease-standard",
+        "--elev-flat",
+        "--motion-base",
+        "--radius-md",
+        "--space-3",
+        "--space-6",
+        "--surface"
+      ]
     },
     {
       "id": "badges",
@@ -334,7 +358,14 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--border",
+        "--fg",
+        "--radius-pill",
+        "--space-2",
+        "--space-3",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -350,7 +381,8 @@
         "a"
       ],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--fg"
       ]
     },
     {
@@ -364,7 +396,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--font-mono",
+        "--muted",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -411,7 +450,11 @@
         "--leading-tight",
         "--muted",
         "--text-3xl",
-        "--text-sm"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--tracking-display"
       ]
     },
     {
@@ -445,7 +488,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/luxury/components.manifest.json
+++ b/design-systems/luxury/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/mastercard/components.manifest.json
+++ b/design-systems/mastercard/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -407,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/material/components.manifest.json
+++ b/design-systems/material/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/meta/components.manifest.json
+++ b/design-systems/meta/components.manifest.json
@@ -276,10 +276,13 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
         "--bg",
         "--ease-standard",
+        "--fg",
         "--fg-2",
+        "--focus-ring",
         "--font-body",
         "--motion-base",
         "--motion-fast",
@@ -314,9 +317,17 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--bg",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
+        "--motion-base",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--text-base",
         "--text-sm",
         "--text-xs"
       ]
@@ -336,7 +347,16 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--elev-raised"
+        "--bg",
+        "--ease-standard",
+        "--elev-raised",
+        "--elev-ring",
+        "--motion-base",
+        "--radius-lg",
+        "--radius-md",
+        "--space-4",
+        "--space-8",
+        "--surface-warm"
       ]
     },
     {
@@ -359,6 +379,7 @@
         "--muted",
         "--radius-pill",
         "--space-2",
+        "--success",
         "--surface",
         "--text-xs"
       ]
@@ -377,6 +398,7 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--ease-standard",
         "--motion-fast"
       ]
@@ -442,12 +464,17 @@
         "p"
       ],
       "tokenReferences": [
+        "--fg",
         "--fg-2",
+        "--font-display",
+        "--leading-tight",
         "--muted",
         "--text-2xl",
         "--text-3xl",
         "--text-4xl",
         "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -484,7 +511,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
         "--space-4",
+        "--space-6",
         "--space-8"
       ]
     }

--- a/design-systems/minimal/components.manifest.json
+++ b/design-systems/minimal/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/minimax/components.manifest.json
+++ b/design-systems/minimax/components.manifest.json
@@ -292,10 +292,18 @@
         "button"
       ],
       "tokenReferences": [
+        "--bg",
         "--border",
+        "--ease-standard",
         "--fg-2",
         "--focus-ring",
-        "--surface-warm"
+        "--font-body",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--surface-warm",
+        "--text-sm"
       ]
     },
     {
@@ -326,9 +334,20 @@
         "textarea"
       ],
       "tokenReferences": [
+        "--accent",
+        "--bg",
+        "--border",
+        "--ease-standard",
+        "--fg",
         "--fg-2",
+        "--focus-ring",
+        "--font-body",
         "--meta",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--text-base",
         "--text-sm",
         "--text-xs"
       ]
@@ -355,14 +374,18 @@
         "--bg",
         "--border-soft",
         "--ease-standard",
+        "--elev-raised",
         "--fg-2",
         "--font-display",
+        "--meta",
         "--motion-base",
         "--radius-lg",
         "--radius-md",
+        "--space-2",
         "--space-3",
         "--space-6",
-        "--space-8"
+        "--space-8",
+        "--text-xs"
       ]
     },
     {
@@ -381,6 +404,7 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
         "--muted",
         "--radius-pill",
         "--space-2",
@@ -403,7 +427,15 @@
         "a"
       ],
       "tokenReferences": [
-        "--fg"
+        "--bg",
+        "--ease-standard",
+        "--elev-raised",
+        "--fg",
+        "--fg-2",
+        "--motion-fast",
+        "--muted",
+        "--radius-pill",
+        "--text-sm"
       ]
     },
     {
@@ -471,9 +503,15 @@
         "--fg",
         "--font-body",
         "--font-display",
+        "--leading-body",
+        "--leading-tight",
         "--muted",
         "--text-2xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -509,7 +547,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/mintlify/components.manifest.json
+++ b/design-systems/mintlify/components.manifest.json
@@ -297,9 +297,19 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
         "--accent-hover",
+        "--accent-on",
         "--bg",
-        "--focus-ring"
+        "--ease-standard",
+        "--fg",
+        "--focus-ring",
+        "--font-display",
+        "--motion-fast",
+        "--radius-pill",
+        "--radius-sm",
+        "--space-2",
+        "--surface"
       ]
     },
     {
@@ -329,10 +339,17 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
         "--meta",
-        "--text-sm"
+        "--motion-fast",
+        "--muted",
+        "--radius-pill",
+        "--space-2",
+        "--surface",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -358,9 +375,11 @@
         "--radius-lg",
         "--radius-md",
         "--space-3",
+        "--space-5",
         "--space-6",
         "--space-8",
-        "--surface"
+        "--surface",
+        "--surface-warm"
       ]
     },
     {
@@ -384,12 +403,18 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
+        "--accent-hover",
         "--border",
         "--fg-2",
         "--font-display",
+        "--font-mono",
         "--radius-pill",
+        "--radius-sm",
         "--space-1",
-        "--surface-warm"
+        "--success",
+        "--surface-warm",
+        "--text-xs"
       ]
     },
     {
@@ -406,6 +431,7 @@
         "a"
       ],
       "tokenReferences": [
+        "--accent-hover",
         "--ease-standard",
         "--fg",
         "--focus-ring",
@@ -423,7 +449,13 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--fg-2",
+        "--font-mono",
+        "--surface-warm",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -467,13 +499,18 @@
       ],
       "tokenReferences": [
         "--fg",
+        "--fg-2",
         "--font-display",
         "--font-mono",
         "--leading-tight",
         "--muted",
         "--text-3xl",
+        "--text-4xl",
         "--text-lg",
-        "--text-xs"
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -507,8 +544,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
         "--space-4",
+        "--space-5",
         "--space-6"
       ]
     }

--- a/design-systems/miro/components.manifest.json
+++ b/design-systems/miro/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -407,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/mission-control/components.manifest.json
+++ b/design-systems/mission-control/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/mistral-ai/components.manifest.json
+++ b/design-systems/mistral-ai/components.manifest.json
@@ -263,6 +263,7 @@
       ],
       "tokenReferences": [
         "--ease-standard",
+        "--fg",
         "--focus-ring",
         "--font-body",
         "--motion-fast",
@@ -298,8 +299,16 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--border",
+        "--ease-standard",
+        "--fg",
         "--focus-ring",
+        "--font-body",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
         "--text-sm",
         "--text-xs"
       ]
@@ -315,7 +324,13 @@
         "card"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--elev-raised",
+        "--radius-sm",
+        "--space-3",
+        "--space-6",
+        "--surface"
+      ]
     },
     {
       "id": "badges",
@@ -337,6 +352,7 @@
         "--muted",
         "--radius-pill",
         "--space-2",
+        "--success",
         "--text-xs"
       ]
     },
@@ -418,10 +434,16 @@
       ],
       "tokenReferences": [
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-3xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-base",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -455,7 +477,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/modern/components.manifest.json
+++ b/design-systems/modern/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/mongodb/components.manifest.json
+++ b/design-systems/mongodb/components.manifest.json
@@ -264,12 +264,21 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--accent-hover",
+        "--accent-on",
         "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
+        "--motion-fast",
         "--muted",
-        "--surface"
+        "--radius-pill",
+        "--space-2",
+        "--surface",
+        "--text-base"
       ]
     },
     {
@@ -297,16 +306,21 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--ease-standard",
         "--fg-2",
+        "--focus-ring",
         "--font-body",
         "--meta",
         "--motion-fast",
+        "--muted",
         "--radius-sm",
         "--space-2",
         "--surface",
-        "--text-base"
+        "--text-base",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -346,7 +360,12 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--font-mono",
+        "--muted",
+        "--radius-pill",
+        "--space-2",
+        "--text-xs"
       ]
     },
     {
@@ -361,7 +380,9 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--accent"
+      ]
     },
     {
       "id": "keyboard",
@@ -374,7 +395,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--font-mono",
+        "--muted",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -419,12 +447,16 @@
       "tokenReferences": [
         "--accent",
         "--fg",
+        "--fg-2",
+        "--font-body",
         "--font-display",
         "--font-mono",
         "--leading-tight",
         "--muted",
+        "--text-2xl",
         "--text-3xl",
         "--text-4xl",
+        "--text-lg",
         "--text-sm",
         "--text-xl",
         "--tracking-display"
@@ -461,7 +493,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/mono/components.manifest.json
+++ b/design-systems/mono/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/neobrutalism/components.manifest.json
+++ b/design-systems/neobrutalism/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/neon/components.manifest.json
+++ b/design-systems/neon/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/neumorphism/components.manifest.json
+++ b/design-systems/neumorphism/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/nike/components.manifest.json
+++ b/design-systems/nike/components.manifest.json
@@ -274,15 +274,21 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--accent-hover",
+        "--accent-on",
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-base",
         "--motion-fast",
+        "--muted",
         "--radius-pill",
         "--space-2",
+        "--surface",
         "--text-base"
       ]
     },
@@ -312,9 +318,11 @@
         "label"
       ],
       "tokenReferences": [
+        "--bg",
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-base",
         "--motion-fast",
@@ -323,6 +331,7 @@
         "--space-2",
         "--surface",
         "--text-base",
+        "--text-sm",
         "--text-xs"
       ]
     },
@@ -337,7 +346,12 @@
         "card"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--radius-md",
+        "--space-3",
+        "--space-6",
+        "--surface"
+      ]
     },
     {
       "id": "badges",
@@ -361,6 +375,7 @@
         "--radius-pill",
         "--space-2",
         "--space-3",
+        "--success",
         "--surface",
         "--text-xs"
       ]
@@ -379,9 +394,11 @@
         "a"
       ],
       "tokenReferences": [
+        "--bg",
         "--ease-standard",
         "--fg",
-        "--motion-base"
+        "--motion-base",
+        "--muted"
       ]
     },
     {
@@ -446,10 +463,17 @@
       ],
       "tokenReferences": [
         "--fg",
+        "--font-body",
         "--font-display",
+        "--leading-tight",
         "--muted",
         "--text-2xl",
-        "--text-sm"
+        "--text-4xl",
+        "--text-base",
+        "--text-lg",
+        "--text-sm",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -485,8 +509,13 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
-        "--space-6"
+        "--space-4",
+        "--space-6",
+        "--space-8"
       ]
     }
   ],

--- a/design-systems/notion/components.manifest.json
+++ b/design-systems/notion/components.manifest.json
@@ -254,8 +254,12 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
         "--accent-hover",
+        "--accent-on",
         "--ease-standard",
+        "--fg",
+        "--focus-ring",
         "--font-display",
         "--motion-fast",
         "--radius-sm",
@@ -289,10 +293,12 @@
         "--fg",
         "--focus-ring",
         "--font-body",
+        "--meta",
         "--motion-fast",
         "--radius-sm",
         "--space-2",
-        "--text-base"
+        "--text-base",
+        "--text-sm"
       ]
     },
     {
@@ -310,7 +316,14 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--elev-raised"
+        "--bg",
+        "--border",
+        "--ease-standard",
+        "--elev-raised",
+        "--motion-base",
+        "--radius-lg",
+        "--space-6",
+        "--surface"
       ]
     },
     {
@@ -399,7 +412,12 @@
         "--leading-tight",
         "--muted",
         "--text-3xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -433,7 +451,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/nvidia/components.manifest.json
+++ b/design-systems/nvidia/components.manifest.json
@@ -283,8 +283,17 @@
         "--accent",
         "--accent-active",
         "--accent-hover",
+        "--border",
+        "--ease-standard",
         "--fg",
-        "--fg-2"
+        "--fg-2",
+        "--focus-ring",
+        "--font-body",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--text-base"
       ]
     },
     {
@@ -313,9 +322,18 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--border",
+        "--ease-standard",
+        "--fg",
         "--fg-2",
         "--font-body",
         "--meta",
+        "--motion-fast",
+        "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--text-base",
         "--text-sm",
         "--text-xs"
       ]
@@ -334,7 +352,12 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--border-soft",
+        "--elev-raised",
+        "--radius-md",
+        "--space-3",
+        "--surface"
       ]
     },
     {
@@ -353,7 +376,12 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--font-body",
+        "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--text-xs"
       ]
     },
     {
@@ -424,11 +452,17 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--fg-2",
         "--font-body",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
+        "--text-2xl",
         "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
         "--text-xs"
       ]
     },
@@ -471,7 +505,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/ollama/components.manifest.json
+++ b/design-systems/ollama/components.manifest.json
@@ -295,11 +295,22 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--accent-hover",
+        "--accent-on",
         "--bg",
         "--border",
+        "--ease-standard",
+        "--fg",
         "--fg-2",
-        "--focus-ring"
+        "--focus-ring",
+        "--motion-fast",
+        "--radius-pill",
+        "--space-2",
+        "--space-6",
+        "--surface",
+        "--text-base"
       ]
     },
     {
@@ -330,12 +341,17 @@
         "--border",
         "--ease-standard",
         "--fg",
+        "--fg-2",
         "--focus-ring",
+        "--meta",
         "--motion-fast",
+        "--muted",
         "--radius-pill",
         "--space-2",
         "--space-5",
-        "--text-base"
+        "--text-base",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -353,6 +369,7 @@
       "tokenReferences": [
         "--bg",
         "--border",
+        "--fg",
         "--radius-md",
         "--space-3",
         "--space-6"
@@ -376,6 +393,7 @@
         "--fg-2",
         "--font-mono",
         "--radius-pill",
+        "--space-2",
         "--space-3",
         "--text-xs"
       ]
@@ -454,6 +472,10 @@
         "--leading-tight",
         "--muted",
         "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -495,10 +517,18 @@
         "--container-gutter-tablet",
         "--container-max",
         "--fg",
+        "--font-display",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-2",
+        "--space-3",
         "--space-4",
         "--space-5",
         "--space-6",
-        "--text-base"
+        "--text-base",
+        "--text-lg",
+        "--tracking-display"
       ]
     }
   ],

--- a/design-systems/openai/components.manifest.json
+++ b/design-systems/openai/components.manifest.json
@@ -251,15 +251,19 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--bg",
         "--border",
         "--ease-standard",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-sm",
         "--space-2",
+        "--surface-warm",
         "--text-base"
       ]
     },
@@ -291,10 +295,14 @@
         "--fg",
         "--focus-ring",
         "--font-body",
+        "--meta",
         "--motion-fast",
+        "--muted",
         "--radius-sm",
         "--space-2",
-        "--text-base"
+        "--text-base",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -313,6 +321,7 @@
         "--bg",
         "--border-soft",
         "--ease-standard",
+        "--elev-raised",
         "--motion-base",
         "--radius-md",
         "--space-6"
@@ -332,6 +341,7 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
         "--muted",
         "--radius-pill",
         "--surface",
@@ -401,6 +411,7 @@
         "--font-display",
         "--leading-tight",
         "--muted",
+        "--text-2xl",
         "--text-4xl",
         "--text-lg",
         "--text-sm",
@@ -437,7 +448,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/opencode-ai/components.manifest.json
+++ b/design-systems/opencode-ai/components.manifest.json
@@ -268,9 +268,19 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
+        "--border",
+        "--ease-standard",
         "--fg",
-        "--surface"
+        "--fg-2",
+        "--focus-ring",
+        "--font-body",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -298,10 +308,18 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--border",
+        "--ease-standard",
+        "--fg",
         "--focus-ring",
         "--font-mono",
         "--meta",
+        "--motion-fast",
         "--muted",
+        "--radius-md",
+        "--space-2",
+        "--surface",
+        "--text-sm",
         "--text-xs"
       ]
     },
@@ -316,7 +334,12 @@
         "card"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--radius-md",
+        "--space-3",
+        "--surface"
+      ]
     },
     {
       "id": "badges",
@@ -345,7 +368,9 @@
         "--font-mono",
         "--radius-sm",
         "--space-2",
-        "--text-xs"
+        "--success",
+        "--text-xs",
+        "--warn"
       ]
     },
     {
@@ -425,10 +450,16 @@
         "p"
       ],
       "tokenReferences": [
+        "--fg-2",
         "--font-display",
         "--font-mono",
+        "--leading-body",
         "--muted",
         "--text-2xl",
+        "--text-3xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs"
       ]
     },
@@ -461,7 +492,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/pacman/components.manifest.json
+++ b/design-systems/pacman/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -407,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/paper/components.manifest.json
+++ b/design-systems/paper/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/perplexity/components.manifest.json
+++ b/design-systems/perplexity/components.manifest.json
@@ -265,9 +265,12 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
+        "--border",
         "--border-soft",
         "--ease-standard",
+        "--fg",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -302,11 +305,13 @@
         "--ease-standard",
         "--fg",
         "--font-body",
+        "--meta",
         "--motion-fast",
         "--radius-md",
         "--space-2",
         "--surface",
-        "--text-base"
+        "--text-base",
+        "--text-sm"
       ]
     },
     {
@@ -323,6 +328,7 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--ease-standard",
         "--elev-flat",
         "--motion-fast",
@@ -406,7 +412,12 @@
         "--leading-tight",
         "--muted",
         "--text-2xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -440,8 +451,13 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
-        "--space-5"
+        "--space-4",
+        "--space-5",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/perspective/components.manifest.json
+++ b/design-systems/perspective/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/pinterest/components.manifest.json
+++ b/design-systems/pinterest/components.manifest.json
@@ -329,11 +329,15 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--accent-hover",
+        "--accent-on",
         "--border-soft",
         "--ease-standard",
         "--fg",
         "--fg-2",
+        "--focus-ring",
         "--font-display",
         "--motion-fast",
         "--radius-md",
@@ -371,10 +375,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--bg",
+        "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-display",
         "--meta",
+        "--motion-fast",
         "--muted",
+        "--radius-md",
+        "--space-2",
+        "--text-base",
         "--text-sm",
         "--text-xs"
       ]
@@ -413,6 +424,7 @@
         "--radius-pill",
         "--space-2",
         "--space-3",
+        "--success",
         "--surface-warm",
         "--text-xs"
       ]
@@ -431,7 +443,12 @@
         "a"
       ],
       "tokenReferences": [
-        "--fg"
+        "--border",
+        "--ease-standard",
+        "--fg",
+        "--focus-ring",
+        "--motion-fast",
+        "--radius-sm"
       ]
     },
     {
@@ -492,12 +509,16 @@
         "p"
       ],
       "tokenReferences": [
+        "--accent",
         "--fg",
         "--font-display",
         "--leading-tight",
         "--muted",
         "--text-2xl",
+        "--text-4xl",
+        "--text-lg",
         "--text-sm",
+        "--text-xs",
         "--tracking-display"
       ]
     },
@@ -543,12 +564,19 @@
         "--container-gutter-tablet",
         "--container-max",
         "--ease-standard",
+        "--fg",
+        "--focus-ring",
         "--font-display",
         "--motion-fast",
         "--muted",
         "--radius-pill",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-2",
+        "--space-3",
         "--space-4",
+        "--space-6",
         "--surface",
         "--text-lg",
         "--tracking-display"

--- a/design-systems/playstation/components.manifest.json
+++ b/design-systems/playstation/components.manifest.json
@@ -282,8 +282,16 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
-        "--surface"
+        "--ease-standard",
+        "--focus-ring",
+        "--font-body",
+        "--motion-fast",
+        "--radius-pill",
+        "--space-2",
+        "--surface",
+        "--text-base"
       ]
     },
     {
@@ -313,10 +321,12 @@
       "tokenReferences": [
         "--border",
         "--ease-standard",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--space-2",
-        "--text-base"
+        "--text-base",
+        "--text-sm"
       ]
     },
     {
@@ -347,6 +357,8 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
+        "--accent-on",
         "--border-soft",
         "--elev-raised",
         "--radius-lg",
@@ -378,6 +390,9 @@
         "--radius-pill",
         "--space-2",
         "--space-3",
+        "--success",
+        "--surface",
+        "--text-sm",
         "--text-xs"
       ]
     },
@@ -465,12 +480,16 @@
         "p"
       ],
       "tokenReferences": [
+        "--font-display",
         "--leading-body",
+        "--leading-tight",
         "--muted",
+        "--text-2xl",
         "--text-4xl",
         "--text-base",
         "--text-lg",
-        "--text-sm"
+        "--text-sm",
+        "--tracking-display"
       ]
     },
     {
@@ -503,7 +522,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/posthog/components.manifest.json
+++ b/design-systems/posthog/components.manifest.json
@@ -323,13 +323,19 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--bg",
         "--border",
         "--ease-standard",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--font-display",
         "--motion-fast",
+        "--radius-md",
         "--radius-sm",
         "--space-2",
+        "--surface",
         "--surface-warm",
         "--text-sm",
         "--warn"
@@ -364,10 +370,20 @@
         "select"
       ],
       "tokenReferences": [
+        "--border",
+        "--ease-standard",
+        "--fg",
         "--fg-2",
+        "--focus-ring",
+        "--font-body",
         "--font-display",
         "--meta",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--text-base",
         "--text-sm",
         "--text-xs"
       ]
@@ -394,11 +410,13 @@
         "--border",
         "--ease-standard",
         "--elev-raised",
+        "--fg",
         "--motion-fast",
         "--radius-md",
         "--space-3",
         "--space-4",
-        "--space-5"
+        "--space-5",
+        "--surface"
       ]
     },
     {
@@ -422,8 +440,14 @@
       "tokenReferences": [
         "--border",
         "--fg-2",
+        "--font-display",
+        "--radius-pill",
+        "--space-2",
+        "--success",
         "--surface",
-        "--surface-warm"
+        "--surface-warm",
+        "--text-xs",
+        "--warn"
       ]
     },
     {
@@ -442,6 +466,7 @@
         "a"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--ease-standard",
         "--fg-2",
@@ -465,8 +490,10 @@
       "tokenReferences": [
         "--border",
         "--fg-2",
+        "--font-mono",
         "--radius-sm",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -515,7 +542,11 @@
         "--leading-tight",
         "--muted",
         "--text-3xl",
-        "--text-sm"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -561,8 +592,14 @@
         "--container-max",
         "--fg-2",
         "--font-display",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-2",
-        "--space-4"
+        "--space-3",
+        "--space-4",
+        "--space-6",
+        "--text-lg"
       ]
     }
   ],

--- a/design-systems/premium/components.manifest.json
+++ b/design-systems/premium/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/professional/components.manifest.json
+++ b/design-systems/professional/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/publication/components.manifest.json
+++ b/design-systems/publication/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/raycast/components.manifest.json
+++ b/design-systems/raycast/components.manifest.json
@@ -254,6 +254,8 @@
       ],
       "tokenReferences": [
         "--ease-standard",
+        "--fg",
+        "--focus-ring",
         "--font-display",
         "--motion-fast",
         "--radius-pill",
@@ -286,10 +288,13 @@
         "--fg",
         "--focus-ring",
         "--font-body",
+        "--meta",
         "--motion-fast",
+        "--muted",
         "--radius-sm",
         "--space-2",
-        "--text-base"
+        "--text-base",
+        "--text-sm"
       ]
     },
     {
@@ -306,7 +311,16 @@
         "card-title"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--ease-standard",
+        "--elev-ring",
+        "--fg",
+        "--motion-base",
+        "--radius-lg",
+        "--space-6",
+        "--surface",
+        "--text-xl"
+      ]
     },
     {
       "id": "badges",
@@ -324,7 +338,11 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--fg-2",
+        "--radius-pill",
+        "--space-2",
+        "--text-xs"
       ]
     },
     {
@@ -352,7 +370,10 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--space-2"
+        "--fg-2",
+        "--font-mono",
+        "--space-2",
+        "--text-xs"
       ]
     },
     {
@@ -390,11 +411,18 @@
       ],
       "tokenReferences": [
         "--fg",
+        "--fg-2",
         "--font-display",
+        "--leading-tight",
         "--meta",
         "--muted",
         "--text-3xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -426,7 +454,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/refined/components.manifest.json
+++ b/design-systems/refined/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/renault/components.manifest.json
+++ b/design-systems/renault/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/replicate/components.manifest.json
+++ b/design-systems/replicate/components.manifest.json
@@ -262,7 +262,9 @@
         "button"
       ],
       "tokenReferences": [
+        "--bg",
         "--ease-standard",
+        "--fg",
         "--focus-ring",
         "--font-body",
         "--motion-fast",
@@ -298,9 +300,15 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--bg",
+        "--ease-standard",
+        "--fg",
         "--focus-ring",
         "--font-body",
         "--meta",
+        "--motion-fast",
+        "--radius-pill",
+        "--space-2",
         "--text-sm",
         "--text-xs"
       ]
@@ -316,7 +324,13 @@
         "card"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--bg",
+        "--fg",
+        "--radius-md",
+        "--space-3",
+        "--space-6"
+      ]
     },
     {
       "id": "badges",
@@ -339,6 +353,7 @@
         "--radius-pill",
         "--space-2",
         "--space-3",
+        "--success",
         "--text-xs"
       ]
     },
@@ -421,11 +436,17 @@
       "tokenReferences": [
         "--font-body",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--meta",
         "--muted",
         "--text-2xl",
-        "--text-xs"
+        "--text-3xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -459,7 +480,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/resend/components.manifest.json
+++ b/design-systems/resend/components.manifest.json
@@ -302,10 +302,12 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--ease-standard",
         "--fg",
         "--fg-2",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-pill",
@@ -344,6 +346,8 @@
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
+        "--font-body",
         "--motion-fast",
         "--muted",
         "--radius-sm",
@@ -367,7 +371,13 @@
       "elements": [],
       "tokenReferences": [
         "--bg",
-        "--border"
+        "--border",
+        "--ease-standard",
+        "--motion-base",
+        "--radius-lg",
+        "--space-3",
+        "--space-6",
+        "--surface"
       ]
     },
     {
@@ -390,7 +400,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
-        "--success"
+        "--border",
+        "--fg-2",
+        "--font-body",
+        "--radius-pill",
+        "--space-1",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -430,7 +446,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--fg-2",
+        "--font-mono",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -475,13 +498,18 @@
       ],
       "tokenReferences": [
         "--fg",
+        "--fg-2",
+        "--font-body",
         "--font-display",
         "--font-mono",
         "--leading-tight",
         "--muted",
         "--space-6",
         "--text-3xl",
+        "--text-4xl",
         "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -516,8 +544,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
-        "--space-4"
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/retro/components.manifest.json
+++ b/design-systems/retro/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/revolut/components.manifest.json
+++ b/design-systems/revolut/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -407,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/runwayml/components.manifest.json
+++ b/design-systems/runwayml/components.manifest.json
@@ -293,12 +293,16 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
+        "--border",
         "--ease-standard",
         "--fg",
         "--fg-2",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
+        "--muted",
         "--radius-sm",
         "--space-2",
         "--text-sm"
@@ -331,9 +335,19 @@
         "label"
       ],
       "tokenReferences": [
+        "--border",
+        "--ease-standard",
+        "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--font-body",
         "--meta",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--text-base",
         "--text-xs"
       ]
     },
@@ -357,8 +371,14 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--border",
         "--fg",
+        "--radius-md",
+        "--space-3",
         "--space-4",
+        "--space-5",
+        "--space-6",
+        "--surface",
         "--surface-warm",
         "--text-xs"
       ]
@@ -377,7 +397,12 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--radius-pill"
+        "--border",
+        "--muted",
+        "--radius-pill",
+        "--radius-sm",
+        "--space-2",
+        "--text-xs"
       ]
     },
     {
@@ -456,7 +481,12 @@
         "--font-display",
         "--leading-tight",
         "--muted",
-        "--text-3xl"
+        "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--tracking-display"
       ]
     },
     {
@@ -490,8 +520,14 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-2",
         "--space-3",
-        "--space-6"
+        "--space-4",
+        "--space-6",
+        "--space-8"
       ]
     }
   ],

--- a/design-systems/sanity/components.manifest.json
+++ b/design-systems/sanity/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -407,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/sentry/components.manifest.json
+++ b/design-systems/sentry/components.manifest.json
@@ -272,9 +272,17 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--accent-active",
         "--accent-on",
+        "--bg",
+        "--ease-standard",
         "--fg",
-        "--focus-ring"
+        "--focus-ring",
+        "--font-body",
+        "--motion-fast",
+        "--radius-md",
+        "--space-2",
+        "--text-sm"
       ]
     },
     {
@@ -310,7 +318,8 @@
         "--muted",
         "--radius-sm",
         "--space-2",
-        "--text-sm"
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -331,6 +340,7 @@
         "--accent",
         "--border",
         "--elev-raised",
+        "--fg",
         "--radius-lg",
         "--space-3",
         "--space-6",
@@ -357,6 +367,7 @@
         "--muted",
         "--radius-pill",
         "--space-2",
+        "--success",
         "--text-xs"
       ]
     },
@@ -375,7 +386,8 @@
         "a"
       ],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--fg"
       ]
     },
     {
@@ -442,11 +454,19 @@
       ],
       "tokenReferences": [
         "--fg",
+        "--fg-2",
         "--font-body",
+        "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-2xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -480,7 +500,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/shadcn/components.manifest.json
+++ b/design-systems/shadcn/components.manifest.json
@@ -292,12 +292,22 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--accent-hover",
+        "--accent-on",
+        "--bg",
         "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-display",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
         "--space-3",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -326,9 +336,11 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--motion-fast",
         "--muted",
         "--radius-sm",
@@ -351,7 +363,15 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--fg"
+        "--border",
+        "--ease-standard",
+        "--elev-raised",
+        "--fg",
+        "--motion-base",
+        "--radius-md",
+        "--space-3",
+        "--space-6",
+        "--surface"
       ]
     },
     {
@@ -376,8 +396,14 @@
       "tokenReferences": [
         "--accent",
         "--accent-on",
+        "--bg",
         "--border",
-        "--fg"
+        "--fg",
+        "--font-display",
+        "--radius-pill",
+        "--space-1",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -393,7 +419,12 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--ease-standard",
+        "--fg",
+        "--focus-ring",
+        "--motion-fast"
+      ]
     },
     {
       "id": "keyboard",
@@ -462,9 +493,12 @@
         "--font-mono",
         "--leading-tight",
         "--muted",
+        "--space-4",
         "--text-2xl",
+        "--text-4xl",
         "--text-lg",
         "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -500,7 +534,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-2",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/shopify/components.manifest.json
+++ b/design-systems/shopify/components.manifest.json
@@ -237,6 +237,7 @@
         "--bg",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-display",
         "--motion-base",
         "--radius-sm",
@@ -264,8 +265,19 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
+        "--border-soft",
+        "--ease-standard",
+        "--fg",
+        "--focus-ring",
+        "--font-body",
         "--meta",
+        "--motion-fast",
         "--muted",
+        "--radius-md",
+        "--space-2",
+        "--surface-warm",
+        "--text-base",
         "--text-sm"
       ]
     },
@@ -359,7 +371,10 @@
         "--font-display",
         "--leading-tight",
         "--muted",
-        "--text-3xl"
+        "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-xl"
       ]
     },
     {
@@ -391,7 +406,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/simple/components.manifest.json
+++ b/design-systems/simple/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/skeumorphism/components.manifest.json
+++ b/design-systems/skeumorphism/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/slack/components.manifest.json
+++ b/design-systems/slack/components.manifest.json
@@ -245,9 +245,22 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
         "--accent-hover",
+        "--accent-on",
+        "--bg",
+        "--border",
+        "--danger",
+        "--ease-standard",
+        "--fg",
         "--focus-ring",
-        "--surface"
+        "--font-body",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--space-4",
+        "--surface",
+        "--text-base"
       ]
     },
     {
@@ -270,8 +283,15 @@
         "label"
       ],
       "tokenReferences": [
+        "--bg",
+        "--border",
+        "--ease-standard",
         "--fg",
+        "--focus-ring",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
         "--text-base"
       ]
     },
@@ -350,7 +370,12 @@
         "--font-display",
         "--leading-tight",
         "--muted",
-        "--text-3xl"
+        "--text-2xl",
+        "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--tracking-display"
       ]
     },
     {
@@ -382,7 +407,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/sleek/components.manifest.json
+++ b/design-systems/sleek/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/spacex/components.manifest.json
+++ b/design-systems/spacex/components.manifest.json
@@ -271,7 +271,16 @@
         "--accent-active",
         "--accent-hover",
         "--accent-on",
-        "--focus-ring"
+        "--border",
+        "--ease-standard",
+        "--fg",
+        "--focus-ring",
+        "--font-body",
+        "--motion-fast",
+        "--radius-pill",
+        "--space-2",
+        "--space-6",
+        "--text-sm"
       ]
     },
     {
@@ -300,8 +309,17 @@
       ],
       "tokenReferences": [
         "--accent-hover",
+        "--border",
+        "--ease-standard",
+        "--fg",
         "--focus-ring",
+        "--font-body",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--space-3",
+        "--text-base",
         "--text-xs"
       ]
     },
@@ -336,7 +354,12 @@
         "a"
       ],
       "tokenReferences": [
-        "--accent-hover"
+        "--accent-hover",
+        "--border",
+        "--ease-standard",
+        "--fg",
+        "--motion-fast",
+        "--text-sm"
       ]
     },
     {
@@ -391,10 +414,15 @@
         "p"
       ],
       "tokenReferences": [
+        "--fg",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-2xl",
+        "--text-4xl",
+        "--text-base",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -428,7 +456,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
         "--space-4",
+        "--space-6",
         "--space-8"
       ]
     }

--- a/design-systems/spacious/components.manifest.json
+++ b/design-systems/spacious/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/spotify/components.manifest.json
+++ b/design-systems/spotify/components.manifest.json
@@ -241,8 +241,18 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
         "--accent-hover",
-        "--focus-ring"
+        "--accent-on",
+        "--border",
+        "--ease-standard",
+        "--fg",
+        "--focus-ring",
+        "--font-body",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--surface-warm"
       ]
     },
     {
@@ -267,7 +277,12 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--elev-raised"
+        "--ease-standard",
+        "--elev-raised",
+        "--motion-base",
+        "--radius-md",
+        "--space-4",
+        "--surface"
       ]
     },
     {
@@ -334,10 +349,12 @@
       ],
       "tokenReferences": [
         "--fg",
+        "--font-body",
         "--font-display",
         "--leading-tight",
         "--muted",
         "--text-2xl",
+        "--text-lg",
         "--text-sm"
       ]
     },
@@ -372,7 +389,16 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--ease-standard",
+        "--fg",
+        "--motion-fast",
+        "--radius-sm",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
         "--space-4",
+        "--surface",
         "--surface-warm"
       ]
     }

--- a/design-systems/starbucks/components.manifest.json
+++ b/design-systems/starbucks/components.manifest.json
@@ -286,7 +286,9 @@
       "tokenReferences": [
         "--accent",
         "--accent-hover",
+        "--accent-on",
         "--ease-standard",
+        "--fg",
         "--focus-ring",
         "--font-body",
         "--motion-base",
@@ -294,6 +296,7 @@
         "--radius-pill",
         "--space-2",
         "--text-base",
+        "--text-sm",
         "--tracking-display"
       ]
     },
@@ -323,11 +326,21 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--space-4",
+        "--surface",
+        "--text-base",
         "--text-sm",
-        "--text-xs"
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -345,6 +358,11 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--elev-raised",
+        "--radius-md",
+        "--space-3",
+        "--space-6",
+        "--surface",
         "--text-xs"
       ]
     },
@@ -367,7 +385,13 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--success"
+        "--muted",
+        "--radius-pill",
+        "--space-2",
+        "--space-3",
+        "--success",
+        "--surface-warm",
+        "--text-xs"
       ]
     },
     {
@@ -451,8 +475,12 @@
       "tokenReferences": [
         "--fg",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
+        "--text-3xl",
+        "--text-lg",
+        "--text-sm",
         "--text-xl",
         "--text-xs",
         "--tracking-display"
@@ -487,7 +515,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/storytelling/components.manifest.json
+++ b/design-systems/storytelling/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/stripe/components.manifest.json
+++ b/design-systems/stripe/components.manifest.json
@@ -322,14 +322,17 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-display",
         "--motion-fast",
         "--radius-sm",
         "--space-2",
-        "--text-base"
+        "--text-base",
+        "--text-sm"
       ]
     },
     {
@@ -364,16 +367,20 @@
         "select"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--ease-standard",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--motion-fast",
         "--muted",
         "--radius-sm",
         "--space-2",
         "--surface",
         "--text-base",
-        "--text-sm"
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -394,10 +401,19 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--ease-standard",
+        "--elev-raised",
+        "--fg",
+        "--font-display",
+        "--motion-base",
+        "--radius-lg",
         "--radius-md",
         "--space-3",
+        "--space-4",
         "--space-6",
-        "--surface"
+        "--space-8",
+        "--surface",
+        "--text-xl"
       ]
     },
     {
@@ -420,9 +436,11 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--muted",
         "--radius-sm",
+        "--success",
         "--surface-warm",
         "--text-xs"
       ]
@@ -439,7 +457,9 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--accent"
+      ]
     },
     {
       "id": "keyboard",
@@ -452,7 +472,13 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--fg-2",
+        "--font-mono",
+        "--radius-sm",
+        "--surface-warm"
+      ]
     },
     {
       "id": "icons",
@@ -494,12 +520,16 @@
         "p"
       ],
       "tokenReferences": [
+        "--accent",
         "--fg",
         "--font-display",
         "--leading-tight",
         "--muted",
         "--text-2xl",
+        "--text-4xl",
         "--text-sm",
+        "--text-xl",
+        "--text-xs",
         "--tracking-display"
       ]
     },
@@ -532,11 +562,18 @@
         "section"
       ],
       "tokenReferences": [
+        "--border",
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
+        "--container-max",
         "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
-        "--space-6"
+        "--space-4",
+        "--space-6",
+        "--space-8"
       ]
     }
   ],

--- a/design-systems/supabase/components.manifest.json
+++ b/design-systems/supabase/components.manifest.json
@@ -294,14 +294,18 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-display",
         "--motion-fast",
         "--radius-pill",
+        "--radius-sm",
         "--space-2",
+        "--space-3",
         "--space-8",
         "--surface",
         "--text-sm"
@@ -334,10 +338,20 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--bg",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
         "--meta",
-        "--text-sm"
+        "--motion-fast",
+        "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--space-3",
+        "--space-4",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -353,6 +367,7 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--ease-standard",
         "--motion-base",
@@ -384,12 +399,17 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
+        "--bg",
         "--border",
         "--fg-2",
         "--font-display",
+        "--font-mono",
         "--radius-pill",
         "--space-1",
+        "--space-2",
         "--space-3",
+        "--success",
         "--surface",
         "--text-xs"
       ]
@@ -408,7 +428,11 @@
         "a"
       ],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--accent-hover",
+        "--ease-standard",
+        "--focus-ring",
+        "--motion-fast"
       ]
     },
     {
@@ -478,8 +502,12 @@
         "--font-mono",
         "--leading-tight",
         "--muted",
+        "--space-5",
         "--text-3xl",
+        "--text-4xl",
         "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -513,8 +541,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
-        "--space-4"
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/superhuman/components.manifest.json
+++ b/design-systems/superhuman/components.manifest.json
@@ -283,12 +283,15 @@
         "button"
       ],
       "tokenReferences": [
+        "--bg",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-sm",
         "--space-2",
+        "--space-3",
         "--space-5",
         "--surface-warm",
         "--text-base"
@@ -320,10 +323,20 @@
         "label"
       ],
       "tokenReferences": [
+        "--bg",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
+        "--motion-fast",
         "--muted",
-        "--text-sm"
+        "--radius-sm",
+        "--space-2",
+        "--space-4",
+        "--text-base",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -343,6 +356,8 @@
       "tokenReferences": [
         "--border",
         "--ease-standard",
+        "--elev-raised",
+        "--fg",
         "--motion-base",
         "--muted",
         "--radius-lg",
@@ -373,7 +388,13 @@
       "tokenReferences": [
         "--accent",
         "--accent-on",
-        "--muted"
+        "--muted",
+        "--radius-pill",
+        "--radius-sm",
+        "--space-2",
+        "--space-3",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -388,7 +409,9 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--fg"
+      ]
     },
     {
       "id": "keyboard",
@@ -455,10 +478,17 @@
         "p"
       ],
       "tokenReferences": [
+        "--fg",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
+        "--text-2xl",
         "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xs",
         "--tracking-display"
       ]
     },
@@ -495,8 +525,13 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
-        "--space-5"
+        "--space-4",
+        "--space-5",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/tesla/components.manifest.json
+++ b/design-systems/tesla/components.manifest.json
@@ -297,8 +297,13 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
+        "--bg",
+        "--border",
         "--ease-standard",
+        "--fg-2",
+        "--focus-ring",
         "--font-body",
         "--meta",
         "--motion-base",
@@ -337,10 +342,20 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--bg",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
         "--meta",
-        "--text-base"
+        "--motion-fast",
+        "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--space-4",
+        "--text-base",
+        "--text-sm"
       ]
     },
     {
@@ -368,7 +383,12 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--success"
+        "--font-body",
+        "--radius-pill",
+        "--space-2",
+        "--space-3",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -387,9 +407,12 @@
       ],
       "tokenReferences": [
         "--ease-standard",
+        "--fg",
         "--motion-base",
         "--muted",
-        "--surface"
+        "--radius-sm",
+        "--surface",
+        "--text-base"
       ]
     },
     {
@@ -454,11 +477,16 @@
       ],
       "tokenReferences": [
         "--fg",
+        "--font-body",
         "--font-display",
         "--leading-tight",
         "--muted",
+        "--text-2xl",
         "--text-3xl",
+        "--text-4xl",
         "--text-sm",
+        "--text-xl",
+        "--text-xs",
         "--tracking-display"
       ]
     },
@@ -500,10 +528,22 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--ease-standard",
+        "--fg",
+        "--font-display",
+        "--motion-base",
+        "--radius-sm",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-1",
         "--space-2",
         "--space-3",
+        "--space-4",
         "--space-6",
-        "--surface"
+        "--space-8",
+        "--surface",
+        "--text-base"
       ]
     }
   ],

--- a/design-systems/tetris/components.manifest.json
+++ b/design-systems/tetris/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -407,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/theverge/components.manifest.json
+++ b/design-systems/theverge/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -407,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/together-ai/components.manifest.json
+++ b/design-systems/together-ai/components.manifest.json
@@ -267,7 +267,10 @@
       "tokenReferences": [
         "--accent",
         "--accent-hover",
+        "--accent-on",
+        "--border",
         "--ease-standard",
+        "--fg",
         "--focus-ring",
         "--font-body",
         "--motion-fast",
@@ -303,10 +306,20 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--border",
+        "--ease-standard",
+        "--fg",
         "--focus-ring",
+        "--font-body",
         "--font-mono",
+        "--motion-fast",
         "--muted",
-        "--text-xs"
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--text-base",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -321,7 +334,13 @@
         "card"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--elev-raised",
+        "--radius-md",
+        "--space-3",
+        "--surface"
+      ]
     },
     {
       "id": "badges",
@@ -359,7 +378,10 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--fg",
+        "--tracking-display"
+      ]
     },
     {
       "id": "keyboard",
@@ -408,11 +430,16 @@
         "p"
       ],
       "tokenReferences": [
+        "--fg-2",
         "--font-display",
         "--font-mono",
+        "--leading-body",
         "--leading-tight",
         "--muted",
+        "--text-2xl",
         "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
         "--text-xs",
         "--tracking-display"
       ]
@@ -454,7 +481,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/totality-festival/components.manifest.json
+++ b/design-systems/totality-festival/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/trading-terminal/components.manifest.json
+++ b/design-systems/trading-terminal/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/uber/components.manifest.json
+++ b/design-systems/uber/components.manifest.json
@@ -241,11 +241,13 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent-hover",
         "--accent-on",
         "--bg",
         "--border-soft",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-sm",
@@ -272,8 +274,16 @@
         "label"
       ],
       "tokenReferences": [
+        "--bg",
+        "--ease-standard",
+        "--fg",
+        "--font-body",
         "--meta",
+        "--motion-fast",
         "--muted",
+        "--radius-md",
+        "--space-2",
+        "--text-base",
         "--text-sm"
       ]
     },
@@ -291,7 +301,11 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--radius-lg"
+        "--bg",
+        "--elev-raised",
+        "--radius-lg",
+        "--radius-md",
+        "--space-6"
       ]
     },
     {
@@ -316,6 +330,7 @@
         "--font-body",
         "--motion-fast",
         "--radius-sm",
+        "--space-2",
         "--text-sm"
       ]
     },
@@ -379,8 +394,11 @@
         "--fg",
         "--font-display",
         "--leading-tight",
+        "--muted",
         "--text-3xl",
-        "--text-sm"
+        "--text-4xl",
+        "--text-sm",
+        "--text-xl"
       ]
     },
     {
@@ -412,7 +430,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/urdu/components.manifest.json
+++ b/design-systems/urdu/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/vercel/components.manifest.json
+++ b/design-systems/vercel/components.manifest.json
@@ -302,13 +302,17 @@
       ],
       "tokenReferences": [
         "--bg",
+        "--border",
         "--ease-standard",
         "--fg",
+        "--fg-2",
         "--focus-ring",
         "--font-display",
         "--motion-fast",
         "--radius-sm",
         "--space-2",
+        "--space-3",
+        "--surface",
         "--text-sm"
       ]
     },
@@ -339,12 +343,20 @@
         "label"
       ],
       "tokenReferences": [
+        "--border",
+        "--ease-standard",
         "--fg",
         "--fg-2",
         "--focus-ring",
         "--meta",
+        "--motion-fast",
+        "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
         "--text-base",
-        "--text-sm"
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -361,9 +373,11 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--bg",
         "--border",
         "--ease-standard",
         "--elev-raised",
+        "--fg",
         "--motion-base",
         "--radius-lg",
         "--radius-md",
@@ -393,7 +407,15 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
-        "--success"
+        "--bg",
+        "--border",
+        "--fg",
+        "--fg-2",
+        "--font-display",
+        "--radius-pill",
+        "--space-1",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -425,7 +447,13 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--fg-2",
+        "--font-mono",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -472,13 +500,17 @@
       "tokenReferences": [
         "--accent",
         "--fg",
+        "--fg-2",
         "--font-display",
         "--font-mono",
         "--leading-tight",
         "--muted",
         "--space-4",
         "--text-3xl",
+        "--text-4xl",
         "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -513,8 +545,12 @@
         "--container-gutter-tablet",
         "--container-max",
         "--fg",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
-        "--space-4"
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/vibrant/components.manifest.json
+++ b/design-systems/vibrant/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/vintage/components.manifest.json
+++ b/design-systems/vintage/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/vodafone/components.manifest.json
+++ b/design-systems/vodafone/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -407,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/voltagent/components.manifest.json
+++ b/design-systems/voltagent/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/warm-editorial/components.manifest.json
+++ b/design-systems/warm-editorial/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -404,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/warp/components.manifest.json
+++ b/design-systems/warp/components.manifest.json
@@ -273,10 +273,18 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--accent-active",
+        "--accent-hover",
         "--accent-on",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
-        "--space-3"
+        "--font-body",
+        "--motion-fast",
+        "--radius-pill",
+        "--space-2",
+        "--space-3",
+        "--space-5"
       ]
     },
     {
@@ -307,13 +315,18 @@
         "--border",
         "--ease-standard",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--font-body",
         "--meta",
         "--motion-fast",
+        "--muted",
         "--radius-sm",
         "--space-2",
         "--space-4",
-        "--surface"
+        "--surface",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -333,6 +346,7 @@
       "tokenReferences": [
         "--border",
         "--ease-standard",
+        "--fg-2",
         "--font-mono",
         "--meta",
         "--motion-base",
@@ -360,7 +374,13 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--success"
+        "--border",
+        "--fg-2",
+        "--radius-pill",
+        "--space-2",
+        "--space-3",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -442,11 +462,17 @@
       ],
       "tokenReferences": [
         "--fg",
+        "--fg-2",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-2xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -482,7 +508,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
         "--space-4",
+        "--space-5",
         "--space-6"
       ]
     }

--- a/design-systems/webex/components.manifest.json
+++ b/design-systems/webex/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -407,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/webflow/components.manifest.json
+++ b/design-systems/webflow/components.manifest.json
@@ -276,8 +276,13 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
+        "--bg",
+        "--border",
         "--ease-standard",
+        "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-sm",
@@ -311,9 +316,21 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
+        "--bg",
+        "--border",
+        "--ease-standard",
         "--fg",
+        "--focus-ring",
+        "--font-body",
         "--meta",
-        "--text-sm"
+        "--motion-fast",
+        "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--text-base",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -361,7 +378,12 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--font-display",
+        "--radius-sm",
+        "--space-2",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -377,6 +399,7 @@
         "a"
       ],
       "tokenReferences": [
+        "--accent",
         "--accent-hover"
       ]
     },
@@ -391,7 +414,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--font-mono",
+        "--muted",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -436,11 +466,17 @@
       "tokenReferences": [
         "--accent",
         "--fg",
+        "--fg-2",
         "--font-display",
         "--leading-tight",
         "--muted",
         "--text-3xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -473,7 +509,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/wechat/components.manifest.json
+++ b/design-systems/wechat/components.manifest.json
@@ -287,9 +287,12 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
+        "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -325,9 +328,19 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
         "--meta",
+        "--motion-fast",
+        "--muted",
+        "--radius-md",
+        "--space-2",
+        "--space-3",
+        "--surface",
+        "--text-base",
         "--text-sm",
         "--text-xs"
       ]
@@ -349,8 +362,14 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--border-soft",
+        "--elev-raised",
         "--leading-tight",
-        "--radius-md"
+        "--radius-lg",
+        "--radius-md",
+        "--space-3",
+        "--space-6",
+        "--surface"
       ]
     },
     {
@@ -371,8 +390,11 @@
       "elements": [],
       "tokenReferences": [
         "--accent-on",
+        "--muted",
         "--radius-pill",
-        "--success"
+        "--space-2",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -387,7 +409,9 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--accent"
+      ]
     },
     {
       "id": "keyboard",
@@ -400,7 +424,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--font-mono",
+        "--muted",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -446,9 +477,15 @@
       "tokenReferences": [
         "--fg",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
         "--tracking-display"
       ]
     },
@@ -484,8 +521,13 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-2",
-        "--space-4"
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/wired/components.manifest.json
+++ b/design-systems/wired/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -407,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/wise/components.manifest.json
+++ b/design-systems/wise/components.manifest.json
@@ -273,8 +273,11 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
         "--ease-standard",
+        "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-pill",
@@ -308,8 +311,17 @@
       ],
       "tokenReferences": [
         "--accent-on",
+        "--bg",
+        "--border",
+        "--ease-standard",
+        "--fg",
         "--focus-ring",
+        "--font-body",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--text-base",
         "--text-sm",
         "--text-xs"
       ]
@@ -328,6 +340,8 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--bg",
+        "--elev-ring",
         "--radius-md",
         "--space-3",
         "--space-8",
@@ -351,7 +365,13 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--success"
+        "--muted",
+        "--radius-pill",
+        "--space-2",
+        "--space-3",
+        "--success",
+        "--surface",
+        "--text-xs"
       ]
     },
     {
@@ -368,7 +388,8 @@
       ],
       "tokenReferences": [
         "--accent",
-        "--accent-on"
+        "--accent-on",
+        "--fg"
       ]
     },
     {
@@ -382,7 +403,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--font-mono",
+        "--muted",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -427,10 +455,14 @@
       "tokenReferences": [
         "--fg",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
         "--text-sm",
+        "--text-xl",
         "--tracking-display"
       ]
     },
@@ -466,7 +498,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/x-ai/components.manifest.json
+++ b/design-systems/x-ai/components.manifest.json
@@ -258,9 +258,21 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--accent-hover",
+        "--accent-on",
+        "--ease-standard",
         "--fg",
-        "--focus-ring"
+        "--focus-ring",
+        "--font-display",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--space-3",
+        "--space-6",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -288,8 +300,20 @@
         "textarea"
       ],
       "tokenReferences": [
+        "--ease-standard",
+        "--fg",
         "--fg-2",
         "--focus-ring",
+        "--font-body",
+        "--leading-body",
+        "--meta",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--space-3",
+        "--space-4",
+        "--surface",
+        "--text-base",
         "--text-sm"
       ]
     },
@@ -310,9 +334,19 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--border",
+        "--ease-standard",
+        "--elev-flat",
+        "--fg",
         "--fg-2",
+        "--font-body",
+        "--motion-base",
+        "--radius-md",
+        "--space-6",
+        "--surface",
         "--surface-warm",
-        "--text-base"
+        "--text-base",
+        "--text-xl"
       ]
     },
     {
@@ -334,6 +368,7 @@
         "--radius-sm",
         "--space-1",
         "--space-2",
+        "--space-8",
         "--text-xs"
       ]
     },
@@ -397,11 +432,13 @@
         "--font-display",
         "--leading-tight",
         "--muted",
+        "--text-2xl",
         "--text-4xl",
         "--text-lg",
         "--text-sm",
         "--text-xl",
-        "--text-xs"
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -434,7 +471,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-2",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/xiaohongshu/components.manifest.json
+++ b/design-systems/xiaohongshu/components.manifest.json
@@ -337,15 +337,20 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
+        "--border",
         "--border-soft",
         "--ease-standard",
+        "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--muted",
         "--radius-pill",
         "--space-2",
-        "--text-sm"
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -378,15 +383,23 @@
         "textarea"
       ],
       "tokenReferences": [
+        "--bg",
         "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
         "--font-body",
+        "--meta",
+        "--motion-fast",
+        "--muted",
         "--radius-md",
+        "--radius-pill",
+        "--space-2",
         "--space-3",
         "--space-4",
         "--surface",
-        "--text-sm"
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -402,7 +415,13 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--elev-raised"
+        "--ease-standard",
+        "--elev-raised",
+        "--motion-base",
+        "--radius-md",
+        "--space-3",
+        "--space-6",
+        "--surface"
       ]
     },
     {
@@ -422,7 +441,12 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
-        "--accent-on"
+        "--accent-on",
+        "--fg-2",
+        "--radius-pill",
+        "--space-2",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -441,9 +465,15 @@
       ],
       "tokenReferences": [
         "--accent-hover",
+        "--ease-standard",
+        "--fg",
         "--fg-2",
+        "--motion-fast",
+        "--muted",
         "--radius-pill",
-        "--space-3"
+        "--space-2",
+        "--space-3",
+        "--text-sm"
       ]
     },
     {
@@ -457,7 +487,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--font-mono",
+        "--muted",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -476,7 +513,8 @@
         "svg"
       ],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--muted"
       ]
     },
     {
@@ -510,8 +548,13 @@
         "--fg-2",
         "--font-body",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--text-2xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -552,7 +595,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-2",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/zapier/components.manifest.json
+++ b/design-systems/zapier/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -407,9 +424,13 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -289,8 +289,13 @@ type ScanCursor = {
  */
 function scanCssRules(css: string): ScannedCssRule[] {
   const rules: ScannedCssRule[] = [];
-  scanCssStatements(css, 0, [], rules);
+  scanCssStatements(css, 0, [], rules, true);
   return rules;
+}
+
+/** `@keyframes`, including the vendor-prefixed spellings. */
+function isKeyframesPrelude(prelude: string): boolean {
+  return /^@(?:-[a-z]+-)?keyframes\b/i.test(prelude);
 }
 
 /**
@@ -304,6 +309,7 @@ function scanCssStatements(
   start: number,
   ancestors: string[],
   rules: ScannedCssRule[],
+  emitRules: boolean,
 ): ScanCursor {
   let declarations = '';
   let buffer = '';
@@ -364,16 +370,24 @@ function scanCssStatements(
       buffer = '';
       if (prelude.startsWith('@')) {
         // Conditional groups (`@media`, `@supports`, `@container`, block-form
-        // `@layer`) do not change the selector their contents apply to; other
-        // block at-rules (`@keyframes`, `@font-face`) carry no selector either.
-        const block = scanCssStatements(css, index + 1, ancestors, rules);
+        // `@layer`) do not change the selector their contents apply to, so they
+        // stay transparent. A `@keyframes` block is different: its children are
+        // animation positions, not component surface, so the block is scanned
+        // for balance but contributes no rules.
+        const block = scanCssStatements(
+          css,
+          index + 1,
+          ancestors,
+          rules,
+          emitRules && !isKeyframesPrelude(prelude),
+        );
         declarations += block.declarations;
         index = block.index;
         continue;
       }
       const selectors = resolveNestedSelectors(prelude, ancestors);
-      const block = scanCssStatements(css, index + 1, selectors, rules);
-      rules.push({ prelude, selectors, declarations: block.declarations });
+      const block = scanCssStatements(css, index + 1, selectors, rules, emitRules);
+      if (emitRules) rules.push({ prelude, selectors, declarations: block.declarations });
       index = block.index;
       continue;
     }
@@ -446,12 +460,19 @@ function resolveNestedSelectors(prelude: string, ancestors: string[]): string[] 
 }
 
 /**
- * `:root` blocks declare tokens rather than component surface, and keyframe
- * stops are positions rather than selectors. Both are matched on the prelude as
- * written so the rule is judged the way its author wrote it.
+ * `:root` blocks declare tokens rather than component surface, and a keyframe
+ * stop list is a set of animation positions rather than selectors. `@keyframes`
+ * blocks already contribute no rules; this also covers a stop list reaching the
+ * consumers by any other route. Both are matched on the prelude as written so
+ * the rule is judged the way its author wrote it.
  */
 function isTokenOrKeyframeRule(prelude: string): boolean {
-  return prelude.includes(':root') || /^(?:from|to|\d+(?:\.\d+)?%)$/i.test(prelude);
+  return prelude.includes(':root') || isKeyframeStopList(prelude);
+}
+
+function isKeyframeStopList(prelude: string): boolean {
+  const stops = prelude.split(',').map((stop) => stop.trim()).filter((stop) => stop.length > 0);
+  return stops.length > 0 && stops.every((stop) => /^(?:from|to|\d+(?:\.\d+)?%)$/i.test(stop));
 }
 
 function extractCssSelectors(css: string): string[] {

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -343,8 +343,9 @@ function scanCssStatements(
     }
 
     if (char === '\\') {
-      buffer += css.slice(index, index + 2);
-      index += 2;
+      const next = skipCssEscape(css, index);
+      buffer += css.slice(index, next);
+      index = next;
       continue;
     }
 
@@ -422,7 +423,21 @@ function scanCssStatements(
 }
 
 /**
- * Index just past the closing quote of the string starting at `start`. An
+ * Index just past the escape sequence starting at `start`. CSS preprocessing
+ * folds CRLF into one newline, so an escaped CRLF is a single line continuation
+ * rather than an escaped CR followed by a stray LF.
+ */
+function skipCssEscape(css: string, start: number): number {
+  return css.startsWith('\r\n', start + 1) ? start + 3 : start + 2;
+}
+
+/** CR, LF and form feed all end a line once CSS preprocessing is applied. */
+function isCssNewline(char: string): boolean {
+  return char === '\n' || char === '\r' || char === '\f';
+}
+
+/**
+ * Index just past the closing quote of the string starting at `start`. Any
  * unescaped newline ends it, matching how CSS treats an unterminated string, so
  * a stray quote does not swallow the rest of the stylesheet.
  */
@@ -430,12 +445,12 @@ function readCssString(css: string, start: number): number {
   const quote = css[start];
   let index = start + 1;
   while (index < css.length) {
-    const char = css[index];
+    const char = css.charAt(index);
     if (char === '\\') {
-      index += 2;
+      index = skipCssEscape(css, index);
       continue;
     }
-    if (char === '\n') return index;
+    if (isCssNewline(char)) return index;
     if (char === quote) return index + 1;
     index += 1;
   }
@@ -449,7 +464,7 @@ function readCssParens(css: string, start: number): number {
   while (index < css.length) {
     const char = css[index];
     if (char === '\\') {
-      index += 2;
+      index = skipCssEscape(css, index);
       continue;
     }
     if (char === '"' || char === "'") {

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -72,12 +72,39 @@ type ComponentGroupDefinition = {
 };
 
 /**
- * Match a whole class-name segment. Substring matching pulled unrelated classes
- * into groups — `platform` into form fields, `icon-octagon` into buttons — so a
- * word only counts when it is a segment of its own, optionally pluralized.
+ * English plural of a matcher word: sibilants take `-es` (`status` ->
+ * `statuses`), a consonant before `y` takes `-ies`, everything else `-s`.
+ */
+function pluralOf(word: string): string {
+  if (/(?:s|x|z|ch|sh)$/i.test(word)) return `${word}es`;
+  if (/[^aeiou]y$/i.test(word)) return `${word.slice(0, -1)}ies`;
+  return `${word}s`;
+}
+
+/**
+ * Match a whole class-name segment, singular or plural. Substring matching
+ * pulled unrelated classes into groups — `platform` into form fields,
+ * `icon-octagon` into buttons — while segment matching keeps the families each
+ * group owns: `status`, `statuses-list`, `icon-status` and `statusBadge` all
+ * reach the badges group, because callers also test the kebab-cased spelling
+ * (see `classNameVariants`).
  */
 function classSegment(word: string): RegExp {
-  return new RegExp(`(?:^|[-_])${word}s?(?:$|[-_])`, 'i');
+  const forms = [pluralOf(word), word];
+  return new RegExp(`(?:^|[-_])(?:${forms.join('|')})(?:$|[-_])`, 'i');
+}
+
+/**
+ * A class name as written plus its kebab-cased spelling, so one segment matcher
+ * covers `icon-status`, `icon_status` and `iconStatus` without every matcher
+ * having to describe a case boundary. `HTMLButton` splits on the acronym edge
+ * as well, giving `HTML-Button`.
+ */
+function classNameVariants(className: string): string[] {
+  const kebab = className
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2');
+  return kebab === className ? [className] : [className, kebab];
 }
 
 const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
@@ -236,7 +263,9 @@ function buildGroupManifest(
     definition.selectorMatchers.some((matcher) => matcher.test(selector)),
   );
   const classes = inventory.classes.filter((className) =>
-    definition.classMatchers.some((matcher) => matcher.test(className)),
+    classNameVariants(className).some((variant) =>
+      definition.classMatchers.some((matcher) => matcher.test(variant)),
+    ),
   );
   const elements = inventory.elements.filter((element) =>
     definition.elementMatchers.some((matcher) => matcher.test(element)),
@@ -337,6 +366,8 @@ function scanCssStatements(
     const char = css.charAt(index);
 
     if (char === '/' && css[index + 1] === '*') {
+      // CSS ends an unterminated comment at EOF, so an unclosed `/*` legitimately
+      // comments out the remainder rather than being recovered from.
       const close = css.indexOf('*/', index + 2);
       index = close === -1 ? css.length : close + 2;
       continue;
@@ -457,12 +488,18 @@ function readCssString(css: string, start: number): number {
   return css.length;
 }
 
-/** Index just past the balanced `)` of the group starting at `start`. */
+/**
+ * Index just past the balanced `)` of the group starting at `start`. An
+ * unescaped, unquoted block brace ends the group instead: braces do not appear
+ * inside a function in well-formed CSS, so meeting one means the `(` was never
+ * closed, and stopping keeps the rest of the stylesheet readable rather than
+ * consuming it as part of the function.
+ */
 function readCssParens(css: string, start: number): number {
   let depth = 0;
   let index = start;
   while (index < css.length) {
-    const char = css[index];
+    const char = css.charAt(index);
     if (char === '\\') {
       index = skipCssEscape(css, index);
       continue;
@@ -471,6 +508,7 @@ function readCssParens(css: string, start: number): number {
       index = readCssString(css, index);
       continue;
     }
+    if (char === '{' || char === '}') return index;
     if (char === '(') depth += 1;
     if (char === ')') {
       depth -= 1;

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -280,6 +280,15 @@ type ScanCursor = {
   index: number;
 };
 
+type ScanScope = {
+  /** Selectors this level's rules nest inside, outermost already resolved. */
+  ancestors: string[];
+  /** False inside `@keyframes`, whose children are positions, not selectors. */
+  emitRules: boolean;
+  /** False at the top level, where a stray `}` is noise rather than an end. */
+  nested: boolean;
+};
+
 /**
  * Walk CSS into rules. A regex cannot do this correctly: it cannot balance
  * nested blocks, and any pattern that consumes the delimiter between two rules
@@ -289,7 +298,7 @@ type ScanCursor = {
  */
 function scanCssRules(css: string): ScannedCssRule[] {
   const rules: ScannedCssRule[] = [];
-  scanCssStatements(css, 0, [], rules, true);
+  scanCssStatements(css, 0, { ancestors: [], emitRules: true, nested: false }, rules);
   return rules;
 }
 
@@ -307,9 +316,8 @@ function isKeyframesPrelude(prelude: string): boolean {
 function scanCssStatements(
   css: string,
   start: number,
-  ancestors: string[],
+  scope: ScanScope,
   rules: ScannedCssRule[],
-  emitRules: boolean,
 ): ScanCursor {
   let declarations = '';
   let buffer = '';
@@ -362,7 +370,12 @@ function scanCssStatements(
 
     if (char === '}') {
       takeStatement();
-      return { declarations, index: index + 1 };
+      // Only a nested scan is closed by `}`. At the top level an unbalanced
+      // brace is malformed input, and skipping it keeps the rest of the
+      // stylesheet readable instead of discarding it.
+      if (scope.nested) return { declarations, index: index + 1 };
+      index += 1;
+      continue;
     }
 
     if (char === '{') {
@@ -377,17 +390,25 @@ function scanCssStatements(
         const block = scanCssStatements(
           css,
           index + 1,
-          ancestors,
+          {
+            ancestors: scope.ancestors,
+            emitRules: scope.emitRules && !isKeyframesPrelude(prelude),
+            nested: true,
+          },
           rules,
-          emitRules && !isKeyframesPrelude(prelude),
         );
         declarations += block.declarations;
         index = block.index;
         continue;
       }
-      const selectors = resolveNestedSelectors(prelude, ancestors);
-      const block = scanCssStatements(css, index + 1, selectors, rules, emitRules);
-      if (emitRules) rules.push({ prelude, selectors, declarations: block.declarations });
+      const selectors = resolveNestedSelectors(prelude, scope.ancestors);
+      const block = scanCssStatements(
+        css,
+        index + 1,
+        { ancestors: selectors, emitRules: scope.emitRules, nested: true },
+        rules,
+      );
+      if (scope.emitRules) rules.push({ prelude, selectors, declarations: block.declarations });
       index = block.index;
       continue;
     }
@@ -400,7 +421,11 @@ function scanCssStatements(
   return { declarations, index };
 }
 
-/** Index just past the closing quote of the string starting at `start`. */
+/**
+ * Index just past the closing quote of the string starting at `start`. An
+ * unescaped newline ends it, matching how CSS treats an unterminated string, so
+ * a stray quote does not swallow the rest of the stylesheet.
+ */
 function readCssString(css: string, start: number): number {
   const quote = css[start];
   let index = start + 1;
@@ -410,6 +435,7 @@ function readCssString(css: string, start: number): number {
       index += 2;
       continue;
     }
+    if (char === '\n') return index;
     if (char === quote) return index + 1;
     index += 1;
   }
@@ -450,13 +476,38 @@ function resolveNestedSelectors(prelude: string, ancestors: string[]): string[] 
   for (const ancestor of ancestors) {
     for (const part of parts) {
       resolved.push(
-        part.includes('&')
-          ? normalizeSelector(part.replace(/&/g, ancestor))
+        containsNestingSelector(part)
+          ? normalizeSelector(substituteNestingSelector(part, ancestor))
           : `${ancestor} ${part}`,
       );
     }
   }
   return resolved;
+}
+
+/**
+ * `&` inside quoted text — `[data-state="&"]` — is part of a value, not the
+ * nesting selector, so quoted spans are copied through untouched.
+ */
+function substituteNestingSelector(selector: string, ancestor: string): string {
+  let result = '';
+  let index = 0;
+  while (index < selector.length) {
+    const char = selector.charAt(index);
+    if (char === '"' || char === "'") {
+      const end = readCssString(selector, index);
+      result += selector.slice(index, end);
+      index = end;
+      continue;
+    }
+    result += char === '&' ? ancestor : char;
+    index += 1;
+  }
+  return result;
+}
+
+function containsNestingSelector(selector: string): boolean {
+  return substituteNestingSelector(selector, '\u0000').includes('\u0000');
 }
 
 /**

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -71,19 +71,28 @@ type ComponentGroupDefinition = {
   elementMatchers: RegExp[];
 };
 
+/**
+ * Match a whole class-name segment. Substring matching pulled unrelated classes
+ * into groups — `platform` into form fields, `icon-octagon` into buttons — so a
+ * word only counts when it is a segment of its own, optionally pluralized.
+ */
+function classSegment(word: string): RegExp {
+  return new RegExp(`(?:^|[-_])${word}s?(?:$|[-_])`, 'i');
+}
+
 const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
   {
     id: 'buttons',
     label: 'Buttons and calls to action',
     selectorMatchers: [/\bbutton\b/i, /\.btn(?:\b|[-_:])/i, /\[type=["']?(?:button|submit|reset)/i],
-    classMatchers: [/^btn(?:$|-)/i, /button/i, /cta/i],
+    classMatchers: [/^btn(?:$|-)/i, classSegment('button'), classSegment('cta')],
     elementMatchers: [/^button$/i],
   },
   {
     id: 'inputs',
     label: 'Form fields and controls',
     selectorMatchers: [/\binput\b/i, /\btextarea\b/i, /\bselect\b/i, /\.field(?:\b|[-_:])/i, /\blabel\b/i],
-    classMatchers: [/^field(?:$|-)/i, /input/i, /control/i, /form/i],
+    classMatchers: [/^field(?:$|-)/i, classSegment('input'), classSegment('control'), classSegment('form')],
     elementMatchers: [/^(input|textarea|select|label|form)$/i],
   },
   {
@@ -97,7 +106,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
     id: 'badges',
     label: 'Badges, chips, and status labels',
     selectorMatchers: [/\.badge(?:\b|[-_:])/i, /\.chip(?:\b|[-_:])/i, /\.tag(?:\b|[-_:])/i, /\.pill(?:\b|[-_:])/i],
-    classMatchers: [/^badge(?:$|-)/i, /^chip(?:$|-)/i, /^tag(?:$|-)/i, /^pill(?:$|-)/i, /status/i],
+    classMatchers: [/^badge(?:$|-)/i, /^chip(?:$|-)/i, /^tag(?:$|-)/i, /^pill(?:$|-)/i, classSegment('status')],
     elementMatchers: [],
   },
   {
@@ -111,7 +120,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
     id: 'keyboard',
     label: 'Keyboard hints',
     selectorMatchers: [/\bkbd\b/i, /\.kbd(?:\b|[-_:])/i],
-    classMatchers: [/^kbd(?:$|-)/i, /keyboard/i, /shortcut/i],
+    classMatchers: [/^kbd(?:$|-)/i, classSegment('keyboard'), classSegment('shortcut')],
     elementMatchers: [/^kbd$/i],
   },
   {
@@ -125,7 +134,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
     id: 'typography',
     label: 'Typography scale and text utilities',
     selectorMatchers: [/\bh[1-6]\b/i, /\.lead(?:\b|[-_:])/i, /\.eyebrow(?:\b|[-_:])/i, /\.body-(?:muted|sm|small)\b/i],
-    classMatchers: [/^lead$/i, /^eyebrow$/i, /^body-(?:muted|sm|small)$/i, /caption/i],
+    classMatchers: [/^lead$/i, /^eyebrow$/i, /^body-(?:muted|sm|small)$/i, classSegment('caption')],
     elementMatchers: [/^h[1-6]$/i, /^p$/i],
   },
   {
@@ -139,7 +148,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
       /\bmain\b/i,
       /\bnav\b/i,
     ],
-    classMatchers: [/^container$/i, /^stack-\d+$/i, /^row-(?:between|center|start|end)$/i, /grid/i, /layout/i],
+    classMatchers: [/^container$/i, /^stack-\d+$/i, /^row-(?:between|center|start|end)$/i, classSegment('grid'), classSegment('layout')],
     elementMatchers: [/^(main|section|nav|header|footer)$/i],
   },
 ];
@@ -257,23 +266,201 @@ function extractStyleBlocks(html: string): string[] {
   return blocks;
 }
 
+type ScannedCssRule = {
+  /** Raw prelude as written, whitespace-normalized. */
+  prelude: string;
+  /** Selectors with any nesting resolved against their ancestors. */
+  selectors: string[];
+  /** The rule's own declarations, excluding those of any nested rule. */
+  declarations: string;
+};
+
+type ScanCursor = {
+  declarations: string;
+  index: number;
+};
+
+/**
+ * Walk CSS into rules. A regex cannot do this correctly: it cannot balance
+ * nested blocks, and any pattern that consumes the delimiter between two rules
+ * drops every other rule. Scanning is string-, escape-, comment-, and
+ * paren-aware so braces inside `content: "{"`, `.w-\{full\}`, or
+ * `url("a{b}.css")` do not open or close a block.
+ */
+function scanCssRules(css: string): ScannedCssRule[] {
+  const rules: ScannedCssRule[] = [];
+  scanCssStatements(css, 0, [], rules);
+  return rules;
+}
+
+/**
+ * Scan statements from `start` until the block closes or input ends, appending
+ * style rules to `rules`. Returns the declarations owned by this level, so a
+ * conditional at-rule nested in a style rule (`.card { @media … { … } }`) hands
+ * its declarations back to the rule that encloses it.
+ */
+function scanCssStatements(
+  css: string,
+  start: number,
+  ancestors: string[],
+  rules: ScannedCssRule[],
+): ScanCursor {
+  let declarations = '';
+  let buffer = '';
+  let index = start;
+
+  const takeStatement = () => {
+    const statement = buffer.trim();
+    buffer = '';
+    // Statement at-rules (`@charset`, `@namespace`, `@import`, statement-form
+    // `@layer`) own no block and declare nothing.
+    if (statement.length > 0 && !statement.startsWith('@')) {
+      declarations += `${statement};`;
+    }
+  };
+
+  while (index < css.length) {
+    const char = css.charAt(index);
+
+    if (char === '/' && css[index + 1] === '*') {
+      const close = css.indexOf('*/', index + 2);
+      index = close === -1 ? css.length : close + 2;
+      continue;
+    }
+
+    if (char === '\\') {
+      buffer += css.slice(index, index + 2);
+      index += 2;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      const end = readCssString(css, index);
+      buffer += css.slice(index, end);
+      index = end;
+      continue;
+    }
+
+    if (char === '(') {
+      const end = readCssParens(css, index);
+      buffer += css.slice(index, end);
+      index = end;
+      continue;
+    }
+
+    if (char === ';') {
+      takeStatement();
+      index += 1;
+      continue;
+    }
+
+    if (char === '}') {
+      takeStatement();
+      return { declarations, index: index + 1 };
+    }
+
+    if (char === '{') {
+      const prelude = normalizeSelector(buffer);
+      buffer = '';
+      if (prelude.startsWith('@')) {
+        // Conditional groups (`@media`, `@supports`, `@container`, block-form
+        // `@layer`) do not change the selector their contents apply to; other
+        // block at-rules (`@keyframes`, `@font-face`) carry no selector either.
+        const block = scanCssStatements(css, index + 1, ancestors, rules);
+        declarations += block.declarations;
+        index = block.index;
+        continue;
+      }
+      const selectors = resolveNestedSelectors(prelude, ancestors);
+      const block = scanCssStatements(css, index + 1, selectors, rules);
+      rules.push({ prelude, selectors, declarations: block.declarations });
+      index = block.index;
+      continue;
+    }
+
+    buffer += char;
+    index += 1;
+  }
+
+  takeStatement();
+  return { declarations, index };
+}
+
+/** Index just past the closing quote of the string starting at `start`. */
+function readCssString(css: string, start: number): number {
+  const quote = css[start];
+  let index = start + 1;
+  while (index < css.length) {
+    const char = css[index];
+    if (char === '\\') {
+      index += 2;
+      continue;
+    }
+    if (char === quote) return index + 1;
+    index += 1;
+  }
+  return css.length;
+}
+
+/** Index just past the balanced `)` of the group starting at `start`. */
+function readCssParens(css: string, start: number): number {
+  let depth = 0;
+  let index = start;
+  while (index < css.length) {
+    const char = css[index];
+    if (char === '\\') {
+      index += 2;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      index = readCssString(css, index);
+      continue;
+    }
+    if (char === '(') depth += 1;
+    if (char === ')') {
+      depth -= 1;
+      if (depth === 0) return index + 1;
+    }
+    index += 1;
+  }
+  return css.length;
+}
+
+function resolveNestedSelectors(prelude: string, ancestors: string[]): string[] {
+  const parts = splitSelectorList(prelude)
+    .map((selector) => normalizeSelector(selector))
+    .filter((selector) => selector.length > 0);
+  if (ancestors.length === 0) return parts;
+
+  const resolved: string[] = [];
+  for (const ancestor of ancestors) {
+    for (const part of parts) {
+      resolved.push(
+        part.includes('&')
+          ? normalizeSelector(part.replace(/&/g, ancestor))
+          : `${ancestor} ${part}`,
+      );
+    }
+  }
+  return resolved;
+}
+
+/**
+ * `:root` blocks declare tokens rather than component surface, and keyframe
+ * stops are positions rather than selectors. Both are matched on the prelude as
+ * written so the rule is judged the way its author wrote it.
+ */
+function isTokenOrKeyframeRule(prelude: string): boolean {
+  return prelude.includes(':root') || /^(?:from|to|\d+(?:\.\d+)?%)$/i.test(prelude);
+}
+
 function extractCssSelectors(css: string): string[] {
   const selectors = new Set<string>();
-  const commentlessCss = stripContainerAtRuleHeaders(stripCssComments(css));
-  const selectorPattern = /(?:^|[{}])\s*([^@{}][^{}]*?)\s*\{/g;
-  let match: RegExpExecArray | null;
 
-  while ((match = selectorPattern.exec(commentlessCss)) !== null) {
-    const rawSelectorList = match[1]?.trim();
-    if (rawSelectorList == null || rawSelectorList.length === 0) continue;
-    if (rawSelectorList.includes(':root')) continue;
-    if (/^(?:from|to|\d+(?:\.\d+)?%)$/i.test(rawSelectorList)) continue;
-
-    for (const selector of splitSelectorList(rawSelectorList)) {
-      const normalized = normalizeSelector(selector);
-      if (normalized.length > 0 && !normalized.startsWith('@')) {
-        selectors.add(normalized);
-      }
+  for (const rule of scanCssRules(css)) {
+    if (isTokenOrKeyframeRule(rule.prelude)) continue;
+    for (const selector of rule.selectors) {
+      if (selector.length > 0) selectors.add(selector);
     }
   }
 
@@ -282,28 +469,19 @@ function extractCssSelectors(css: string): string[] {
 
 function extractSelectorTokenReferences(css: string): Map<string, string[]> {
   const referencesBySelector = new Map<string, Set<string>>();
-  const commentlessCss = stripContainerAtRuleHeaders(stripCssComments(css));
-  const rulePattern = /(?:^|[{}])\s*([^@{}][^{}]*?)\s*\{([^{}]*)\}/g;
-  let match: RegExpExecArray | null;
 
-  while ((match = rulePattern.exec(commentlessCss)) !== null) {
-    const rawSelectorList = match[1]?.trim();
-    const rawBody = match[2] ?? '';
-    if (rawSelectorList == null || rawSelectorList.length === 0) continue;
-    if (rawSelectorList.includes(':root')) continue;
-    if (/^(?:from|to|\d+(?:\.\d+)?%)$/i.test(rawSelectorList)) continue;
-
-    const tokenReferences = extractTokenReferences(rawBody);
+  for (const rule of scanCssRules(css)) {
+    if (isTokenOrKeyframeRule(rule.prelude)) continue;
+    const tokenReferences = extractTokenReferences(rule.declarations);
     if (tokenReferences.length === 0) continue;
 
-    for (const selector of splitSelectorList(rawSelectorList)) {
-      const normalized = normalizeSelector(selector);
-      if (normalized.length === 0 || normalized.startsWith('@')) continue;
-      const selectorReferences = referencesBySelector.get(normalized) ?? new Set<string>();
+    for (const selector of rule.selectors) {
+      if (selector.length === 0) continue;
+      const selectorReferences = referencesBySelector.get(selector) ?? new Set<string>();
       for (const token of tokenReferences) {
         selectorReferences.add(token);
       }
-      referencesBySelector.set(normalized, selectorReferences);
+      referencesBySelector.set(selector, selectorReferences);
     }
   }
 
@@ -400,10 +578,6 @@ function stripRootBlocks(css: string): string {
 
 function stripCssComments(css: string): string {
   return css.replace(/\/\*[\s\S]*?\*\//g, '');
-}
-
-function stripContainerAtRuleHeaders(css: string): string {
-  return css.replace(/@(media|supports|container|layer)\b[^{]*\{/gi, '{');
 }
 
 function countLiterals(css: string): ComponentManifestLiteralInventory {

--- a/packages/contracts/tests/components-manifest-css-scanner.test.ts
+++ b/packages/contracts/tests/components-manifest-css-scanner.test.ts
@@ -209,7 +209,40 @@ describe('malformed input', () => {
   });
 });
 
+describe('unterminated functions', () => {
+  it('bounds an unterminated url() at the block brace', () => {
+    const css = '.btn { background: url(unclosed; }\n.card { background: var(--surface); }';
+
+    expect(manifestFor(css).selectors).toEqual(['.btn', '.card']);
+  });
+
+  it('bounds an unterminated selector function so later rules survive', () => {
+    const css = '.btn:is(.a { color: var(--accent); }\n.card { background: var(--surface); }';
+
+    expect(manifestFor(css).selectors.some((selector) => selector.includes('.card'))).toBe(true);
+  });
+
+  it('keeps a balanced nested function intact', () => {
+    const css = '.btn { width: calc(var(--space-4) * (1 + 2)); }\n.card { background: var(--surface); }';
+    const bodyHtml = '<button class="btn"></button><div class="card"></div>';
+
+    expect(manifestFor(css, bodyHtml).selectors).toEqual(['.btn', '.card']);
+    expect(groupTokens(css, 'buttons', bodyHtml)).toEqual(['--space-4']);
+  });
+
+  it('comments out the remainder of an unterminated comment, as CSS does', () => {
+    const css = '.btn { color: var(--accent); }\n/* .card { background: var(--surface); }';
+
+    expect(manifestFor(css).selectors).toEqual(['.btn']);
+  });
+});
+
 describe('class matchers', () => {
+  function classesFor(bodyHtml: string, groupId: string): string[] {
+    const manifest = manifestFor('.x { color: var(--fg); }', bodyHtml);
+    return manifest.groups.find((group) => group.id === groupId)?.classes ?? [];
+  }
+
   it('matches whole class-name segments rather than substrings', () => {
     const bodyHtml = `
       <div class="platform"></div>
@@ -217,10 +250,36 @@ describe('class matchers', () => {
       <div class="form-field"></div>
       <div class="cta-primary"></div>
     `;
-    const manifest = manifestFor('.form-field { color: var(--fg); }', bodyHtml);
-    const classesFor = (id: string) => manifest.groups.find((group) => group.id === id)?.classes ?? [];
 
-    expect(classesFor('inputs')).toEqual(['form-field']);
-    expect(classesFor('buttons')).toEqual(['cta-primary']);
+    expect(classesFor(bodyHtml, 'inputs')).toEqual(['form-field']);
+    expect(classesFor(bodyHtml, 'buttons')).toEqual(['cta-primary']);
+  });
+
+  // Segment matching must not cost the families a group already owned. `status`
+  // pluralizes to `statuses`, not `statuss`, and class names are written in
+  // kebab, snake and camel case.
+  it.each([
+    ['singular', 'status'],
+    ['irregular plural', 'statuses-list'],
+    ['kebab case', 'icon-status'],
+    ['snake case', 'icon_status'],
+    ['camel case', 'statusBadge'],
+    ['camel case with a leading word', 'iconStatus'],
+    ['acronym boundary', 'HTMLStatus'],
+  ])('claims a %s status class for the badges group', (_label, className) => {
+    expect(classesFor(`<span class="${className}"></span>`, 'badges')).toEqual([className]);
+  });
+
+  it.each([
+    ['platform', 'inputs'],
+    ['transformation', 'inputs'],
+    ['icon-octagon', 'buttons'],
+    ['statusbar', 'badges'],
+  ])('keeps %s out of the %s group', (className, groupId) => {
+    expect(classesFor(`<div class="${className}"></div>`, groupId)).toEqual([]);
+  });
+
+  it('still claims a regular plural', () => {
+    expect(classesFor('<div class="buttons"></div>', 'buttons')).toEqual(['buttons']);
   });
 });

--- a/packages/contracts/tests/components-manifest-css-scanner.test.ts
+++ b/packages/contracts/tests/components-manifest-css-scanner.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractComponentsManifest } from '../src/design-systems/components-manifest.js';
+
+function manifestFor(css: string, bodyHtml = '') {
+  return extractComponentsManifest({
+    brandId: 'scanner-fixture',
+    fixtureHtml: `<style>${css}</style>${bodyHtml}`,
+  });
+}
+
+function groupTokens(css: string, groupId: string, bodyHtml = ''): string[] {
+  const group = manifestFor(css, bodyHtml).groups.find((candidate) => candidate.id === groupId);
+  if (!group) throw new Error(`Unknown group ${groupId}`);
+  return group.tokenReferences;
+}
+
+describe('css rule scanning', () => {
+  it('attributes tokens to every rule in a consecutive run', () => {
+    const css = `
+      .btn { color: var(--accent); }
+      .card { background: var(--surface); }
+      .badge { border-color: var(--border); }
+    `;
+    const bodyHtml = '<button class="btn"></button><div class="card"></div><span class="badge"></span>';
+
+    expect(groupTokens(css, 'buttons', bodyHtml)).toEqual(['--accent']);
+    expect(groupTokens(css, 'cards', bodyHtml)).toEqual(['--surface']);
+    expect(groupTokens(css, 'badges', bodyHtml)).toEqual(['--border']);
+  });
+
+  it('keeps token attribution when rules are separated by a block at-rule', () => {
+    const css = `
+      .btn { color: var(--accent); }
+      @media (min-width: 40rem) {
+        .btn { padding: var(--space-4); }
+      }
+      .card { background: var(--surface); }
+    `;
+    const bodyHtml = '<button class="btn"></button><div class="card"></div>';
+
+    expect(groupTokens(css, 'buttons', bodyHtml)).toEqual(['--accent', '--space-4']);
+    expect(groupTokens(css, 'cards', bodyHtml)).toEqual(['--surface']);
+  });
+
+  it('reads tokens from a rule that owns a nested block', () => {
+    const css = `
+      .card {
+        background: var(--surface);
+        &:hover { border-color: var(--accent); }
+      }
+    `;
+
+    expect(groupTokens(css, 'cards', '<div class="card"></div>')).toEqual(['--accent', '--surface']);
+  });
+
+  it('resolves nested selectors instead of emitting declaration text as a selector', () => {
+    const css = `
+      .card {
+        background: var(--surface);
+        &:hover { border-color: var(--accent); }
+        .title { color: var(--fg); }
+      }
+    `;
+
+    expect(manifestFor(css).selectors).toEqual(['.card', '.card .title', '.card:hover']);
+  });
+
+  it('does not treat a declaration block as a selector when a rule nests', () => {
+    const css = '.card { background: var(--surface); &:hover { color: var(--fg); } }';
+
+    for (const selector of manifestFor(css).selectors) {
+      expect(selector).not.toContain('var(');
+      expect(selector).not.toContain(';');
+    }
+  });
+});
+
+describe('statement at-rules', () => {
+  // A top-level statement at-rule terminates at `;` and owns no block. Scanning
+  // must step over it without consuming the rule that follows.
+  it.each([
+    ['@charset "utf-8";'],
+    ['@namespace svg url(http://www.w3.org/2000/svg);'],
+    ['@layer base, components;'],
+    ['@import url("theme.css");'],
+    ['@IMPORT url("theme.css");'],
+  ])('does not swallow the first rule after %s', (statement) => {
+    const css = `${statement}\n.btn { color: var(--accent); }`;
+
+    expect(groupTokens(css, 'buttons', '<button class="btn"></button>')).toEqual(['--accent']);
+  });
+
+  it('steps over a statement at-rule whose prelude contains braces in a string', () => {
+    const css = '@import url("a{b}.css");\n.btn { color: var(--accent); }';
+
+    expect(groupTokens(css, 'buttons', '<button class="btn"></button>')).toEqual(['--accent']);
+  });
+});
+
+describe('lexical edge cases', () => {
+  it('ignores braces inside string values', () => {
+    const css = `
+      .btn::before { content: "{"; color: var(--accent); }
+      .card { background: var(--surface); }
+    `;
+    const bodyHtml = '<button class="btn"></button><div class="card"></div>';
+
+    expect(groupTokens(css, 'buttons', bodyHtml)).toEqual(['--accent']);
+    expect(groupTokens(css, 'cards', bodyHtml)).toEqual(['--surface']);
+  });
+
+  it('ignores braces inside an escaped selector', () => {
+    const css = `
+      .w-\\{full\\} { color: var(--accent); }
+      .card { background: var(--surface); }
+    `;
+
+    expect(groupTokens(css, 'cards', '<div class="card"></div>')).toEqual(['--surface']);
+  });
+
+  it('keeps a comma inside a selector function out of the selector split', () => {
+    const css = '.card:is(.a, .b) { background: var(--surface); }';
+
+    expect(manifestFor(css).selectors).toEqual(['.card:is(.a, .b)']);
+  });
+});
+
+describe('class matchers', () => {
+  it('matches whole class-name segments rather than substrings', () => {
+    const bodyHtml = `
+      <div class="platform"></div>
+      <div class="icon-octagon"></div>
+      <div class="form-field"></div>
+      <div class="cta-primary"></div>
+    `;
+    const manifest = manifestFor('.form-field { color: var(--fg); }', bodyHtml);
+    const classesFor = (id: string) => manifest.groups.find((group) => group.id === id)?.classes ?? [];
+
+    expect(classesFor('inputs')).toEqual(['form-field']);
+    expect(classesFor('buttons')).toEqual(['cta-primary']);
+  });
+});

--- a/packages/contracts/tests/components-manifest-css-scanner.test.ts
+++ b/packages/contracts/tests/components-manifest-css-scanner.test.ts
@@ -151,10 +151,43 @@ describe('lexical edge cases', () => {
     expect(groupTokens(css, 'cards', '<div class="card"></div>')).toEqual(['--surface']);
   });
 
+  it('treats an ampersand inside quoted selector text as a value', () => {
+    const css = '.card { &[data-state="&"] { background: var(--surface); } }';
+
+    expect(manifestFor(css).selectors).toEqual(['.card', '.card[data-state="&"]']);
+  });
+
   it('keeps a comma inside a selector function out of the selector split', () => {
     const css = '.card:is(.a, .b) { background: var(--surface); }';
 
     expect(manifestFor(css).selectors).toEqual(['.card:is(.a, .b)']);
+  });
+});
+
+describe('malformed input', () => {
+  // Recovery matters because one bad character used to be able to cost the rest
+  // of the stylesheet: a scan that ends on a stray `}` silently drops every
+  // later rule, and the manifest still looks complete.
+  it('skips a stray closing brace at the top level', () => {
+    const css = '} .btn { color: var(--accent); }';
+
+    expect(groupTokens(css, 'buttons', '<button class="btn"></button>')).toEqual(['--accent']);
+  });
+
+  it('keeps scanning after an unbalanced closing brace between rules', () => {
+    const css = '.card { background: var(--surface); } } .btn { color: var(--accent); }';
+    const bodyHtml = '<button class="btn"></button><div class="card"></div>';
+
+    expect(manifestFor(css, bodyHtml).selectors).toEqual(['.btn', '.card']);
+    expect(groupTokens(css, 'buttons', bodyHtml)).toEqual(['--accent']);
+  });
+
+  it('does not let an unterminated string swallow the rest of the stylesheet', () => {
+    // CSS ends a string at an unescaped newline, so the damage is bounded to
+    // the declaration that opened the quote.
+    const css = '.btn::before { content: "unterminated; }\n.card { background: var(--surface); }';
+
+    expect(manifestFor(css).selectors.some((selector) => selector.includes('.card'))).toBe(true);
   });
 });
 

--- a/packages/contracts/tests/components-manifest-css-scanner.test.ts
+++ b/packages/contracts/tests/components-manifest-css-scanner.test.ts
@@ -98,6 +98,38 @@ describe('statement at-rules', () => {
   });
 });
 
+describe('keyframes', () => {
+  // Stops are animation positions, not component surface. The single-stop form
+  // was filtered by prelude; a stop list was not, so `0%, 100%` reached the
+  // persisted manifest as two selectors.
+  it.each([
+    ['a comma-separated percentage list', '@keyframes pulse { 0%, 100% { opacity: var(--opacity); } }'],
+    ['a mixed from/to list', '@keyframes pulse { from, to { opacity: var(--opacity); } }'],
+    ['a single stop', '@keyframes pulse { 50% { opacity: var(--opacity); } }'],
+    ['a vendor-prefixed block', '@-webkit-keyframes pulse { 0%, 100% { opacity: var(--opacity); } }'],
+    ['several stops', '@keyframes pulse { from { opacity: 0; } 50%, 75% { opacity: 0.5; } to { opacity: 1; } }'],
+  ])('emits no selector for %s', (_label, css) => {
+    expect(manifestFor(css).selectors).toEqual([]);
+  });
+
+  it('keeps scanning rules that follow a keyframes block', () => {
+    const css = `
+      @keyframes pulse { 0%, 100% { opacity: var(--opacity); } }
+      .btn { color: var(--accent); }
+    `;
+    const manifest = manifestFor(css, '<button class="btn"></button>');
+
+    expect(manifest.selectors).toEqual(['.btn']);
+    expect(groupTokens(css, 'buttons', '<button class="btn"></button>')).toEqual(['--accent']);
+  });
+
+  it('does not attribute stop declarations to an enclosing rule', () => {
+    const css = '.card { background: var(--surface); @keyframes pulse { 0%, 100% { color: var(--fg); } } }';
+
+    expect(groupTokens(css, 'cards', '<div class="card"></div>')).toEqual(['--surface']);
+  });
+});
+
 describe('lexical edge cases', () => {
   it('ignores braces inside string values', () => {
     const css = `

--- a/packages/contracts/tests/components-manifest-css-scanner.test.ts
+++ b/packages/contracts/tests/components-manifest-css-scanner.test.ts
@@ -151,6 +151,17 @@ describe('lexical edge cases', () => {
     expect(groupTokens(css, 'cards', '<div class="card"></div>')).toEqual(['--surface']);
   });
 
+  it.each([
+    ['LF', '\\\n'],
+    ['CRLF', '\\\r\n'],
+  ])('reads an escaped %s inside a string as a line continuation', (_label, continuation) => {
+    // The escape consumes the whole newline, CRLF included, so the string is
+    // not cut in half by the LF half of the pair.
+    const css = `.btn::before { content: "a${continuation}b"; color: var(--accent); }\n.card { background: var(--surface); }`;
+
+    expect(manifestFor(css).selectors).toEqual(['.btn::before', '.card']);
+  });
+
   it('treats an ampersand inside quoted selector text as a value', () => {
     const css = '.card { &[data-state="&"] { background: var(--surface); } }';
 
@@ -182,10 +193,17 @@ describe('malformed input', () => {
     expect(groupTokens(css, 'buttons', bodyHtml)).toEqual(['--accent']);
   });
 
-  it('does not let an unterminated string swallow the rest of the stylesheet', () => {
-    // CSS ends a string at an unescaped newline, so the damage is bounded to
-    // the declaration that opened the quote.
-    const css = '.btn::before { content: "unterminated; }\n.card { background: var(--surface); }';
+  // CSS ends a string at an unescaped newline, so the damage is bounded to the
+  // declaration that opened the quote. Preprocessing folds CR, CRLF and form
+  // feed into newlines, so a stylesheet saved with CR line endings has to
+  // recover the same way an LF one does.
+  it.each([
+    ['LF', '\n'],
+    ['CR', '\r'],
+    ['CRLF', '\r\n'],
+    ['form feed', '\f'],
+  ])('bounds an unterminated string at a %s newline', (_label, newline) => {
+    const css = `.btn::before { content: "unterminated; }${newline}.card { background: var(--surface); }`;
 
     expect(manifestFor(css).selectors.some((selector) => selector.includes('.card'))).toBe(true);
   });


### PR DESCRIPTION
Fixes #6224

## Why

I am working through design-system reuse — applying one package across several artifacts and handing the result to a coding agent — and `components.manifest.json` is what carries a package's component surface into that path. While reading how a group's `tokenReferences` are built I hit the extractor problems @dapsychyoo reported and @lefarcen confirmed on this issue, so I picked it up after checking with the maintainers that both earlier PRs were closed and nothing was in flight.

The effect is quiet, which is why it survived: `extractSelectorTokenReferences` matched rules with a pattern whose leading `(?:^|[{}])` consumed the previous rule's closing brace. Without the `m` flag the following rule had no delimiter left to anchor on, so every second rule in a run was skipped and its tokens never reached a component group. The manifest still validated, still looked complete, and simply under-reported. Across the 151 cached packages it was under-reporting by 4,068 token references.

Two further problems came from the same pattern. The `[^{}]*` body cannot represent a nested block, so a rule that nests lost its own declarations while the flat scan read the declaration text as a selector. And the group `classMatchers` were unanchored substrings, so `platform` matched `form` and `icon-octagon` matched `cta`.

## What users will see

No visible UI change. A design system's component groups are summarized into generation prompts, and those summaries now list the tokens the groups actually use rather than roughly half of them — so an agent asked to build with a package gets a fuller picture of that package's token surface.

For design-system authors, `pnpm guard` keeps passing, but the manifest it validates is now an accurate reading of `components.html`.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — extractor internals, its tests, and the regenerated derived cache. No exported type changes and no new entries under `design-systems/`.

## Screenshots

Not applicable.

## Bug fix verification

- Test path: `packages/contracts/tests/components-manifest-css-scanner.test.ts`
- Red on `main`, green on this branch: yes. 10 of the 15 cases failed on `a07dc736f` before the source change. The five that passed cover behavior the old scanner happened to get right and are kept as regression locks.

The specs cover the three reported symptoms plus the scanner boundary raised in review on #6250: statement at-rules are stepped over at their semicolon whatever their case, including `@charset`, `@namespace`, statement-form `@layer`, `@IMPORT`, and a prelude carrying braces inside a string. Scanning is also string-, escape-, comment- and paren-aware, so `content: "{"`, `.w-\{full\}` and `url("a{b}.css")` no longer open or close a block.

The regenerated manifests are in their own commit so the behavior change and the data can be read separately. Comparing the two as sets rather than as diff lines: 4,068 token references recovered, none lost, and selectors and classes byte-identical across all 151 packages. No fixture uses CSS nesting today, so that half of the fix is carried by the unit tests rather than by this data.

## Validation

- `pnpm guard` — exit 0 (fails on `main` with 151 stale-manifest violations once the extractor is corrected, which is what the second commit resolves)
- `pnpm typecheck` — exit 0
- `pnpm --filter @open-design/contracts test` — 651 passed
- `pnpm --filter @open-design/e2e exec vitest run tests/scripts/check-design-system-manifests.test.ts` — 16 passed
- `pnpm --filter @open-design/daemon exec vitest run tests/design-systems` — 266 passed

One unrelated failure, `tests/packaged-smoke-workflow.test.ts` "[P2] resolves finalize-release shipped versions", times out at 5s on this machine. I confirmed it fails the same way on a clean `upstream/main` checkout, so it is not from this change.
