### PR TITLE
Add Source Project Context plugin

### DIFF
--- a/plugins/community/source-project-context-mts1dumb/SKILL.md
+++ b/plugins/community/source-project-context-mts1dumb/SKILL.md
@@ -1,0 +1,71 @@
+# Source Project Context
+
+This design-system workspace was created from an existing OpenDesign project. Treat the copied project files as the primary source evidence for the generated design system.
+
+## Source project
+
+- Source project id: bb760814-bca2-4004-a0cd-40f826270efa
+- Source project name: Your Core Visual System Should Be
+- New design-system project id: 79208616-2e51-4e2f-8a2f-e75f4448722e
+- New design-system id: user:your-core-visual-system-should-be-design-system
+- Source skill id: (none)
+- Source design system id: professional
+
+## Source metadata
+
+```json
+{
+  "kind": "prototype",
+  "nameSource": "prompt",
+  "localCatalogScopes": {
+    "designSystem": {
+      "workspaceId": "sqin0z6pa1gqmzzguxe6fikj",
+      "workspaceMemberId": "t6x0oi04oo7bogetnus0nzc4"
+    }
+  },
+  "strategyBinding": {
+    "schemaVersion": 1,
+    "provenance": "automatic_default",
+    "taskProfile": "prototype",
+    "boundAt": 1788041295016
+  },
+  "exampleBinding": {
+    "schemaVersion": 1,
+    "provenance": "example_card",
+    "pluginId": "example-social-carousel",
+    "pluginSource": "/private/var/folders/y_/47p1qycd5jb64fkw04h6n9200000gn/T/AppTranslocation/2F480632-8D4B-429E-8F56-C621EB42C9BA/d/Open Design.app/Contents/Resources/open-design/plugins/_official/examples/social-carousel",
+    "manifestSourceDigest": "sha256:cb0c3ac321cbd850a53da00a6ad1b901d40dc89e447c61ed697b456628776f28",
+    "boundAt": 1788041295016
+  },
+  "scenarioBinding": {
+    "schemaVersion": 1,
+    "provenance": "automatic_default",
+    "pluginId": "example-web-prototype",
+    "snapshotId": "2aa978b6-49a1-4eb7-86ef-4e997da222b0",
+    "taskProfile": "prototype",
+    "boundAt": 1788042067062
+  }
+}
+```
+
+## Copied files
+
+- preview.png
+- south-florida-elevated-carousel.html
+- brand-spec.md
+
+## Skipped files
+
+- (none)
+
+## Generation contract
+
+- Read this file before editing design-system outputs.
+- Read the copied files directly from the project workspace; they are source evidence, not generated design-system output.
+- Preserve high-signal assets, source examples, UI surfaces, copy, tokens, typography, and interaction patterns from the copied project.
+- Generate a reusable OpenDesign design-system package in this same project: DESIGN.md, README.md, SKILL.md, colors_and_type.css, context/provenance, focused preview cards, preserved assets/build/fonts when available, and ui_kits/app/.
+- Before final response, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every actionable issue.
+
+## Provenance
+
+Formalized by OpenDesign from candidate ab0c7fc4-bd16-4e9e-9a91-eabb2bbb0879.

--- a/plugins/community/source-project-context-mts1dumb/open-design.json
+++ b/plugins/community/source-project-context-mts1dumb/open-design.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "source-project-context-mts1dumb",
+  "title": "Source Project Context",
+  "version": "0.1.0",
+  "description": "This design-system workspace was created from an existing OpenDesign project. Treat the copied project files as the primary source evidence for the generated design system.",
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject"
+    ]
+  }
+}

