### PR TITLE
feat(release): alert through the other Feishu bot when the prerelease card goes silent

### DIFF
--- a/.github/workflows/release-prerelease-card.yml
+++ b/.github/workflows/release-prerelease-card.yml
@@ -17,6 +17,13 @@ name: release-prerelease-card
 # It is dispatched by release-prerelease.yml's `dispatch_validation` job at the
 # moment the build commit is resolved — before any package exists — and it holds
 # a concurrency group of its own, so its long watch cannot delay a build.
+#
+# Being the ONLY prerelease notification makes every way this workflow can break
+# a silent one: the pipeline stays green, the packages ship, and the channel
+# hears nothing. `fallback_notice` below is the answer — it fires only when the
+# card did not reach the group, and it delivers through the custom-bot webhook,
+# a different bot with a different secret, so an expired application credential
+# cannot take the alert down with the card.
 
 on:
   workflow_dispatch:
@@ -76,6 +83,14 @@ jobs:
     # watcher's own budget set below it so the card gets a final "timed out"
     # update instead of being killed mid-poll.
     timeout-minutes: 150
+    outputs:
+      # "The card's FINAL state is in the chat", written by the watcher itself.
+      # Deliberately not derivable from this job's result: the watcher catches
+      # every Feishu error on purpose (one hiccup must not end a two-hour watch)
+      # and exits 0 regardless, so an application bot whose credentials expired
+      # produces a green job and an empty channel. The fallback job below keys
+      # on this, not on `result`.
+      delivered: ${{ steps.track.outputs.card_delivered }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -150,6 +165,7 @@ jobs:
           fi
 
       - name: Track the prerelease on one card
+        id: track
         env:
           BRANCH: ${{ inputs.branch }}
           CARD_TIMEOUT_MS: "8400000"
@@ -168,3 +184,95 @@ jobs:
           RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
           VERSION: ${{ inputs.version }}
         run: node --experimental-strip-types tools/release/src/notifications/prerelease-progress-card.ts
+
+  fallback_notice:
+    name: Alert when the card never reached the group
+    needs: card
+    # `always() && !cancelled()` is load-bearing, not decoration. GitHub applies
+    # an implicit `success()` to a job with `needs`, which would skip this one in
+    # exactly the case it exists for — a card job that died — without ever
+    # evaluating the conditions below. (The same trap skipped
+    # release-prerelease.yml's `dispatch_smoke` for N runs.) `card` is this
+    # workflow's only other job and sits downstream of nothing, so that break is
+    # the whole reachability story here: the permanently-skipped `build_linux`
+    # chain that poisons release-prerelease.yml's graph does not exist in this
+    # two-job workflow.
+    #
+    # The last clause is the "never fire on a healthy release" rule. A green
+    # watcher that ALSO reports a delivered card is the normal outcome and must
+    # skip this job; a green watcher without that report is the silent failure.
+    # Reading `needs.card.result` alone would miss every credential failure.
+    #
+    # The repository guard mirrors `card`'s own: a fork has neither bot's
+    # credentials, and must not be told its card lane is broken.
+    if: >-
+      ${{
+        always() && !cancelled() &&
+        github.repository == 'nexu-io/open-design' &&
+        !(needs.card.result == 'success' && needs.card.outputs.delivered == 'true')
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      # The OTHER bot, on purpose. The card posts through the Feishu application
+      # bot (FEISHU_APP_ID / FEISHU_APP_SECRET / FEISHU_RELEASE_CHAT_ID); this
+      # posts through the custom-bot webhook that the retired one-shot card used.
+      # A fallback sharing the primary's credentials would cover nothing —
+      # "the application bot expired or was removed from the chat" is one of the
+      # ways the card goes silent, and it must not take the alert down too.
+      FEISHU_SIGN_SECRET: ${{ secrets.FEISHU_RELEASE_SIGN_SECRET }}
+      FEISHU_WEBHOOK: ${{ secrets.FEISHU_RELEASE_WEBHOOK }}
+    steps:
+      - name: Checkout notifier
+        uses: actions/checkout@v6.0.2
+        with:
+          # Both scripts below import nothing but node builtins, so this job
+          # needs no dependency install — which is the point: the last-resort
+          # path should have as little between it and the POST as possible.
+          fetch-depth: 1
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Compose the fallback notice
+        id: notice
+        env:
+          BRANCH: ${{ inputs.branch }}
+          CARD_DELIVERED: ${{ needs.card.outputs.delivered }}
+          CARD_JOB_RESULT: ${{ needs.card.result }}
+          CARD_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          CHANNEL_LABEL: Prerelease
+          COMMIT: ${{ inputs.commit }}
+          GH_TOKEN: ${{ github.token }}
+          LANE_SUMMARY: "card job=${{ needs.card.result }} · delivered=${{ needs.card.outputs.delivered || 'false' }}"
+          # The card is dispatched before any package exists, so unlike
+          # release-prerelease.yml this caller holds no version_metadata_url.
+          # It reconstructs the same R2 object and HEADs it, which is the same
+          # authority by a different route, and asks the origin run whether the
+          # pipeline is still going — that is what tells "never shipped" apart
+          # from "has not shipped yet" when the card dies early.
+          ORIGIN_RUN_ID: ${{ inputs.origin_run_id }}
+          ORIGIN_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ inputs.origin_run_id }}
+          RELEASE_CHANNEL: prerelease
+          RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
+          STAGE: watch
+          VERSION: ${{ inputs.version }}
+        run: node --experimental-strip-types tools/release/src/notifications/prerelease-fallback-notice.ts
+
+      - name: Fail loudly when the fallback bot is itself unconfigured
+        # Both notification paths being down at once is an incident of its own,
+        # and a red job in the Actions list is the only channel left to say so.
+        if: ${{ steps.notice.outputs.alert == 'true' && env.FEISHU_WEBHOOK == '' }}
+        run: |
+          echo "::error::the prerelease card lane went silent and FEISHU_RELEASE_WEBHOOK is unset, so no fallback notice could be delivered"
+          exit 1
+
+      - name: Post the fallback notice
+        if: ${{ steps.notice.outputs.alert == 'true' && env.FEISHU_WEBHOOK != '' }}
+        env:
+          NOTICE_BODY: ${{ steps.notice.outputs.body }}
+          NOTICE_TEMPLATE: ${{ steps.notice.outputs.template }}
+          NOTICE_TITLE: ${{ steps.notice.outputs.title }}
+          RUN_URL: ${{ steps.notice.outputs.run_url }}
+        run: node --experimental-strip-types tools/release/src/notifications/feishu-notice.ts

--- a/.github/workflows/release-prerelease-card.yml
+++ b/.github/workflows/release-prerelease-card.yml
@@ -263,13 +263,25 @@ jobs:
       - name: Fail loudly when the fallback bot is itself unconfigured
         # Both notification paths being down at once is an incident of its own,
         # and a red job in the Actions list is the only channel left to say so.
-        if: ${{ steps.notice.outputs.alert == 'true' && env.FEISHU_WEBHOOK == '' }}
+        # `always()` because the whole point is to speak after something
+        # broke — without it GitHub's implicit success() skips this step in
+        # every run where an earlier step already failed. The outcome check
+        # is the other half: never act on a composer that did not finish.
+        if: >-
+          ${{
+            always() && steps.notice.outcome == 'success' &&
+            steps.notice.outputs.alert == 'true' && env.FEISHU_WEBHOOK == ''
+          }}
         run: |
           echo "::error::the prerelease card lane went silent and FEISHU_RELEASE_WEBHOOK is unset, so no fallback notice could be delivered"
           exit 1
 
       - name: Post the fallback notice
-        if: ${{ steps.notice.outputs.alert == 'true' && env.FEISHU_WEBHOOK != '' }}
+        if: >-
+          ${{
+            always() && steps.notice.outcome == 'success' &&
+            steps.notice.outputs.alert == 'true' && env.FEISHU_WEBHOOK != ''
+          }}
         env:
           NOTICE_BODY: ${{ steps.notice.outputs.body }}
           NOTICE_TEMPLATE: ${{ steps.notice.outputs.template }}

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -292,11 +292,24 @@ jobs:
     #
     # A dispatch failure is loud (this job goes red) and harmless: nothing
     # depends on this job, so `publish` cannot see it.
+    #
+    # Red is not, however, a channel anyone watches. The progressive card is the
+    # ONLY prerelease notification left, so a card that was never dispatched is
+    # a release the team never hears about. The last steps below are the ping
+    # for that, and they live in this job rather than a job of their own
+    # precisely because nothing may depend on the dispatchers.
     needs: metadata
     if: ${{ needs.metadata.result == 'success' }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
+      # Read only by the last step, which alerts when the card was not
+      # dispatched. Deliberately the OTHER bot: the card posts through the
+      # Feishu application bot below, so an application credential that expired
+      # (or was emptied, which silently skips the dispatch step) must not take
+      # the alert down with it.
+      FEISHU_SIGN_SECRET: ${{ secrets.FEISHU_RELEASE_SIGN_SECRET }}
+      FEISHU_WEBHOOK: ${{ secrets.FEISHU_RELEASE_WEBHOOK }}
       GH_REPO: ${{ github.repository }}
       PRIMARY_REF: ${{ needs.metadata.outputs.branch }}
       FALLBACK_REF: ${{ github.event.repository.default_branch || 'main' }}
@@ -307,6 +320,7 @@ jobs:
       FEISHU_RELEASE_CHAT_ID: ${{ secrets.FEISHU_RELEASE_CHAT_ID }}
     steps:
       - name: Checkout dispatch helper
+        id: checkout
         uses: actions/checkout@v6.0.2
         with:
           # Deliberately the ref this workflow was loaded from, NOT the built
@@ -315,6 +329,7 @@ jobs:
           # break the moment a release branch carried an older .github tree.
           fetch-depth: 1
       - name: Dispatch prerelease code tests
+        id: tests_dispatch
         if: ${{ inputs.enable_tests }}
         env:
           COMMIT: ${{ needs.metadata.outputs.commit }}
@@ -325,6 +340,7 @@ jobs:
             -f "version=$VERSION" \
             -f "origin_run_id=$GITHUB_RUN_ID"
       - name: Dispatch progressive Feishu card
+        id: card_dispatch
         if: ${{ env.FEISHU_APP_ID != '' && env.FEISHU_RELEASE_CHAT_ID != '' }}
         env:
           BRANCH: ${{ needs.metadata.outputs.branch }}
@@ -342,6 +358,77 @@ jobs:
             -f "origin_run_id=$GITHUB_RUN_ID" \
             -f "expect_tests=$EXPECT_TESTS" \
             -f "expect_smoke=$EXPECT_SMOKE"
+          # Only reached when the dispatch above actually succeeded — the helper
+          # exits non-zero on every ref it could not dispatch on, and `run:`
+          # blocks stop at the first failure. Empty therefore covers every way
+          # the card fails to start: the helper could not dispatch on any ref,
+          # an earlier step in this job died, or this step was skipped because
+          # the application bot's credentials are missing.
+          echo "dispatched=true" >> "$GITHUB_OUTPUT"
+
+      # ---- Fallback when the card never started --------------------------
+      # `always()` so a failed dispatch above still reaches these; gated on the
+      # checkout because both scripts come from the working tree. They run on
+      # every prerelease and stay silent on the healthy ones — the composer
+      # refuses to emit `alert=true` when the card was dispatched, which is the
+      # same rule this repository cannot afford to get wrong: a fallback that
+      # also posts on good days is just a second card.
+      #
+      # This ping is necessarily early. It fires beside the build, before any
+      # package exists, so it reports where the version metadata WILL appear
+      # instead of claiming a publication verdict it cannot have yet. Once the
+      # card workflow IS running, release-prerelease-card.yml's own
+      # `fallback_notice` job owns the rest of the lane — the two are mutually
+      # exclusive, so a release can never draw both.
+      - name: Setup Node.js for the fallback notifier
+        if: >-
+          ${{
+            always() && github.repository == 'nexu-io/open-design' &&
+            steps.checkout.outcome == 'success'
+          }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - name: Compose the fallback notice
+        id: notice
+        if: >-
+          ${{
+            always() && github.repository == 'nexu-io/open-design' &&
+            steps.checkout.outcome == 'success'
+          }}
+        env:
+          BRANCH: ${{ needs.metadata.outputs.branch }}
+          CARD_DISPATCHED: ${{ steps.card_dispatch.outputs.dispatched }}
+          CHANNEL_LABEL: Prerelease
+          COMMIT: ${{ needs.metadata.outputs.commit }}
+          LANE_SUMMARY: "card dispatch=${{ steps.card_dispatch.outcome }} · tests dispatch=${{ steps.tests_dispatch.outcome }}"
+          ORIGIN_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # This job runs beside the build, so the packages are still coming.
+          # A probe would be worse than useless here: a job cannot ask the API
+          # whether its own run has finished.
+          PIPELINE_PROGRESS: running
+          RELEASE_CHANNEL: prerelease
+          RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
+          STAGE: dispatch
+          VERSION: ${{ needs.metadata.outputs.release_version }}
+        run: node --experimental-strip-types tools/release/src/notifications/prerelease-fallback-notice.ts
+      - name: Fail loudly when the fallback bot is itself unconfigured
+        # Both notification paths down at once is an incident of its own, and a
+        # red job is the only channel left to say so. Only reachable on this
+        # repository: the composer above is scoped to it, so a fork — which has
+        # neither bot — leaves `alert` empty and never goes red for this.
+        if: ${{ steps.notice.outputs.alert == 'true' && env.FEISHU_WEBHOOK == '' }}
+        run: |
+          echo "::error::the prerelease card was never dispatched and FEISHU_RELEASE_WEBHOOK is unset, so no fallback notice could be delivered"
+          exit 1
+      - name: Post the fallback notice
+        if: ${{ steps.notice.outputs.alert == 'true' && env.FEISHU_WEBHOOK != '' }}
+        env:
+          NOTICE_BODY: ${{ steps.notice.outputs.body }}
+          NOTICE_TEMPLATE: ${{ steps.notice.outputs.template }}
+          NOTICE_TITLE: ${{ steps.notice.outputs.title }}
+          RUN_URL: ${{ steps.notice.outputs.run_url }}
+        run: node --experimental-strip-types tools/release/src/notifications/feishu-notice.ts
   build_mac:
     name: Build prerelease mac arm64
     # Deliberately NOT gated on any test suite, and neither is `publish`. A

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -417,12 +417,24 @@ jobs:
         # red job is the only channel left to say so. Only reachable on this
         # repository: the composer above is scoped to it, so a fork — which has
         # neither bot — leaves `alert` empty and never goes red for this.
-        if: ${{ steps.notice.outputs.alert == 'true' && env.FEISHU_WEBHOOK == '' }}
+        # `always()` because the whole point is to speak after something
+        # broke — without it GitHub's implicit success() skips this step in
+        # every run where an earlier step already failed. The outcome check
+        # is the other half: never act on a composer that did not finish.
+        if: >-
+          ${{
+            always() && steps.notice.outcome == 'success' &&
+            steps.notice.outputs.alert == 'true' && env.FEISHU_WEBHOOK == ''
+          }}
         run: |
           echo "::error::the prerelease card was never dispatched and FEISHU_RELEASE_WEBHOOK is unset, so no fallback notice could be delivered"
           exit 1
       - name: Post the fallback notice
-        if: ${{ steps.notice.outputs.alert == 'true' && env.FEISHU_WEBHOOK != '' }}
+        if: >-
+          ${{
+            always() && steps.notice.outcome == 'success' &&
+            steps.notice.outputs.alert == 'true' && env.FEISHU_WEBHOOK != ''
+          }}
         env:
           NOTICE_BODY: ${{ steps.notice.outputs.body }}
           NOTICE_TEMPLATE: ${{ steps.notice.outputs.template }}

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -83,6 +83,14 @@ const releasePrereleaseTestsWorkflowPath = join(workspaceRoot, ".github", "workf
 const releasePrereleaseSmokeWorkflowPath = join(workspaceRoot, ".github", "workflows", "release-prerelease-smoke.yml");
 const releasePrereleaseCardWorkflowPath = join(workspaceRoot, ".github", "workflows", "release-prerelease-card.yml");
 const prereleaseCardScriptPath = join(workspaceRoot, "tools", "release", "src", "notifications", "prerelease-progress-card.ts");
+const prereleaseFallbackScriptPath = join(
+  workspaceRoot,
+  "tools",
+  "release",
+  "src",
+  "notifications",
+  "prerelease-fallback-notice.ts",
+);
 const mainPrereleaseWinSmokeWorkflowPath = join(
   workspaceRoot,
   ".github",
@@ -2937,6 +2945,74 @@ process.stdin.on("end", () => {
     expect(feishuCard).toContain("const smokeFailures = packagePublished");
     expect(feishuCard).toContain("return packagePublished ? \"blue\" : \"red\";");
     expect(notifyDaily).toContain("tools/release/src/notifications/feishu.ts");
+  });
+
+  it("[P1] alerts through the other Feishu bot when the prerelease card lane goes silent", async () => {
+    // The progressive card is now the ONLY prerelease notification, and every
+    // way it breaks is silent: the pipeline stays green, the packages ship, and
+    // the channel hears nothing. Two fallback jobs close that, and both have to
+    // hold three properties or they are worse than useless.
+    const [prerelease, card, watcher, fallback, notice] = await Promise.all([
+      readFile(releasePrereleaseWorkflowPath, "utf8"),
+      readFile(releasePrereleaseCardWorkflowPath, "utf8"),
+      readFile(prereleaseCardScriptPath, "utf8"),
+      readFile(prereleaseFallbackScriptPath, "utf8"),
+      readFile(feishuNoticeScriptPath, "utf8"),
+    ]);
+
+    // 1. A different bot. The card posts through the Feishu APPLICATION bot; the
+    //    fallback must post through the custom-bot WEBHOOK, or "the application
+    //    credential expired" — one of the ways the card goes silent — takes the
+    //    alert down with it.
+    const fallbackStart = card.indexOf("  fallback_notice:");
+    expect(fallbackStart).toBeGreaterThanOrEqual(0);
+    const fallbackJob = card.slice(fallbackStart);
+    expect(card).toContain("FEISHU_WEBHOOK: ${{ secrets.FEISHU_RELEASE_WEBHOOK }}");
+    expect(card).toContain("FEISHU_SIGN_SECRET: ${{ secrets.FEISHU_RELEASE_SIGN_SECRET }}");
+    expect(fallbackJob).not.toContain("${{ secrets.FEISHU_APP_SECRET }}");
+    expect(fallbackJob).not.toContain("${{ secrets.FEISHU_APP_ID }}");
+    expect(fallbackJob).toContain("tools/release/src/notifications/feishu-notice.ts");
+    expect(notice).toContain('required("FEISHU_WEBHOOK")');
+
+    // 2. Reachable. A job with `needs` carries an implicit success(), which
+    //    would skip the fallback in exactly the case it exists for — the trap
+    //    that skipped `dispatch_smoke` for N runs. It must break that itself.
+    expect(fallbackJob).toContain("always() && !cancelled()");
+    // The dispatch-side ping is steps of `dispatch_validation`, NOT a job:
+    // nothing may appear in a `needs:` on the dispatchers (asserted in
+    // tools/pack/tests/release-workflows.test.ts), and a step needs no such
+    // edge to read the dispatch outcome.
+    const dispatchJob = sectionBetween(prerelease, "  dispatch_validation:", "  build_mac:");
+    expect(dispatchJob).toContain("tools/release/src/notifications/prerelease-fallback-notice.ts");
+    expect(dispatchJob).toContain("tools/release/src/notifications/feishu-notice.ts");
+    expect(dispatchJob).toContain("STAGE: dispatch");
+    // `always()` so a dispatch that failed above still reaches the notifier.
+    expect(dispatchJob).toContain("always() && github.repository == 'nexu-io/open-design' &&");
+    expect(dispatchJob).toContain("steps.checkout.outcome == 'success'");
+
+    // 3. Silent on a healthy release. A green watcher job is NOT proof of a
+    //    delivered card — the watcher catches every Feishu error on purpose and
+    //    exits 0 — so the gate reads the watcher's own delivery report, and the
+    //    watcher writes it only for a card whose final state reached the chat.
+    expect(fallbackJob).toContain(
+      "!(needs.card.result == 'success' && needs.card.outputs.delivered == 'true')",
+    );
+    expect(card).toContain("delivered: ${{ steps.track.outputs.card_delivered }}");
+    expect(watcher).toContain('appendFileSync(file, "card_delivered=true\\n")');
+    expect(watcher).toContain("if (chatHoldsLatest) reportDelivered();");
+    expect(dispatchJob).toContain("CARD_DISPATCHED: ${{ steps.card_dispatch.outputs.dispatched }}");
+    // The dispatch helper exits non-zero on failure and `run:` blocks stop at
+    // the first failure, so the marker is only written when a card workflow was
+    // really requested — and stays empty when the step is skipped for missing
+    // application-bot credentials.
+    expect(dispatchJob).toContain('echo "dispatched=true" >> "$GITHUB_OUTPUT"');
+    expect(dispatchJob).toContain("if: ${{ env.FEISHU_APP_ID != '' && env.FEISHU_RELEASE_CHAT_ID != '' }}");
+
+    // The notice itself has to stand alone: version, whether a package shipped,
+    // and where to look.
+    expect(fallback).toContain("VERSION_METADATA_URL");
+    expect(fallback).toContain("probeMetadata");
+    expect(fallback).toContain('setOutput("alert", "false")');
   });
 
   it("[P1] keeps download actions on a beta card with a failed Windows smoke", async () => {

--- a/tools/pack/tests/release-workflows.test.ts
+++ b/tools/pack/tests/release-workflows.test.ts
@@ -105,10 +105,73 @@ function transitiveNeeds(jobs: Map<string, WorkflowJob>, name: string): string[]
   return [...seen];
 }
 
+type WorkflowStep = { job: string; name: string; if: string };
+
+/**
+ * Minimal `steps:` reader: every step in the file as job id + step name +
+ * step-level `if` (block scalars folded onto one line).
+ *
+ * Same rationale as parseJobGraph — hand-written workflows with stable
+ * indentation, and this is a topology assertion rather than a YAML feature
+ * test. Keys of a step sit at exactly eight spaces (or on the `- ` line), so
+ * `run:`/`env:` bodies, which must be indented deeper than their key, never
+ * look like one.
+ */
+function parseWorkflowSteps(content: string): WorkflowStep[] {
+  const steps: WorkflowStep[] = [];
+  let job: string | null = null;
+  let inSteps = false;
+  let collectingIf = false;
+  for (const line of content.split("\n")) {
+    const header = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line);
+    if (header?.[1] != null) {
+      job = header[1];
+      inSteps = false;
+      collectingIf = false;
+      continue;
+    }
+    if (/^ {4}steps:\s*$/.test(line)) {
+      inSteps = true;
+      continue;
+    }
+    if (!inSteps || job == null) continue;
+
+    const isStepKey = /^ {6}- |^ {8}[A-Za-z_-]+:/.test(line);
+    if (collectingIf && !isStepKey) {
+      const last = steps[steps.length - 1];
+      const text = line.trim();
+      if (last != null && text.length > 0 && !text.startsWith("#")) last.if += ` ${text}`;
+      continue;
+    }
+    collectingIf = false;
+
+    if (/^ {6}- /.test(line)) steps.push({ job, name: "", if: "" });
+    const current = steps[steps.length - 1];
+    if (current == null) continue;
+
+    const name = /^(?: {6}- | {8})name:\s*(.*)$/.exec(line);
+    if (name?.[1] != null) {
+      current.name = name[1].trim();
+      continue;
+    }
+    const condition = /^(?: {6}- | {8})if:\s*(.*)$/.exec(line);
+    if (condition != null) {
+      current.if = (condition[1] ?? "").trim();
+      collectingIf = true;
+    }
+  }
+  return steps;
+}
+
 /**
  * Status-check functions that make a job evaluate its own `if` instead of
  * inheriting a skip from somewhere up the chain. `success()` does not count:
  * it is what GitHub already applies implicitly.
+ *
+ * The same list applies one level down. A step-level `if` without a status
+ * function also gets an implicit `success()`, evaluated against the job's
+ * status SO FAR — so a step placed after one that failed is skipped before its
+ * own condition is read, exactly as a job is.
  */
 const SKIP_CHAIN_BREAKERS = ["always(", "cancelled(", "failure("];
 
@@ -452,6 +515,13 @@ describe("release workflows", () => {
       "release-beta.yml",
       "release-stable.yml",
       "notify-release-feishu.yml",
+      // The dispatched prerelease lanes were outside this sweep, which left
+      // release-prerelease-card.yml's `fallback_notice` — a job whose `if`
+      // hand-checks `needs.card.result` — uncovered by the very rule it has to
+      // obey.
+      "release-prerelease-card.yml",
+      "release-prerelease-tests.yml",
+      "release-prerelease-smoke.yml",
     ];
     const contents = await Promise.all(
       files.map((file) => readFile(new URL(`../../../.github/workflows/${file}`, import.meta.url), "utf8")),
@@ -480,6 +550,66 @@ describe("release workflows", () => {
     expect(transitiveNeeds(prerelease, "dispatch_smoke")).toContain("build_linux");
     expect(prerelease.get("build_linux")?.if).toContain("vars.ENABLE_STABLE_LINUX");
     expect(SKIP_CHAIN_BREAKERS.some((breaker) => (dispatchSmoke?.if ?? "").includes(breaker))).toBe(true);
+  });
+
+  it("keeps the prerelease card fallback reachable after the step it alerts on has failed", async () => {
+    // The job-level trap above has a step-level twin, and it is easier to walk
+    // into because there is no `needs:` to remind you. GitHub applies an
+    // implicit `success()` to any step-level `if` that carries no status
+    // function, and that success() is evaluated against the JOB'S STATUS SO
+    // FAR. So a step placed after a step that failed is skipped before its own
+    // condition is ever read.
+    //
+    // That is fatal for exactly one kind of step: one whose job is to speak up
+    // BECAUSE something earlier failed. The prerelease card fallback is that
+    // kind. `dispatch-validation.sh` exits non-zero when it could not dispatch
+    // the card on any ref, which marks the job failed — and a card that was
+    // never dispatched is the headline reason the fallback exists. A notifier
+    // that inherits success() there is silent in precisely its own emergency.
+    //
+    // Not a rule that generalizes to every step: most steps SHOULD stop when
+    // something before them broke. It binds the fallback notifier group, whose
+    // whole contract is the opposite.
+    const [prerelease, card] = await Promise.all([
+      readFile(new URL("../../../.github/workflows/release-prerelease.yml", import.meta.url), "utf8"),
+      readFile(new URL("../../../.github/workflows/release-prerelease-card.yml", import.meta.url), "utf8"),
+    ]);
+
+    // The notifier group inside `dispatch_validation` sits after two dispatch
+    // steps that can fail, so every step of it needs a status function.
+    const dispatchSteps = parseWorkflowSteps(prerelease).filter((step) => step.job === "dispatch_validation");
+    const notifierStart = dispatchSteps.findIndex((step) => step.name === "Setup Node.js for the fallback notifier");
+    expect(notifierStart, "release-prerelease.yml must still carry the fallback notifier").toBeGreaterThan(0);
+    const stranded = dispatchSteps
+      .slice(notifierStart)
+      .filter((step) => !SKIP_CHAIN_BREAKERS.some((breaker) => step.if.includes(breaker)));
+    expect(
+      stranded.map((step) => step.name),
+      "these fallback steps inherit success() and are skipped by the very dispatch failure they exist to report",
+    ).toEqual([]);
+
+    // Wherever the composed notice is consumed, same rule — and one more: a
+    // consumer must require the composer to have SUCCEEDED. `alert` is written
+    // last precisely so a half-written notice cannot claim to be one, and the
+    // outcome check says the same thing at the workflow layer, so neither a
+    // crashed nor a skipped composer can hand feishu-notice.ts an empty body.
+    for (const [file, content] of [
+      ["release-prerelease.yml", prerelease],
+      ["release-prerelease-card.yml", card],
+    ] as const) {
+      const consumers = parseWorkflowSteps(content).filter((step) => step.if.includes("steps.notice.outputs"));
+      expect(consumers.length, `${file} must consume the composed notice`).toBeGreaterThan(0);
+      for (const consumer of consumers) {
+        expect(
+          SKIP_CHAIN_BREAKERS.some((breaker) => consumer.if.includes(breaker)),
+          `${file}:${consumer.job}:${consumer.name} inherits success() and cannot report an upstream failure`,
+        ).toBe(true);
+        expect(
+          consumer.if,
+          `${file}:${consumer.job}:${consumer.name} must not post a notice its composer failed to finish`,
+        ).toContain("steps.notice.outcome == 'success'");
+      }
+    }
   });
 
   it("keeps every prerelease validation lane out of the release concurrency group", async () => {

--- a/tools/release/src/notifications/prerelease-fallback-notice.ts
+++ b/tools/release/src/notifications/prerelease-fallback-notice.ts
@@ -140,8 +140,8 @@ async function main(): Promise<void> {
     // The healthy path, and the one that matters most: the card did its job, so
     // this step must leave the channel alone.
     console.log("[fallback] the prerelease card lane reported in; nothing to post");
-    setOutput("alert", "false");
     setOutput("reason", "card-lane-healthy");
+    setOutput("alert", "false");
     return;
   }
 
@@ -169,12 +169,17 @@ async function main(): Promise<void> {
   });
 
   console.warn(`::warning::prerelease card lane silent (${silence}); posting the webhook fallback notice`);
-  setOutput("alert", "true");
+  // `alert` goes LAST, after every field a poster reads. It is the one output
+  // the workflow branches on, so writing it first would let a crash between two
+  // appends leave `alert=true` beside an empty body — and feishu-notice.ts would
+  // then die on a required env instead of delivering. Written last, `alert=true`
+  // means the whole notice is on disk.
   setOutput("reason", silence);
   setOutput("title", notice.title);
   setOutput("template", notice.template);
   setOutput("body", notice.body);
   setOutput("run_url", notice.runUrl);
+  setOutput("alert", "true");
 }
 
 await main();

--- a/tools/release/src/notifications/prerelease-fallback-notice.ts
+++ b/tools/release/src/notifications/prerelease-fallback-notice.ts
@@ -1,0 +1,180 @@
+// Decides whether the prerelease card lane went silent and, if it did, writes
+// the fallback notice into $GITHUB_OUTPUT for feishu-notice.ts to post.
+//
+// This step never talks to Feishu. Delivery stays with feishu-notice.ts — the
+// custom-bot webhook poster every other alert in this repository already uses —
+// so the last-resort path is the one transport with the most mileage on it, and
+// the decision above it stays a pure function that can be tested without a
+// network (see prerelease-fallback.ts and tests/prerelease-fallback.test.ts).
+//
+// It is also the second gate. The calling job's `if:` already refuses to run on
+// a healthy release; this script refuses to emit `alert=true` for one as well,
+// so loosening the YAML condition cannot on its own turn the fallback into a
+// duplicate card.
+//
+// Inputs (all via env):
+//   STAGE                  (required) "dispatch" | "watch" — which caller this is
+//   CARD_DISPATCHED        stage=dispatch: "true" when the card workflow was dispatched
+//   CARD_JOB_RESULT        stage=watch: needs.card.result
+//   CARD_DELIVERED         stage=watch: needs.card.outputs.delivered
+//   VERSION / BRANCH / COMMIT             what is being released (may be empty)
+//   CHANNEL_LABEL          default "Prerelease"
+//   RELEASE_CHANNEL        default "prerelease" — R2 channel prefix
+//   RELEASE_PUBLIC_ORIGIN  enables the version-metadata probe
+//   VERSION_METADATA_URL   the publish job's own output, when the caller holds it
+//   ORIGIN_RUN_URL / CARD_RUN_URL         where to look
+//   ORIGIN_RUN_ID          enables the "is the pipeline still running?" probe
+//   PIPELINE_PROGRESS      "finished" | "running" — skips that probe when the
+//                          caller already knows (a job inside the pipeline
+//                          cannot probe its own run: it always reads in_progress)
+//   LANE_SUMMARY           raw per-job results, free text
+//
+// Outputs (via $GITHUB_OUTPUT): alert, reason, title, template, body, run_url.
+
+import { appendFileSync, existsSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+
+import {
+  cardLaneSilence,
+  renderFallbackNotice,
+  resolvePackagePublication,
+  versionMetadataUrl,
+} from "./prerelease-fallback.ts";
+import type { CardLaneProbe, MetadataProbe, PipelineProgress } from "./prerelease-fallback.ts";
+
+function optional(name: string, fallback = ""): string {
+  const value = process.env[name];
+  return value == null || value.length === 0 ? fallback : value;
+}
+
+function required(name: string): string {
+  const value = optional(name);
+  if (value.length === 0) throw new Error(`${name} is required`);
+  return value;
+}
+
+function isTrue(name: string): boolean {
+  return optional(name).toLowerCase() === "true";
+}
+
+function setOutput(name: string, value: string): void {
+  const file = process.env.GITHUB_OUTPUT;
+  if (file == null || file.length === 0 || !existsSync(file)) {
+    console.log(`[fallback] ${name}=${value.includes("\n") ? "<multiline>" : value}`);
+    return;
+  }
+  // Multi-line values need the delimiter form, and the delimiter must be
+  // something the body cannot contain — a rendered notice carrying a fixed
+  // marker would otherwise let arbitrary commit text close the block early.
+  const delimiter = `od-fallback-${randomUUID()}`;
+  appendFileSync(file, `${name}<<${delimiter}\n${value}\n${delimiter}\n`);
+}
+
+/** HEAD the published version metadata. This is the "did a package ship?" authority. */
+async function probeMetadata(url: string): Promise<MetadataProbe> {
+  if (url.length === 0) return "skipped";
+  try {
+    const response = await fetch(url, { method: "HEAD", redirect: "follow" });
+    if (response.ok) return "found";
+    if (response.status === 403 || response.status === 404) return "missing";
+    console.warn(`[fallback] metadata probe returned HTTP ${response.status}`);
+    return "error";
+  } catch (error) {
+    console.warn(`[fallback] metadata probe threw: ${error instanceof Error ? error.message : String(error)}`);
+    return "error";
+  }
+}
+
+/**
+ * Whether the build pipeline has finished, which is what tells "the package
+ * never shipped" apart from "the package has not shipped YET" — the card lane
+ * can die minutes into a build that goes on to publish normally.
+ */
+async function probePipeline(runId: string): Promise<PipelineProgress> {
+  const token = optional("GH_TOKEN") || optional("GITHUB_TOKEN");
+  const repo = optional("GITHUB_REPOSITORY");
+  if (runId.length === 0 || token.length === 0 || repo.length === 0) return "unknown";
+  const apiBase = optional("GITHUB_API_URL", "https://api.github.com").replace(/\/+$/u, "");
+  try {
+    const response = await fetch(`${apiBase}/repos/${repo}/actions/runs/${runId}`, {
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "x-github-api-version": "2022-11-28",
+      },
+    });
+    if (!response.ok) {
+      console.warn(`[fallback] pipeline probe returned HTTP ${response.status}`);
+      return "unknown";
+    }
+    const body = (await response.json()) as { status?: unknown };
+    return body.status === "completed" ? "finished" : "running";
+  } catch (error) {
+    console.warn(`[fallback] pipeline probe threw: ${error instanceof Error ? error.message : String(error)}`);
+    return "unknown";
+  }
+}
+
+async function resolvePipeline(): Promise<PipelineProgress> {
+  const declared = optional("PIPELINE_PROGRESS");
+  if (declared === "finished" || declared === "running") return declared;
+  return await probePipeline(optional("ORIGIN_RUN_ID"));
+}
+
+function readProbe(): CardLaneProbe {
+  const stage = required("STAGE");
+  if (stage === "dispatch") return { stage: "dispatch", dispatched: isTrue("CARD_DISPATCHED") };
+  if (stage === "watch") {
+    return {
+      stage: "watch",
+      jobResult: optional("CARD_JOB_RESULT"),
+      deliveredFinalCard: isTrue("CARD_DELIVERED"),
+    };
+  }
+  throw new Error(`STAGE must be "dispatch" or "watch", got "${stage}"`);
+}
+
+async function main(): Promise<void> {
+  const silence = cardLaneSilence(readProbe());
+  if (silence == null) {
+    // The healthy path, and the one that matters most: the card did its job, so
+    // this step must leave the channel alone.
+    console.log("[fallback] the prerelease card lane reported in; nothing to post");
+    setOutput("alert", "false");
+    setOutput("reason", "card-lane-healthy");
+    return;
+  }
+
+  const version = optional("VERSION");
+  const declaredMetadataUrl = optional("VERSION_METADATA_URL");
+  const probeUrl =
+    declaredMetadataUrl.length > 0
+      ? declaredMetadataUrl
+      : versionMetadataUrl(optional("RELEASE_PUBLIC_ORIGIN"), optional("RELEASE_CHANNEL", "prerelease"), version);
+  const probe = declaredMetadataUrl.length > 0 ? ("skipped" as MetadataProbe) : await probeMetadata(probeUrl);
+  const publication = resolvePackagePublication({ declaredMetadataUrl, probe });
+
+  const notice = renderFallbackNotice({
+    silence,
+    channelLabel: optional("CHANNEL_LABEL", "Prerelease"),
+    version,
+    branch: optional("BRANCH"),
+    commit: optional("COMMIT"),
+    publication,
+    metadataUrl: probeUrl,
+    pipeline: publication === "published" ? "finished" : await resolvePipeline(),
+    originRunUrl: optional("ORIGIN_RUN_URL"),
+    cardRunUrl: optional("CARD_RUN_URL"),
+    laneSummary: optional("LANE_SUMMARY"),
+  });
+
+  console.warn(`::warning::prerelease card lane silent (${silence}); posting the webhook fallback notice`);
+  setOutput("alert", "true");
+  setOutput("reason", silence);
+  setOutput("title", notice.title);
+  setOutput("template", notice.template);
+  setOutput("body", notice.body);
+  setOutput("run_url", notice.runUrl);
+}
+
+await main();

--- a/tools/release/src/notifications/prerelease-fallback.ts
+++ b/tools/release/src/notifications/prerelease-fallback.ts
@@ -1,0 +1,180 @@
+// Pure decision + rendering for the prerelease card's last-resort alert.
+//
+// The progressive card (release-prerelease-card.yml) is now the ONLY prerelease
+// notification, and every way it can break is silent: the pipeline stays green,
+// the packages ship, and the channel hears nothing. This module decides whether
+// that happened and renders the one plain notice that goes out instead.
+//
+// Two rules shape everything here.
+//
+//   1. It must never fire on a healthy release. A fallback that also posts on
+//      good days is just a second card, and a channel that gets two messages
+//      per release stops reading either.
+//   2. It must not depend on the card's own credentials. The alert is delivered
+//      by the custom-bot webhook (FEISHU_RELEASE_WEBHOOK), which is a different
+//      bot with a different secret from the application bot the card uses — so
+//      "the app bot's credentials expired" is a failure the alert survives. A
+//      fallback sharing the primary's credentials covers nothing.
+//
+// Everything in this file is pure so the "when do we alert" question can be
+// tested without a network or a workflow run.
+
+/**
+ * What the caller has observed about the card lane.
+ *
+ * `dispatch` is release-prerelease.yml, which only knows whether it managed to
+ * dispatch the card workflow at all. `watch` is release-prerelease-card.yml
+ * itself, which knows how its own watcher job ended AND whether that watcher
+ * ever got a card into the chat — two different facts, because the watcher
+ * swallows Feishu failures by design and exits 0 anyway.
+ */
+export type CardLaneProbe =
+  | { stage: "dispatch"; dispatched: boolean }
+  | { stage: "watch"; jobResult: string; deliveredFinalCard: boolean };
+
+export type CardLaneSilence =
+  /** The card workflow was never asked to run, so no card exists at all. */
+  | "never-dispatched"
+  /** The watcher job did not finish successfully; any card it posted is frozen mid-release. */
+  | "watcher-not-completed"
+  /** The watcher finished cleanly but never got the card's final state into the chat. */
+  | "card-not-delivered";
+
+/**
+ * The alert condition, in one place.
+ *
+ * A green watcher job is NOT proof of a delivered card: `sendCard`/`patchCard`
+ * failures are caught on purpose (one Feishu hiccup must not end a two-hour
+ * watch) and the job still exits 0. Expired application-bot credentials, or the
+ * bot being removed from the chat, look exactly like a successful run. Only the
+ * watcher's own delivery report separates them.
+ */
+export function cardLaneSilence(probe: CardLaneProbe): CardLaneSilence | null {
+  if (probe.stage === "dispatch") return probe.dispatched ? null : "never-dispatched";
+  if (probe.jobResult !== "success") return "watcher-not-completed";
+  return probe.deliveredFinalCard ? null : "card-not-delivered";
+}
+
+/** Whether a package actually shipped. Never guessed — `unknown` is a real answer. */
+export type PackagePublication = "published" | "absent" | "unknown";
+
+/** Outcome of a HEAD against the version metadata object. */
+export type MetadataProbe = "found" | "missing" | "error" | "skipped";
+
+/**
+ * The R2 key `publish-metadata` writes this build's version metadata to, which
+ * is the same URL release-prerelease.yml exports as `version_metadata_url`.
+ * Keep in step with `versionPrefix` in tools/release/src/storage/publish-metadata.ts.
+ */
+export function versionMetadataUrl(publicOrigin: string, channel: string, version: string): string {
+  const origin = publicOrigin.replace(/\/+$/u, "");
+  if (origin.length === 0 || version.length === 0 || channel.length === 0) return "";
+  return `${origin}/${channel}/versions/${version}/metadata.json`;
+}
+
+/**
+ * "Did a package actually ship?" — deliberately NOT the workflow conclusion,
+ * which goes red for a failed advisory lane while the packages sit downloadable
+ * in R2. A non-empty `version_metadata_url` means the publish job wrote
+ * metadata; when the caller does not hold that output, the metadata object
+ * itself is the next best authority.
+ */
+export function resolvePackagePublication(input: {
+  declaredMetadataUrl: string;
+  probe: MetadataProbe;
+}): PackagePublication {
+  if (input.declaredMetadataUrl.length > 0) return "published";
+  if (input.probe === "found") return "published";
+  if (input.probe === "missing") return "absent";
+  return "unknown";
+}
+
+/** Whether the build pipeline had finished when the alert was composed. */
+export type PipelineProgress = "running" | "finished" | "unknown";
+
+export type FallbackNoticeInput = {
+  silence: CardLaneSilence;
+  channelLabel: string;
+  /** Empty when the pipeline died before it resolved a version. */
+  version: string;
+  branch: string;
+  commit: string;
+  publication: PackagePublication;
+  /** The authoritative metadata URL, when the caller holds or built one. */
+  metadataUrl: string;
+  pipeline: PipelineProgress;
+  originRunUrl: string;
+  cardRunUrl: string;
+  /** Raw per-job results, so the reader can tell the failure modes apart. */
+  laneSummary: string;
+};
+
+export type FallbackNotice = {
+  title: string;
+  template: string;
+  body: string;
+  runUrl: string;
+};
+
+const SILENCE_TEXT: Record<CardLaneSilence, string> = {
+  "never-dispatched": "进度卡片工作流从未被调起，本次发布没有任何卡片。",
+  "watcher-not-completed": "进度卡片 job 未正常结束，卡片可能缺失，或停在中间状态不再更新。",
+  "card-not-delivered": "进度卡片 job 正常结束，但卡片从未送进群——应用机器人凭证失效或被移出群的典型症状。",
+};
+
+function publicationLine(input: FallbackNoticeInput): string {
+  if (input.publication === "published") {
+    const suffix = input.metadataUrl.length > 0 ? ` — ${input.metadataUrl}` : "";
+    return `✅ 已发布，包在 R2 上可以下载${suffix}`;
+  }
+  // Naming the object that would prove publication turns "go check yourself"
+  // into one clickable check, which matters most on the early alert: the card
+  // can die minutes into a build that goes on to publish perfectly.
+  const hint = input.metadataUrl.length > 0 ? `；发布后 version metadata 会出现在 ${input.metadataUrl}` : "";
+  if (input.publication === "unknown") {
+    const check = input.metadataUrl.length > 0 ? `，请自行核对 ${input.metadataUrl}` : "";
+    return `❓ 未知，本条消息发出时无法确认 version metadata${check}`;
+  }
+  if (input.pipeline === "running") {
+    return `⏳ 尚未发布，打包流水线仍在进行${hint}`;
+  }
+  if (input.pipeline === "finished") {
+    return `❌ 未发布，打包流水线已结束且 version metadata 不存在${hint}`;
+  }
+  return `❌ 未发布，本条消息发出时 version metadata 不存在${hint}`;
+}
+
+/**
+ * The alert has to stand on its own: whoever reads it should not have to guess
+ * which release it is about, whether they can still install something, or where
+ * to look. It carries the version, the publication verdict, why the card lane
+ * went quiet, and both run links.
+ */
+export function renderFallbackNotice(input: FallbackNoticeInput): FallbackNotice {
+  const version = input.version.length > 0 ? `\`${input.version}\`` : "未确定（流水线未产出版本号）";
+  const branch = input.branch.length > 0 ? `\`${input.branch}\`` : "未确定";
+  const commit = input.commit.length > 0 ? `\`${input.commit.slice(0, 10)}\`` : "未确定";
+
+  const lines = [
+    `${input.channelLabel} 的飞书进度卡片这次没有正常送达。本条是兜底告警，走自定义机器人 webhook 发出，和卡片用的应用机器人不是同一套凭证。`,
+    "",
+    `**版本**: ${version}`,
+    `**分支 / 提交**: ${branch} @ ${commit}`,
+    `**发包状态**: ${publicationLine(input)}`,
+    `**卡片链路**: ${SILENCE_TEXT[input.silence]}`,
+  ];
+  if (input.laneSummary.length > 0) lines.push(`**各 job 结果**: ${input.laneSummary}`);
+  lines.push("", "**去哪看**");
+  if (input.originRunUrl.length > 0) lines.push(`- 打包流水线: ${input.originRunUrl}`);
+  if (input.cardRunUrl.length > 0) lines.push(`- 进度卡片 run: ${input.cardRunUrl}`);
+
+  const versionSuffix = input.version.length > 0 ? ` · ${input.version}` : "";
+  return {
+    title: `🚨 ${input.channelLabel} 进度卡片失联${versionSuffix}`,
+    // Packages that shipped are a different incident from packages that never
+    // did: one broke only the notification, the other broke the release.
+    template: input.publication === "published" ? "orange" : "red",
+    body: lines.join("\n"),
+    runUrl: input.originRunUrl.length > 0 ? input.originRunUrl : input.cardRunUrl,
+  };
+}

--- a/tools/release/src/notifications/prerelease-progress-card.ts
+++ b/tools/release/src/notifications/prerelease-progress-card.ts
@@ -19,7 +19,7 @@
 // build dies. The one exception is total failure, where silence would hide an
 // incident — see shouldPostFirstCard.
 
-import { existsSync, readFileSync } from "node:fs";
+import { appendFileSync, existsSync, readFileSync } from "node:fs";
 
 import { FeishuAppClient } from "./feishu-app.ts";
 import {
@@ -254,6 +254,28 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * The watcher's report to the fallback job: `card_delivered=true` means the
+ * card's FINAL state is in the chat.
+ *
+ * The job's own result cannot carry this. Every Feishu failure below is caught
+ * on purpose — one hiccup must not end a two-hour watch — so an application bot
+ * whose credentials expired, or which was removed from the chat, produces a
+ * green job and an empty channel. Writing the signal only on the delivered path
+ * is what lets the fallback tell that apart from a healthy release, and writing
+ * it for the FINAL render (not the first) also catches a card that was posted
+ * and then froze because the closing update could not be written.
+ */
+function reportDelivered(): void {
+  const file = process.env.GITHUB_OUTPUT;
+  if (file == null || file.length === 0) return;
+  try {
+    appendFileSync(file, "card_delivered=true\n");
+  } catch (error) {
+    console.warn(`[card] could not record delivery: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
 type Watch = {
   originJobs: GithubJob[];
   publish: LaneStatus;
@@ -414,6 +436,8 @@ async function main(): Promise<void> {
   };
   let messageId: string | null = null;
   let lastRendered = "";
+  // Whether the chat currently holds the render this loop last produced.
+  let chatHoldsLatest = false;
 
   for (;;) {
     const timedOut = Date.now() - startedAt > timeoutMs;
@@ -440,15 +464,19 @@ async function main(): Promise<void> {
             console.log("[card] updated");
           }
           lastRendered = rendered;
+          chatHoldsLatest = true;
         } catch (error) {
           // Keep watching. The next cycle re-renders from the same state and
           // tries again, so one Feishu hiccup does not lose the card.
           console.warn(`[card] delivery failed: ${error instanceof Error ? error.message : String(error)}`);
+          chatHoldsLatest = false;
         }
       }
     }
 
     if (done) {
+      if (chatHoldsLatest) reportDelivered();
+      else console.warn("::warning::the prerelease card never reached the chat; the fallback notice takes over");
       if (timedOut && !state.finished) {
         console.warn(`::warning::prerelease card watcher timed out after ${Math.round(timeoutMs / 60000)} minutes`);
       }

--- a/tools/release/tests/prerelease-card-delivery-signal.test.ts
+++ b/tools/release/tests/prerelease-card-delivery-signal.test.ts
@@ -1,0 +1,127 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import type { Server } from "node:http";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// The watcher's self-report is what the fallback job keys on, so it has to be
+// exercised through the real script: the interesting case is one where the
+// script exits 0, which is exactly what a job-result-only signal cannot see.
+const releaseRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const watcherScript = join(releaseRoot, "src", "notifications", "prerelease-progress-card.ts");
+
+const JOBS = [
+  { name: "Build prerelease mac arm64", status: "completed", conclusion: "success" },
+  { name: "Publish prerelease release", status: "completed", conclusion: "success" },
+];
+
+type Stub = { url: string; sends: number };
+
+async function startStub(options: { tokenFails: boolean }): Promise<{ stub: Stub; server: Server }> {
+  const stub: Stub = { url: "", sends: 0 };
+  const server = createServer((request, response) => {
+    const path = (request.url ?? "").split("?")[0] ?? "";
+    const json = (status: number, body: unknown): void => {
+      response.writeHead(status, { "content-type": "application/json" });
+      response.end(JSON.stringify(body));
+    };
+    if (path.endsWith("/jobs")) {
+      json(200, { jobs: JOBS, total_count: JOBS.length });
+      return;
+    }
+    if (path === "/open-apis/auth/v3/tenant_access_token/internal") {
+      // A 200 carrying a non-retryable Feishu error code is what an expired app
+      // secret or a bot removed from the chat actually looks like.
+      if (options.tokenFails) json(200, { code: 99991663, msg: "app ticket invalid" });
+      else json(200, { code: 0, tenant_access_token: "t-stub", expire: 7200 });
+      return;
+    }
+    if (path === "/open-apis/im/v1/messages") {
+      stub.sends += 1;
+      json(200, { code: 0, data: { message_id: "om_stub" } });
+      return;
+    }
+    json(404, { code: 404 });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address == null || typeof address === "string") throw new Error("stub server has no port");
+  stub.url = `http://127.0.0.1:${address.port}`;
+  return { stub, server };
+}
+
+async function runWatcher(outputFile: string, baseUrl: string): Promise<number> {
+  // The runner always hands a step an existing (empty) $GITHUB_OUTPUT file, and
+  // "the script wrote nothing" is a real assertion here, not an absent file.
+  await writeFile(outputFile, "");
+  return await new Promise<number>((resolve, reject) => {
+    const child = spawn(process.execPath, ["--experimental-strip-types", watcherScript], {
+      env: {
+        ...process.env,
+        CARD_POLL_INTERVAL_MS: "10",
+        COMMIT: "0123456789abcdef0123456789abcdef01234567",
+        EXPECT_SMOKE: "false",
+        EXPECT_TESTS: "false",
+        FEISHU_APP_ID: "cli_stub",
+        FEISHU_APP_SECRET: "secret_stub",
+        FEISHU_BASE_URL: baseUrl,
+        FEISHU_RELEASE_CHAT_ID: "oc_stub",
+        GH_TOKEN: "gh_stub",
+        GITHUB_API_URL: baseUrl,
+        GITHUB_OUTPUT: outputFile,
+        GITHUB_REPOSITORY: "nexu-io/open-design",
+        ORIGIN_RUN_ID: "4242",
+        RELEASE_PUBLIC_ORIGIN: "",
+        VERSION: "0.21.1-prerelease.3",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stdout.resume();
+    child.stderr.resume();
+    child.on("error", reject);
+    child.on("close", (code) => resolve(code ?? -1));
+  });
+}
+
+describe("progressive card delivery signal", () => {
+  let workdir = "";
+  let server: Server | null = null;
+
+  beforeEach(async () => {
+    workdir = await mkdtemp(join(tmpdir(), "od-card-delivery-"));
+  });
+
+  afterEach(async () => {
+    if (server != null) await new Promise<void>((resolve) => server?.close(() => resolve()));
+    server = null;
+    await rm(workdir, { force: true, recursive: true });
+  });
+
+  it("reports the card as delivered once its final state is in the chat", async () => {
+    const started = await startStub({ tokenFails: false });
+    server = started.server;
+    const outputFile = join(workdir, "delivered.txt");
+
+    expect(await runWatcher(outputFile, started.stub.url)).toBe(0);
+    expect(started.stub.sends).toBe(1);
+    expect(await readFile(outputFile, "utf8")).toContain("card_delivered=true");
+  });
+
+  it("exits green but claims no delivery when the application bot is rejected", async () => {
+    // This is the silent path the fallback exists for. The watcher swallows a
+    // Feishu failure on purpose (one hiccup must not end a 2-hour watch), so
+    // the job goes green with nothing in the channel. Only an explicit
+    // "delivered" signal can tell this apart from a healthy release.
+    const started = await startStub({ tokenFails: true });
+    server = started.server;
+    const outputFile = join(workdir, "not-delivered.txt");
+
+    expect(await runWatcher(outputFile, started.stub.url)).toBe(0);
+    expect(started.stub.sends).toBe(0);
+    expect(await readFile(outputFile, "utf8")).not.toContain("card_delivered=true");
+  });
+});

--- a/tools/release/tests/prerelease-fallback-notice-cli.test.ts
+++ b/tools/release/tests/prerelease-fallback-notice-cli.test.ts
@@ -1,0 +1,88 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// The composer hands its verdict to the workflow through $GITHUB_OUTPUT, and
+// the workflow branches on one key. Both properties below are about that file,
+// so they are exercised through the real script rather than the pure module.
+const releaseRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const composerScript = join(releaseRoot, "src", "notifications", "prerelease-fallback-notice.ts");
+
+async function compose(outputFile: string, env: Record<string, string>): Promise<number> {
+  await writeFile(outputFile, "");
+  return await new Promise<number>((resolve, reject) => {
+    const child = spawn(process.execPath, ["--experimental-strip-types", composerScript], {
+      env: {
+        ...process.env,
+        CHANNEL_LABEL: "Prerelease",
+        GITHUB_OUTPUT: outputFile,
+        ORIGIN_RUN_URL: "https://github.com/nexu-io/open-design/actions/runs/111",
+        // No public origin and a declared pipeline state: the composer then
+        // needs no network at all, so this test cannot reach out.
+        PIPELINE_PROGRESS: "finished",
+        VERSION: "0.21.1-prerelease.3",
+        ...env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stdout.resume();
+    child.stderr.resume();
+    child.on("error", reject);
+    child.on("close", (code) => resolve(code ?? -1));
+  });
+}
+
+/** Keys in the order the script appended them, ignoring heredoc bodies. */
+function keyOrder(raw: string): string[] {
+  const keys: string[] = [];
+  const lines = raw.split("\n");
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = /^([a-z_]+)<<(od-fallback-[0-9a-f-]+)$/.exec(lines[index] ?? "");
+    if (match?.[1] == null || match[2] == null) continue;
+    keys.push(match[1]);
+    while (index < lines.length && lines[index + 1] !== match[2]) index += 1;
+  }
+  return keys;
+}
+
+describe("prerelease fallback composer CLI", () => {
+  let workdir = "";
+
+  beforeEach(async () => {
+    workdir = await mkdtemp(join(tmpdir(), "od-fallback-cli-"));
+  });
+
+  afterEach(async () => {
+    await rm(workdir, { force: true, recursive: true });
+  });
+
+  it("emits no notice payload at all on a healthy release", async () => {
+    const outputFile = join(workdir, "healthy.txt");
+    expect(await compose(outputFile, { STAGE: "watch", CARD_JOB_RESULT: "success", CARD_DELIVERED: "true" })).toBe(0);
+    const raw = await readFile(outputFile, "utf8");
+    expect(keyOrder(raw)).toEqual(["reason", "alert"]);
+    expect(raw).toContain("false");
+    expect(raw).not.toContain("进度卡片失联");
+  });
+
+  it("writes `alert` only after every field a poster reads", async () => {
+    // The workflow branches on `alert`, and $GITHUB_OUTPUT is append-only. If
+    // `alert` went first, a crash between two appends would leave `alert=true`
+    // beside an empty body and feishu-notice.ts would die on a required env
+    // instead of delivering. Written last, `alert=true` means the whole notice
+    // is on disk — which is what makes the workflow's gate safe.
+    const outputFile = join(workdir, "silent.txt");
+    expect(await compose(outputFile, { STAGE: "watch", CARD_JOB_RESULT: "success", CARD_DELIVERED: "" })).toBe(0);
+    const order = keyOrder(await readFile(outputFile, "utf8"));
+    expect(order).toContain("alert");
+    expect(order).toContain("body");
+    expect(order.indexOf("alert")).toBe(order.length - 1);
+    for (const key of ["reason", "title", "template", "body", "run_url"]) {
+      expect(order.indexOf(key), `${key} must be written before alert`).toBeLessThan(order.indexOf("alert"));
+    }
+  });
+});

--- a/tools/release/tests/prerelease-fallback.test.ts
+++ b/tools/release/tests/prerelease-fallback.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  cardLaneSilence,
+  renderFallbackNotice,
+  resolvePackagePublication,
+  versionMetadataUrl,
+} from "../src/notifications/prerelease-fallback.ts";
+import type { FallbackNoticeInput } from "../src/notifications/prerelease-fallback.ts";
+
+const ORIGIN_RUN = "https://github.com/nexu-io/open-design/actions/runs/111";
+const CARD_RUN = "https://github.com/nexu-io/open-design/actions/runs/222";
+const METADATA = "https://releases.example/prerelease/versions/0.21.1-prerelease.3/metadata.json";
+
+function notice(overrides: Partial<FallbackNoticeInput> = {}): FallbackNoticeInput {
+  return {
+    silence: "card-not-delivered",
+    channelLabel: "Prerelease",
+    version: "0.21.1-prerelease.3",
+    branch: "release/v0.21.1",
+    commit: "0123456789abcdef0123456789abcdef01234567",
+    publication: "published",
+    metadataUrl: METADATA,
+    pipeline: "finished",
+    originRunUrl: ORIGIN_RUN,
+    cardRunUrl: CARD_RUN,
+    laneSummary: "card job=success · delivered=false",
+    ...overrides,
+  };
+}
+
+describe("cardLaneSilence", () => {
+  it("stays quiet when the watcher finished and the card reached the chat", () => {
+    // The whole point of the fallback: on a healthy prerelease it must post
+    // nothing, or the channel gets two messages per release and the alert
+    // stops meaning anything.
+    expect(cardLaneSilence({ stage: "watch", jobResult: "success", deliveredFinalCard: true })).toBeNull();
+  });
+
+  it("stays quiet when the card workflow was dispatched", () => {
+    expect(cardLaneSilence({ stage: "dispatch", dispatched: true })).toBeNull();
+  });
+
+  it("alerts when the watcher job finished but no card was ever delivered", () => {
+    // The headline silent path: the application bot's credentials expire or it
+    // is removed from the chat, every send/patch throws, the watcher swallows
+    // the delivery failure by design, and the job still exits 0. A fallback
+    // keyed only on the job result would see green here.
+    expect(cardLaneSilence({ stage: "watch", jobResult: "success", deliveredFinalCard: false })).toBe(
+      "card-not-delivered",
+    );
+  });
+
+  it("alerts when the watcher job did not complete successfully", () => {
+    for (const jobResult of ["failure", "cancelled", "skipped", ""]) {
+      expect(cardLaneSilence({ stage: "watch", jobResult, deliveredFinalCard: false })).toBe(
+        "watcher-not-completed",
+      );
+      // A job that died carries no trustworthy delivery claim either way: the
+      // card is at best frozen mid-release, so it is still an alert.
+      expect(cardLaneSilence({ stage: "watch", jobResult, deliveredFinalCard: true })).toBe(
+        "watcher-not-completed",
+      );
+    }
+  });
+
+  it("alerts when the card workflow was never dispatched", () => {
+    expect(cardLaneSilence({ stage: "dispatch", dispatched: false })).toBe("never-dispatched");
+  });
+});
+
+describe("versionMetadataUrl", () => {
+  it("reproduces the key publish-metadata writes the version metadata to", () => {
+    expect(versionMetadataUrl("https://releases.example", "prerelease", "0.21.1-prerelease.3")).toBe(METADATA);
+  });
+
+  it("tolerates a trailing slash on the public origin", () => {
+    expect(versionMetadataUrl("https://releases.example/", "prerelease", "0.21.1-prerelease.3")).toBe(METADATA);
+  });
+
+  it("returns nothing when the origin or the version is unknown", () => {
+    expect(versionMetadataUrl("", "prerelease", "0.21.1-prerelease.3")).toBe("");
+    expect(versionMetadataUrl("https://releases.example", "prerelease", "")).toBe("");
+  });
+});
+
+describe("resolvePackagePublication", () => {
+  it("trusts a metadata URL the caller already holds", () => {
+    // release-prerelease.yml's publish job hands over the real output; there is
+    // nothing more authoritative to probe for.
+    expect(resolvePackagePublication({ declaredMetadataUrl: METADATA, probe: "skipped" })).toBe("published");
+  });
+
+  it("reads the probe when the caller holds no URL", () => {
+    expect(resolvePackagePublication({ declaredMetadataUrl: "", probe: "found" })).toBe("published");
+    expect(resolvePackagePublication({ declaredMetadataUrl: "", probe: "missing" })).toBe("absent");
+  });
+
+  it("never claims a verdict it could not check", () => {
+    expect(resolvePackagePublication({ declaredMetadataUrl: "", probe: "error" })).toBe("unknown");
+    expect(resolvePackagePublication({ declaredMetadataUrl: "", probe: "skipped" })).toBe("unknown");
+  });
+});
+
+describe("renderFallbackNotice", () => {
+  it("names the version and both runs so the reader needs nothing else", () => {
+    const rendered = renderFallbackNotice(notice());
+    expect(rendered.title).toContain("0.21.1-prerelease.3");
+    expect(rendered.body).toContain("0.21.1-prerelease.3");
+    expect(rendered.body).toContain("release/v0.21.1");
+    expect(rendered.body).toContain(ORIGIN_RUN);
+    expect(rendered.body).toContain(CARD_RUN);
+    expect(rendered.runUrl).toBe(ORIGIN_RUN);
+  });
+
+  it("reports a published package with its version metadata URL", () => {
+    const rendered = renderFallbackNotice(notice({ publication: "published" }));
+    expect(rendered.body).toContain("已发布");
+    expect(rendered.body).toContain(METADATA);
+    // The packages shipped; only the notification broke. That is not the same
+    // incident as "nothing was released", and the colour has to say so.
+    expect(rendered.template).toBe("orange");
+  });
+
+  it("separates a package that never shipped from one that has not shipped yet", () => {
+    const finished = renderFallbackNotice(notice({ publication: "absent", pipeline: "finished", metadataUrl: "" }));
+    expect(finished.body).toContain("未发布");
+    expect(finished.body).toContain("已结束");
+    expect(finished.template).toBe("red");
+
+    const running = renderFallbackNotice(notice({ publication: "absent", pipeline: "running", metadataUrl: "" }));
+    expect(running.body).toContain("尚未发布");
+    expect(running.body).toContain("仍在进行");
+  });
+
+  it("does not claim the pipeline finished when it could not find out", () => {
+    // Absent metadata plus an unknown pipeline state: the object is not there,
+    // but nothing licenses "已结束" or "仍在进行".
+    const rendered = renderFallbackNotice(notice({ publication: "absent", pipeline: "unknown" }));
+    expect(rendered.body).toContain("未发布");
+    expect(rendered.body).not.toContain("已结束");
+    expect(rendered.body).not.toContain("仍在进行");
+  });
+
+  it("names where the version metadata will appear when nothing has shipped yet", () => {
+    // The dispatch-side alert fires beside the build, so "not published" is the
+    // expected reading. Handing over the object that would prove publication
+    // turns "go look" into one clickable check.
+    const rendered = renderFallbackNotice(notice({ publication: "absent", pipeline: "running" }));
+    expect(rendered.body).toContain(METADATA);
+    expect(rendered.body).not.toContain("已发布");
+  });
+
+  it("says so plainly when it could not establish whether a package shipped", () => {
+    const rendered = renderFallbackNotice(notice({ publication: "unknown", metadataUrl: "" }));
+    expect(rendered.body).toContain("未知");
+    expect(rendered.template).toBe("red");
+  });
+
+  it("explains which way the card lane went silent", () => {
+    expect(renderFallbackNotice(notice({ silence: "never-dispatched" })).body).toContain("从未");
+    expect(renderFallbackNotice(notice({ silence: "watcher-not-completed" })).body).toContain("未正常结束");
+    expect(renderFallbackNotice(notice({ silence: "card-not-delivered" })).body).toContain("凭证");
+    // The raw per-job results travel with the notice, so the reader can tell a
+    // dispatch that never fired from a watcher that died.
+    expect(renderFallbackNotice(notice()).body).toContain("card job=success · delivered=false");
+  });
+
+  it("stays readable when the pipeline died before a version existed", () => {
+    const rendered = renderFallbackNotice(
+      notice({ version: "", branch: "", commit: "", metadataUrl: "", publication: "absent", pipeline: "finished" }),
+    );
+    expect(rendered.title).not.toContain("undefined");
+    expect(rendered.body).not.toContain("undefined");
+    expect(rendered.body).toContain("未确定");
+    expect(rendered.runUrl).toBe(ORIGIN_RUN);
+  });
+
+  it("falls back to the card run link when the origin run is unknown", () => {
+    expect(renderFallbackNotice(notice({ originRunUrl: "" })).runUrl).toBe(CARD_RUN);
+  });
+});


### PR DESCRIPTION
## Why

Retiring the transitional webhook card (#7867) left the progressive Feishu card
(`release-prerelease-card.yml`) as the **only** prerelease notification — and
every way that lane can break is silent. The pipeline stays green, the packages
land in R2, and the channel hears nothing. Nobody is watching a workflow's red
dot for a notification lane, so the first sign of trouble would be somebody
asking "was there a prerelease today?".

The nastiest shape is credential failure. `prerelease-progress-card.ts` catches
every Feishu send/patch error on purpose — one hiccup must not end a two-hour
watch — and then exits 0. An application bot whose secret expired, or that was
removed from the release chat, therefore produces a **green job and an empty
channel**. A fallback keyed on the job result would see that as healthy, and a
fallback delivered through the *same* bot would be down for the same reason.

I hit this while looking at what #7867 left uncovered, right after the card
lane's `dispatch_smoke` had already been skipped for N runs by an unrelated
`needs`-chain trap — the same class of "the safety net was never reachable"
failure this PR has to avoid reintroducing.

## What users will see

Nothing on a healthy release: the fallback is silent, and the channel keeps
getting exactly one progressive card per prerelease.

When the card lane breaks, the release group gets one plain notice from the
**custom-bot webhook** (the bot the retired one-shot card used) that stands on
its own:

> 🚨 Prerelease 进度卡片失联 · 0.21.1-prerelease.9
>
> Prerelease 的飞书进度卡片这次没有正常送达。本条是兜底告警，走自定义机器人 webhook 发出，和卡片用的应用机器人不是同一套凭证。
>
> **版本**: `0.21.1-prerelease.9`
> **分支 / 提交**: `release/v0.21.1` @ `0123456789`
> **发包状态**: ✅ 已发布，包在 R2 上可以下载 — https://…/prerelease/versions/0.21.1-prerelease.9/metadata.json
> **卡片链路**: 进度卡片 job 正常结束，但卡片从未送进群——应用机器人凭证失效或被移出群的典型症状。
> **各 job 结果**: card job=success · delivered=false
>
> **去哪看**
> - 打包流水线: https://github.com/nexu-io/open-design/actions/runs/111
> - 进度卡片 run: https://github.com/nexu-io/open-design/actions/runs/222

Header colour carries the incident class: orange when the packages shipped and
only the notification broke, red when nothing shipped or the verdict is unknown.
"包发没发" is answered from `version_metadata_url` — the publish job's own output
where the caller holds it, otherwise a HEAD against the same R2 object — never
from the workflow conclusion, which goes red for any advisory lane while the
packages sit downloadable.

## Surface area

- [x] **CLI / env var** — no `od` subcommand; two CI-only entrypoints
  (`tools/release/src/notifications/prerelease-fallback-notice.ts` and its pure
  sibling) plus new workflow env: `STAGE`, `CARD_DISPATCHED`, `CARD_JOB_RESULT`,
  `CARD_DELIVERED`, `PIPELINE_PROGRESS`, `LANE_SUMMARY`, `ORIGIN_RUN_URL`,
  `CARD_RUN_URL`. These are release-infrastructure inputs, not product surface,
  so there is no UI counterpart to pair them with. Existing secrets only —
  `FEISHU_RELEASE_WEBHOOK` / `FEISHU_RELEASE_SIGN_SECRET`, which #7867
  deliberately kept.
- [ ] UI / Keyboard shortcut / API contract / Extension point / i18n / New root
  dependency / Default behavior change

## Design

**One rule above all: never fire on a healthy release.** A fallback that also
posts on good days is just a second card, and a channel that gets two messages
per release stops reading either. That rule is enforced twice — in the job/step
`if:`, and again inside `prerelease-fallback.ts`'s `cardLaneSilence()`, so
loosening the YAML cannot on its own turn the fallback into a duplicate.

**Second rule: a different bot.** The card posts through the Feishu *application*
bot (`FEISHU_APP_ID` / `FEISHU_APP_SECRET` / `FEISHU_RELEASE_CHAT_ID`); the
fallback posts through the *custom-bot webhook*. Sharing credentials would cover
nothing, since "the application credential expired" is one of the failures.

**The delivery signal.** `prerelease-progress-card.ts` now writes
`card_delivered=true` to `$GITHUB_OUTPUT` when — and only when — the card's
**final** render is in the chat. Final, not first: that also catches a card that
was posted and then froze because the closing update could not be written. The
`card` job exports it as `outputs.delivered`.

**Delivery reuses `feishu-notice.ts`.** The composer never talks to Feishu; it
writes `title` / `template` / `body` / `run_url` into `$GITHUB_OUTPUT` and the
existing signed-webhook poster (already used by `cut-release`, `cut-patch-release`,
`main-prerelease-win-smoke`, `notify-daily-feishu`) sends it. That keeps the
last-resort path on the transport with the most mileage and keeps the decision a
pure function testable without a network. `.github/scripts/release_notice.ts` has
the identical contract but is not referenced by any workflow, so I stayed on the
live copy. `tools/release/src/notifications/feishu.ts` is untouched.

Neither fallback needs `pnpm install`: both scripts import only node builtins.

## Reachability

This is the part that has bitten this workflow family before, so, explicitly:

**`fallback_notice` (release-prerelease-card.yml)** — `needs: card`.
- A job with `needs` carries an implicit `success()`. Without a break, GitHub
  would skip this job *in exactly the case it exists for* — a card job that
  failed — and never evaluate its conditions. `always() && !cancelled()` is
  therefore mandatory here on its own merits, before any skip-propagation
  argument.
- The `build_linux` hazard **cannot reach this workflow**. `build_linux` is a job
  of `release-prerelease.yml`; `release-prerelease-card.yml` is a separate
  `workflow_dispatch` run whose entire graph is `card` → `fallback_notice`.
  `card` has no `needs` at all, so nothing upstream of it can be skipped.
- `card`'s own `if: github.repository == 'nexu-io/open-design'` is the one way
  `card` can be skipped, and `fallback_notice` carries the same guard, so a fork
  skips both rather than alerting.
- Verified conditions, as parsed from the YAML:
  `always() && !cancelled() && github.repository == 'nexu-io/open-design' && !(needs.card.result == 'success' && needs.card.outputs.delivered == 'true')`.

**Dispatch-side steps (release-prerelease.yml → `dispatch_validation`)** — these
are **steps, not a job**, deliberately: `tools/pack/tests/release-workflows.test.ts`
locks "dispatchers, and nothing depending on them" (`not.toContain("- dispatch_validation")`),
and a job would have needed exactly that edge. As steps they have no `needs` edge
to break — but a step-level `if` without a status function still inherits
`success()` against the job's status so far, so **every** step of the notifier
group carries one. Setup + compose use
`always() && github.repository == … && steps.checkout.outcome == 'success'`;
the two delivery steps use
`always() && steps.notice.outcome == 'success' && …`, so a failed dispatch
still reaches them while a crashed or skipped composer never does. (Review
round 1 caught the delivery steps missing theirs — see the Bug fix
verification section.)

**Cost on the happy path.** `fallback_notice` is skipped before it starts. The
dispatch-side steps do run every time (~5s of setup-node + one composer that
prints "nothing to post"), inside a job that already runs beside the builds — it
adds nothing to the pipeline's critical path and holds the repository-wide
concurrency group no longer than the builds already do.

**No double-posting.** If the card was dispatched, the dispatch-side steps stay
silent and only `fallback_notice` can fire; if it was not, the card workflow
never runs and only the dispatch-side steps can fire. The two are mutually
exclusive.

## The four silent paths

| # | Path | Covered? | By what |
|---|---|---|---|
| 1 | Dispatch never fired | **Mostly** | Dispatch-side steps. `card_dispatched` is written only after `dispatch-validation.sh` exits 0, so it stays empty when the helper failed on every ref, when an earlier step in the job died, **and** when the dispatch step was skipped for missing `FEISHU_APP_ID` / `FEISHU_RELEASE_CHAT_ID` — i.e. path 1 and the dispatch-side half of path 3. |
| 2 | Card job dies in checkout / setup | **Yes** | `needs.card.result != 'success'` → `fallback_notice` fires. Nothing was ever delivered, so the notice says the card lane died and reports where the metadata will appear. |
| 3 | Application-bot credentials expired, or bot removed from the chat | **Yes** | The headline case. Job exits 0, `card_delivered` never written → `fallback_notice` fires. This is the case a result-only gate would miss, and it is pinned by a spec (below). |
| 4 | 150-minute job timeout, and the closing write needs the same credentials | **Yes** | Two sub-cases. Hard `timeout-minutes` kill → job result is `failure` → fires. Watcher hits its own 140-minute budget and the closing PATCH fails → `card_delivered` never written (it tracks the *final* render) → fires. |

### Not covered, and why

- **`gh workflow run` returns 204 but GitHub never creates the run.** The
  dispatch-side steps see a successful dispatch and stay silent; the card
  workflow never runs, so its fallback cannot fire either. Closing this needs a
  post-publish poller for a run carrying the `origin-run <id>` marker, which is
  the kind of job `release-prerelease.yml`'s concurrency doctrine exists to keep
  out. Left open on purpose.
- **`dispatch_validation`'s own checkout fails.** The notifier scripts come from
  the working tree, so there is nothing to run. The job is red, but silent.
- **`metadata` fails.** `dispatch_validation` is skipped entirely, so no card and
  no fallback. This is outside the card lane — a prerelease that died before it
  had a version — and widening the alert to cover it would ping the group for
  every experimental dispatch that fails `check-storage`. Listed as an adjacent
  issue rather than folded in.
- **A card posted, kept updating, and the run was cancelled by a human.**
  `!cancelled()` suppresses the alert, which is intended: somebody chose that.
- **The webhook bot itself is also broken.** Nothing is left to notify with. The
  job goes red with an explicit `::error::` naming the double failure, which is
  the loudest remaining channel.

## Adjacent issues (not fixed here)

- `dispatch_validation` dispatches the code tests **before** the card. If the
  tests dispatch fails, the card dispatch step never runs and the card lane dies
  for a reason that has nothing to do with it. Swapping the two steps would make
  the notification lane independent of the tests lane — a two-line change, but a
  behaviour change outside this PR's scope.
- `.github/scripts/release_notice.ts` is a full duplicate of
  `tools/release/src/notifications/feishu-notice.ts` and is referenced by no
  workflow. Worth deleting or consolidating separately.

## Bug fix verification

Not a bug fix, but the same red-first discipline was applied.

- **Red specs:**
  - `tools/release/tests/prerelease-fallback.test.ts` — the decision and the
    rendered notice. Went red as `Cannot find module '../src/notifications/prerelease-fallback.ts'`
    before the module existed.
  - `tools/release/tests/prerelease-card-delivery-signal.test.ts` — runs the real
    watcher as a child process against a stub GitHub jobs API and a stub Feishu.
    Went red with `expected '' to contain 'card_delivered=true'` before the
    signal existed. Its sibling case pins the headline silent path: with the
    stub rejecting the token (`code 99991663`, non-retryable), the watcher
    **exits 0, sends nothing, and writes no delivery signal**.
  - `e2e/tests/packaged-smoke-workflow.test.ts` → "[P1] alerts through the other
    Feishu bot when the prerelease card lane goes silent" — went red on
    `expect(fallbackStart).toBeGreaterThanOrEqual(0)` against `origin/main`'s
    workflow files.
- **Verified the specs are not vacuous:** with `reportDelivered()` made
  unconditional, the "exits green but claims no delivery" case goes red
  (`expected '…card_delivered=true…' not to contain 'card_delivered=true'`) —
  the negative assertion really bites rather than passing on an absent file.
- **Step-level reachability (added after review, #7873 review round 1):**
  `tools/pack/tests/release-workflows.test.ts` → "keeps the prerelease card
  fallback reachable after the step it alerts on has failed". The two steps that
  actually deliver the notice carried no status function, so GitHub's implicit
  `success()` skipped them whenever `dispatch-validation.sh` had exited non-zero
  — Path 1 was silent in its own emergency. Went red naming exactly those two
  steps, green after the fix, and red again when each half of the fix
  (`always()`, then `steps.notice.outcome == 'success'`) was reverted
  separately. The sweep also gained the three dispatched lanes, so
  `fallback_notice`'s job-level `always()` is now guarded too.
- **Output ordering:** `tools/release/tests/prerelease-fallback-notice-cli.test.ts`
  pins `alert` as the last key written to `$GITHUB_OUTPUT` — append-only, so
  writing it first would let a crash mid-write claim `alert=true` beside an
  empty body. Red when `alert` is moved back to first.
- **End-to-end wiring smoke:** ran the composer with `GITHUB_OUTPUT` set, then
  fed its multi-line `body` through the real `feishu-notice.ts` against a local
  stub webhook. The signed `msg_type: interactive` envelope arrived with the
  expected header template and body.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/tools-release test` — 14 files / 123 tests pass
- `pnpm --filter @open-design/tools-release typecheck` — pass
- `pnpm --filter @open-design/e2e typecheck` — pass
- `e2e/tests/packaged-smoke-workflow.test.ts` — 82 pass / 1 skipped (ran 6×)
- `tools/pack/tests/release-workflows.test.ts` — 9 pass
- `actionlint 1.7.12` (CI-pinned) + `shellcheck 0.11.0` over all workflows — clean,
  exit 0, same as the `origin/main` baseline
- `python3 .github/scripts/scopes.py plan --context pr` over the changed files —
  `workspace_unit_tests` and `e2e_vitest` both enabled, so both suites run in CI
  without a scopes change

One unrelated test in `packaged-smoke-workflow.test.ts` failed once when the
suite was run concurrently with `tools/pack`'s; it passed on six subsequent runs
including another concurrent one. That file spawns `git` / `python3` / `bash`
subprocesses under fixed timeouts, so it is instrument contention, not this
change — the test added here only reads files.

