### PR TITLE
fix(web): drop the session-mode chip from the Home composer

### DIFF
--- a/apps/web/src/analytics/events.ts
+++ b/apps/web/src/analytics/events.ts
@@ -828,6 +828,9 @@ export function trackChatPanelClick(
   send(track, 'ui_click', props);
 }
 
+// Dormant with `ComposerModePicker` (see that file's header): both composers
+// have dropped the mode chip, so nothing calls this today. Kept so the picker
+// can be restored in one step — do NOT delete it as dead code.
 export function trackComposerSessionModeClick(
   track: Track,
   props: ComposerSessionModeClickProps,

--- a/apps/web/src/components/ComposerModePicker.tsx
+++ b/apps/web/src/components/ComposerModePicker.tsx
@@ -13,6 +13,28 @@
 // the mode the request will actually run in is stated on screen instead of
 // being an invisible default behind a neutral glyph. The × still clears it
 // back to the neutral trigger.
+//
+// ⚠️ **休眠件(2026-09-08)** —— 产品直接指令拿掉入口:「这些代码先讲提示词干掉,
+// 组件代码注释, 后续可能要找回」。**正常流程里没有上游会再挂载这个组件。**
+//
+// 摘掉的顺序是两步:项目页的输入框先走(2026-08-19,见 `ChatComposer.tsx` 里
+// 那颗 picker 原来的位置),首页输入区最后走(2026-09-08,见 `HomeHero.tsx` 的
+// `home-hero__foot-right`)。两处都留了原地注释,写清楚怎么接回来。
+//
+// **行为没变,只是控件没了**:`design` 一直是 app 默认档,两个宿主(`HomeView`
+// 的 `sessionMode` state、项目会话存下来的 mode)都还各自持有 mode 并把它送进
+// 请求;只是不再从这颗 chip 上选。项目侧的 next-step 动作仍会改会话的 mode
+// (`ChatPane.handleNextStepPromptAction`),那条路和这颗 chip 无关。
+//
+// **想找回**:回到对应宿主的注释锚点,重新 import 本组件、把宿主的 mode /
+// onModeChange 接回来即可 —— 本组件、它的 i18n key(`chat.modePicker.*`)、
+// `.composer-mode*` 样式、以及 `tests/components/ComposerModePicker.test.tsx`
+// 都**原样保留**,就是为了这一步能一次接回。
+//
+// **不要**因为「线上看不到它」就删组件、删样式、删 i18n key 或删它的单测。
+// 反过来,`HomeView.mode-picker-removed.test.tsx` 和
+// `ChatComposer.mode-picker-removal.test.tsx` 钉的是「宿主不许挂载它」,那两条
+// 才是当前生效的裁决。
 import {
   useEffect,
   useLayoutEffect,

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -40,13 +40,11 @@ import type { SkillSummary } from '../types';
 import { Icon, type IconName } from './Icon';
 import { useAnalytics } from '../analytics/provider';
 import {
-  trackComposerSessionModeClick,
   trackContextLinkResult,
   trackFigmaHelpModalSurfaceView,
   trackHomeChatComposerClick,
   trackProjectReferenceModalSurfaceView,
 } from '../analytics/events';
-import { sessionModeToTracking } from '@open-design/contracts/analytics';
 import {
   chipsForGroup,
   HOME_APPLY_TEMPLATE_EVENT,
@@ -99,7 +97,6 @@ import { FigmaHelpModal } from './FigmaHelpModal';
 import { TemplatePicker } from './home-hero/TemplatePicker';
 import { TypePillRow } from './home-hero/TypePillRow';
 import { LibraryPicker } from './LibraryPicker';
-import { ComposerModePicker } from './ComposerModePicker';
 import { assetTitle } from './LibraryAssetMeta';
 import { libraryAssetRawUrl } from '../providers/registry';
 import type { LibraryAsset } from '@open-design/contracts';
@@ -158,6 +155,11 @@ interface Props {
   // showing: the host seeds the prompt with `scenario.text`, binds the
   // scenario's template, and creates the project -- one-click "just start".
   onSubmitScenario?: (scenario: PlaceholderScenario) => void;
+  // Wiring for the dormant `ComposerModePicker` (see the composer footer
+  // below). Nothing in HomeHero reads these while the picker is off screen —
+  // the host keeps its own `sessionMode` state, which now stays on the app
+  // default. They are kept declared so the HomeView call site (and the restore
+  // path) stays intact.
   sessionMode?: ChatSessionMode;
   onSessionModeChange?: (mode: ChatSessionMode) => void;
   activePluginTitle: string | null;
@@ -307,8 +309,6 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
     onPromptChange,
     onSubmit,
     onSubmitScenario = () => undefined,
-    sessionMode = 'design',
-    onSessionModeChange,
     firstRunGuide,
     activePluginTitle,
     activePluginIsExplicit = false,
@@ -2029,21 +2029,24 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
             ) : null}
           </div>
           <div className="home-hero__foot-right">
-            <ComposerModePicker
-              mode={sessionMode}
-              onModeChange={(next) => {
-                if (next !== sessionMode) {
-                  trackComposerSessionModeClick(analytics.track, {
-                    page_name: 'home',
-                    area: 'chat_composer',
-                    element: 'session_mode_toggle',
-                    mode_before: sessionModeToTracking(sessionMode),
-                    mode_after: sessionModeToTracking(next),
-                  });
-                }
-                onSessionModeChange?.(next);
-              }}
-            />
+            {/* No mode picker on Home (2026-09-08, product): the 「设计 ×」 chip
+                used to sit here, left of the model switcher. The project
+                composer dropped the same chooser first (2026-08-19 — see the
+                matching comment in `ChatComposer.tsx`); Home was the last
+                surface still carrying it, and every Home request defaulted
+                past it to Design anyway.
+
+                Behaviour is unchanged, only the control is gone: `HomeView`
+                still owns the `sessionMode` state that feeds `conversationMode`
+                (plus the task profile and plugin provenance), and with nothing
+                calling `setSessionMode` it stays on the app default, `design`.
+
+                To restore: re-add `import { ComposerModePicker } from
+                './ComposerModePicker'`, re-destructure the `sessionMode` /
+                `onSessionModeChange` props (still declared above, still passed
+                by `HomeView`), and render the picker here with the
+                `trackComposerSessionModeClick` call it had. Pinned by
+                `tests/components/HomeView.mode-picker-removed.test.tsx`. */}
             {executionSwitcher ? (
               <div className="home-hero__execution-switcher">
                 {executionSwitcher}

--- a/apps/web/tests/components/HomeView.media-options.test.tsx
+++ b/apps/web/tests/components/HomeView.media-options.test.tsx
@@ -101,19 +101,19 @@ describe('HomeView media composer options', () => {
     expect((prototypeTab as HTMLButtonElement).disabled).toBe(false);
   });
 
-  it('shows the Home composer mode picker and still defaults to Design mode', async () => {
+  it('defaults to Design mode with no mode picker in the composer', async () => {
     stubFetch();
     const onSubmit = vi.fn();
     renderHome({ onSubmit });
 
     await screen.findByTestId('home-hero-input');
 
-    // 设计 is the app default AND the default SELECTION: the composer opens with
-    // the Design pill showing, so the mode the request will run in is stated on
-    // screen rather than hidden behind a neutral glyph. The submitted payload
-    // carries design either way.
-    expect(screen.getByTestId('composer-mode-trigger').getAttribute('aria-label')).toBe('Mode: Design');
-    expect(screen.getByTestId('composer-mode-clear')).toBeTruthy();
+    // 设计 is the app default, and since the mode chip left the Home composer
+    // (2026-09-08, product) it is also the only mode Home submits — nothing on
+    // this surface can move it any more. Absence is pinned in full by
+    // `HomeView.mode-picker-removed.test.tsx`; this spec keeps the payload half
+    // of the pair, so a picker coming back cannot quietly change what Home runs.
+    expect(screen.queryByTestId('composer-mode-trigger')).toBeNull();
 
     await setHomePrompt('Create a clean loading animation');
     await submitHome();

--- a/apps/web/tests/components/HomeView.mode-picker-removed.test.tsx
+++ b/apps/web/tests/components/HomeView.mode-picker-removed.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+//
+// Home's composer no longer mounts the session-mode picker chip.
+//
+// The chip sat in the composer footer immediately left of the model switcher
+// and the send button: a mode glyph + the mode name (「设计」) + an × that
+// cleared it. The project composer already dropped it (2026-08-19, product —
+// see the comment at the mode-picker's old slot in `ChatComposer.tsx`, and
+// `ChatComposer.mode-picker-removal.test.tsx`); Home is the last surface that
+// still carried it, so this pins the same removal at the Home mount point.
+//
+// The component itself (`ComposerModePicker`) stays in the tree as a dormant
+// part — see its file header. This spec is about the ENTRY, not the part:
+// nothing on Home may mount it.
+//
+// Two things are deliberately pinned alongside the removal, because the risk
+// here is removing more than was asked for:
+//   1. Home still submits `conversationMode: 'design'`. Design was always the
+//      app default; taking away the chip must change what the user SEES, not
+//      what the request DOES.
+//   2. The send button that sat directly right of the chip survives.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('../../src/components/home-hero/PlaceholderCarousel', () => ({
+  PlaceholderCarousel: () => null,
+}));
+
+import { HomeView } from '../../src/components/HomeView';
+import { I18nProvider } from '../../src/i18n';
+import { setHomeHeroPrompt } from '../helpers/home-hero-lexical';
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function stubFetch() {
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    cb(0);
+    return 0;
+  });
+  vi.stubGlobal('fetch', vi.fn(async (url: RequestInfo | URL) => {
+    const href = typeof url === 'string' ? url : String(url);
+    if (href === '/api/plugins') return json({ plugins: [] });
+    if (href === '/api/mcp/servers') return json({ servers: [], templates: [] });
+    if (href === '/api/workspace/directory') return json({ items: [], activeWorkspaceId: null });
+    return json({});
+  }));
+}
+
+function renderHome(overrides: Partial<React.ComponentProps<typeof HomeView>> = {}) {
+  return render(
+    <I18nProvider initial="en">
+      <HomeView
+        projects={[] as never}
+        onSubmit={() => undefined}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+        {...overrides}
+      />
+    </I18nProvider>,
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  cleanup();
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+});
+
+describe('HomeView — composer session-mode picker', () => {
+  it('does not render the mode chip anywhere in the Home composer', async () => {
+    stubFetch();
+    renderHome();
+
+    // The composer is really painted, so the negative assertions below cannot
+    // pass for the wrong reason (an empty render would satisfy them too).
+    await waitFor(() => expect(screen.getByTestId('home-hero-input')).toBeTruthy());
+    expect(screen.getByTestId('home-hero-submit')).toBeTruthy();
+
+    expect(screen.queryByTestId('composer-mode-trigger')).toBeNull();
+    expect(screen.queryByTestId('composer-mode-clear')).toBeNull();
+    expect(screen.queryByTestId('composer-mode-menu')).toBeNull();
+    // The chip's own class, in case the test hooks ever move.
+    expect(document.querySelector('.composer-mode')).toBeNull();
+    // The label the chip rendered when Design was the selection.
+    expect(screen.queryByLabelText('Mode: Design')).toBeNull();
+    expect(screen.queryByLabelText('Choose a mode')).toBeNull();
+  });
+
+  it('still submits Design as the conversation mode', async () => {
+    stubFetch();
+    const onSubmit = vi.fn();
+    renderHome({ onSubmit });
+
+    await waitFor(() => expect(screen.getByTestId('home-hero-input')).toBeTruthy());
+
+    setHomeHeroPrompt('Create a clean loading animation');
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect((screen.getByTestId('home-hero-submit') as HTMLButtonElement).disabled).toBe(false),
+    );
+    fireEvent.click(screen.getByTestId('home-hero-submit'));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0]?.[0]).toMatchObject({
+      prompt: 'Create a clean loading animation',
+      conversationMode: 'design',
+    });
+  });
+});