--- a/plugins/community/source-project-context-mts1dumb/references/provenance.json
+++ b/plugins/community/source-project-context-mts1dumb/references/provenance.json
@@ -1,0 +1,47 @@
+{
+  "candidateId": "ab0c7fc4-bd16-4e9e-9a91-eabb2bbb0879",
+  "projectId": "79208616-2e51-4e2f-8a2f-e75f4448722e",
+  "runId": "e6f2ac06-a01a-477e-b946-928f1ec8be92",
+  "conversationId": "c83794b8-38f2-4a56-9a07-043de893c375",
+  "provenance": {
+    "summary": "Detected from context/source-context.md, README.md, SKILL.md, ui_kits/app/README.md, context/provenance.md after a successful run.",
+    "detectedAt": 1788493269967
+  },
+  "sourceRefs": [
+    {
+      "kind": "file",
+      "value": "context/source-context.md",
+      "label": "context/source-context.md",
+      "size": 2534,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "README.md",
+      "label": "README.md",
+      "size": 6671,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "SKILL.md",
+      "label": "SKILL.md",
+      "size": 4188,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "ui_kits/app/README.md",
+      "label": "ui_kits/app/README.md",
+      "size": 4654,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "context/provenance.md",
+      "label": "context/provenance.md",
+      "size": 2507,
+      "copied": true
+    }
+  ]
+}

--- a/plugins/community/source-project-context-mts1dumb/references/source-1-source-context.md
+++ b/plugins/community/source-project-context-mts1dumb/references/source-1-source-context.md
@@ -1,0 +1,67 @@
+# Source Project Context
+
+This design-system workspace was created from an existing OpenDesign project. Treat the copied project files as the primary source evidence for the generated design system.
+
+## Source project
+
+- Source project id: bb760814-bca2-4004-a0cd-40f826270efa
+- Source project name: Your Core Visual System Should Be
+- New design-system project id: 79208616-2e51-4e2f-8a2f-e75f4448722e
+- New design-system id: user:your-core-visual-system-should-be-design-system
+- Source skill id: (none)
+- Source design system id: professional
+
+## Source metadata
+
+```json
+{
+  "kind": "prototype",
+  "nameSource": "prompt",
+  "localCatalogScopes": {
+    "designSystem": {
+      "workspaceId": "sqin0z6pa1gqmzzguxe6fikj",
+      "workspaceMemberId": "t6x0oi04oo7bogetnus0nzc4"
+    }
+  },
+  "strategyBinding": {
+    "schemaVersion": 1,
+    "provenance": "automatic_default",
+    "taskProfile": "prototype",
+    "boundAt": 1788041295016
+  },
+  "exampleBinding": {
+    "schemaVersion": 1,
+    "provenance": "example_card",
+    "pluginId": "example-social-carousel",
+    "pluginSource": "/private/var/folders/y_/47p1qycd5jb64fkw04h6n9200000gn/T/AppTranslocation/2F480632-8D4B-429E-8F56-C621EB42C9BA/d/Open Design.app/Contents/Resources/open-design/plugins/_official/examples/social-carousel",
+    "manifestSourceDigest": "sha256:cb0c3ac321cbd850a53da00a6ad1b901d40dc89e447c61ed697b456628776f28",
+    "boundAt": 1788041295016
+  },
+  "scenarioBinding": {
+    "schemaVersion": 1,
+    "provenance": "automatic_default",
+    "pluginId": "example-web-prototype",
+    "snapshotId": "2aa978b6-49a1-4eb7-86ef-4e997da222b0",
+    "taskProfile": "prototype",
+    "boundAt": 1788042067062
+  }
+}
+```
+
+## Copied files
+
+- preview.png
+- south-florida-elevated-carousel.html
+- brand-spec.md
+
+## Skipped files
+
+- (none)
+
+## Generation contract
+
+- Read this file before editing design-system outputs.
+- Read the copied files directly from the project workspace; they are source evidence, not generated design-system output.
+- Preserve high-signal assets, source examples, UI surfaces, copy, tokens, typography, and interaction patterns from the copied project.
+- Generate a reusable OpenDesign design-system package in this same project: DESIGN.md, README.md, SKILL.md, colors_and_type.css, context/provenance, focused preview cards, preserved assets/build/fonts when available, and ui_kits/app/.
+- Before final response, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every actionable issue.

