### PR TITLE
fix(web): resolve the composer plan tier through the approved workspace projection

### DIFF
--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -36,7 +36,7 @@ import { isMacPlatform } from '../utils/platform';
 import {
   useWorkspaceBillingResponse,
   useWorkspaceContext,
-  workspaceBillingSnapshotForContext,
+  workspaceBillingSummaryForContext,
 } from '../collab/useWorkspaceContext';
 import {
   projectWorkspaceContext,
@@ -278,13 +278,43 @@ export function AvatarMenu({
       cancelled = true;
     };
   }, [open, amrAvailable]);
-  const exactWorkspaceSnapshot = workspaceBillingSnapshotForContext(
+  /*
+   * The plan tier of the workspace in scope, read through the ONE projection
+   * that is allowed to answer that question.
+   *
+   * This used to read the exact billing SNAPSHOT directly, which is the same
+   * source `workspaceBillingSummaryForContext` consults first — but only the
+   * first. The projection also carries a fallback that was approved and is
+   * load-bearing: when a TEAM workspace has no authorized snapshot, a
+   * team-namespaced account tier may stand in for it (a personal tier may not,
+   * because it describes the account's own subscription and cannot name a team
+   * workspace's plan). Reading the snapshot directly walked around that
+   * fallback, and there was no third source to catch the fall.
+   *
+   * The snapshot goes missing for reasons that have nothing to do with the
+   * viewer's entitlements: A answers the snapshot route 409
+   * `billing_workspace_snapshot_unsupported` while `/wallet/balance` still
+   * answers 200; a rolling deploy leaves an old API pod 404/405-ing the route
+   * for a few minutes; a local vela CLI predates `--workspace-id`. The daemon
+   * then omits the `workspaceSnapshot` key entirely. On this surface that
+   * turned into `scopedPlanId: null`, `canUpgradeVelaPlan(null) === false`, and
+   * a veto landing BEFORE `canReachWorkspaceBillingEntrance` ever got asked —
+   * so a team owner clicked a plan-gated model and nothing happened at all.
+   *
+   * Ordering is unchanged where it matters: the projection consults the
+   * snapshot FIRST, so a present snapshot still outranks the account tier.
+   *
+   * It is a pure function of the response this component already holds, so the
+   * corrected tier lands on the same render frame — there is no second async
+   * hop that would paint the wrong identity first and fix it later.
+   */
+  const scopedWorkspaceBilling = workspaceBillingSummaryForContext(
     workspaceBillingResponse,
     workspaceContext,
   );
   const scopedPlanId =
     workspaceContext?.workspaceType === 'team'
-      ? exactWorkspaceSnapshot?.billing.planId?.trim() || null
+      ? scopedWorkspaceBilling?.membershipTier?.trim() || null
       : workspaceContext?.workspaceType === 'personal'
         ? workspaceBillingResponse?.summary?.membershipTier?.trim() || null
         : null;

--- a/apps/web/tests/components/AvatarMenu.test.tsx
+++ b/apps/web/tests/components/AvatarMenu.test.tsx
@@ -3,8 +3,13 @@
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { buildWorkspacePermissions, type WorkspaceCollabContext } from '@open-design/contracts';
+import {
+  buildWorkspacePermissions,
+  type WorkspaceBillingResponse,
+  type WorkspaceCollabContext,
+} from '@open-design/contracts';
 
+import { workspaceBillingSummaryForContext } from '../../src/collab/useWorkspaceContext';
 import { AvatarMenu } from '../../src/components/AvatarMenu';
 import { providerModelsCacheKey } from '../../src/components/providerModelsCache';
 import type { ProjectWorkspaceScopeState } from '../../src/collab/useProjectWorkspaceScope';
@@ -826,6 +831,265 @@ describe('AvatarMenu', () => {
     expect(onAgentModelChange).not.toHaveBeenCalled();
     expect(new URL(openExternalUrlMock.mock.calls[0]![0]).searchParams.get('workspaceId'))
       .toBe('workspace-a');
+  });
+
+  /*
+   * A team workspace whose exact billing SNAPSHOT is missing.
+   *
+   * The daemon spreads `workspaceSnapshot` into the response only when it can
+   * authorize one for the requested workspace + member
+   * (`apps/daemon/src/routes/collab-context.ts`), so production omits the KEY —
+   * it never sends `workspaceSnapshot: null`. Three real paths reach that shape:
+   * A answering 409 `billing_workspace_snapshot_unsupported` while
+   * `/wallet/balance` still answers 200; a rolling deploy leaving an old API pod
+   * that 404/405s the snapshot route; and a local vela CLI old enough to reject
+   * `--workspace-id`. Fixtures that hand this surface a snapshot cannot see any
+   * of them, which is why this one omits the key.
+   */
+  function teamBillingResponseBody(options: {
+    workspaceId: string;
+    accountMembershipTier: string;
+    /**
+     * Omit to model the missing-snapshot shape. `planId: null` +
+     * `billingState: 'free'` is how B reports a team workspace nobody has
+     * subscribed yet.
+     */
+    snapshot?: { planId: string | null; billingState: 'active' | 'free' };
+  }) {
+    return {
+      // ACCOUNT-scoped read: the contract pins its workspaceId to null.
+      summary: { membershipTier: options.accountMembershipTier },
+      workspaceBalance: {
+        billingScopeVersion: 2,
+        workspaceId: options.workspaceId,
+        workspaceMemberId: 'member-a',
+        balanceUsd: '9.12',
+        expiresAt: null,
+        updatedAt: '2026-07-27T00:00:00.000Z',
+      },
+      ...(options.snapshot
+        ? {
+            workspaceSnapshot: {
+              ...workspaceSnapshot(
+                options.workspaceId,
+                'member-a',
+                options.snapshot.planId ?? '',
+                '9.12',
+              ),
+              billing: options.snapshot,
+            },
+          }
+        : {}),
+    };
+  }
+
+  function stubTeamPlanFetch(options: {
+    workspaceId: string;
+    ambientContext: WorkspaceCollabContext;
+    accountMembershipTier: string;
+    snapshot?: { planId: string | null; billingState: 'active' | 'free' };
+  }) {
+    const urls: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      urls.push(url);
+      if (url === '/api/integrations/vela/status') {
+        return new Response(JSON.stringify({
+          loggedIn: true,
+          loginInFlight: false,
+          profile: 'feature-test',
+          user: { id: 'u1', email: 'a@b.c' },
+          account: { plan: 'max', balanceUsd: '9.12' },
+          configPath: '/Users/test/.amr/config.json',
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (url === '/api/workspace/directory') {
+        const ambient = options.ambientContext;
+        return new Response(JSON.stringify({
+          items: [{
+            workspaceId: ambient.workspaceId,
+            workspaceName: ambient.workspaceId,
+            workspaceType: ambient.workspaceType,
+            workspaceMemberId: ambient.workspaceMemberId,
+            role: ambient.role,
+            memberStatus: ambient.memberStatus,
+            lifecycleState: ambient.lifecycleState,
+          }],
+          activeWorkspaceId: ambient.workspaceId,
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (url === '/api/workspace/context') {
+        return workspaceContextResponse(options.ambientContext);
+      }
+      if (url === `/api/workspace/billing?scope=workspace&workspaceId=${options.workspaceId}`) {
+        return new Response(JSON.stringify(teamBillingResponseBody(options)), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response('{}', { status: 202 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    return { fetchMock, urls };
+  }
+
+  function teamOwnerAmbientContext() {
+    return teamMemberWorkspaceContext({
+      workspaceId: 'workspace-a',
+      workspaceMemberId: 'member-a',
+      role: 'owner',
+      permissions: buildWorkspacePermissions({
+        role: 'owner',
+        lifecycleState: 'active',
+        memberStatus: 'active',
+      }),
+    });
+  }
+
+  /*
+   * Static control against a blanket rewrite.
+   *
+   * The two tiers deliberately disagree AND point opposite ways: the
+   * snapshot says `team_max` (the top tier — nothing left to upgrade to,
+   * so the entry must stay closed) while the account says `team_pro`
+   * (upgradeable, so the entry would open). Whatever the tier is read
+   * through, the snapshot must keep outranking the account fallback; a
+   * change that let the account tier win anywhere turns this green case red.
+   */
+  it('keeps the exact snapshot outranking the account tier when the snapshot is present', async () => {
+    stubTeamPlanFetch({
+      workspaceId: 'workspace-a',
+      ambientContext: teamOwnerAmbientContext(),
+      accountMembershipTier: 'team_pro',
+      snapshot: { planId: 'team_max', billingState: 'active' },
+    });
+    openExternalUrlMock.mockResolvedValue(true);
+
+    const { onAgentModelChange } = renderLockedModelMenu(projectScopeContext());
+
+    openMenu();
+    await waitFor(() =>
+      expect(screen.getByRole('radio', { name: /Paid model/i })).toBeTruthy());
+    for (let i = 0; i < 8; i += 1) {
+      await act(async () => { await Promise.resolve(); });
+    }
+    fireEvent.click(screen.getByRole('radio', { name: /Paid model/i }));
+    await act(async () => { await Promise.resolve(); });
+
+    expect(onAgentModelChange).not.toHaveBeenCalled();
+    expect(openExternalUrlMock).not.toHaveBeenCalled();
+  });
+
+  /*
+   * The same defect, reached from the other side, and the one BEHAVIOUR CHANGE
+   * this fix makes while the snapshot is present.
+   *
+   * B reports a team workspace nobody has subscribed as `billingState: 'free'`
+   * with a null `planId`. Reading `planId` raw turned that positive "free" into
+   * `null` — an UNKNOWN tier — and `canUpgradeVelaPlan(null)` is false, so the
+   * owner of a free team could not reach the plans page from a locked model
+   * either. The projection normalizes that state to the tier `'free'`, which is
+   * both known and upgradeable, so the entry opens.
+   */
+  it('opens the upgrade entry for an unsubscribed team the snapshot reports as free', async () => {
+    stubTeamPlanFetch({
+      workspaceId: 'workspace-a',
+      ambientContext: teamOwnerAmbientContext(),
+      accountMembershipTier: '',
+      snapshot: { planId: null, billingState: 'free' },
+    });
+    openExternalUrlMock.mockResolvedValue(true);
+
+    renderLockedModelMenu(projectScopeContext());
+
+    openMenu();
+    await waitFor(() => {
+      fireEvent.click(screen.getByRole('radio', { name: /Paid model/i }));
+      expect(openExternalUrlMock).toHaveBeenCalled();
+    });
+    expect(new URL(openExternalUrlMock.mock.calls[0]![0]).searchParams.get('workspaceId'))
+      .toBe('workspace-a');
+  });
+
+  /*
+   * The defect. A team OWNER on a paid team, whose snapshot did not come back,
+   * clicks a plan-gated model and nothing happens at all — the tier resolved to
+   * null, `canUpgradeVelaPlan(null)` is false, and that veto lands BEFORE the
+   * billing-entrance check that would have said yes.
+   *
+   * `workspaceBillingSummaryForContext` already carries the approved fallback
+   * for exactly this shape (a TEAM-namespaced account tier may stand in for a
+   * missing team snapshot; a personal tier may not). Reading the raw snapshot
+   * here walked around it.
+   */
+  it('falls back to the team-namespaced account tier when the snapshot is missing', async () => {
+    const { urls } = stubTeamPlanFetch({
+      workspaceId: 'workspace-a',
+      ambientContext: teamOwnerAmbientContext(),
+      accountMembershipTier: 'team_pro',
+    });
+    openExternalUrlMock.mockResolvedValue(true);
+
+    const { onAgentModelChange } = renderLockedModelMenu(projectScopeContext());
+
+    openMenu();
+    await waitFor(() => {
+      fireEvent.click(screen.getByRole('radio', { name: /Paid model/i }));
+      expect(openExternalUrlMock).toHaveBeenCalled();
+    });
+
+    expect(onAgentModelChange).not.toHaveBeenCalled();
+    const target = new URL(openExternalUrlMock.mock.calls[0]![0]);
+    expect(target.origin + target.pathname).toBe('https://open-design.ai/amr/dashboard');
+    expect(target.searchParams.get('workspaceId')).toBe('workspace-a');
+    expect(target.searchParams.get('billing')).toBe('plan');
+
+    // The tier now comes from data this popover already fetched. Reading it
+    // must not have added a request of its own — the endpoints below are
+    // exactly the ones the popover already talked to. (The billing-interest
+    // registration carries a per-mount id, so it is normalized before the
+    // comparison; everything else is compared literally, on purpose, so a new
+    // network dependency on this path cannot slip in unremarked.)
+    const requested = [...new Set(urls.map((url) =>
+      url.replace(/\/api\/workspace\/billing\/interests\/[^/?]+$/, '/api/workspace/billing/interests/:id'),
+    ))].sort();
+    expect(requested).toEqual([
+      '/api/integrations/vela/status',
+      '/api/workspace/billing/interests/:id',
+      '/api/workspace/billing?scope=workspace&workspaceId=workspace-a',
+      '/api/workspace/context',
+      '/api/workspace/directory',
+    ]);
+  });
+
+  /*
+   * The property the user asked for by name: the corrected identity must be the
+   * FIRST thing painted, not a late correction of a wrong one. So the tier
+   * projection may not be an async hop.
+   *
+   * Instrument: a `fetch` that throws if it is touched at all. The projection
+   * still answers, on the calling frame, from the response the component
+   * already holds — no request, no await, nothing to wait out.
+   */
+  it('resolves the fallback tier synchronously, without touching the network', () => {
+    const throwingFetch = vi.fn(() => {
+      throw new Error('resolving the workspace plan tier must not fetch');
+    });
+    vi.stubGlobal('fetch', throwingFetch);
+
+    const response = teamBillingResponseBody({
+      workspaceId: 'workspace-a',
+      accountMembershipTier: 'team_pro',
+    }) as unknown as WorkspaceBillingResponse;
+    expect('workspaceSnapshot' in response).toBe(false);
+
+    const summary = workspaceBillingSummaryForContext(
+      response,
+      teamOwnerAmbientContext(),
+    );
+
+    expect(summary?.membershipTier).toBe('team_pro');
+    expect(throwingFetch).not.toHaveBeenCalled();
   });
 
 });


### PR DESCRIPTION
## Why

**My use case.** I was auditing the AMR plan-gate path in the composer popover after the
`canReachWorkspaceBillingEntrance` fix landed, and found that the tier feeding that gate is read
from a different source than every other billing surface in the app.

**The pain.** `AvatarMenu` resolved a team workspace's plan tier by reading the exact billing
SNAPSHOT directly. `workspaceBillingSummaryForContext` reads that same snapshot first — but it
also carries a fallback that was approved and is load-bearing: when a TEAM workspace has no
authorized snapshot, a team-namespaced account tier may stand in for it. (A personal tier may
not, because it describes the account's own subscription and cannot name a team workspace's
plan.) That fallback exists because dropping it flashed the free-tier upsell at Team Plus
members — a 飞书 P0. Reading the snapshot raw walked around it, and there was no third source to
catch the fall.

The snapshot goes missing for reasons that have nothing to do with the viewer's entitlements.
The daemon spreads the `workspaceSnapshot` key into the response only when it can authorize one
for the requested workspace + member (`apps/daemon/src/routes/collab-context.ts`), so production
omits the KEY entirely — it never sends `workspaceSnapshot: null`. Three paths reach that:

- A returns 409 `billing_workspace_snapshot_unsupported` when its workspace billing revision
  store is absent, while `/wallet/balance` only checks a different flag and still answers 200 —
  so "snapshot 409, balance 200" is the normal shape when the realtime channel isn't wired.
- **The likeliest one:** during a rolling deploy, an old API pod 404/405s the snapshot route,
  the CLI maps that to its unsupported sentinel, and the daemon falls back to `workspace-balance`.
  Transient, and nobody would notice it happening.
- A local vela CLI old enough to reject `--workspace-id`.

On this surface a missing snapshot became `scopedPlanId: null`, `canUpgradeVelaPlan(null)` is
false, and that veto lands **before** `canReachWorkspaceBillingEntrance` — which would have said
yes — is ever asked.

`apps/web/src/App.tsx`, `EntryShell.tsx`, `EntryNavRail.tsx`, `SettingsDialog.tsx` and
`ProjectView.tsx` all already go through the projection. `AvatarMenu` was the only holdout.

## What users will see

A team **owner** on a project page clicks a plan-gated model in the composer's model picker. Today,
during any of the windows above, the row keeps its "upgrade to use this" tooltip and **nothing at
all happens on click** — no navigation, no dialog, no error. After this change the click opens the
workspace-pinned plans page, exactly as it does when the snapshot is present.

Two shapes are fixed:

- A **paid** team whose snapshot didn't come back — the click now works instead of dying silently.
- An **unsubscribed** team, which B reports as `billingState: 'free'` with a null `planId`. Reading
  `planId` raw turned that positive "free" into an unknown tier, so a free team's owner also
  couldn't reach the plans page. This is the one behaviour change that applies while the snapshot
  *is* present, and it is called out in a dedicated test.

Nothing changes when the snapshot is present and names a plan: the projection consults the
snapshot first, so it still outranks the account fallback. The personal-workspace branch is
untouched.

## Surface area

- [x] **UI** — the AMR plan-gated model row in the composer popover (`apps/web/src/components/AvatarMenu.tsx`)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [x] **Default behavior change** — a plan-gated model click that used to be inert during a missing-snapshot window now routes to the plans page; an unsubscribed team's owner gains the upgrade entry
- [ ] **None**

No CLI counterpart: this is the click behaviour of one popover row, not a capability. The
underlying data (`GET /api/workspace/billing`) is unchanged and already reachable from both
surfaces; nothing new was added to the daemon.

## Screenshots

Not attached — the symptom is the **absence** of a navigation on click, which a still frame cannot
show. The entry point is the existing model row in the composer popover; its rendering is byte-for-byte
unchanged (`aria-disabled="true"`, same tooltip). Only what happens on click changes, and that is
pinned by the tests below. Real-runtime confirmation against a live backend is listed under
Validation.

## Bug fix verification

- **Test path:** `apps/web/tests/components/AvatarMenu.test.tsx`
- **Red on `main`, green on this branch:** yes. Both new failing cases were confirmed red with the
  source change removed (`git show HEAD:apps/web/src/components/AvatarMenu.tsx` restored over the
  branch file, tests kept) and green with it restored.

Three facts are pinned, and one of them is a static control:

1. **`keeps the exact snapshot outranking the account tier when the snapshot is present`** — the
   control against a blanket rewrite. The two tiers deliberately disagree *and point opposite
   ways*: snapshot says `team_max` (top tier, entry must stay closed) while the account says
   `team_pro` (upgradeable, entry would open). Green before and after; it turns red the moment the
   account tier is allowed to win anywhere.
2. **`falls back to the team-namespaced account tier when the snapshot is missing`** — the defect.
   Red before, green after.
3. **`opens the upgrade entry for an unsubscribed team the snapshot reports as free`** — the
   behaviour change noted above. Red before, green after.
4. **`resolves the fallback tier synchronously, without touching the network`** — the property that
   the corrected identity is the *first* thing painted, not a late correction of a wrong one. The
   instrument is a `fetch` that throws if touched at all; the projection still answers on the
   calling frame. The instrument was validated by injecting a `fetch` into
   `workspaceBillingSummaryForContext` and confirming it goes red — it does, and so does the
   companion assertion in (2) that the popover's requested-URL set is unchanged.

The existing fixture could not see any of this: `stubLockedModelFetch` gives every team path a
snapshot fixed at `team_pro`. The new fixture omits the `workspaceSnapshot` **key**, matching what
the daemon actually sends — not `null`, which production never produces.

### Adjacent issue (not fixed here, deliberately)

A missing snapshot also drags the **balance branch** down: `workspaceBillingSummaryForContext`
returns `membershipTier: ''` for "team + no snapshot + account tier is not team-namespaced", so
`resolveAmrBalanceBranch` reads `below_max` and the 「Max · owner → 自动充值」 cell degrades to
Pricing. **That is a different location and this PR does not touch it.** Both
`resolveAmrBalanceBranch` call sites (`EntryShell.tsx`, `ProjectView.tsx`) already feed it the
projection, so the team-namespaced case (`team_max` account tier, no snapshot) already resolves
to `max` today — verified locally. What remains degraded is only the sub-case where the account
tier is *personal* or empty, and that is the projection's deliberate contract (a personal tier
cannot name a team workspace's plan), not a bypassed fallback. Changing it means changing the
shared helper, which also feeds the nav-rail badge, Settings, and the App upsell gate — its own
PR, its own red spec.

### Dead code confirmed, left in place

`amrPlanId`'s `scopedPlanId ?? accountPlan` fallback (the `else` half of the ternary at
`AvatarMenu.tsx`) is unreachable in production: `AvatarMenu` has exactly one render site
(`ProjectView.tsx:12946`) and it always passes `projectWorkspaceScope`, whose hook
(`useProjectWorkspaceScope`) returns an object on every path. It is left untouched here — deleting
it is a separate change that also has to deal with the two tests that pin it.

## Validation

- `pnpm guard` — exit 0
- `pnpm typecheck` (root, all workspaces) — exit 0
- `apps/web` focused: `AvatarMenu.test.tsx` — 15/15, exit 0
- `apps/web` neighbours, 17 files / 287 tests, exit 0: `AvatarMenu.open-signal`, `amr-balance-branch`,
  `amr-balance-gate`, `amr-balance-gate-personal-tiers`, `amr-guidance`, `amr-plans-console-deeplink`,
  `useWorkspaceBilling.scope`, `team-plan`, `ProjectView.amr-balance-branches`,
  `ProjectView.amr-balance-card`, `ProjectView.opend2720-billing-authority`,
  `EntryShell.amr-balance-branches`, `EntryShell.workspace-plan-badge-scope`,
  `EntryNavRail.team-plan-badge`, `EntryNavRail.billing-card`, `EntryNavRail.top-tier-upgrade`
- `packages/contracts` untouched, so no dist rebuild was needed.

**Still wants a real-runtime pass** (jsdom cannot produce the server states): a team owner on a
runtime pointed at a backend that answers the snapshot route 409/404 while `/wallet/balance`
answers 200, clicking a plan-gated model and landing on the workspace-pinned plans page; and the
same on a genuinely unsubscribed team workspace.
