### PR TITLE
fix(daemon): fill the codex command row in while the command runs

### DIFF
--- a/apps/daemon/src/agent-protocol/codex-app-server/normalize.ts
+++ b/apps/daemon/src/agent-protocol/codex-app-server/normalize.ts
@@ -73,6 +73,25 @@ function execPatchKind(kind: unknown): string {
   return isRecord(kind) ? str(kind.type) : '';
 }
 
+/**
+ * Bounds on the in-progress command output carried to the client.
+ *
+ * Both numbers are taken from the ACP bridge rather than invented here
+ * (`agent-protocol/acp/constants.ts`: `ACP_IN_FLIGHT_TOOL_OUTPUT_LIMIT`,
+ * `ACP_IN_FLIGHT_TOOL_MIN_INTERVAL_MS`), because this is the same event on the
+ * same contract feeding the same row, and two transports disagreeing about how
+ * much of a running command's output is "enough" would be a difference no user
+ * could explain. They are re-declared instead of imported so the codex
+ * transport does not take a dependency on the ACP module's internals.
+ *
+ * The CAP bounds one event; the INTERVAL bounds how many events a chatty
+ * command can produce. Neither alone is sufficient: `yes` would defeat the cap
+ * by frequency, and a single `cat` of a large file would defeat the interval by
+ * size.
+ */
+const COMMAND_OUTPUT_LIMIT = 2_000;
+const COMMAND_OUTPUT_MIN_INTERVAL_MS = 250;
+
 /** Item types whose `exec --json` branch ends an assistant-message run. */
 const BOUNDARY_CLEARING_ITEM_TYPES = new Set([
   'command_execution',
@@ -163,6 +182,13 @@ export interface CodexAppServerNormalizer {
 
 export function createCodexAppServerNormalizer(
   onEvent: CodexAppServerEventHandler,
+  /**
+   * Injectable clock, for the publication throttle only. The parser is
+   * otherwise a pure function of its frames; tests drive a whole turn inside a
+   * single millisecond, which would let the throttle swallow every update after
+   * the first and make an accumulation bug invisible.
+   */
+  now: () => number = Date.now,
 ): CodexAppServerNormalizer {
   let emittedCount = 0;
   const emit = (event: AgentEvent) => {
@@ -199,6 +225,85 @@ export function createCodexAppServerNormalizer(
     const before = emittedCount;
     const consumed = codex.handleFrame(frame);
     return consumed && emittedCount > before;
+  }
+
+  /**
+   * Commands whose `item/started` has arrived and whose `item/completed` has
+   * not. Only this transport can populate it: `exec --json` has no output-delta
+   * frame, so a command row there is silent until it exits.
+   */
+  type RunningCommand = {
+    command: string;
+    startedAt: number;
+    output: string;
+    published: boolean;
+    lastPublishedAt: number;
+    lastSignature: string;
+  };
+  const runningCommands = new Map<string, RunningCommand>();
+
+  /**
+   * Publish the early form of a running command row.
+   *
+   * Why the early form and not the settled `tool_use` the `exec --json` branch
+   * emits at `item.started`: the client retires an early row into the settled
+   * row that shares its id, and it does that by dropping every early row whose
+   * id ALREADY has a settled one (`dropSupersededInFlightToolUses` in
+   * `apps/web/src/runtime/tool-events.ts`). Forwarding the started frame and
+   * then sending output updates would therefore emit events that the client
+   * discards without rendering — the row would sit empty for the whole run and
+   * every test at this layer would still be green. The settled pair is emitted
+   * from `item.completed` instead, which is where the output is final anyway.
+   *
+   * `startedAt` is the item's own start, never the moment a delta arrived: it
+   * is what the row's stopwatch counts from, and it is what the client carries
+   * onto the settled row when it retires this one. Reading the clock here would
+   * restart the stopwatch on every chunk.
+   *
+   * The first publication of a call is never throttled — a row must appear when
+   * the command starts, which is the entire answer to "where is it stuck". Only
+   * the updates that follow are rate-limited, and only when they would say
+   * something new.
+   */
+  function publishRunningCommand(id: string, run: RunningCommand): void {
+    const output = run.output.slice(0, COMMAND_OUTPUT_LIMIT);
+    const signature = output;
+    if (run.published) {
+      if (signature === run.lastSignature) return;
+      if (now() - run.lastPublishedAt < COMMAND_OUTPUT_MIN_INTERVAL_MS) return;
+    }
+    run.published = true;
+    run.lastSignature = signature;
+    run.lastPublishedAt = now();
+    emit({
+      type: 'tool_in_flight',
+      id,
+      name: 'Bash',
+      input: { command: run.command },
+      startedAt: run.startedAt,
+      ...(output ? { output } : {}),
+    });
+  }
+
+  /**
+   * `item/commandExecution/outputDelta` — the child's stdout/stderr as it is
+   * produced. Recorded against codex-cli 0.153.4 (2026-09-08): one frame per
+   * write, `{ threadId, turnId, itemId, delta }`.
+   *
+   * A frame naming no known running command is dropped rather than raised: the
+   * app-server protocol ships no version negotiation, so a codex that reorders
+   * or renames its lifecycle must cost one row, never the run.
+   */
+  function handleCommandOutputDelta(params: JsonObject): void {
+    const id = str(params.itemId);
+    if (!id) return;
+    const run = runningCommands.get(id);
+    if (!run) return;
+    const delta = params.delta;
+    if (typeof delta !== 'string' || delta.length === 0) return;
+    // Stop growing the buffer once it can no longer change what is published.
+    if (run.output.length < COMMAND_OUTPUT_LIMIT) run.output += delta;
+    publishRunningCommand(id, run);
   }
 
   function emitMessageText(itemId: string, text: string): void {
@@ -320,6 +425,35 @@ export function createCodexAppServerNormalizer(
       if (lifecycle === 'item.completed') handleReasoningCompleted(item);
       return;
     }
+    /*
+     * A command row is owned here for the length of its run, because only this
+     * transport can fill it in while it runs (`item/commandExecution/
+     * outputDelta`). Routing the started frame would emit the SETTLED row, and
+     * a settled row makes every later update invisible — see
+     * `publishRunningCommand`. The settled pair still comes from the completed
+     * frame below, unchanged.
+     */
+    if (item.type === 'commandExecution' && lifecycle === 'item.started') {
+      const id = str(item.id);
+      if (id) {
+        runningCommands.set(id, {
+          command: str(item.command),
+          startedAt: num(params.startedAtMs) ?? now(),
+          output: '',
+          published: false,
+          lastPublishedAt: 0,
+          lastSignature: '',
+        });
+        publishRunningCommand(id, runningCommands.get(id) as RunningCommand);
+        previousEventWasMessage = false;
+        lastMessageEndedWithNewline = false;
+        return;
+      }
+    }
+    if (item.type === 'commandExecution' && lifecycle === 'item.completed') {
+      runningCommands.delete(str(item.id));
+    }
+
     const execItem = toExecItem(item);
     if (!execItem) {
       unknownItems += 1;
@@ -472,6 +606,9 @@ export function createCodexAppServerNormalizer(
           return;
         case 'item/reasoning/textDelta':
           handleReasoningTextDelta(params);
+          return;
+        case 'item/commandExecution/outputDelta':
+          handleCommandOutputDelta(params);
           return;
         case 'thread/tokenUsage/updated':
           handleTokenUsage(params);

--- a/apps/daemon/tests/codex-app-server-command-output-stream.test.ts
+++ b/apps/daemon/tests/codex-app-server-command-output-stream.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+import { createCodexAppServerNormalizer } from '../src/agent-protocol/codex-app-server/normalize.js';
+
+/**
+ * A codex command row must fill in while the command runs, not only when it
+ * exits.
+ *
+ * Recorded against codex-cli 0.153.4 on 2026-09-08 (`codex app-server`,
+ * `for i in $(seq 1 8); do echo "line $i"; sleep 1; done`): the wire delivers
+ *
+ *   item/started                       (commandExecution, status inProgress)
+ *   item/commandExecution/outputDelta  x7, one per second, delta "line N\n"
+ *   item/completed                     (commandExecution, aggregatedOutput)
+ *
+ * Before this behaviour existed the seven middle frames were counted as
+ * `unknownNotifications` and dropped, so a command that printed for eight
+ * seconds showed an empty terminal for eight seconds.
+ *
+ * The invariant this pins is deliberately about WHICH FORM the row takes while
+ * it runs, not merely that some event was emitted. The client retires an early
+ * `tool_in_flight` into the settled `tool_use` that shares its id
+ * (`dropSupersededInFlightToolUses`), and it does so by DROPPING every
+ * in-flight row whose id already has a settled row. So a settled `tool_use` at
+ * `item/started` — which is what the `exec --json` branch emits, and what this
+ * transport used to forward — makes every later in-flight update invisible on
+ * screen. Emitting the events is not the same as showing them; the assertions
+ * below therefore require the settled row to be ABSENT until the command ends.
+ */
+
+type Ev = Record<string, unknown>;
+
+/**
+ * The real wire spaces these frames a second apart; a test drives them inside
+ * one millisecond. Advancing a fake clock past the publication throttle is what
+ * keeps this suite measuring accumulation rather than measuring the throttle —
+ * with a real clock every assertion below would read the FIRST chunk and pass
+ * even if later chunks were dropped on the floor.
+ */
+function drive(frames: Array<{ method: string; params?: unknown }>) {
+  const events: Ev[] = [];
+  let clock = STARTED_AT;
+  const normalizer = createCodexAppServerNormalizer(
+    (ev) => events.push(ev),
+    () => clock,
+  );
+  for (const frame of frames) {
+    normalizer.handleNotification(frame.method, frame.params ?? {});
+    clock += 1_000;
+  }
+  return { events, stats: normalizer.stats() };
+}
+
+const THREAD = { threadId: 't1', turnId: 'turn1' };
+const CMD_ID = 'exec-9db7fe16-4e52-4cf0-9b1f-0a1b2c3d4e5f';
+const COMMAND = '/bin/zsh -lc \'for i in $(seq 1 3); do echo "line $i"; sleep 1; done\'';
+const STARTED_AT = 1_700_000_000_000;
+
+const startedFrame = {
+  method: 'item/started',
+  params: {
+    ...THREAD,
+    startedAtMs: STARTED_AT,
+    item: {
+      type: 'commandExecution',
+      id: CMD_ID,
+      command: COMMAND,
+      cwd: '/w',
+      commandActions: [],
+      status: 'inProgress',
+      aggregatedOutput: null,
+      exitCode: null,
+    },
+  },
+};
+
+const deltaFrame = (delta: string) => ({
+  method: 'item/commandExecution/outputDelta',
+  params: { ...THREAD, itemId: CMD_ID, delta },
+});
+
+const completedFrame = {
+  method: 'item/completed',
+  params: {
+    ...THREAD,
+    completedAtMs: STARTED_AT + 3_000,
+    item: {
+      type: 'commandExecution',
+      id: CMD_ID,
+      command: COMMAND,
+      cwd: '/w',
+      commandActions: [],
+      status: 'completed',
+      aggregatedOutput: 'line 1\nline 2\nline 3\n',
+      exitCode: 0,
+    },
+  },
+};
+
+const RUNNING_TURN = [startedFrame, deltaFrame('line 1\n'), deltaFrame('line 2\n')];
+
+describe('codex app-server: streaming command output', () => {
+  it('shows the command row in its early form while the command is still running', () => {
+    const { events } = drive(RUNNING_TURN);
+
+    const inFlight = events.filter((e) => e.type === 'tool_in_flight');
+    expect(inFlight.length).toBeGreaterThan(0);
+
+    const last = inFlight.at(-1) as Ev;
+    expect(last.id).toBe(CMD_ID);
+    expect(last.name).toBe('Bash');
+    expect(last.input).toMatchObject({ command: COMMAND });
+    expect(last.output).toBe('line 1\nline 2\n');
+  });
+
+  it('starts the row clock at the item start, not at the first delta', () => {
+    const { events } = drive(RUNNING_TURN);
+    const inFlight = events.filter((e) => e.type === 'tool_in_flight');
+    for (const ev of inFlight) expect(ev.startedAt).toBe(STARTED_AT);
+  });
+
+  it('keeps the settled row out until the command ends, so the early row survives', () => {
+    const { events } = drive(RUNNING_TURN);
+    const settled = events.filter((e) => e.type === 'tool_use' && e.id === CMD_ID);
+    expect(settled).toEqual([]);
+  });
+
+  it('emits exactly one settled pair when the command ends', () => {
+    const { events } = drive([...RUNNING_TURN, deltaFrame('line 3\n'), completedFrame]);
+
+    const settled = events.filter((e) => e.type === 'tool_use' && e.id === CMD_ID);
+    expect(settled).toHaveLength(1);
+    expect(settled[0]).toMatchObject({ name: 'Bash', input: { command: COMMAND } });
+
+    const results = events.filter((e) => e.type === 'tool_result' && e.toolUseId === CMD_ID);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ content: 'line 1\nline 2\nline 3\n', isError: false });
+
+    // ordering: every early row precedes the settled one
+    const settledAt = events.findIndex((e) => e.type === 'tool_use' && e.id === CMD_ID);
+    const lastInFlightAt = events.map((e) => e.type).lastIndexOf('tool_in_flight');
+    expect(lastInFlightAt).toBeLessThan(settledAt);
+  });
+
+  it('bounds the carried output instead of forwarding an unbounded stream', () => {
+    const { events } = drive([startedFrame, deltaFrame('x'.repeat(50_000))]);
+    const last = events.filter((e) => e.type === 'tool_in_flight').at(-1) as Ev;
+    expect(typeof last.output).toBe('string');
+    expect((last.output as string).length).toBeLessThanOrEqual(2_000);
+  });
+
+  it('no longer counts the delta frames as unknown notifications', () => {
+    const { stats } = drive(RUNNING_TURN);
+    expect(stats.unknownNotifications).toBe(0);
+  });
+
+  /**
+   * The app-server protocol ships no version negotiation, so a delta frame from
+   * an older or newer codex that omits a field must degrade to "one row less",
+   * never to a crash or a bogus row. See the module docstring in normalize.ts.
+   */
+  it('ignores a delta that names no item, and one for an unknown item', () => {
+    const orphan = drive([
+      { method: 'item/commandExecution/outputDelta', params: { ...THREAD, delta: 'x' } },
+      { method: 'item/commandExecution/outputDelta', params: { ...THREAD, itemId: 'nope', delta: 'y' } },
+    ]);
+    expect(orphan.events.filter((e) => e.type === 'tool_in_flight')).toEqual([]);
+  });
+
+  it('ignores a delta whose payload carries no string', () => {
+    const { events } = drive([
+      startedFrame,
+      { method: 'item/commandExecution/outputDelta', params: { ...THREAD, itemId: CMD_ID } },
+    ]);
+    // The started frame's own row is expected; the malformed delta must not add
+    // a second one, and must not put anything on the first.
+    const inFlight = events.filter((e) => e.type === 'tool_in_flight');
+    expect(inFlight).toHaveLength(1);
+    expect((inFlight[0] as Ev).output).toBeUndefined();
+  });
+
+  /**
+   * The cap bounds one event, the interval bounds how many. A command that
+   * writes continuously must not turn one call into a frame-rate event stream.
+   */
+  it('rate-limits updates from a command that writes continuously', () => {
+    const events: Ev[] = [];
+    let clock = STARTED_AT;
+    const normalizer = createCodexAppServerNormalizer(
+      (ev) => events.push(ev),
+      () => clock,
+    );
+    normalizer.handleNotification(startedFrame.method, startedFrame.params);
+    // 100 writes, 10ms apart => 1s of wall clock at 100 frames/s
+    for (let i = 0; i < 100; i += 1) {
+      clock += 10;
+      const f = deltaFrame(`chunk ${i}\n`);
+      normalizer.handleNotification(f.method, f.params);
+    }
+    const inFlight = events.filter((e) => e.type === 'tool_in_flight');
+    // 1s at a 250ms floor: the started row plus at most four updates.
+    expect(inFlight.length).toBeLessThanOrEqual(5);
+    expect(inFlight.length).toBeGreaterThan(1);
+  });
+
+  /**
+   * A command that never prints must still get a row the moment it starts —
+   * that row carries the stopwatch, which is the whole answer to "where is it
+   * stuck". Output is what is unknown, not the call.
+   */
+  it('shows a silent command as soon as it starts', () => {
+    const { events } = drive([startedFrame]);
+    const inFlight = events.filter((e) => e.type === 'tool_in_flight');
+    expect(inFlight).toHaveLength(1);
+    expect(inFlight[0]).toMatchObject({ id: CMD_ID, name: 'Bash', startedAt: STARTED_AT });
+    expect((inFlight[0] as Ev).output).toBeUndefined();
+  });
+});

--- a/apps/daemon/tests/codex-app-server-normalize.test.ts
+++ b/apps/daemon/tests/codex-app-server-normalize.test.ts
@@ -280,7 +280,24 @@ describe('codex app-server -> OpenDesign event normalization', () => {
           },
         },
       ]);
+      /*
+       * `item/started` now opens the row in its EARLY form rather than its
+       * settled one, so the row can fill in from
+       * `item/commandExecution/outputDelta` while the command runs — a settled
+       * row makes every later update invisible, because the client drops any
+       * early row whose id already has a settled one. The settled pair below is
+       * unchanged and still arrives from `item/completed`. Full rationale and
+       * the timing assertions live in
+       * `codex-app-server-command-output-stream.test.ts`.
+       */
       expect(events).toEqual([
+        {
+          type: 'tool_in_flight',
+          id: 'c1',
+          name: 'Bash',
+          input: { command: 'echo hi' },
+          startedAt: expect.any(Number),
+        },
         { type: 'tool_use', id: 'c1', name: 'Bash', input: { command: 'echo hi' } },
         { type: 'tool_result', toolUseId: 'c1', content: 'hi\n', isError: false },
       ]);

--- a/apps/daemon/tests/codex-app-server-parity.test.ts
+++ b/apps/daemon/tests/codex-app-server-parity.test.ts
@@ -54,6 +54,22 @@ function canonicalize(events: Ev[]): Ev[] {
   const out: Ev[] = [];
   for (const ev of events) {
     if (ev.type === 'raw') continue;
+    /*
+     * The early form of a command row is the third app-server superset,
+     * alongside token usage and file-change line counts. Only this wire sends
+     * `item/commandExecution/outputDelta`, so only this transport can fill a
+     * command row in while the command runs; `exec --json` is silent until the
+     * command exits and has no shape that could carry it.
+     *
+     * Dropping it here compares what BOTH transports can know. It is safe to
+     * drop precisely because the client does the same thing — an early row is
+     * retired into the settled `tool_use` that shares its id
+     * (`dropSupersededInFlightToolUses`), which IS compared below, pairing and
+     * all. The early rows themselves are asserted separately, in
+     * `codex-app-server-command-output-stream.test.ts`, so a regression that
+     * stopped emitting them cannot hide inside this drop.
+     */
+    if (ev.type === 'tool_in_flight') continue;
     if (ev.type === 'text_delta' || ev.type === 'thinking_delta') {
       const prev = out.at(-1);
       if (prev && prev.type === ev.type) {


### PR DESCRIPTION
## Why

**Use case.** While investigating a user report about a codex turn that showed nothing for two minutes, I recorded the real `codex app-server` wire (codex-cli 0.153.4, 2026-09-08) and found that codex *does* stream a running command's stdout as it is produced — `item/commandExecution/outputDelta`, one frame per write — and that Open Design was throwing every one of those frames away. They were counted as `unknownNotifications` in the normalizer and dropped.

Captured frame timing from that recording (`for i in $(seq 1 8); do echo "line $i"; sleep 1; done`):

```
 9.52s  item/started                      commandExecution/inProgress
10.41s  item/commandExecution/outputDelta delta "line 1\n"
11.41s  item/commandExecution/outputDelta delta "line 2\n"
   ...  (7 frames, one per second)
17.54s  item/completed                    commandExecution/completed
```

**Pain.** A command that prints for eight seconds showed an empty terminal box for eight seconds, then everything at once. The information was already on the wire and on the floor. This is the cheap half of a broader "codex goes quiet" problem — the expensive half (tool-call *arguments* streaming) is not fixable here, because codex's protocol has no notification for it at all.

## What users will see

When Codex runs a shell command that prints as it goes — a build, a test run, a long script — the command's output now appears in the row's terminal box **while it runs**, instead of the box staying empty until the command exits. The row keeps its running spinner and its ticking stopwatch the whole time, and settles into the normal finished row with the full output when the command ends.

Nothing changes for commands that finish instantly or print nothing: those already showed a row the moment they started, and still do.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [x] **Default behavior change** — a running codex command row now fills in live. No setting, no opt-in. Existing `tool_in_flight` / `tool_use` / `tool_result` contract shapes are reused as-is; nothing in `packages/contracts` changed.
- [ ] **None**

Rendering is unchanged code: this emits the same `tool_in_flight` shape the ACP bridge already emits, into the same agent-agnostic row.

## Screenshots

No new UI. The row, its terminal box, and the retirement of the early row into the settled one are existing rendering, already pinned by `apps/web/tests/components/chat/w123-acp-inflight-tool-row.test.tsx` (which covers exactly "intermediate output appears in the terminal box while the row stays pending").

## The part worth reviewing

Routing the delta frames alone would **not** have worked, and would have looked like it did.

The client retires an early `tool_in_flight` row into the settled `tool_use` sharing its id, and it does that by *dropping every early row whose id already has a settled one* (`dropSupersededInFlightToolUses`, `apps/web/src/runtime/tool-events.ts`). `item/started` was being forwarded to the `exec --json` branch, which emits the **settled** row. So a naive "add a case" would have emitted a stream of events the client discards without rendering — empty row for the whole run, every daemon-side test green.

So `item/started` for a `commandExecution` now opens the row in its **early** form, and the settled pair comes from `item/completed`, where the output is final anyway. The test asserts the settled row is *absent* until completion, which is the assertion that actually protects the behavior.

Two consequences a reviewer should weigh:

1. **Transport divergence is now real and deliberate.** `exec --json` has no output-delta frame, so it cannot do this. The parity test drops `tool_in_flight` for the same reason it already drops `raw`, with the rationale written next to it, and the early rows are asserted separately so a regression can't hide in the drop.
2. **Bounds are borrowed, not invented.** 2000 chars per event and 250ms between publications for one call are the ACP bridge's existing numbers (`ACP_IN_FLIGHT_TOOL_OUTPUT_LIMIT`, `ACP_IN_FLIGHT_TOOL_MIN_INTERVAL_MS`). Re-declared rather than imported so codex doesn't depend on ACP internals. The cap bounds one event, the interval bounds how many; `yes` would defeat the cap by frequency and one `cat` of a big file would defeat the interval by size, so both are needed.

Compatibility: the app-server protocol ships no version negotiation, so a delta naming no known item, naming an unknown item, or carrying no string is dropped rather than raised — matching the module docstring's existing rule that a codex upgrade costs "one row less", never the run. Tests cover all three. Runtimes on `json-event-stream.ts` directly (opencode, byok-opencode, mimo, cursor-agent) never reach this normalizer and are untouched.

## Bug fix verification

- Test path: `apps/daemon/tests/codex-app-server-command-output-stream.test.ts`
- Red on `main`, green on this branch: **yes**
  - initial red (test written before implementation): `Tests 5 failed | 4 passed (9)`
  - green after implementation: `Tests 10 passed (10)`
  - implementation ablated (`git show HEAD:normalize.ts > normalize.ts`, test untouched) to prove the test isn't vacuous: `Tests 7 failed | 3 passed (10)`

The 3 that survive ablation are the degradation guards, which pass vacuously when nothing is emitted at all — they exist to pin the compatibility behavior, not the feature.

Two existing pins were updated deliberately, each with the reason written in place: the parity test's `canonicalize` (drops the early form) and `codex-app-server-normalize.test.ts`'s `maps commandExecution onto the Bash tool pair` (now expects the early row before the settled pair).

## Validation

- `pnpm guard` — exit 0
- `pnpm typecheck` — exit 0
- `pnpm --filter @open-design/daemon build` — exit 0
- Focused codex/tool/golden daemon suite (43 files: every `*codex*`, `*tool*`, and `mocks-golden`) — `42 passed | 1 skipped (43)`, `707 passed | 4 skipped (711)`, exit 0
- Real-wire evidence for the frame shape and cadence came from driving `codex app-server` over stdio JSON-RPC with the same handshake `session.ts` uses, against codex-cli 0.153.4.