--- a/plugins/community/source-project-context-mts1dumb/references/source-2-README.md
+++ b/plugins/community/source-project-context-mts1dumb/references/source-2-README.md
@@ -1,0 +1,100 @@
+# South Florida Elevated — Design System Package
+
+A complete, reusable OpenDesign design-system package distilled from the "Your Core Visual System Should Be" project — the South Florida Elevated identity by Miguel Perez.
+
+## Product overview
+
+**South Florida Elevated** is a boutique luxury real-estate practice for the modern South Florida life: local expertise, elevated white-glove service, and an eye for the extraordinary. The brand package turns that positioning into a **luxury-editorial visual identity** — deep onyx nights, champagne-gold rules, restrained Florida teal, and instrument-serif headlines — reading like a high-end fashion magazine crossed with a waterfront property publication.
+
+**Primary surfaces the package supports:**
+- Instagram carousels (the source artifact is a 5-frame 1080 × 1350 px "Who We Are" deck)
+- Pitch / presentation decks
+- Marketing & landing pages
+- Brand assets (wordmark mark, lockup, skyline silhouette, palette)
+- Applied product UI (see `ui_kits/app/`)
+
+**Core capabilities:** a bindable OKLch token set with hex references, a two-typeface system (Instrument Serif + Cairo), sharp-cornered editorial component frames, art-directed dusk photographic plates, and a data-driven applied UI kit.
+
+## Product context
+
+Created in the "Your Core Visual System Should Be" project and preserved as the "professional" design system. The governing brief (`brand-spec.md`) binds the direction: **gold is the material, teal is the accent**, editorial restraint with one serif headline per frame, cinematic dusk photographic treatment, and a confident local voice ("down to the waterline"). Provenance is documented in `context/provenance.md`; source handoff metadata in `context/source-context.md`.
+
+## Source & context references
+
+| Reference | Path |
+|---|---|
+| Source handoff metadata | `context/source-context.md` |
+| Provenance & derivation | `context/provenance.md` |
+| Client master style prompt | `brand-spec.md` |
+| Canonical source artifact | `south-florida-elevated-carousel.html` |
+| Source render | `preview.png` |
+
+## Package contents
+
+| Path | What it is |
+|---|---|
+| `DESIGN.md` | Authoritative visual system (theme, color, type, spacing, layout, components, motion, voice, anti-patterns) |
+| `colors_and_type.css` | Bindable OKLch tokens + concrete hex references + type / layout variables |
+| `SKILL.md` | Discoverable skill package for generating on-brand artifacts |
+| `fonts/` | Font loading contract (Instrument Serif + Cairo via Google Fonts CDN) |
+
+### Preserved source examples & assets
+
+- **`south-florida-elevated-carousel.html`** — preserved verbatim at the root (with `.artifact.json` manifest). The 5-frame carousel is the definitive implementation reference; keep it intact, never strip it to a stub.
+- **`assets/`** — real source-derived assets: `sfe-wordmark-mark.svg`, `sfe-wordmark.svg`, `skyline-coversheet.svg`, `sfe-palette.svg`, plus the shipped "MP × Elevated" brand logo set (`sfe-symbol.png`, `sfe-lockup-transparent-light.png`, `sfe-lockup-transparent-dark.png`), and monochrome lockup concepts in `logo-concepts/` (see `assets/README.md`).
+
+### build/ — runtime hooks
+
+- `build/lib/sfe-common.css` — component CSS distilled exactly from the source carousel (masthead, chips, rails/slugs, keyline + grain, dusk plates, focus ring).
+- `build/lib/sfe-components.js` — bootstraps the wordmark mark and index marks.
+- `build/runtime-hooks.json` — machine-readable manifest of marks, labels, and hook paths.
+
+### preview/ — review cards
+
+Focused review surfaces that visibly load the preserved files:
+
+| Card | Path |
+|---|---|
+| Color tokens | `preview/colors.html`, `preview/colors-primary.html` |
+| Typography specimens | `preview/typography-specimens.html` |
+| Spacing, radius, rhythm | `preview/spacing-tokens.html` |
+| Components & marks | `preview/components-buttons.html` |
+| Brand assets | `preview/brand-assets.html` (loads `assets/*`) |
+| Applied UI surface | `preview/applied-ui.html` |
+
+### ui_kits/app/ — applied interface kit
+
+- `ui_kits/app/index.html` — composed cardinal interface (loads `../../colors_and_type.css` + `components/`).
+- `ui_kits/app/pillars.html`, `showcase.html` — applied editorial surfaces.
+- `ui_kits/app/components/app.css` + `brand-config.js` — modular app chrome and shared data.
+- `ui_kits/app/README.md` — how to reuse the kit.
+
+## Preview manifest
+
+Concrete review cards generated under `preview/` — reviewers and future agents can inspect them directly:
+
+| Card | Path | What to check |
+|---|---|---|
+| Color tokens · primary | `preview/colors-primary.html` | OKLch palette + semantic roles + state pairs |
+| Color tokens | `preview/colors.html` | Alias of the primary color card |
+| Themes · light/dark kits | `preview/themes-light-dark.html` | Semantic role tokens remapped for the onyx night + ivory editorial kits |
+| Typography specimens | `preview/typography-specimens.html` | Two-face scale, letter-spacing, emphasis voice |
+| Spacing & radius | `preview/spacing-tokens.html` | Spacing scale, sharp-corner radius rule, layout rhythm |
+| Components & marks | `preview/components-buttons.html` | Wordmark, chips, rails, actions, dusk plate |
+| Brand assets | `preview/brand-assets.html` | Preserved `assets/*` files load live |
+| Applied UI | `preview/applied-ui.html` | Tokens composed onto a real interface surface |
+
+## Reuse workflow
+
+1. **Bind tokens** — import `colors_and_type.css` (or paste its `:root`) into your first `<style>`; load the fonts. Components consume the **semantic role tokens** (`--surface-1`, `--text-primary`, `--action`, `--mark`, `--border-subtle`, `--focus-ring`), so the whole surface remaps when you apply `data-theme="light"` / `.light`.
+2. **Read the rules** — follow `DESIGN.md` (sharp corners, gold/teal discipline, one serif headline, dusk plates, anti-patterns, accessibility contract).
+3. **Reuse source** — pull component CSS from `build/lib/sfe-common.css` and assets from `assets/`.
+4. **Compose UI** — import `ui_kits/app/components/*` for product surfaces, or reuse the whole kit. For a product UI, set semantic surfaces on `body` and build chrome from role tokens so the light kit comes for free.
+
+## Review workflow
+
+1. Open the **color** card (`preview/colors-primary.html`) to sanity-check the palette.
+2. Open **typography** (`preview/typography-specimens.html`) for the two-face hierarchy.
+3. Open **applied UI** (`preview/applied-ui.html`) and `ui_kits/app/index.html` to see the tokens composed.
+4. Open **brand-assets** (`preview/brand-assets.html`) to verify preserved files load.
+5. Cross-check behavior against the preserved source carousel.

