### PR TITLE
fix(web): read project run status from one shared feed for the rail and the tab switcher (OPEND-2553 PR-F2)

### DIFF
--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -75,7 +75,7 @@ import { useProjectDeleteFlow } from './project-actions/useProjectDeleteFlow';
 import { useProjectDuplicateFlow } from './project-actions/useProjectDuplicateFlow';
 import { useWorkspaceProjectMove } from './project-actions/useWorkspaceProjectMove';
 import type { SharedProjectPredicate } from '../collab/all-projects-list';
-import { useProjectRunSummaries } from '../hooks/useProjectRunStatuses';
+import { acknowledgeProjectCompletion, useProjectRunStatuses } from '../hooks/useProjectRunStatuses';
 import { MessageCenter } from './MessageCenter';
 import type { EntrySettingsSection } from './EntrySettingsMenu';
 import type { Project } from '../types';
@@ -350,6 +350,13 @@ function NavButton({
  *  control. */
 const RECENT_SECTION_STORAGE_KEY = 'od.entry.railRecentOpen';
 
+/**
+ * How many rows the 最近项目 list shows before it scrolls — 11 × 38px rows on a
+ * desktop window (see `.entry-nav-rail__recent-list`). The head of the list
+ * whose status is asked for before the scroll observer has reported.
+ */
+const RECENT_STATUS_HEAD_ROWS = 11;
+
 function readStoredRecentOpen(): boolean {
   if (typeof window === 'undefined') return true;
   try {
@@ -358,53 +365,6 @@ function readStoredRecentOpen(): boolean {
     return window.localStorage.getItem(RECENT_SECTION_STORAGE_KEY) !== 'false';
   } catch {
     return true;
-  }
-}
-
-/**
- * Which finished run the user has already looked at, per project (per product:
- * 点进去之后对号换回默认 icon).
- *
- * Invariant: a ✓ is acknowledged for ONE specific finished run — the value is
- * that run's id — and a newer finished run is a new notice. Keyed on the run
- * rather than the project so the acknowledgement stays correct even when the
- * section was collapsed (and not polling) for the whole of the next run: on
- * re-expanding, the newest terminal run's id no longer matches and the ✓ shows
- * again. Only a project whose live status is `succeeded` consults this at all.
- *
- * Persisted next to the section's own open/closed flag: a reload re-reads the
- * same runs feed and would otherwise re-raise every ✓ the user has already
- * cleared.
- */
-const RECENT_SEEN_DONE_STORAGE_KEY = 'od.entry.railRecentSeenDone';
-
-type AcknowledgedRuns = Readonly<Record<string, string>>;
-
-function readStoredSeenDone(): AcknowledgedRuns {
-  if (typeof window === 'undefined') return {};
-  try {
-    const raw = window.localStorage.getItem(RECENT_SEEN_DONE_STORAGE_KEY);
-    const parsed: unknown = raw ? JSON.parse(raw) : null;
-    // Anything but a plain object of run ids — including a bare list of
-    // project ids, which cannot say which run it meant — reads as "nothing
-    // acknowledged". The worst case is one ✓ the user has already seen, never a
-    // missing one.
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
-    const acknowledged: Record<string, string> = {};
-    for (const [projectId, runId] of Object.entries(parsed as Record<string, unknown>)) {
-      if (typeof runId === 'string' && runId) acknowledged[projectId] = runId;
-    }
-    return acknowledged;
-  } catch {
-    return {};
-  }
-}
-
-function writeStoredSeenDone(acknowledged: AcknowledgedRuns): void {
-  try {
-    window.localStorage.setItem(RECENT_SEEN_DONE_STORAGE_KEY, JSON.stringify(acknowledged));
-  } catch {
-    // Private mode / storage disabled: the ✓ still clears for this session.
   }
 }
 
@@ -507,14 +467,16 @@ function RailRecentSection({
   // Run status for the rows' leading glyph. `Project.status` cannot serve it —
   // it only arrives on the UNSCOPED project list, so it is absent for every
   // workspace-bound project (see the hook's own note) — and this is the same
-  // feed the workspace tab dropdown reads, which is what keeps the two glyph
-  // columns telling one story.
+  // feed, with the same display mapping (✓-spending included), that the
+  // workspace tab dropdown reads, which is what keeps the two glyph columns
+  // telling one story about a project (OPEND-2795).
   const recentListRef = useRef<HTMLUListElement>(null);
-  const [runStatusProjectIds, setRunStatusProjectIds] = useState<string[]>([]);
   // Keep the full catalog navigable, but poll only rows intersecting its
   // scrollport. The list's existing height cap bounds the status request set.
+  // `null` until the observer has reported once; never reset on a catalog
+  // hand-over, so a re-render cannot blank the rows' glyphs.
+  const [visibleProjectIds, setVisibleProjectIds] = useState<string[] | null>(null);
   useEffect(() => {
-    setRunStatusProjectIds([]);
     const list = recentListRef.current;
     if (!open || !list || typeof IntersectionObserver === 'undefined') return;
     const visible = new Set<string>();
@@ -525,36 +487,38 @@ function RailRecentSection({
         if (entry.isIntersecting) visible.add(id);
         else visible.delete(id);
       }
-      setRunStatusProjectIds([...visible]);
+      const next = [...visible].sort();
+      setVisibleProjectIds((prev) =>
+        prev && prev.length === next.length && prev.every((id, index) => id === next[index])
+          ? prev
+          : next);
     }, { root: list });
     for (const row of list.children) observer.observe(row);
     return () => observer.disconnect();
   }, [items, open]);
-  const runSummaryByProjectId = useProjectRunSummaries(runStatusProjectIds, {
+  // Until the observer has spoken, ask for the head of the list — the rows the
+  // cap shows on a desktop window — in the same commit that paints them
+  // (OPEND-2762). The observer's first report lands a frame later, and waiting
+  // for it is what left the rows a round trip ahead of their glyphs.
+  const runStatusProjectIds = useMemo(
+    () => visibleProjectIds
+      ?? items.slice(0, RECENT_STATUS_HEAD_ROWS).map((project) => project.id),
+    [visibleProjectIds, items],
+  );
+  const runStatusByProjectId = useProjectRunStatuses(runStatusProjectIds, {
     enabled: open,
     workspaceContext,
   });
-  const [seenDone, setSeenDone] = useState<AcknowledgedRuns>(readStoredSeenDone);
 
   // Opening a project is what spends its ✓ (per product): the finished run on
-  // screen is recorded as seen. Recorded only when there is actually one, so
-  // the store stays the list of notices the user has dismissed rather than of
-  // every project ever opened.
+  // screen is recorded as seen — in the shared feed, so the tab switcher drops
+  // the mark in the same moment.
   const openProject = useCallback(
     (id: string) => {
-      const summary = runSummaryByProjectId.get(id);
-      if (summary?.status === 'succeeded' && summary.latestTerminalRunId) {
-        const runId = summary.latestTerminalRunId;
-        setSeenDone((prev) => {
-          if (prev[id] === runId) return prev;
-          const next = { ...prev, [id]: runId };
-          writeStoredSeenDone(next);
-          return next;
-        });
-      }
+      acknowledgeProjectCompletion(id);
       return onOpen?.(id);
     },
-    [onOpen, runSummaryByProjectId],
+    [onOpen],
   );
 
   function toggle() {
@@ -598,22 +562,12 @@ function RailRecentSection({
         <div className="accordion-collapsible-inner">
           <ul ref={recentListRef} className="entry-nav-rail__recent-list">
             {items.map((project) => {
-              const summary = runSummaryByProjectId.get(project.id);
-              const status = summary?.status;
-              // An acknowledged ✓ is DROPPED, not drawn quieter: the row goes
-              // back to its default chat mark (per product). Every other status
-              // is live and stays. Acknowledged means THIS finished run was
-              // seen; a newer one is a new notice.
-              const acknowledged =
-                status === 'succeeded'
-                && summary?.latestTerminalRunId !== undefined
-                && seenDone[project.id] === summary.latestTerminalRunId;
               return (
                 <li key={project.id} data-project-id={project.id}>
                   <RailRecentRow
                     project={project}
                     workspaceContext={workspaceContext}
-                    runStatus={acknowledged ? undefined : status}
+                    runStatus={runStatusByProjectId.get(project.id)}
                     ownedBySelf={ownedBySelf(project.id)}
                     shared={isSharedProject(project.id)}
                     moveToTeamAvailable={moveToTeamAvailable}

--- a/apps/web/src/components/WorkspaceTabsBar.tsx
+++ b/apps/web/src/components/WorkspaceTabsBar.tsx
@@ -23,7 +23,7 @@ import {
   ProjectHoverPreviewCard,
   useProjectHoverCover,
 } from './entry-nav-rail/ProjectHoverPreview';
-import { useProjectRunStatuses } from '../hooks/useProjectRunStatuses';
+import { acknowledgeProjectCompletion, useProjectRunStatuses } from '../hooks/useProjectRunStatuses';
 import { STATUS_LABEL_KEYS } from '../state/projectRunStatus';
 import {
   HOME_APPLY_TEMPLATE_EVENT,
@@ -1526,6 +1526,9 @@ export function WorkspaceTabsBar({
       activateTab({ ...tab, view: 'home' });
       return;
     }
+    // Opening a project is what spends its ✓ (per product) — the same rule,
+    // in the same shared feed, as the rail's 最近项目 rows (OPEND-2795).
+    if (tab.kind === 'project') acknowledgeProjectCompletion(tab.projectId);
     activateTab(tab);
   }
 

--- a/apps/web/src/hooks/useProjectRunStatuses.ts
+++ b/apps/web/src/hooks/useProjectRunStatuses.ts
@@ -1,5 +1,5 @@
 /**
- * Live `Map<projectId, ProjectDisplayStatus>` for a known set of projects.
+ * The ONE live project-run-status feed every glyph surface reads.
  *
  * Exists because `Project.status` is unreadable in a workspace-scoped session:
  * only the unscoped `GET /api/projects` attaches it, and that endpoint lists
@@ -9,88 +9,270 @@
  * Asks per project id rather than for the whole catalogue: the unscoped
  * `GET /api/runs` answers 400 `PROJECT_SCOPE_REQUIRED` as soon as one run
  * belongs to a workspace-bound project. See `listRunsForProject`.
+ *
+ * Why a module-level store rather than per-hook state (OPEND-2795 /
+ * OPEND-2762): the rail's 最近项目 rows and the workspace tab switcher each
+ * used to keep their own copy, polling their own id set from a blank start.
+ * Two copies meant two answers for one project (the rail had spent a ✓ the
+ * switcher still drew), and a surface that remounted — Home, after leaving a
+ * project — painted its rows first and their statuses a round trip later.
+ * Here every surface subscribes to one cache: a project asked for by two
+ * surfaces costs one request, a remount reads the last known answer in its
+ * first render (and revalidates), and the one display mapping —
+ * `displayStatusForSummary`, ✓-spending included — applies everywhere.
  */
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
 import type { ProjectDisplayStatus, WorkspaceCollabContext } from '@open-design/contracts';
 import { listRunsForProject, RUNS_CHANGED_EVENT } from '../providers/daemon';
 import {
+  displayStatusForSummary,
   foldRunsToProjectRunSummaries,
+  readStoredAcknowledgedRuns,
+  writeStoredAcknowledgedRuns,
+  type AcknowledgedRuns,
   type ProjectRunSummary,
 } from '../state/projectRunStatus';
 
-/** Backstop only — `RUNS_CHANGED_EVENT` is what makes this feel immediate. */
+/**
+ * Backstop only — `RUNS_CHANGED_EVENT` is what makes a change this client
+ * caused feel immediate; the poll catches runs started elsewhere (the CLI,
+ * another window). One timer for every subscribed surface together.
+ */
 const POLL_MS = 4000;
 
-const EMPTY: ReadonlyMap<string, ProjectRunSummary> = new Map();
+const EMPTY_SUMMARIES: ReadonlyMap<string, ProjectRunSummary> = new Map();
+const EMPTY_STATUSES: ReadonlyMap<string, ProjectDisplayStatus> = new Map();
 
 export interface UseProjectRunStatusesOptions {
   enabled?: boolean;
   workspaceContext?: WorkspaceCollabContext | null;
 }
 
+interface Subscription {
+  ids: readonly string[];
+  /** Read at request time: the context object is rebuilt on unrelated renders. */
+  contextRef: { readonly current: WorkspaceCollabContext | null };
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+/**
+ * Last known summary per project. `null` records an answer of "no runs", so a
+ * project asked about and found quiet is not re-treated as unknown. Absent
+ * means never answered. A failed read never writes here: it says nothing about
+ * the project, and blanking the row would flash the default mark and back.
+ */
+const summaries = new Map<string, ProjectRunSummary | null>();
+let acknowledged: AcknowledgedRuns | null = null;
+const subscriptions = new Set<Subscription>();
+const inFlight = new Set<string>();
+const listeners = new Set<() => void>();
+let version = 0;
+/** Bumped by a reset so a read started before it cannot land afterwards. */
+let generation = 0;
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+let listeningForRunsChanged = false;
+
+function acknowledgedRuns(): AcknowledgedRuns {
+  if (acknowledged === null) acknowledged = readStoredAcknowledgedRuns();
+  return acknowledged;
+}
+
+function emit(): void {
+  version += 1;
+  for (const listener of listeners) listener();
+}
+
+function subscribeToStore(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getVersion(): number {
+  return version;
+}
+
+function sameSummary(a: ProjectRunSummary | null | undefined, b: ProjectRunSummary | null): boolean {
+  if (!a || !b) return (a ?? null) === b;
+  return a.status === b.status
+    && a.latestTerminalRunId === b.latestTerminalRunId
+    && a.latestTerminalUpdatedAt === b.latestTerminalUpdatedAt;
+}
+
+async function readProject(projectId: string, context: WorkspaceCollabContext | null): Promise<void> {
+  const startedIn = generation;
+  const result = await listRunsForProject(projectId, context);
+  if (startedIn !== generation) return;
+  // An unreadable project yields null; keeping whatever was known leaves the
+  // row as it was rather than asserting a status nobody verified.
+  if (!result) return;
+  const next = foldRunsToProjectRunSummaries(result.runs, result.awaitingInputProjectIds)
+    .get(projectId) ?? null;
+  const previous = summaries.get(projectId);
+  summaries.set(projectId, next);
+  // Nothing drawn changes between "unknown" and "no runs", so no re-render.
+  if (previous === undefined && next === null) return;
+  if (!sameSummary(previous, next)) emit();
+}
+
+/** Ask about each id not already being asked about. Answers land as they come. */
+function refresh(ids: Iterable<string>, contextFor: (projectId: string) => WorkspaceCollabContext | null): void {
+  for (const projectId of ids) {
+    if (inFlight.has(projectId)) continue;
+    inFlight.add(projectId);
+    void readProject(projectId, contextFor(projectId)).finally(() => {
+      inFlight.delete(projectId);
+    });
+  }
+}
+
+function contextForSubscribed(projectId: string): WorkspaceCollabContext | null {
+  for (const subscription of subscriptions) {
+    if (subscription.ids.includes(projectId)) return subscription.contextRef.current;
+  }
+  return null;
+}
+
+/** Every subscribed surface's ids together, each once. */
+function refreshAll(): void {
+  const union = new Set<string>();
+  for (const subscription of subscriptions) {
+    for (const projectId of subscription.ids) union.add(projectId);
+  }
+  refresh(union, contextForSubscribed);
+}
+
+function startFeed(): void {
+  if (typeof window === 'undefined') return;
+  if (pollTimer === null) pollTimer = setInterval(refreshAll, POLL_MS);
+  if (!listeningForRunsChanged) {
+    window.addEventListener(RUNS_CHANGED_EVENT, refreshAll);
+    listeningForRunsChanged = true;
+  }
+}
+
+function stopFeed(): void {
+  if (pollTimer !== null) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+  if (listeningForRunsChanged) {
+    window.removeEventListener(RUNS_CHANGED_EVENT, refreshAll);
+    listeningForRunsChanged = false;
+  }
+}
+
+function addSubscription(subscription: Subscription): void {
+  subscriptions.add(subscription);
+  // Always revalidate on subscribe — a surface that comes back shows its last
+  // known answer at once and catches up on whatever moved meanwhile — but
+  // never blank: the cache is only ever replaced, not cleared.
+  refresh(subscription.ids, () => subscription.contextRef.current);
+  startFeed();
+}
+
+function removeSubscription(subscription: Subscription): void {
+  subscriptions.delete(subscription);
+  if (subscriptions.size === 0) stopFeed();
+}
+
+/**
+ * Opening a project is what spends its ✓ (per product). Recorded once, for the
+ * finished run currently shown, and announced to every surface at once — the
+ * rail and the tab switcher drop the mark in the same moment (OPEND-2795).
+ * A project whose live status is not `succeeded` has nothing to spend.
+ */
+export function acknowledgeProjectCompletion(projectId: string): void {
+  const summary = summaries.get(projectId);
+  if (!summary || summary.status !== 'succeeded' || !summary.latestTerminalRunId) return;
+  const runId = summary.latestTerminalRunId;
+  const current = acknowledgedRuns();
+  if (current[projectId] === runId) return;
+  acknowledged = { ...current, [projectId]: runId };
+  writeStoredAcknowledgedRuns(acknowledged);
+  emit();
+}
+
+/**
+ * Forget every cached status, acknowledgement and in-flight read. Test seam,
+ * following `resetCoalescedGet`: the cache is module-level on purpose (it must
+ * survive a surface remount), so a test boundary has to clear it explicitly.
+ */
+export function resetProjectRunStatusStore(): void {
+  generation += 1;
+  summaries.clear();
+  acknowledged = null;
+  inFlight.clear();
+  subscriptions.clear();
+  stopFeed();
+  version += 1;
+}
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
 /**
  * Live `Map<projectId, ProjectRunSummary>`: the status plus the newest
- * finished run's identity, for a consumer that acknowledges notices per run.
+ * finished run's identity, for a consumer that needs the run behind a ✓.
+ * Glyph surfaces want {@link useProjectRunStatuses} instead.
  */
 export function useProjectRunSummaries(
   projectIds: readonly string[],
   options?: UseProjectRunStatusesOptions,
 ): ReadonlyMap<string, ProjectRunSummary> {
   const enabled = options?.enabled ?? true;
-  const workspaceContext = options?.workspaceContext ?? null;
-  const [summaries, setSummaries] = useState<ReadonlyMap<string, ProjectRunSummary>>(EMPTY);
-
-  // One request per id, so the effect must not re-run just because the caller
-  // rebuilt the array. Sorted + joined is the identity that actually matters.
-  const idsKey = useMemo(() => [...projectIds].sort().join('\u0000'), [projectIds]);
-  // Read inside the effect without making it a dependency: the context object
-  // is rebuilt on unrelated renders and would restart polling each time.
-  const workspaceContextRef = useRef(workspaceContext);
-  workspaceContextRef.current = workspaceContext;
+  // One subscription per id set, so the effect must not re-run just because
+  // the caller rebuilt the array. Sorted + joined is the identity that matters.
+  const idsKey = useMemo(() => [...projectIds].sort().join(' '), [projectIds]);
+  const contextRef = useRef<WorkspaceCollabContext | null>(options?.workspaceContext ?? null);
+  contextRef.current = options?.workspaceContext ?? null;
+  const storeVersion = useSyncExternalStore(subscribeToStore, getVersion, getVersion);
 
   useEffect(() => {
-    const ids = idsKey ? idsKey.split('\u0000') : [];
-    if (!enabled || ids.length === 0) {
-      setSummaries(EMPTY);
-      return undefined;
-    }
-    let cancelled = false;
-
-    const refresh = async () => {
-      const results = await Promise.all(
-        ids.map((id) => listRunsForProject(id, workspaceContextRef.current)),
-      );
-      if (cancelled) return;
-      // An unreadable project yields null; skipping it leaves that row blank
-      // rather than asserting a status nobody verified.
-      const runs = results.flatMap((result) => result?.runs ?? []);
-      const awaiting = results.flatMap((result) => result?.awaitingInputProjectIds ?? []);
-      setSummaries(foldRunsToProjectRunSummaries(runs, awaiting));
-    };
-
-    void refresh();
-    const onRunsChanged = () => void refresh();
-    window.addEventListener(RUNS_CHANGED_EVENT, onRunsChanged);
-    const timer = window.setInterval(() => void refresh(), POLL_MS);
-    return () => {
-      cancelled = true;
-      window.removeEventListener(RUNS_CHANGED_EVENT, onRunsChanged);
-      window.clearInterval(timer);
-    };
+    if (!enabled || !idsKey) return undefined;
+    const subscription: Subscription = { ids: idsKey.split(' '), contextRef };
+    addSubscription(subscription);
+    return () => removeSubscription(subscription);
   }, [idsKey, enabled]);
 
-  return summaries;
+  return useMemo(() => {
+    if (!enabled || !idsKey) return EMPTY_SUMMARIES;
+    const result = new Map<string, ProjectRunSummary>();
+    for (const projectId of idsKey.split(' ')) {
+      const summary = summaries.get(projectId);
+      if (summary) result.set(projectId, summary);
+    }
+    return result;
+    // storeVersion is the cache's change counter: the map is rebuilt when it
+    // moves, and only then.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [idsKey, enabled, storeVersion]);
 }
 
-/** The status half of {@link useProjectRunSummaries}, for glyph-only consumers. */
+/**
+ * Live `Map<projectId, ProjectDisplayStatus>` — what a glyph surface should
+ * DRAW per project, the one display mapping every surface shares
+ * (`displayStatusForSummary`). A project absent from the map shows its default
+ * mark: unknown, quiet, or a ✓ the user has already spent.
+ */
 export function useProjectRunStatuses(
   projectIds: readonly string[],
   options?: UseProjectRunStatusesOptions,
 ): ReadonlyMap<string, ProjectDisplayStatus> {
-  const summaries = useProjectRunSummaries(projectIds, options);
+  const runSummaries = useProjectRunSummaries(projectIds, options);
   return useMemo(() => {
+    if (runSummaries.size === 0) return EMPTY_STATUSES;
+    const seen = acknowledgedRuns();
     const statuses = new Map<string, ProjectDisplayStatus>();
-    for (const [projectId, summary] of summaries) statuses.set(projectId, summary.status);
+    for (const [projectId, summary] of runSummaries) {
+      const status = displayStatusForSummary(projectId, summary, seen);
+      if (status) statuses.set(projectId, status);
+    }
     return statuses;
-  }, [summaries]);
+  }, [runSummaries]);
 }

--- a/apps/web/src/state/projectRunStatus.ts
+++ b/apps/web/src/state/projectRunStatus.ts
@@ -142,6 +142,79 @@ export function foldRunsToProjectRunSummaries(
 }
 
 /**
+ * Which finished run the user has already looked at, per project (per product:
+ * 点进去之后对号换回默认 icon).
+ *
+ * Invariant: a ✓ is acknowledged for ONE specific finished run — the value is
+ * that run's id — and a newer finished run is a new notice. Keyed on the run
+ * rather than the project so the acknowledgement stays correct even when no
+ * surface was polling for the whole of the next run: the newest terminal run's
+ * id no longer matches and the ✓ shows again. Only a project whose live status
+ * is `succeeded` consults this at all.
+ *
+ * Persisted so a reload, which re-reads the same runs feed, does not re-raise
+ * every ✓ the user has already cleared. The key predates the shared feed (it
+ * was the rail's own), and is kept so existing acknowledgements survive.
+ */
+export type AcknowledgedRuns = Readonly<Record<string, string>>;
+
+export const ACKNOWLEDGED_RUNS_STORAGE_KEY = 'od.entry.railRecentSeenDone';
+
+export function readStoredAcknowledgedRuns(): AcknowledgedRuns {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(ACKNOWLEDGED_RUNS_STORAGE_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : null;
+    // Anything but a plain object of run ids — including a bare list of
+    // project ids, which cannot say which run it meant — reads as "nothing
+    // acknowledged". The worst case is one ✓ the user has already seen, never a
+    // missing one.
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const acknowledged: Record<string, string> = {};
+    for (const [projectId, runId] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof runId === 'string' && runId) acknowledged[projectId] = runId;
+    }
+    return acknowledged;
+  } catch {
+    return {};
+  }
+}
+
+export function writeStoredAcknowledgedRuns(acknowledged: AcknowledgedRuns): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(ACKNOWLEDGED_RUNS_STORAGE_KEY, JSON.stringify(acknowledged));
+  } catch {
+    // Private mode / storage disabled: the ✓ still clears for this session.
+  }
+}
+
+/**
+ * The status a glyph surface should DRAW for a project — the one display
+ * mapping every surface (the rail's 最近项目 rows, the workspace tab switcher)
+ * applies, so they can never tell different stories about the same project
+ * (OPEND-2795).
+ *
+ * An acknowledged ✓ is DROPPED (`undefined`: the row goes back to its default
+ * mark), not drawn quieter. Every other status is live and stays: a running,
+ * blocked or failed project is not a notice the user can spend.
+ */
+export function displayStatusForSummary(
+  projectId: string,
+  summary: ProjectRunSummary,
+  acknowledged: AcknowledgedRuns,
+): ProjectDisplayStatus | undefined {
+  if (
+    summary.status === 'succeeded'
+    && summary.latestTerminalRunId !== undefined
+    && acknowledged[projectId] === summary.latestTerminalRunId
+  ) {
+    return undefined;
+  }
+  return summary.status;
+}
+
+/**
  * `Map<projectId, ProjectDisplayStatus>` for every project the runs cover —
  * the status half of {@link foldRunsToProjectRunSummaries}, for consumers that
  * only draw a glyph and never acknowledge anything.

--- a/apps/web/tests/components/EntryNavRail.recent-section.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.recent-section.test.tsx
@@ -202,6 +202,56 @@ describe('EntryNavRail 最近浏览过 section', () => {
     expect(runRequests()).toHaveLength(44);
   });
 
+  it('asks for the rows\' statuses in the same commit that paints them (OPEND-2762)', () => {
+    // No hop through the scroll observer, no timer: the head of the list is
+    // known the moment the rows render, so its status reads leave right then.
+    renderRail();
+    const runRequests = vi.mocked(fetch).mock.calls.filter(([url]) =>
+      String(url).startsWith('/api/runs?projectId='));
+    // Ten rows: fewer than the head window, so every one of them.
+    expect(runRequests.map(([url]) => String(url)).sort()).toEqual(
+      Array.from({ length: 10 }, (_, i) => `/api/runs?projectId=p${i + 1}`).sort(),
+    );
+  });
+
+  it('keeps every glyph when the catalog is handed over again (OPEND-2762)', async () => {
+    // EntryShell rebuilds the catalog array on unrelated renders. That must
+    // neither blank the glyphs (a flash to the default mark and back) nor
+    // re-ask for statuses it already has.
+    const catalog = () => Array.from({ length: 10 }, (_, index) =>
+      project(`p${index + 1}`, 1_000 - index));
+    const tree = (projects: Project[]) => (
+      <I18nProvider initial="en">
+        <EntryNavRail
+          view="home"
+          onViewChange={() => {}}
+          onNewProject={() => {}}
+          open
+          context={signedInContext}
+          recentProjects={projects}
+        />
+      </I18nProvider>
+    );
+    const { rerender } = render(tree(catalog()));
+    const rowFor = (id: string) =>
+      screen.getAllByTestId('entry-nav-recent-item').find((row) => row.textContent === `Project ${id}`)!;
+    await waitFor(() => {
+      expect(within(rowFor('p4')).getByRole('img', { name: 'Completed' })).toBeTruthy();
+    });
+    const runRequests = () => vi.mocked(fetch).mock.calls.filter(([url]) =>
+      String(url).startsWith('/api/runs?projectId='));
+    const before = runRequests().length;
+
+    rerender(tree(catalog()));
+    // Synchronously after the commit, and again once the observer has had its
+    // say: the ✓ never leaves.
+    expect(within(rowFor('p4')).getByRole('img', { name: 'Completed' })).toBeTruthy();
+    expect(within(rowFor('p1')).getByRole('img', { name: 'Running' })).toBeTruthy();
+    await act(async () => { await Promise.resolve(); });
+    expect(within(rowFor('p4')).getByRole('img', { name: 'Completed' })).toBeTruthy();
+    expect(runRequests()).toHaveLength(before);
+  });
+
   it('renders nothing without projects or without a cloud identity', () => {
     renderRail({ recentProjects: [] });
     expect(screen.queryByTestId('entry-nav-recent-toggle')).toBeNull();

--- a/apps/web/tests/components/WorkspaceTabsBar.test.tsx
+++ b/apps/web/tests/components/WorkspaceTabsBar.test.tsx
@@ -2,7 +2,7 @@
 // @vitest-environment jsdom
 
 import { StrictMode } from 'react';
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -1841,6 +1841,69 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
       expect(JSON.stringify(parsed.scopes?.['user-1::ws-a'] ?? {})).toContain(
         'project-alpha',
       );
+    });
+  });
+});
+
+// OPEND-2795: the dock dropdown's lead glyph and the rail's 最近项目 rows read
+// ONE run-status feed, with one display mapping — including the rule that
+// opening a project spends its ✓. Before this, the switcher still drew a ✓ the
+// rail had already cleared for the same project.
+describe('WorkspaceTabsBar dock dropdown run status', () => {
+  const originalFetch = globalThis.fetch;
+  const dock = document.createElement('div');
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.clearAllMocks();
+    document.body.append(dock);
+    setWorkspaceTabsDock(dock);
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (url === '/api/runs?projectId=project-alpha') {
+        return new Response(JSON.stringify({
+          runs: [{
+            id: 'run-alpha-1',
+            projectId: 'project-alpha',
+            conversationId: null,
+            assistantMessageId: null,
+            agentId: 'claude',
+            status: 'succeeded',
+            createdAt: 1,
+            updatedAt: 2,
+          }],
+          awaitingInputProjectIds: [],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.fetch = originalFetch;
+    setWorkspaceTabsDock(null);
+    dock.remove();
+  });
+
+  it('leads a finished project with the ✓ and spends it when the row opens it', async () => {
+    render(<WorkspaceTabsBar route={{ ...projectRoute }} projects={[project]} />);
+    fireEvent.click(await screen.findByTestId('workspace-tabs-dropdown-trigger'));
+    const listbox = screen.getByRole('listbox');
+    await waitFor(() => {
+      expect(within(listbox).getByRole('img', { name: 'designs.status.succeeded' })).toBeTruthy();
+    });
+
+    fireEvent.click(within(listbox).getByRole('option', { name: /Project Alpha/ }));
+    // Same acknowledgement record the rail keeps, keyed on THIS finished run.
+    expect(JSON.parse(window.localStorage.getItem('od.entry.railRecentSeenDone') ?? '{}')).toEqual({
+      'project-alpha': 'run-alpha-1',
+    });
+
+    fireEvent.click(screen.getByTestId('workspace-tabs-dropdown-trigger'));
+    const reopened = screen.getByRole('listbox');
+    await waitFor(() => {
+      expect(within(reopened).queryByRole('img', { name: 'designs.status.succeeded' })).toBeNull();
     });
   });
 });

--- a/apps/web/tests/hooks/useProjectRunStatuses.test.tsx
+++ b/apps/web/tests/hooks/useProjectRunStatuses.test.tsx
@@ -1,0 +1,228 @@
+// @vitest-environment jsdom
+//
+// The one project-run-status feed every glyph surface reads (OPEND-2795,
+// OPEND-2762). The rail's 最近项目 rows and the workspace tab switcher used to
+// hold separate copies of it, each polling its own id set from a blank start;
+// these cases pin the invariants that make the two tell one story and paint
+// it with the list instead of after it.
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  acknowledgeProjectCompletion,
+  resetProjectRunStatusStore,
+  useProjectRunStatuses,
+  useProjectRunSummaries,
+} from '../../src/hooks/useProjectRunStatuses';
+import { RUNS_CHANGED_EVENT } from '../../src/providers/daemon';
+
+type RunFixture = { status: string; awaiting?: boolean; runId?: string; http?: number };
+
+const DEFAULT_RUNS: Record<string, RunFixture> = {
+  p1: { status: 'running' },
+  p2: { status: 'succeeded', awaiting: true },
+  p3: { status: 'failed' },
+  p4: { status: 'succeeded', runId: 'r1' },
+};
+
+let RUNS: Record<string, RunFixture> = { ...DEFAULT_RUNS };
+
+const originalFetch = globalThis.fetch;
+
+function stubFetch() {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    const match = /^\/api\/runs\?projectId=([^&]+)$/.exec(url);
+    if (!match) {
+      return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    const id = decodeURIComponent(match[1]!);
+    const fixture = RUNS[id];
+    if (fixture?.http && fixture.http !== 200) {
+      return new Response('{}', { status: fixture.http });
+    }
+    const runs = fixture
+      ? [{
+          id: fixture.runId ?? `run-${id}`,
+          projectId: id,
+          conversationId: null,
+          assistantMessageId: null,
+          agentId: 'claude',
+          status: fixture.status,
+          createdAt: 1,
+          updatedAt: 2,
+        }]
+      : [];
+    return new Response(
+      JSON.stringify({ runs, awaitingInputProjectIds: fixture?.awaiting ? [id] : [] }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  }) as unknown as typeof fetch;
+}
+
+function runRequests(projectId?: string): string[] {
+  return vi.mocked(fetch).mock.calls
+    .map(([url]) => String(url))
+    .filter((url) => url.startsWith('/api/runs?projectId=')
+      && (projectId === undefined || url === `/api/runs?projectId=${projectId}`));
+}
+
+async function flush() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0);
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  window.localStorage.clear();
+  RUNS = { ...DEFAULT_RUNS };
+  resetProjectRunStatusStore();
+  stubFetch();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.useRealTimers();
+});
+
+describe('useProjectRunStatuses — one feed for every surface', () => {
+  it('answers two surfaces asking about one project from one request', async () => {
+    // The rail asks for its visible rows, the tab switcher for its open tabs.
+    // Both include p1: exactly one `/api/runs?projectId=p1` may go out.
+    const rail = renderHook(() => useProjectRunStatuses(['p1', 'p2']));
+    const switcher = renderHook(() => useProjectRunStatuses(['p1', 'p3']));
+    await flush();
+
+    expect(runRequests('p1')).toHaveLength(1);
+    expect(rail.result.current.get('p1')).toBe('running');
+    expect(switcher.result.current.get('p1')).toBe('running');
+    expect(rail.result.current.get('p2')).toBe('awaiting_input');
+    expect(switcher.result.current.get('p3')).toBe('failed');
+  });
+
+  it('hands a remounting surface its last known statuses in the first render', async () => {
+    // Leaving a project for Home remounts the rail. It must not start blank
+    // and wait for the network again: the feed already knows the answer.
+    const first = renderHook(() => useProjectRunStatuses(['p1', 'p4']));
+    await flush();
+    expect(first.result.current.get('p1')).toBe('running');
+    first.unmount();
+
+    const second = renderHook(() => useProjectRunStatuses(['p1', 'p4']));
+    // Synchronously — before any request could have answered.
+    expect(second.result.current.get('p1')).toBe('running');
+    expect(second.result.current.get('p4')).toBe('succeeded');
+    // …and it still revalidates, so a status that moved while nobody was
+    // subscribed catches up without waiting for the poll.
+    expect(runRequests('p1')).toHaveLength(2);
+  });
+
+  it('keeps the last known status when one read fails, rather than blanking the row', async () => {
+    const { result } = renderHook(() => useProjectRunStatuses(['p1']));
+    await flush();
+    expect(result.current.get('p1')).toBe('running');
+
+    RUNS = { ...DEFAULT_RUNS, p1: { status: 'running', http: 502 } };
+    await act(async () => {
+      window.dispatchEvent(new Event(RUNS_CHANGED_EVENT));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    // A failed read says nothing about the project; the row must not flip to
+    // its default mark and back.
+    expect(result.current.get('p1')).toBe('running');
+  });
+
+  it('refreshes on the runs-changed event and keeps the poll as a backstop', async () => {
+    const { result } = renderHook(() => useProjectRunStatuses(['p1']));
+    await flush();
+    expect(runRequests('p1')).toHaveLength(1);
+
+    RUNS = { ...DEFAULT_RUNS, p1: { status: 'succeeded' } };
+    await act(async () => {
+      window.dispatchEvent(new Event(RUNS_CHANGED_EVENT));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.get('p1')).toBe('succeeded');
+    expect(runRequests('p1')).toHaveLength(2);
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(3_999); });
+    expect(runRequests('p1')).toHaveLength(2);
+    await act(async () => { await vi.advanceTimersByTimeAsync(1); });
+    expect(runRequests('p1')).toHaveLength(3);
+  });
+
+  it('polls the union of every surface once per tick, not once per surface', async () => {
+    renderHook(() => useProjectRunStatuses(['p1', 'p2']));
+    renderHook(() => useProjectRunStatuses(['p1', 'p3']));
+    await flush();
+    expect(runRequests()).toHaveLength(3);
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(4_000); });
+    expect(runRequests()).toHaveLength(6);
+    expect(runRequests('p1')).toHaveLength(2);
+  });
+
+  it('stops polling once the last surface lets go', async () => {
+    const only = renderHook(() => useProjectRunStatuses(['p1']));
+    await flush();
+    only.unmount();
+    await act(async () => { await vi.advanceTimersByTimeAsync(8_000); });
+    expect(runRequests('p1')).toHaveLength(1);
+  });
+
+  it('spends a finished run\'s ✓ on every surface at once, and re-raises it for a newer run', async () => {
+    const rail = renderHook(() => useProjectRunStatuses(['p4']));
+    const switcher = renderHook(() => useProjectRunStatuses(['p4', 'p1']));
+    await flush();
+    expect(rail.result.current.get('p4')).toBe('succeeded');
+    expect(switcher.result.current.get('p4')).toBe('succeeded');
+
+    // Opening the project (from either surface) is what spends the notice.
+    act(() => { acknowledgeProjectCompletion('p4'); });
+    expect(rail.result.current.get('p4')).toBeUndefined();
+    expect(switcher.result.current.get('p4')).toBeUndefined();
+    // Persisted per run, under the key the rail has always used.
+    expect(JSON.parse(window.localStorage.getItem('od.entry.railRecentSeenDone') ?? '{}')).toEqual({
+      p4: 'r1',
+    });
+
+    // A NEW finished run is a new notice for both.
+    RUNS = { ...DEFAULT_RUNS, p4: { status: 'succeeded', runId: 'r2' } };
+    await act(async () => { await vi.advanceTimersByTimeAsync(4_000); });
+    expect(rail.result.current.get('p4')).toBe('succeeded');
+    expect(switcher.result.current.get('p4')).toBe('succeeded');
+  });
+
+  it('only a succeeded run can be spent; running, failed and awaiting stay live', async () => {
+    const { result } = renderHook(() => useProjectRunStatuses(['p1', 'p2', 'p3']));
+    await flush();
+    act(() => {
+      acknowledgeProjectCompletion('p1');
+      acknowledgeProjectCompletion('p2');
+      acknowledgeProjectCompletion('p3');
+    });
+    expect(result.current.get('p1')).toBe('running');
+    expect(result.current.get('p2')).toBe('awaiting_input');
+    expect(result.current.get('p3')).toBe('failed');
+    expect(window.localStorage.getItem('od.entry.railRecentSeenDone')).toBeNull();
+  });
+
+  it('exposes the raw summary (run identity included) beside the display status', async () => {
+    const { result } = renderHook(() => useProjectRunSummaries(['p4']));
+    await flush();
+    expect(result.current.get('p4')).toEqual({
+      status: 'succeeded',
+      latestTerminalRunId: 'r1',
+      latestTerminalUpdatedAt: 2,
+    });
+  });
+
+  it('reads nothing and asks nothing while disabled', async () => {
+    const { result } = renderHook(() => useProjectRunStatuses(['p1'], { enabled: false }));
+    await flush();
+    expect(result.current.size).toBe(0);
+    expect(runRequests()).toHaveLength(0);
+  });
+});

--- a/apps/web/tests/setup/coalesced-get-reset.ts
+++ b/apps/web/tests/setup/coalesced-get-reset.ts
@@ -13,6 +13,7 @@ import { resetHtmlThumbnailSourceCache } from '../../src/components/html-thumbna
 import { resetProjectCoverSnapshots } from '../../src/lib/project-cover-cache';
 import { resetThumbnailLoadGateForTests } from '../../src/lib/thumbnail-load-gate';
 import { resetSharedCancellableGet } from '../../src/lib/shared-cancellable-get';
+import { resetProjectRunStatusStore } from '../../src/hooks/useProjectRunStatuses';
 
 beforeEach(() => {
   resetCoalescedGet();
@@ -29,4 +30,8 @@ beforeEach(() => {
   resetProjectCoverSnapshots();
   resetThumbnailLoadGateForTests();
   resetSharedCancellableGet();
+  // The project run-status feed is module-level so a remounting surface reads
+  // its last answer at once; clear it so one test's statuses (or spent ✓s)
+  // never seed the next.
+  resetProjectRunStatusStore();
 });

--- a/e2e/ui/entry-rail-run-status.test.ts
+++ b/e2e/ui/entry-rail-run-status.test.ts
@@ -1,0 +1,405 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '@/playwright/suite';
+import { applyStandardMocks } from '@/playwright/mock-factory';
+import { ensureRailOpen } from '@/playwright/rail';
+import { T } from '@/timeouts';
+
+// OPEND-2762 / OPEND-2795 — the rail's 最近项目 run-status glyphs, watched at
+// the browser boundary: when the status reads leave relative to the rows
+// painting, whether a glyph ever flashes away, and whether the same project
+// reads the same in the rail and the project switcher.
+//
+// The daemon is real; the signed-in Workspace, its project list and the
+// per-project runs feed are route mocks so each status is a known fixture and
+// the runs feed has a visible, controlled latency.
+
+const WORKSPACE = {
+  workspaceId: 'ui-ws-run-status',
+  workspaceName: 'Run status workspace',
+  workspaceType: 'personal',
+  workspaceMemberId: 'ui-wm-run-status',
+  role: 'owner',
+  memberStatus: 'active',
+  lifecycleState: 'active',
+  billingState: 'free',
+  planId: null,
+  seatSummary: { seatLimit: 1, usedSeats: 1, availableSeats: 0, isSeatFull: true },
+  permissions: {
+    canInviteMembers: false,
+    canManageBilling: true,
+    canViewWorkspaceSettings: true,
+    canManageSharedResources: false,
+    canShareProjects: false,
+    canWriteSyncedFiles: true,
+  },
+  workspaceSettingsUrl: 'https://console.example.test/settings?workspaceId=ui-ws-run-status',
+} as const;
+
+type RunStatus = 'running' | 'succeeded' | 'failed';
+
+const PROJECTS: ReadonlyArray<{
+  id: string;
+  name: string;
+  run: RunStatus | null;
+  awaiting?: boolean;
+}> = [
+  { id: 'ui-rs-running', name: 'Campaign landing (running)', run: 'running' },
+  { id: 'ui-rs-awaiting', name: 'Brand deck (awaiting)', run: 'succeeded', awaiting: true },
+  { id: 'ui-rs-done', name: 'Pricing page (done)', run: 'succeeded' },
+  { id: 'ui-rs-failed', name: 'Onboarding flow (failed)', run: 'failed' },
+  { id: 'ui-rs-quiet', name: 'Untouched notes', run: null },
+];
+
+/** How long the mocked runs feed takes to answer: long enough to see. */
+const RUNS_LATENCY_MS = 300;
+
+function projectRow(project: (typeof PROJECTS)[number]) {
+  const base = {
+    id: project.id,
+    name: project.name,
+    skillId: null,
+    designSystemId: null,
+    createdAt: 1_720_000_000_000,
+    updatedAt: 1_720_000_000_000 + PROJECTS.length - PROJECTS.indexOf(project),
+    metadata: { kind: 'prototype', nameSource: 'user' },
+    workspaceId: WORKSPACE.workspaceId,
+  };
+  return {
+    ...base,
+    visibility: 'personal',
+    resourceState: 'active',
+    createdByWorkspaceMemberId: WORKSPACE.workspaceMemberId,
+    updatedByWorkspaceMemberId: WORKSPACE.workspaceMemberId,
+    resourceHubResourceId: null,
+    cloudTombstonedAt: null,
+    syncState: 'local_only',
+    currentUserAccess: {
+      canOpen: true,
+      canRename: true,
+      canDelete: true,
+      canDuplicate: true,
+      canMoveToTeam: false,
+      canMoveToPersonal: false,
+      canExport: true,
+      canSendTo: true,
+      canRestoreVersion: true,
+    },
+    project: base,
+  };
+}
+
+async function wireSignedInWorkspace(page: Page): Promise<{ runsRequests: string[] }> {
+  const runsRequests: string[] = [];
+
+  await page.route('**/api/integrations/vela/status', async (route) => {
+    await route.fulfill({
+      json: {
+        loggedIn: true,
+        loginInFlight: false,
+        profile: 'test',
+        user: { id: 'ui-run-status-user', email: 'run-status@example.com', name: 'Run Status', plan: 'free' },
+        account: { plan: 'free', balanceUsd: '0.00' },
+        configPath: '/tmp/.amr/config.json',
+      },
+    });
+  });
+
+  await page.route('**/api/workspace/**', async (route) => {
+    const request = route.request();
+    const { pathname } = new URL(request.url());
+    const method = request.method();
+    if (pathname === '/api/workspace/context' && method === 'GET') {
+      await route.fulfill({ json: { context: WORKSPACE } });
+      return;
+    }
+    if (pathname === '/api/workspace/directory' && method === 'GET') {
+      await route.fulfill({
+        json: {
+          items: [{
+            workspaceId: WORKSPACE.workspaceId,
+            workspaceName: WORKSPACE.workspaceName,
+            workspaceType: WORKSPACE.workspaceType,
+            workspaceMemberId: WORKSPACE.workspaceMemberId,
+            role: WORKSPACE.role,
+            memberStatus: WORKSPACE.memberStatus,
+            lifecycleState: WORKSPACE.lifecycleState,
+          }],
+          activeWorkspaceId: WORKSPACE.workspaceId,
+        },
+      });
+      return;
+    }
+    if (pathname === '/api/workspace/billing' && method === 'GET') {
+      await route.fulfill({
+        json: {
+          summary: null,
+          workspaceBalance: {
+            workspaceId: WORKSPACE.workspaceId,
+            workspaceMemberId: WORKSPACE.workspaceMemberId,
+            balanceUsd: '0.00',
+            billingScopeVersion: 2,
+            expiresAt: null,
+            updatedAt: '2026-07-31T00:00:00.000Z',
+          },
+        },
+      });
+      return;
+    }
+    if (pathname === '/api/workspace/projects/team' && method === 'GET') {
+      await route.fulfill({ json: { projects: [] } });
+      return;
+    }
+    await route.fallback();
+  });
+
+  await page.route('**/api/workspaces/*/projects**', async (route) => {
+    const request = route.request();
+    if (request.method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({ json: { projects: PROJECTS.map(projectRow) } });
+  });
+
+  await page.route('**/api/projects/*/workspace-scope', async (route) => {
+    const projectId = decodeURIComponent(new URL(route.request().url()).pathname.split('/').at(-2) ?? '');
+    await route.fulfill({
+      json: {
+        scope: {
+          kind: 'personal',
+          projectId,
+          workspaceId: WORKSPACE.workspaceId,
+          visibility: 'personal',
+          context: WORKSPACE,
+        },
+      },
+    });
+  });
+  await page.route('**/api/projects/*/files**', async (route) => {
+    await route.fulfill({ json: { files: [] } });
+  });
+  await page.route('**/api/projects/*/conversations**', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({ json: { conversations: [] } });
+  });
+  await page.route('**/api/projects/*', async (route) => {
+    const request = route.request();
+    const projectId = decodeURIComponent(new URL(request.url()).pathname.split('/').at(-1) ?? '');
+    const project = PROJECTS.find((candidate) => candidate.id === projectId);
+    if (request.method() !== 'GET' || !project) {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({ json: { project: projectRow(project).project } });
+  });
+
+  await page.route('**/api/runs?projectId=*', async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const projectId = url.searchParams.get('projectId') ?? '';
+    const project = PROJECTS.find((candidate) => candidate.id === projectId);
+    if (request.method() !== 'GET' || !project) {
+      await route.fallback();
+      return;
+    }
+    runsRequests.push(projectId);
+    await new Promise((resolve) => setTimeout(resolve, RUNS_LATENCY_MS));
+    await route.fulfill({
+      json: {
+        runs: project.run
+          ? [{
+              id: `run-${project.id}`,
+              projectId: project.id,
+              conversationId: null,
+              assistantMessageId: null,
+              agentId: 'claude',
+              status: project.run,
+              createdAt: 1_720_000_000_000,
+              updatedAt: 1_720_000_001_000,
+            }]
+          : [],
+        awaitingInputProjectIds: project.awaiting ? [project.id] : [],
+      },
+    });
+  });
+
+  return { runsRequests };
+}
+
+type PaintLog = {
+  /** performance.now() when the first 最近项目 row was attached. */
+  rowsAt: number | null;
+  /** performance.now() when the first status glyph inside a row was attached. */
+  glyphAt: number | null;
+  /** Status glyphs removed from the DOM — every one is a visible flash. */
+  glyphRemovals: number;
+};
+
+/**
+ * Watch the rail from inside the page: a MutationObserver stamps the first row
+ * and the first status glyph as they attach, and counts glyphs detaching.
+ * `reset()` re-arms it for a second navigation.
+ */
+async function installPaintLog(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const ROW = '[data-testid="entry-nav-recent-item"]';
+    const GLYPH = `${ROW} [role="img"]`;
+    const log: PaintLog = { rowsAt: null, glyphAt: null, glyphRemovals: 0 };
+    (window as unknown as { __odPaintLog: PaintLog }).__odPaintLog = log;
+    (window as unknown as { __odPaintLogReset: () => void }).__odPaintLogReset = () => {
+      log.rowsAt = null;
+      log.glyphAt = null;
+      log.glyphRemovals = 0;
+    };
+    const matches = (node: Node, selector: string) =>
+      node instanceof Element && (node.matches(selector) || node.querySelector(selector) !== null);
+    const observer = new MutationObserver((records) => {
+      const now = performance.now();
+      for (const record of records) {
+        for (const node of record.addedNodes) {
+          if (log.rowsAt === null && matches(node, ROW)) log.rowsAt = now;
+          if (log.glyphAt === null && matches(node, GLYPH)) log.glyphAt = now;
+        }
+        for (const node of record.removedNodes) {
+          if (node instanceof Element && (node.matches('[role="img"]') || node.querySelector('[role="img"]'))
+            && record.target instanceof Element && record.target.closest(ROW)) {
+            log.glyphRemovals += 1;
+          }
+        }
+      }
+    });
+    // `document` itself: an init script can run before <html> exists, and a
+    // subtree watch from the document node covers everything that follows.
+    observer.observe(document, { childList: true, subtree: true });
+  });
+}
+
+async function readPaintLog(page: Page): Promise<PaintLog> {
+  return page.evaluate(() => (window as unknown as { __odPaintLog: PaintLog }).__odPaintLog);
+}
+
+async function resetPaintLog(page: Page): Promise<void> {
+  await page.evaluate(() => (window as unknown as { __odPaintLogReset: () => void }).__odPaintLogReset());
+}
+
+/** The pinned Home tab inside a project: the SPA way back, not a reload. */
+function projectHomeTab(page: Page) {
+  return page.getByRole('banner', { name: /Workspace tabs/ }).getByRole('button', { name: /^(Home|首页)$/ });
+}
+
+function recentRow(page: Page, name: string) {
+  return page.getByTestId('entry-nav-recent-item').filter({ hasText: name }).first();
+}
+
+async function gotoHome(page: Page): Promise<void> {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.getByText('Loading OpenDesign…').waitFor({ state: 'hidden', timeout: T.long });
+  await expect(page.getByTestId('home-hero')).toBeVisible({ timeout: T.medium });
+  await ensureRailOpen(page);
+}
+
+async function expectRailStatuses(page: Page): Promise<void> {
+  await expect(recentRow(page, 'Campaign landing').getByRole('img', { name: /Running|运行中/ })).toBeVisible();
+  await expect(recentRow(page, 'Brand deck').getByRole('img', { name: /Needs input|等待输入/ })).toBeVisible();
+  await expect(recentRow(page, 'Pricing page').getByRole('img', { name: /Completed|已完成/ })).toBeVisible();
+  await expect(recentRow(page, 'Onboarding flow').getByRole('img', { name: /Failed|失败/ })).toBeVisible();
+  await expect(recentRow(page, 'Untouched notes').getByRole('img')).toHaveCount(0);
+}
+
+test.describe.configure({ timeout: T.xlong });
+
+test.beforeEach(async ({ page }) => {
+  await applyStandardMocks(page);
+  await installPaintLog(page);
+});
+
+test('[P1] first paint asks for every visible row\'s status once and never flashes a glyph away', async ({ page }) => {
+  const { runsRequests } = await wireSignedInWorkspace(page);
+  await gotoHome(page);
+  await expectRailStatuses(page);
+
+  const log = await readPaintLog(page);
+  const perProject = new Map<string, number>();
+  for (const id of runsRequests) perProject.set(id, (perProject.get(id) ?? 0) + 1);
+  await test.info().attach('rail-paint-log', {
+    body: JSON.stringify({ ...log, runsRequestsPerProject: Object.fromEntries(perProject) }, null, 2),
+    contentType: 'application/json',
+  });
+  expect(log.rowsAt).not.toBeNull();
+  expect(log.glyphAt).not.toBeNull();
+  // The glyphs can only land after the mocked feed answers; what must not
+  // happen is a glyph appearing and being torn down again while the catalog
+  // settles.
+  expect(log.glyphRemovals).toBe(0);
+  // One read per row while Home settles: the feed is asked as the rows paint,
+  // not once per re-render of the catalog.
+  for (const project of PROJECTS) expect(perProject.get(project.id), project.id).toBe(1);
+});
+
+test('[P1] returning from a project paints the rows and their statuses together', async ({ page }) => {
+  await wireSignedInWorkspace(page);
+  await gotoHome(page);
+  await expectRailStatuses(page);
+
+  // Into the running project (not a finished one, so nothing is spent) …
+  await recentRow(page, 'Campaign landing').click();
+  await expect(page).toHaveURL(/\/projects\/ui-rs-running/, { timeout: T.medium });
+  await expect(page.getByTestId('entry-nav-recent-item')).toHaveCount(0);
+
+  // … and back to Home through the pinned Home tab (the SPA path, not a reload).
+  await resetPaintLog(page);
+  await projectHomeTab(page).click();
+  await expect(page.getByTestId('home-hero')).toBeVisible({ timeout: T.medium });
+  await ensureRailOpen(page);
+  await expectRailStatuses(page);
+
+  const log = await readPaintLog(page);
+  await test.info().attach('rail-paint-log', {
+    body: JSON.stringify(log, null, 2),
+    contentType: 'application/json',
+  });
+  expect(log.rowsAt).not.toBeNull();
+  expect(log.glyphAt).not.toBeNull();
+  // The feed already knows these statuses: the rows and their glyphs are one
+  // paint, not a round trip apart.
+  expect(log.glyphAt! - log.rowsAt!).toBeLessThan(RUNS_LATENCY_MS / 2);
+  expect(log.glyphRemovals).toBe(0);
+});
+
+test('[P1] the project switcher and the rail tell one story about a finished project', async ({ page }) => {
+  await wireSignedInWorkspace(page);
+  await gotoHome(page);
+  await expectRailStatuses(page);
+
+  // Open the finished project from the rail: that spends its ✓.
+  await recentRow(page, 'Pricing page').click();
+  await expect(page).toHaveURL(/\/projects\/ui-rs-done/, { timeout: T.medium });
+
+  // The switcher inside the project reads the same feed — and the same rule.
+  // Wait for its own read of this project to land before judging: an early
+  // look would pass on a blank column that was about to fill with a ✓.
+  const switcherRead = page.waitForResponse((response) =>
+    response.request().method() === 'GET'
+    && response.url().includes('/api/runs?projectId=ui-rs-done'));
+  await page.getByTestId('workspace-tabs-dropdown-trigger').click();
+  const listbox = page.getByRole('listbox');
+  await expect(listbox.getByRole('option', { name: /Pricing page/ })).toBeVisible();
+  expect((await switcherRead).ok()).toBe(true);
+  await expect(listbox.getByRole('option', { name: /Pricing page/ }).getByRole('img', { name: /Completed|已完成/ })).toHaveCount(0);
+  await page.keyboard.press('Escape');
+
+  // Back on Home the rail agrees: the ✓ is gone there too, while every live
+  // status stays.
+  await projectHomeTab(page).click();
+  await expect(page.getByTestId('home-hero')).toBeVisible({ timeout: T.medium });
+  await ensureRailOpen(page);
+  await expect(recentRow(page, 'Pricing page')).toBeVisible();
+  await expect(recentRow(page, 'Pricing page').getByRole('img')).toHaveCount(0);
+  await expect(recentRow(page, 'Campaign landing').getByRole('img', { name: /Running|运行中/ })).toBeVisible();
+  await expect(recentRow(page, 'Brand deck').getByRole('img', { name: /Needs input|等待输入/ })).toBeVisible();
+  await expect(recentRow(page, 'Onboarding flow').getByRole('img', { name: /Failed|失败/ })).toBeVisible();
+});


### PR DESCRIPTION
Plane: [OPEND-2795](https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/236ff518-94bc-4a1a-8ebd-cc9ff0633042/) · [OPEND-2762](https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/546a716e-22fd-47ad-bb09-b6ae67d2362d/) — OPEND-2553 一期收口 PR-F2. Base is `feat/home-entry-refresh`, not `main`.

## Why

Two acceptance findings from the second round of OPEND-2553 (首页链路 Demo 复刻), both about the run-status glyph that leads a project row.

**OPEND-2795 — the rail and the project switcher disagreed about the same project.** A finished project showed the default icon in the rail's 最近项目 list and a green ✓ in the switcher inside the project. Root cause, verified with a browser spec: the two surfaces held *separate* copies of the run-status feed (`useProjectRunSummaries` in the rail, `useProjectRunStatuses` in the switcher — each with its own fetch, cache and poll timer), and only the rail applied the "opening a project spends its ✓" display rule (a per-run acknowledgement in localStorage). So the moment you opened a finished project from the rail, the rail cleared its ✓ and the switcher — reading its own copy with no acknowledgement — kept drawing one.

**OPEND-2762 — the rail's rows painted well ahead of their status glyphs, and the glyphs flashed.** Root cause, measured at the browser boundary with a 300 ms mocked runs feed:

- The rail asked for statuses only after a hop through an `IntersectionObserver` callback, and reset its request set to `[]` in an effect keyed on the catalog array — which `EntryShell` rebuilds on every render. Each rebuild blanked every glyph (hook state → empty map) and re-issued every request. On the baseline the same five projects were each requested **12 times** while Home settled, with **4 glyph tear-downs** (visible flashes), and the first glyph landed **787 ms** after the first row.
- Leaving a project unmounts the rail; coming back started the hook from an empty map, so the rows painted **623 ms** before their glyphs on the return path.

Neither root cause is in the daemon: `GET /api/runs?projectId=` answered in single-digit ms in the harness. The remaining per-project request shape and the 4 s poll backstop are daemon-side follow-ups (see "Adjacent issues").

## What users will see

- The 最近项目 rail rows and the project switcher dropdown always show the same status for the same project: running / needs-input / completed / failed glyphs are drawn by the same component from the same data, and change together.
- Opening a finished project — from the rail **or** from the switcher — spends its ✓ in both places at once (the existing product rule, now applied consistently). A newer finished run raises it again in both.
- Coming back to Home from a project, the rows and their status glyphs appear in the same paint; nothing pops in a moment later.
- On a cold load / refresh the rows show the neutral default mark until the runs feed answers, then the glyphs land once — no flash to default and back while the page settles, and no burst of repeated requests.
- A momentary failed read no longer blanks a row: the last known status stays until a good answer replaces it.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

No CLI surface: this changes how the web app reads an existing endpoint (`GET /api/runs?projectId=`), which `od run list --project` already exposes unchanged.

## Screenshots

Captured from `e2e/ui/entry-rail-run-status.test.ts` running against the baseline and this branch (same fixtures, same 300 ms mocked runs feed).

**OPEND-2795 — same finished project, opened from the rail, then the switcher inside it**

| Before | After |
|---|---|
| ![before: switcher still draws the ✓ the rail cleared](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f2/before-switcher-check.png) | ![after: the switcher agrees with the rail](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f2/after-switcher.png?v=2) |
| ![before: rail after returning home](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f2/before-rail.png) | ![after: rail after returning home](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f2/after-rail.png) |

**OPEND-2762 — Home → running project → back to Home**

| Before (glyphs 623 ms behind the rows; cold load also flashes ×4 with 12 requests per project) | After (rows and glyphs in one paint; one request per project) |
|---|---|
| ![before](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f2/return-home-before.gif) | ![after](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f2/return-home-after.gif) |

## Bug fix verification

Red on the base branch (`feat/home-entry-refresh`, the four source files swapped back) and green on this branch:

- `e2e/ui/entry-rail-run-status.test.ts` (Playwright, real daemon + route-mocked signed-in workspace and runs feed). Each spec attaches a `rail-paint-log` with the numbers below.
  - *first paint asks for every visible row's status once and never flashes a glyph away* — base: 4 glyph removals, 12 requests per project → branch: 0 removals, 1 request per project.
  - *returning from a project paints the rows and their statuses together* — base: glyph 623 ms after the first row → branch: 0 ms (same mutation batch).
  - *the project switcher and the rail tell one story about a finished project* — base: switcher draws a ✓ after its own read lands → branch: none, and the rail agrees on return.
- `apps/web/tests/hooks/useProjectRunStatuses.test.tsx` (new): one request for two subscribers of one project; a remount reads its last known statuses synchronously; a failed read keeps the last status; runs-changed event refresh + 4 s poll backstop (shared, stops with the last subscriber); acknowledgement spends the ✓ for every surface and re-raises for a newer run; only `succeeded` can be spent.
- `apps/web/tests/components/EntryNavRail.recent-section.test.tsx` (+2): status reads leave in the commit that paints the rows; re-handing the catalog array neither blanks a glyph nor re-requests.
- `apps/web/tests/components/WorkspaceTabsBar.test.tsx` (+1): the dock dropdown leads a finished project with the ✓ and opening it from there spends it (same localStorage record the rail keeps).

Went red on base, green on branch: **yes** (all 13 Vitest cases and all 3 Playwright cases).

## Validation

- `pnpm guard` ✅
- `pnpm typecheck` ✅ (`pnpm --filter @open-design/web typecheck`, `pnpm --filter @open-design/e2e typecheck`)
- `pnpm --filter @open-design/web test` ✅ — 690 files, 7325 passed, 1 expected fail, 11 skipped
- `pnpm -C e2e exec playwright test -c playwright.config.ts ui/entry-rail-run-status.test.ts` ✅ 3/3 on this branch; 3/3 red against base sources

## Design notes

- One module-level store in `apps/web/src/hooks/useProjectRunStatuses.ts` (subscribe via `useSyncExternalStore`): a project asked for by N surfaces costs one in-flight request; answers are only ever *replaced*, never cleared, so a remount paints the last known map in its first render and revalidates. One shared 4 s poll timer and one `RUNS_CHANGED_EVENT` listener for all subscribers; both stop with the last unsubscribe.
- The display mapping — including the per-run ✓ acknowledgement — moved out of the rail into `state/projectRunStatus.ts` (`displayStatusForSummary`, `readStoredAcknowledgedRuns`), so `useProjectRunStatuses` returns *what to draw* and both surfaces consume it. `acknowledgeProjectCompletion` is called from the rail row and from the switcher's `openTab`.
- The rail keeps its bounded polling (only rows in the scrollport), but asks for the head of the list (11 rows, the list's visible cap) synchronously with the first paint, and the observer set is no longer reset on every catalog hand-over.
- Cross-surface behaviour worth a product glance: the ✓-spending rule now also applies when a finished project is opened from the switcher. That is the consistent reading of "打开即消费"; if product wants completion to stay green everywhere instead, it is a one-line change in `displayStatusForSummary`.

## Adjacent issues (not in this PR)

- Daemon: there is no batch form of `GET /api/runs?projectId=` (the unscoped list 400s in a workspace session), so the rail still costs one request per visible row per poll. A `projectIds=` batch or attaching `status` to `GET /api/workspaces/:id/projects` would remove the round trip entirely on cold load.
- Daemon: no SSE for run lifecycle outside this client; runs started from the CLI or another window still surface on the 4 s backstop.