--- a/e2e/ui/entry-chrome-flows.test.ts
+++ b/e2e/ui/entry-chrome-flows.test.ts
@@ -1142,7 +1142,10 @@ test('[P0] signed-out Local setup can navigate the surviving rail destinations',
 test('[P0] @critical home composer delegates the default prototype scenario to daemon authority', async ({ page }) => {
   await gotoEntryHome(page);
 
-  await expect(page.getByTestId('composer-mode-trigger')).toHaveAttribute('aria-label', 'Mode: Design');
+  // The mode chip left the Home composer (2026-09-08, product) — Design is
+  // still what this request routes as, it just is not stated on a control any
+  // more. The routing itself is asserted from the request body below.
+  await expect(page.getByTestId('composer-mode-trigger')).toHaveCount(0);
 
   const input = page.getByTestId('home-hero-input');
   const prompt =

--- a/e2e/ui/home-hero-rail.test.ts
+++ b/e2e/ui/home-hero-rail.test.ts
@@ -1401,36 +1401,26 @@ test('[P0] empty home composer submits the active prototype suggestion without e
   await expect(page).toHaveURL(/\/projects\//);
 });
 
-test('[P1] home session mode toggle switches Ask planning prompts away from design routing', async ({ page }) => {
+// This spec used to drive the Home mode chip: pick 「提问」, submit, and check
+// the request switched to `conversationMode: 'chat'` with no plugin. The chip
+// left the Home composer (2026-09-08, product — see the comment at its old slot
+// in `HomeHero.tsx`), so Home has no surface that can select Ask any more and
+// that half is unreachable from here rather than broken.
+//
+// What survives is the half that still describes Home: with no picker on
+// screen, every Home submission routes Design and carries a plugin. Ask/Plan
+// routing itself is untouched and still covered where it is still reachable —
+// the project side keeps its stored session mode (`project-management-flows`
+// "project detail turns carry the stored design session mode…").
+test('[P1] home composer routes every request as design with no mode picker on screen', async ({ page }) => {
   await routeProjectCreates(page);
   await routeRunsAccepted(page);
   await gotoEntryHome(page);
 
-  const modeTrigger = page.getByTestId('composer-mode-trigger');
-  // Design is the app default and is now represented as an explicit selection.
-  await expect(modeTrigger).toHaveAttribute('aria-label', 'Mode: Design');
-  await modeTrigger.click();
-  // Every mode description is always visible in the open menu (no hover card).
-  await expect(page.getByText(/planning, and discussion/i)).toBeVisible();
+  await expect(page.getByTestId('composer-mode-trigger')).toHaveCount(0);
+  await expect(page.getByTestId('composer-mode-clear')).toHaveCount(0);
+  await expect(page.getByTestId('composer-mode-menu')).toHaveCount(0);
 
-  await page.getByTestId('composer-mode-menu-chat').click();
-  await expect(modeTrigger).toContainText('Ask');
-  await page.getByTestId('home-hero-input').fill('Help me plan the IA before designing screens.');
-
-  const askRequestPromise = page.waitForRequest((request) =>
-    request.method() === 'POST' && new URL(request.url()).pathname === '/api/projects',
-  );
-  await page.getByTestId('home-hero-submit').click();
-  const askBody = await askRequestPromise.then((request) => request.postDataJSON() as {
-    conversationMode?: string;
-    pluginId?: string | null;
-  });
-
-  expect(askBody.conversationMode).toBe('chat');
-  expect(askBody.pluginId ?? null).toBeNull();
-
-  await gotoEntryHome(page);
-  await expect(page.getByTestId('composer-mode-trigger')).toHaveAttribute('aria-label', 'Mode: Design');
   await page.getByTestId('home-hero-input').fill('Design the screens from this brief.');
 
   const designRequestPromise = page.waitForRequest((request) =>


### PR DESCRIPTION
## Why

Direct product instruction: the mode chip in the Home composer goes away.

It came back by accident. It had already been taken off both composers, but
`b5c9723aca` (#7843) reverted the Home entry refresh (#7730 + #7731) wholesale so
the long-lived `feat/home-entry-refresh` branch could land as one piece — and the
Home mode chip rode back in with it. It is now visible again in the prerelease
build, which is where it was spotted.

The pain is the chip itself. It states a choice that was never really a choice on
Home: Design is the app default, and in practice every Home request goes out as
Design anyway. So the chip spends a permanent slot in the composer footer to
announce the default, next to a × that clears a selection back to… the same
default. The project composer already dropped the same chooser for the same
reason (2026-08-19); Home was the last surface still carrying it.

## What users will see

One fewer chip in the Home input area. The composer footer used to end with
「设计 ×」 (a mode glyph, the mode name, and a small × to clear it) sitting
immediately left of the model chip; that whole control is gone, and the model
chip plus the send button close out the row.

Nothing else changes. Home requests still run as Design exactly as before — the
mode simply is not stated on a control any more. The Plan / Ask modes are not
removed from the product: a project conversation still keeps its own mode, and
next-step actions still switch it.

## Surface area

- [x] **UI** — the Home composer footer loses the session-mode chip in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency**
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None**

Not checked, deliberately:

- **i18n keys** — none added, and none removed either. `chat.modePicker.*` stays
  in all 19 locales because the component stays.
- **Default behavior change** — Design was already the default and still is. The
  control that could move it off the default is what left; the default itself is
  untouched.

### What is kept, on purpose

The entry is removed; the part is not. Per the standing ruling on this kind of
removal (「这些代码先讲提示词干掉, 组件代码注释, 后续可能要找回」),
`ComposerModePicker.tsx` stays in the tree with a dormancy note in its header
saying when and why it was unhooked, what is still live, and exactly how to hook
it back up. Left untouched alongside it so the restore is one step:

- the `.composer-mode*` styles
- the `chat.modePicker.*` i18n keys, in all 19 locales
- `tests/components/ComposerModePicker.test.tsx` (the component's own unit test —
  still green, since the component still works)
- `trackComposerSessionModeClick` in `analytics/events.ts`, now annotated as
  dormant so it is not swept up as dead code

`HomeView` still owns the `sessionMode` state that feeds `conversationMode`, the
automatic task profile and plugin provenance. With nothing calling
`setSessionMode` it stays on the app default, `design` — which is why this is a
control change and not a behaviour change.

## Screenshots

_Entry-point screenshot pending — see the note in the PR thread._

## Bug fix verification

- Test path that reproduces the bug:
  `apps/web/tests/components/HomeView.mode-picker-removed.test.tsx`
- Did the test go red on `main` and green on this branch? **yes**

Three-step evidence:

1. **Red first.** Written against unmodified `main`, the spec failed on
   `expected <button …> to be null`, with the received node being the live
   `data-testid="composer-mode-trigger"` carrying `aria-label="Mode: Design"` and
   the 「Design」 label span. `1 failed | 1 passed (2)`.
2. **Green after the change.** `2 passed (2)`.
3. **Red again with the implementation backed out.** `HomeHero.tsx` alone was
   restored to `HEAD` (spec kept as written) and re-run together with
   `HomeView.media-options`: `2 failed | 21 passed (23)`, both failures on the
   same `expected <button …> to be null`. So the spec is biting on the change and
   not passing for an unrelated reason.

The spec pins two things, because the risk on a removal is removing more than was
asked for: (1) no mode trigger / clear / menu, no `.composer-mode` node and no
`Mode: Design` label anywhere in a fully painted Home composer; and (2) Home still
submits `conversationMode: 'design'`.

### Specs that asserted the chip's presence

Four assertions across three files asserted the chip existed. All of them are
Home-side; every project-side spec already asserted its absence and is untouched.

- `apps/web/tests/components/HomeView.media-options.test.tsx` — was
  `shows the Home composer mode picker and still defaults to Design mode`,
  asserting `aria-label === 'Mode: Design'` plus the presence of the clear ×.
  Retargeted to `defaults to Design mode with no mode picker in the composer`:
  it keeps the payload half of the pair (`conversationMode: 'design'`) and now
  asserts the trigger is absent.
- `e2e/ui/entry-chrome-flows.test.ts:1145` — a one-line presence check inside the
  `[P0] @critical home composer delegates the default prototype scenario to daemon
  authority` spec. Flipped to `toHaveCount(0)`. That spec already asserts
  `body.conversationMode === 'design'`, so the routing it cared about is still
  covered.
- `e2e/ui/home-hero-rail.test.ts:1403` — `[P1] home session mode toggle switches
  Ask planning prompts away from design routing`. This one is not a one-line flip:
  the spec's whole first half drives the chip to pick Ask and asserts the request
  switches to `conversationMode: 'chat'` with no plugin. With no picker on Home,
  no user path can select Ask there, so that half is **unreachable, not broken**.
  The spec now pins the surviving truth — no picker on screen, and every Home
  submission routes design with a plugin — and says so in a comment. Ask/Plan
  routing itself is untouched and still covered where it is still reachable, on
  the project side (`project-management-flows` → `project detail turns carry the
  stored design session mode into daemon runs and message history`).

The e2e retarget is isolated in its own commit (`test(e2e): retarget the two Home
specs that asserted the mode chip`) so it can be reviewed — or reverted —
separately from the removal itself.

## Validation

All run on this branch, in a clean worktree off `main` (`a07dc736fd`):

- `pnpm guard` → **0**
- `pnpm typecheck` (root, all workspaces) → **0**
- `pnpm --filter @open-design/web typecheck` → **0**
- `pnpm --filter @open-design/e2e typecheck` → **0**
- `apps/web` vitest over every `HomeView.*`, `HomeHero.*`, `ComposerModePicker`
  and `ChatComposer.*` spec → **0**, `40 files / 311 tests passed`

Playwright UI specs were not executed here — this machine does not have (and must
not install) Playwright browsers. The two retargeted `e2e/ui` specs typecheck
clean and are left for CI.