--- a/plugins/community/source-project-context-mts1dumb/references/source-3-SKILL.md
+++ b/plugins/community/source-project-context-mts1dumb/references/source-3-SKILL.md
@@ -1,0 +1,52 @@
+---
+name: south-florida-elevated-design-system
+description: Apply the South Florida Elevated luxury-editorial design system — deep onyx nights, champagne-gold rules, restrained Florida teal, Instrument Serif + Cairo. Use for any deliverable for Miguel Perez's boutique South Florida real-estate brand: Instagram carousels, pitch decks, landing pages, brand assets, and applied UI.
+user-invocable: true
+---
+
+# South Florida Elevated — Design System Skill
+
+A reusable skill package for generating on-brand artifacts for **South Florida Elevated**, distilled from the source OpenDesign project "Your Core Visual System Should Be".
+
+## What is inside
+
+- `DESIGN.md` — the authoritative visual system (theme, color, type, spacing, layout, components, motion, voice, anti-patterns).
+- `colors_and_type.css` — bindable OKLch token stylesheet with concrete hex references.
+- `brand-spec.md` — the preserved client master-style prompt.
+- `south-florida-elevated-carousel.html` — the canonical 5-frame brand carousel (source reference).
+- `assets/` — preserved brand assets: wordmark mark, wordmark lockup, skyline silhouette, palette reference, plus the shipped "MP × Elevated" brand symbol and light/dark transparent logo lockups (`logo-concepts/` holds monochrome explorations).
+- `build/lib/sfe-common.css` — component CSS distilled from the source carousel.
+- `preview/` — six focused review cards (color, type, spacing, components, brand, applied UI).
+- `ui_kits/app/` — an applied interface kit composing the tokens into working product UI.
+
+## Source context
+
+- **Source project:** "Your Core Visual System Should Be" (`bb760814-bca2-4004-a0cd-40f826270efa`).
+- **Source evidence:** `south-florida-elevated-carousel.html` (5-frame carousel for @southfloridaelevated) and `brand-spec.md` (client master style prompt). All tokens/values are extracted from these files, not invented.
+- **Design system id:** `user:your-core-visual-system-should-be-design-system`.
+- **Provenance:** see `context/provenance.md`.
+
+## When to use this skill
+
+Use whenever a deliverable carries the South Florida Elevated identity — an Instagram carousel, a pitch/presentation deck, a marketing or landing page, brand assets, signage, or an applied interface kit. Also use it to review or extend any existing SFE artifact.
+
+## How to use
+
+1. **Bind tokens:** copy `colors_and_type.css` (or its `:root`) into the artifact's first `<style>`. Compose components against the **semantic role tokens** so a `data-theme="light"` / `.light` scope remaps the whole surface for free. Load the two Google Fonts per `fonts/README.md`.
+2. **Read the rules:** follow `DESIGN.md` for color, type, spacing, layout, and anti-patterns (plus the accessibility contract in §10).
+3. **Reuse source components:** pull masthead, chips, rails, keyline/grain frames, and dusk plates from `build/lib/sfe-common.css` and `assets/`.
+4. **Carousel:** reuse the 5-frame arc (cover → three pillars → close) from the preserved source HTML.
+5. **Applied UI:** compose product surfaces by importing `ui_kits/app/components/app.css` and `brand-config.js`; for a product shell set `--surface-1`/`--text-primary` on `body`.
+
+## Design system highlights
+
+- **Gold is the material; teal is the accent.** Thin metallic gold rules and serif-italic gold emphasis carry the identity; Florida teal stays small and rare (index numerals, dots, eyebrows).
+- **Sharp corners everywhere.** `border-radius: 0` is a hard rule.
+- **One serif headline per frame** in Instrument Serif; **italic for emphasis**; Cairo supports with letterspaced caps.
+- **Cinematic dusk** photographic treatment — deep onyx with champagne horizon glow and fine grain, never stock-bright.
+- **Voice:** confident, local, specific ("down to the waterline"); no invented metrics.
+- **Accessibility:** onyx/ivory text pairs hold strong contrast; hover/focus never reduce foreground lightness; gold keyline focus ring required.
+
+## Anti-patterns
+
+Purple washes, rounded corners, multiple solid CTAs, teal surfaces, emoji icons, bright stock photography, invented metrics, and AI-slop typography (untracked caps, unjustified serif). Full list in `DESIGN.md` §9.

--- a/plugins/community/source-project-context-mts1dumb/references/source-4-README.md
+++ b/plugins/community/source-project-context-mts1dumb/references/source-4-README.md
@@ -1,0 +1,74 @@
+# South Florida Elevated — Applied UI Kit
+
+An applied interface kit that mounts the South Florida Elevated design system onto working product UI, so future agents can see and reuse how the tokens, typography, and component language compose into real screens. It is **data-driven**, not a static mock.
+
+## Source basis
+
+The kit is composed entirely from this package's design system:
+
+- **Tokens:** `../../colors_and_type.css` (OKLch palette with hex references, fonts, spacing/layout variables).
+- **Component language:** the source carousel `south-florida-elevated-carousel.html` and `../../build/lib/sfe-common.css` (sharp corners, gold hairlines, serif-emphasis headlines, chips/rails/slugs, dusk plates).
+- **Rules:** `../../DESIGN.md` (gold-as-material, teal-as-accent, onyx/ivory duality, one serif idea per frame, anti-patterns).
+
+## Structure
+
+The kit is a small set of screen files that all share the same token imports, plus a `components/` folder of modular app chrome, data, and an `App` entry component:
+
+```
+ui_kits/app/
+├── index.html        # kit overview — mounts the App, renders the cardinal grid
+├── pillars.html      # the three editorial pillars as interface cards
+├── showcase.html     # the cinematic dusk-plate treatment
+├── components/
+│   ├── app.css         # App chrome + layout composed on brand tokens
+│   ├── app.jsx         # App entry component — window.SFEAPP.mount()
+│   └── brand-config.js # shared wordmark mark SVG + cardinal data (window.SFEKIT)
+└── README.md          # this reuse guide
+```
+
+## Component files
+
+The kit is composed from reusable component files and the preserved review cards, so each screen is a PreviewCard built on the same tokens:
+
+| File | Role |
+|---|---|
+| `index.html` | Kit overview — mounts the `App` (`components/app.jsx`) and renders the cardinal grid |
+| `pillars.html` | The three editorial pillars composed as interface PreviewCards (onyx + ivory variants) |
+| `showcase.html` | The cinematic dusk-plate treatment composed as a PreviewCard cover/close frame |
+| `components/app.jsx` | `App` entry component — `window.SFEAPP.mount({ mark, grid })` renders data-driven surfaces |
+| `components/app.css` | `App` chrome + layout composed on the brand tokens |
+| `components/brand-config.js` | Brand config — wordmark mark SVG + cardinal data as `window.SFEKIT` |
+
+## Usage workflow
+
+1. **Bind tokens** — every screen imports `../../colors_and_type.css` before its own styles:
+   ```html
+   <link rel="stylesheet" href="../../colors_and_type.css" />
+   <link rel="stylesheet" href="components/app.css" />
+   ```
+2. **Import chrome** — `components/app.css` (rail, cards, actions, focus rings) or copy individual rules into your own stylesheet.
+3. **Drive with data** — `components/brand-config.js` exports the mark + pillar data as `window.SFEKIT`; `components/app.jsx` reads it and `index.html` calls `window.SFEAPP.mount()` to render. Extend the array and re-render to adapt the kit to new content.
+4. **Extend** — add new screen files alongside `index.html` reusing the same imports and the `data-od-id` inspection attributes.
+
+## Design notes
+
+- **Sharp corners only.** No radius anywhere (`--radius: 0`) — matches the source.
+- **Gold is the material, teal the accent.** Teal appears only in numerals/marks; gold carries emphasis.
+- **Exactly one primary per action** — the `action` hairline button; `action.ghost` for secondary, distinct copy.
+- **Hover moves the keyline/background, never foreground lightness;** focus uses a visible gold ring.
+- **Semantic tokens, not raw palette.** Components bind `--surface-1/2`, `--text-primary/secondary`, `--action`, `--mark`, `--border-subtle`, `--focus-ring`. Apply `data-theme="light"` (or `.light`) on `<html>` to remap the whole shell to the ivory editorial kit — on ivory, swap to `--ink` + `--gold-deep` (never reuse the dark-surface text colors).
+- **Disabled is the only low-contrast state**; target size ≥ `--control-h` 44px; `:focus-visible` always shows the gold ring.
+
+## Light/dark switch
+
+The kit is dark-by-default (onyx nights). To preview the ivory editorial kit, add the light theme to the document root:
+
+```html
+<html lang="en" data-theme="light">
+```
+
+No per-component changes are needed — the rail, cards, chips, and actions all rebind through the role tokens in `colors_and_type.css`.
+
+## Reusing in a new project
+
+Copy the `components/` folder and the import lines, or reference this kit as the canonical applied example. Keep brand rules from `../../DESIGN.md` in force; when in doubt, bind tokens rather than hardcoding values.

--- a/plugins/community/source-project-context-mts1dumb/references/source-5-provenance.md
+++ b/plugins/community/source-project-context-mts1dumb/references/source-5-provenance.md
@@ -1,0 +1,40 @@
+# Provenance
+
+## Source project
+- **Source project id:** bb760814-bca2-4004-a0cd-40f826270efa
+- **Source project name:** Your Core Visual System Should Be
+- **Source skill id:** (none)
+- **Active design system id (source):** professional
+
+## This workspace
+- **Design-system project id:** 79208616-2e51-4e2f-8a2f-e75f4448722e
+- **Design-system id:** user:your-core-visual-system-should-be-design-system
+- **Created at:** 2026-08-29
+
+## Source evidence
+Copied files, treated as primary evidence:
+- `../preview.png` — rendered preview of the source carousel (6057 KB)
+- `../south-florida-elevated-carousel.html` — the 5-frame "Who We Are" Instagram carousel (31 KB) authored for @southfloridaelevated by Miguel Perez; the definitive token/component/typography reference
+- `../brand-spec.md` — the client's master style prompt "South Florida Elevated", listing OKLch tokens and observed design rules
+
+## Source metadata bindings
+- Kind: `prototype`; source `exampleBinding.pluginId = example-social-carousel`; scenario `snapshotId = 2aa978b6-49a1-4eb7-86ef-4e997da222b0`; task profile `prototype`.
+
+## What was derived and how
+Every token in `colors_and_type.css`, `DESIGN.md`, and the previews/kit was extracted from the source carousel's `:root` block and `brand-spec.md` — the OKLch values are copied, not invented. The wordmark SVG mark, skyline silhouettes, dusk-plate gradients, keyline/grain treatments, and the editorial layout system are preserved relationships, not guesses.
+
+## Derived package layout
+- `DESIGN.md` — the authoritative visual system
+- `colors_and_type.css` — bindable token stylesheet
+- `brand-spec.md` — preserved client spec (source)
+- `south-florida-elevated-carousel.html` — preserved source artifact (see below)
+- `preview.png` — preserved source preview (see below)
+- `assets/` — preserved brand assets (wordmark mark, palette)
+- `build/` — extracted component/library hooks (runtime icons/labels)
+- `fonts/` — font fallback notes (webfonts loaded from Google Fonts CDN; no local files shipped)
+- `preview/` — focused review cards
+- `ui_kits/app/` — applied interface kit reflecting the source project
+
+## Preservation notice
+- `south-florida-elevated-carousel.html` and `preview.png` remain at the project root as unmodified source evidence (their `.artifact.json` manifests exist alongside).
+- Fonts are served from Google Fonts CDN (Instrument Serif + Cairo). No proprietary font files are redistributed; `fonts/` documents the loading contract.


### PR DESCRIPTION
Add Source Project Context (source-project-context-mts1dumb) plugin.
Version: 0.1.0
Description: This design-system workspace was created from an existing OpenDesign project. Treat the copied project files as the primary source evidence for the generated design system.