### PR TITLE
fix(web): rail recent list scrolls in the sidebar, row menu gains duplicate/move-to-team, delete confirms in a dialog (OPEND-2553 F1)

### DIFF
--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -47,6 +47,8 @@ import {
   type WorkspaceCollabContext,
   type WorkspaceDirectoryItem,
   type WorkspaceDirectoryResponse,
+  type WorkspaceProjectSummary,
+  workspaceContextHasTeamIdentity,
 } from '@open-design/contracts';
 import {
   fetchVelaLoginStatus,
@@ -61,7 +63,18 @@ import { GITHUB_STARS_FALLBACK_LABEL, formatStars, useGithubStars } from './useG
 import { PlanWordmark, planBadgeTierForWorkspace } from './PlanWordmark';
 import { RemixIcon } from './RemixIcon';
 import { InviteDialog } from './InviteDialog';
-import { RailRecentRow } from './entry-nav-rail/RailRecentRow';
+import {
+  closeRailRecentRowMenu,
+  openRailRecentRowMenu,
+  RailRecentRow,
+} from './entry-nav-rail/RailRecentRow';
+import { MoveToTeamConfirmDialog, moveConfirmSkipped } from './MoveToTeamConfirmDialog';
+import { ProjectDeleteConfirmDialog } from './project-actions/ProjectDeleteConfirmDialog';
+import { projectOwnedBySelf } from './project-actions/ownership';
+import { useProjectDeleteFlow } from './project-actions/useProjectDeleteFlow';
+import { useProjectDuplicateFlow } from './project-actions/useProjectDuplicateFlow';
+import { useWorkspaceProjectMove } from './project-actions/useWorkspaceProjectMove';
+import type { SharedProjectPredicate } from '../collab/all-projects-list';
 import { useProjectRunSummaries } from '../hooks/useProjectRunStatuses';
 import { MessageCenter } from './MessageCenter';
 import type { EntrySettingsSection } from './EntrySettingsMenu';
@@ -88,6 +101,7 @@ import { useDeepSeekV4FlashCampaignVisibility } from '../campaigns/use-deepseek-
 import type { EntryHomeView } from '../router';
 import type {
   AccountMenuClickProps,
+  TrackingProjectCollectionPage,
   TrackingWorkspacePage,
 } from '@open-design/contracts/analytics';
 import { useAnalytics } from '../analytics/provider';
@@ -254,9 +268,22 @@ interface Props {
    *  never drift; this list only takes the head of it. Empty (or absent) hides
    *  the section entirely. */
   recentProjects?: Project[];
-  /** Row actions for the 最近浏览过 list's ⋮ menu. Omit either to drop its item. */
+  /** Row actions for the 最近项目 list's ⋮ menu (重命名 / 复制 / 转入团队空间 /
+   *  删除 — OPEND-2686, OPEND-2794). Omit one to drop its item. They are the
+   *  SAME handlers the project cards drive their menu with, so an action from
+   *  the rail lands in exactly one place. */
   onRenameRecentProject?: (id: string, name: string) => void;
   onDeleteRecentProject?: (id: string) => Promise<boolean | void> | boolean | void;
+  onDuplicateRecentProject?: (id: string) => Promise<void> | void;
+  /** The one shared-state answer for a row (see `createSharedProjectPredicate`)
+   *  and the hub's projectId → sharing member map; together they decide which
+   *  rows the member may mutate and which are already in the team space. */
+  isSharedRecentProject?: SharedProjectPredicate;
+  recentProjectOwnerMemberIds?: ReadonlyMap<string, string>;
+  /** Optimistic shared-state markers for a 转入团队空间 from the rail — the
+   *  same callbacks EntryShell hands the project cards. */
+  onRecentProjectShared?: (project: WorkspaceProjectSummary) => void;
+  onRecentProjectShareFailed?: (projectId: string) => void;
   /** Opens one of those projects — the pull-first opener, so a shared project
    *  that is not local yet still lands. */
   onOpenRecentProject?: (id: string) => void | Promise<unknown>;
@@ -395,17 +422,81 @@ function RailRecentSection({
   onOpen,
   onRename,
   onDelete,
+  onDuplicate,
+  isShared,
+  ownerMemberIds,
+  onProjectShared,
+  onProjectShareFailed,
   workspaceContext,
+  analyticsPage,
   label,
 }: {
   projects: Project[];
   onOpen?: (id: string) => void | Promise<unknown>;
   onRename?: (id: string, name: string) => void;
   onDelete?: (id: string) => Promise<boolean | void> | boolean | void;
+  onDuplicate?: (id: string) => Promise<void> | void;
+  isShared?: SharedProjectPredicate;
+  ownerMemberIds?: ReadonlyMap<string, string>;
+  onProjectShared?: (project: WorkspaceProjectSummary) => void;
+  onProjectShareFailed?: (projectId: string) => void;
   workspaceContext?: WorkspaceCollabContext | null;
+  analyticsPage: TrackingWorkspacePage;
   label: string;
 }) {
   const [open, setOpen] = useState(readStoredRecentOpen);
+  // The row actions report under the project-collection page the rail is
+  // standing on; every other entry view files under Home, where the rail's
+  // list is the recent-projects surface.
+  const collectionPage: TrackingProjectCollectionPage =
+    analyticsPage === 'drafts' || analyticsPage === 'all_projects' ? analyticsPage : 'home';
+  // The same gates the project cards apply (RecentProjectsStrip): a move needs
+  // a team plane to move into AND the right to share, and only the member's
+  // own projects can be changed at all.
+  const moveToTeamAvailable =
+    workspaceContextHasTeamIdentity(workspaceContext)
+    && workspaceContext?.permissions.canShareProjects === true;
+  const isSharedProject: SharedProjectPredicate = isShared ?? (() => false);
+  const ownedBySelf = (projectId: string) => projectOwnedBySelf({
+    projectId,
+    ownerMemberIds,
+    selfMemberId: workspaceContext?.workspaceMemberId,
+    isShared: isSharedProject,
+  });
+  // 删除 confirms through the shared project delete dialog (OPEND-2797) — one
+  // component for the rail and the project cards.
+  const deleteFlow = useProjectDeleteFlow({
+    onDelete,
+    analyticsPage: collectionPage,
+    workspaceContext,
+  });
+  const duplicateFlow = useProjectDuplicateFlow({
+    onDuplicate,
+    analyticsPage: collectionPage,
+    workspaceContext,
+  });
+  // 转入团队空间 runs the flow the project cards run, confirmation dialog
+  // included. Its progress and failure show in the row's ⋮ menu — the card
+  // menu is where the cards report theirs — so the section re-opens that menu
+  // once the request is on its way and closes it again on success.
+  const moveFlow = useWorkspaceProjectMove({
+    workspaceContext,
+    analyticsPage: collectionPage,
+    onProjectShared,
+    onProjectShareFailed,
+    onMoveStart: (project) => openRailRecentRowMenu(project.id),
+    onMoveSettled: (project, _action, ok) => {
+      if (ok) closeRailRecentRowMenu(project.id);
+    },
+  });
+  const [moveTarget, setMoveTarget] = useState<Project | null>(null);
+  function requestMoveToTeam(project: Project) {
+    if (moveConfirmSkipped()) {
+      void moveFlow.shareToTeam(project);
+      return;
+    }
+    setMoveTarget(project);
+  }
   // Every recent project, newest first (OPEND-2757: the old 8-row cap hid the
   // rest from the rail entirely). The LIST scrolls past ~11 rows, not the rail
   // — see `.entry-nav-rail__recent-list` in entry-layout.css.
@@ -523,9 +614,16 @@ function RailRecentSection({
                     project={project}
                     workspaceContext={workspaceContext}
                     runStatus={acknowledged ? undefined : status}
+                    ownedBySelf={ownedBySelf(project.id)}
+                    shared={isSharedProject(project.id)}
+                    moveToTeamAvailable={moveToTeamAvailable}
+                    sharing={moveFlow.sharingId === project.id}
+                    shareError={moveFlow.error?.projectId === project.id ? moveFlow.error.kind : null}
                     onOpen={openProject}
                     onRename={onRename}
-                    onDelete={onDelete}
+                    onDuplicate={onDuplicate ? (target) => { void duplicateFlow.duplicate(target); } : undefined}
+                    onMoveToTeam={requestMoveToTeam}
+                    onDelete={onDelete ? deleteFlow.request : undefined}
                   />
                 </li>
               );
@@ -533,6 +631,26 @@ function RailRecentSection({
           </ul>
         </div>
       </div>
+      {deleteFlow.target ? (
+        <ProjectDeleteConfirmDialog
+          projectName={deleteFlow.target.name}
+          pending={deleteFlow.pending}
+          failed={deleteFlow.failed}
+          onCancel={deleteFlow.cancel}
+          onConfirm={() => void deleteFlow.commit()}
+        />
+      ) : null}
+      {moveTarget ? (
+        <MoveToTeamConfirmDialog
+          action="to-team"
+          onCancel={() => setMoveTarget(null)}
+          onConfirm={() => {
+            const project = moveTarget;
+            setMoveTarget(null);
+            void moveFlow.shareToTeam(project);
+          }}
+        />
+      ) : null}
     </div>
   );
 }
@@ -1519,6 +1637,11 @@ export function EntryNavRail({
   onOpenRecentProject,
   onRenameRecentProject,
   onDeleteRecentProject,
+  onDuplicateRecentProject,
+  isSharedRecentProject,
+  recentProjectOwnerMemberIds,
+  onRecentProjectShared,
+  onRecentProjectShareFailed,
   priorityAnnouncementActive,
   onPriorityAnnouncementPendingChange,
   priorityAnnouncementCurrentPlanId,
@@ -2046,7 +2169,13 @@ export function EntryNavRail({
               onOpen={onOpenRecentProject}
               onRename={onRenameRecentProject}
               onDelete={onDeleteRecentProject}
+              onDuplicate={onDuplicateRecentProject}
+              isShared={isSharedRecentProject}
+              ownerMemberIds={recentProjectOwnerMemberIds}
+              onProjectShared={onRecentProjectShared}
+              onProjectShareFailed={onRecentProjectShareFailed}
               workspaceContext={context}
+              analyticsPage={analyticsPage}
               label={t('recentProjects.title')}
             />
             {/* Product decision (2026-07-20): 成员 and 数据大盘 leave the rail

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -1751,6 +1751,13 @@ export function EntryShell({
              rename or a delete from the rail lands in exactly one place. */
           onRenameRecentProject={onRenameProject}
           onDeleteRecentProject={onDeleteProject}
+          onDuplicateRecentProject={onDuplicateProject}
+          /* And the same shared-state answer + optimistic markers the grids
+             get, so 转入团队空间 from the rail updates every list at once. */
+          isSharedRecentProject={isSharedProject}
+          recentProjectOwnerMemberIds={teamProjectOwnerMemberIds}
+          onRecentProjectShared={markProjectShared}
+          onRecentProjectShareFailed={markProjectShareFailed}
           priorityAnnouncementActive={
             view === 'home'
             && goPlanSunsetMessagePending

--- a/apps/web/src/components/RecentProjectsStrip.tsx
+++ b/apps/web/src/components/RecentProjectsStrip.tsx
@@ -29,6 +29,10 @@ import type { DesignSystemSummary, Project, ProjectDisplayStatus, ProjectFile } 
 import { Icon } from './Icon';
 import type { IconName } from './Icon';
 import { InviteDialog } from './InviteDialog';
+import { ProjectDeleteConfirmDialog } from './project-actions/ProjectDeleteConfirmDialog';
+import { useProjectDeleteFlow } from './project-actions/useProjectDeleteFlow';
+import { useProjectDuplicateFlow } from './project-actions/useProjectDuplicateFlow';
+import { useWorkspaceProjectMove } from './project-actions/useWorkspaceProjectMove';
 import { STATUS_LABEL_KEYS } from './DesignsTab';
 import { isDesignSystemProject, isPublishedDesignSystemProject } from './design-system-project';
 import type { SharedProjectPredicate } from '../collab/all-projects-list';
@@ -44,7 +48,7 @@ import {
   workspaceInviteAvailableSeats,
   workspaceUpgradeUrl,
 } from './EntryNavRail';
-import { moveWorkspaceProject, workspaceProjectMoveErrorCode } from '../state/projects';
+import { moveWorkspaceProject } from '../state/projects';
 import {
   workspaceContextHasTeamIdentity,
   type WorkspaceCollabContext,
@@ -76,7 +80,6 @@ import {
 } from '../analytics/events';
 import {
   countBucket,
-  stableAnalyticsRequestErrorCode,
   workspaceAnalyticsDimensions,
 } from '../analytics/workspace';
 import type { ProjectCollectionClickProps } from '@open-design/contracts/analytics';
@@ -486,24 +489,27 @@ export function RecentProjectsStrip({
   const [menuPlacement, setMenuPlacement] = useState<'down' | 'up'>('down');
   const [renameTarget, setRenameTarget] = useState<{ id: string; original: string } | null>(null);
   const [renameInput, setRenameInput] = useState('');
-  const [confirmTarget, setConfirmTarget] = useState<Project | null>(null);
-  // recvqbh189zBY6: commitDelete used to await onDelete and drop the result on
-  // the floor either way — a 403/network failure closed the dialog exactly
-  // like a success, leaving the project right where it was with no signal
-  // that anything went wrong. Track failure so the dialog can stay open and
-  // say so instead of silently doing nothing.
-  const [deleteFailed, setDeleteFailed] = useState(false);
-  const [deletePending, setDeletePending] = useState(false);
-  // Project → team-space sharing (the project card entry). The daemon gates on
-  // `canShareProjects` (403 off-team / no rights), so we only badge on success.
-  const [sharingId, setSharingId] = useState<string | null>(null);
-  const [unsharingId, setUnsharingId] = useState<string | null>(null);
-  const [shareErrorProjectId, setShareErrorProjectId] = useState<string | null>(null);
-  // 'owner-conflict' is the daemon's TEAM_PROJECT_OWNER_CONFLICT refusal: the
-  // team hub already registers this project under another member's ownership.
-  // That state is permanent until the registered owner unshares, so it gets
-  // its own message instead of the retryable 'share' hint.
-  const [shareErrorKind, setShareErrorKind] = useState<'share' | 'unshare' | 'owner-conflict'>('share');
+  // Delete confirm → request → settle, shared with the rail's 最近项目 rows
+  // (OPEND-2797) so both entry points open the very same dialog. A failed
+  // request keeps that dialog open with a visible reason (recvqbh189zBY6).
+  const deleteFlow = useProjectDeleteFlow({ onDelete, analyticsPage, workspaceContext });
+  const duplicateFlow = useProjectDuplicateFlow({ onDuplicate, analyticsPage, workspaceContext });
+  // Project → team-space sharing (the project card entry), through the flow
+  // the rail rows share. The card menu is this surface's progress readout: it
+  // stays open to say 分享中… and to hold the failure text, so a move keeps
+  // (re)opening it until the request succeeds.
+  const moveFlow = useWorkspaceProjectMove({
+    workspaceContext,
+    analyticsPage,
+    onProjectShared,
+    onProjectShareFailed,
+    onProjectUnshared,
+    onMoveStart: (project) => setMenuOpenId(project.id),
+    onMoveSettled: (project, _action, ok) => setMenuOpenId(ok ? null : project.id),
+  });
+  const { sharingId, unsharingId } = moveFlow;
+  const shareErrorProjectId = moveFlow.error?.projectId ?? null;
+  const shareErrorKind = moveFlow.error?.kind ?? 'share';
   // Whether a card is team-shared is decided upstream, not here — the grids'
   // 全部项目 / 草稿 partition reads the very same predicate, so the badge and the
   // card's grid can no longer disagree.
@@ -562,7 +568,6 @@ export function RecentProjectsStrip({
   const menuContainerRef = useRef<HTMLDivElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
   const renameTitleId = useId();
-  const confirmTitleId = useId();
   const moveTitleId = useId();
   const bulkMoveTitleId = useId();
   const bulkDeleteTitleId = useId();
@@ -1050,109 +1055,17 @@ export function RecentProjectsStrip({
       project_relation: 'self',
     });
     setMenuOpenId(null);
-    setDeleteFailed(false);
-    setConfirmTarget(project);
+    deleteFlow.request(project);
   }
 
   // Promote/demote a project through the same workspace move endpoint used by
   // the full project grid so cards and in-file sharing cannot drift.
-  async function handleShareToTeam(project: Project) {
-    const startedAt = performance.now();
-    setShareErrorProjectId(null);
-    setMenuOpenId(project.id);
-    setSharingId(project.id);
-    try {
-      const movedProject = await moveWorkspaceProject({
-        projectId: project.id,
-        visibility: 'team',
-        workspaceContext,
-      });
-      onProjectShared?.(movedProject);
-      notifyTeamProjectsChanged();
-      setMenuOpenId(null);
-      trackWorkspaceProjectActionResult(analytics.track, {
-        page_name: analyticsPage,
-        area: 'project_collection',
-        action: 'move_to_team',
-        result: 'success',
-        requested_count: 1,
-        succeeded_count: 1,
-        failed_count: 0,
-        duration_ms: Math.round(performance.now() - startedAt),
-        ...workspaceDimensions,
-      });
-    } catch (err) {
-      onProjectShareFailed?.(project.id);
-      console.warn('[RecentProjectsStrip] share project to team failed:', err);
-      setShareErrorProjectId(project.id);
-      setShareErrorKind(
-        workspaceProjectMoveErrorCode(err) === 'TEAM_PROJECT_OWNER_CONFLICT'
-          ? 'owner-conflict'
-          : 'share',
-      );
-      setMenuOpenId(project.id);
-      trackWorkspaceProjectActionResult(analytics.track, {
-        page_name: analyticsPage,
-        area: 'project_collection',
-        action: 'move_to_team',
-        result: 'failed',
-        requested_count: 1,
-        succeeded_count: 0,
-        failed_count: 1,
-        duration_ms: Math.round(performance.now() - startedAt),
-        error_code: workspaceProjectMoveErrorCode(err) ?? 'request_failed',
-        ...workspaceDimensions,
-      });
-    } finally {
-      setSharingId(null);
-    }
+  function handleShareToTeam(project: Project) {
+    return moveFlow.shareToTeam(project);
   }
 
-  async function handleUnshareFromTeam(project: Project) {
-    const startedAt = performance.now();
-    setShareErrorProjectId(null);
-    setMenuOpenId(project.id);
-    setUnsharingId(project.id);
-    try {
-      await moveWorkspaceProject({
-        projectId: project.id,
-        visibility: 'personal',
-        workspaceContext,
-      });
-      onProjectUnshared?.(project.id);
-      notifyTeamProjectsChanged();
-      setMenuOpenId(null);
-      trackWorkspaceProjectActionResult(analytics.track, {
-        page_name: analyticsPage,
-        area: 'project_collection',
-        action: 'move_to_personal',
-        result: 'success',
-        requested_count: 1,
-        succeeded_count: 1,
-        failed_count: 0,
-        duration_ms: Math.round(performance.now() - startedAt),
-        ...workspaceDimensions,
-      });
-    } catch (err) {
-      console.warn('[RecentProjectsStrip] unshare project from team failed:', err);
-      setShareErrorProjectId(project.id);
-      setShareErrorKind('unshare');
-      setMenuOpenId(project.id);
-      trackWorkspaceProjectActionResult(analytics.track, {
-        page_name: analyticsPage,
-        area: 'project_collection',
-        action: 'move_to_personal',
-        result: 'failed',
-        requested_count: 1,
-        succeeded_count: 0,
-        failed_count: 1,
-        duration_ms: Math.round(performance.now() - startedAt),
-        error_code: workspaceProjectMoveErrorCode(err) ?? 'request_failed',
-        ...workspaceDimensions,
-      });
-    } finally {
-      setUnsharingId(null);
-    }
+  function handleUnshareFromTeam(project: Project) {
+    return moveFlow.unshareFromTeam(project);
   }
 
   function requestDuplicate(project: Project) {
@@ -1168,94 +1081,7 @@ export function RecentProjectsStrip({
       project_relation: 'self',
     });
     setMenuOpenId(null);
-    const startedAt = performance.now();
-    void Promise.resolve(onDuplicate(project.id)).then(() => {
-      trackWorkspaceProjectActionResult(analytics.track, {
-        page_name: analyticsPage,
-        area: 'project_collection',
-        action: 'duplicate',
-        result: 'success',
-        requested_count: 1,
-        succeeded_count: 1,
-        failed_count: 0,
-        duration_ms: Math.round(performance.now() - startedAt),
-        ...workspaceDimensions,
-      });
-    }).catch((err) => {
-      console.warn('[RecentProjectsStrip] duplicate project failed:', err);
-      trackWorkspaceProjectActionResult(analytics.track, {
-        page_name: analyticsPage,
-        area: 'project_collection',
-        action: 'duplicate',
-        result: 'failed',
-        requested_count: 1,
-        succeeded_count: 0,
-        failed_count: 1,
-        duration_ms: Math.round(performance.now() - startedAt),
-        error_code: 'request_failed',
-        ...workspaceDimensions,
-      });
-    });
-  }
-
-  async function commitDelete() {
-    if (!confirmTarget || !onDelete || deletePending) return;
-    const target = confirmTarget;
-    const startedAt = performance.now();
-    setDeleteFailed(false);
-    setDeletePending(true);
-    try {
-      const result = await onDelete(target.id);
-      // A falsy result (false, or void from a caller that never resolves the
-      // promise either way) means the daemon refused or the request failed —
-      // keep the dialog open with a visible reason instead of closing it as
-      // if the project were gone (recvqbh189zBY6).
-      if (result === false) {
-        trackWorkspaceProjectActionResult(analytics.track, {
-          page_name: analyticsPage,
-          area: 'project_collection',
-          action: 'delete',
-          result: 'failed',
-          requested_count: 1,
-          succeeded_count: 0,
-          failed_count: 1,
-          duration_ms: Math.round(performance.now() - startedAt),
-          error_code: 'request_failed',
-          ...workspaceDimensions,
-        });
-        setDeleteFailed(true);
-        return;
-      }
-      setConfirmTarget(null);
-      trackWorkspaceProjectActionResult(analytics.track, {
-        page_name: analyticsPage,
-        area: 'project_collection',
-        action: 'delete',
-        result: 'success',
-        requested_count: 1,
-        succeeded_count: 1,
-        failed_count: 0,
-        duration_ms: Math.round(performance.now() - startedAt),
-        ...workspaceDimensions,
-      });
-    } catch (err) {
-      console.warn('[RecentProjectsStrip] delete project failed:', err);
-      setDeleteFailed(true);
-      trackWorkspaceProjectActionResult(analytics.track, {
-        page_name: analyticsPage,
-        area: 'project_collection',
-        action: 'delete',
-        result: 'failed',
-        requested_count: 1,
-        succeeded_count: 0,
-        failed_count: 1,
-        duration_ms: Math.round(performance.now() - startedAt),
-        error_code: stableAnalyticsRequestErrorCode(err),
-        ...workspaceDimensions,
-      });
-    } finally {
-      setDeletePending(false);
-    }
+    void duplicateFlow.duplicate(project);
   }
 
   function toggleSelection(projectId: string) {
@@ -1917,7 +1743,7 @@ export function RecentProjectsStrip({
                         project_key: project.id,
                         project_relation: creator.ownedBySelf ? 'self' : 'other',
                       });
-                      setShareErrorProjectId(null);
+                      moveFlow.clearError();
                       setMenuOpenId((current) => current === project.id ? null : project.id);
                     }}
                   >
@@ -2071,48 +1897,14 @@ export function RecentProjectsStrip({
           </DialogFooter>
         </Dialog>
       ) : null}
-      {confirmTarget ? (
-        <Dialog
-          className="modal-confirm"
-          role="alertdialog"
-          onClose={() => {
-            if (deletePending) return;
-            setConfirmTarget(null);
-            setDeleteFailed(false);
-          }}
-          closeOnBackdrop={!deletePending}
-          ariaLabelledBy={confirmTitleId}
-        >
-          <DialogTitle id={confirmTitleId}>{t('designs.deleteTitle')}</DialogTitle>
-          <DialogDescription>
-            {t('designs.deleteConfirm', { name: confirmTarget.name })}
-          </DialogDescription>
-          {deleteFailed ? (
-            <p className="recent-projects__card-menu-error" role="alert">
-              {t('ds.actionFailed')}
-            </p>
-          ) : null}
-          <DialogFooter className="row">
-            <button
-              type="button"
-              disabled={deletePending}
-              onClick={() => {
-                setConfirmTarget(null);
-                setDeleteFailed(false);
-              }}
-            >
-              {t('designs.renameCancel')}
-            </button>
-            <button
-              type="button"
-              className="primary danger"
-              disabled={deletePending}
-              onClick={() => void commitDelete()}
-            >
-              {t('designs.menuDelete')}
-            </button>
-          </DialogFooter>
-        </Dialog>
+      {deleteFlow.target ? (
+        <ProjectDeleteConfirmDialog
+          projectName={deleteFlow.target.name}
+          pending={deleteFlow.pending}
+          failed={deleteFlow.failed}
+          onCancel={deleteFlow.cancel}
+          onConfirm={() => void deleteFlow.commit()}
+        />
       ) : null}
       {moveTarget ? (
         <Dialog

--- a/apps/web/src/components/entry-nav-rail/RailRecentRow.tsx
+++ b/apps/web/src/components/entry-nav-rail/RailRecentRow.tsx
@@ -5,17 +5,17 @@
 // `ProjectHoverPreview.tsx`, shared with the chat project switcher so both
 // surfaces show one and the same card for a project (OPEND-2694).
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import type { ProjectDisplayStatus, WorkspaceCollabContext } from '@open-design/contracts';
 
 import { useT } from '../../i18n';
-import { RemixIcon } from '../RemixIcon';
+import { Icon } from '../Icon';
 import { hasRunStatusGlyph, ProjectRunStatusIcon } from '../ProjectRunStatusIcon';
 import { STATUS_LABEL_KEYS } from '../../state/projectRunStatus';
-import { exportProjectAsZip } from '../../runtime/exports';
 import type { Project } from '../../types';
+import type { ProjectMoveErrorKind } from '../project-actions/useWorkspaceProjectMove';
 import { ProjectHoverPreviewCard, useProjectHoverCover } from './ProjectHoverPreview';
 
 /**
@@ -41,6 +41,21 @@ function claimPopup(next: PopupClaim) {
  *  by an earlier row's pointer-leave arriving afterwards. */
 function releasePopup(rowId: string, kind: 'preview' | 'menu') {
   if (popupClaim?.rowId === rowId && popupClaim.kind === kind) claimPopup(null);
+}
+
+/**
+ * Open (or close) one row's ⋮ menu from outside the row. The menu is where a
+ * row reports the progress and the failure of a move to the team space — the
+ * same readout the project cards keep in THEIR menu — but the confirm dialog
+ * that precedes the move has already dismissed it, so the section re-opens it
+ * once the request is on its way. The row measures its own anchor when the
+ * claim lands (see `useLayoutEffect` in `RailRecentRow`).
+ */
+export function openRailRecentRowMenu(rowId: string) {
+  claimPopup({ rowId, kind: 'menu' });
+}
+export function closeRailRecentRowMenu(rowId: string) {
+  releasePopup(rowId, 'menu');
 }
 
 /** Gap between the rail's right edge and the popup that hangs off it (per
@@ -138,8 +153,15 @@ export function RailRecentRow({
   project,
   workspaceContext,
   runStatus,
+  ownedBySelf = true,
+  shared = false,
+  moveToTeamAvailable = false,
+  sharing = false,
+  shareError = null,
   onOpen,
   onRename,
+  onDuplicate,
+  onMoveToTeam,
   onDelete,
 }: {
   project: Project;
@@ -147,9 +169,28 @@ export function RailRecentRow({
   /** This project's live run status, when it has one (per product: 如果有项目在
    *  进行，这个 icon 换成状态). Drives the leading glyph and nothing else. */
   runStatus?: ProjectDisplayStatus;
+  /** The daemon's canMutate is privileged-or-self-created and 403s the rest,
+   *  so a row someone else shared keeps its mutations disabled with the same
+   *  explanation the project cards give (`recentProjects.ownOnlyMutation`). */
+  ownedBySelf?: boolean;
+  /** Already in the team space: 转入团队空间 reads 已在团队空间 and is inert. */
+  shared?: boolean;
+  /** Whether the workspace has a team plane to move into at all; a personal
+   *  workspace hides the item entirely rather than offering a 403. */
+  moveToTeamAvailable?: boolean;
+  /** A move for THIS row is in flight: the item reads 分享中… and is inert. */
+  sharing?: boolean;
+  /** The last move for THIS row failed; shown under the items until the menu
+   *  closes. */
+  shareError?: ProjectMoveErrorKind | null;
   onOpen?: (id: string) => void | Promise<unknown>;
   onRename?: (id: string, name: string) => void;
-  onDelete?: (id: string) => Promise<boolean | void> | boolean | void;
+  onDuplicate?: (project: Project) => void;
+  onMoveToTeam?: (project: Project) => void;
+  /** Asks the SECTION to confirm (OPEND-2797): the row never deletes on its
+   *  own — the confirmation is the shared project delete dialog, the same one
+   *  the project cards open. */
+  onDelete?: (project: Project) => void;
 }) {
   const t = useT();
   const hoverCover = useProjectHoverCover(project, workspaceContext);
@@ -166,19 +207,24 @@ export function RailRecentRow({
   }, []);
   const ownsPreview = claim?.rowId === project.id && claim.kind === 'preview';
   const menuOpen = claim?.rowId === project.id && claim.kind === 'menu';
+  const rootRef = useRef<HTMLDivElement | null>(null);
   // The menu opens where the preview would have been (per product), which puts
-  // it outside the rail — so it needs its own anchor, frozen at click time.
-  // `anchor` cannot serve: it is cleared the moment the pointer leaves the row,
-  // which happens on the way to the menu itself.
+  // it outside the rail — so it needs its own anchor, frozen when the menu
+  // claim lands. `anchor` cannot serve: it is cleared the moment the pointer
+  // leaves the row, which happens on the way to the menu itself. Measured in
+  // an effect rather than in the ⋮ click so a menu the SECTION opens (to show
+  // a move's progress, see `openRailRecentRowMenu`) lands on the row too.
   const [menuAnchor, setMenuAnchor] = useState<{ top: number; left: number } | null>(null);
-  // Delete asks in place rather than through a dialog: the rail is a narrow
-  // column and a modal over it to confirm a one-line row is heavier than the
-  // action. The menu swaps to a confirm row and the click that destroys is a
-  // second, differently-labelled one.
-  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  useLayoutEffect(() => {
+    if (!menuOpen) {
+      setMenuAnchor(null);
+      return;
+    }
+    const rect = rootRef.current?.getBoundingClientRect();
+    if (rect) setMenuAnchor({ top: rect.top + rect.height / 2, left: rect.right + POPUP_GAP_PX });
+  }, [menuOpen]);
   const [renaming, setRenaming] = useState(false);
   const [draftName, setDraftName] = useState(project.name);
-  const rootRef = useRef<HTMLDivElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
   const renameInputRef = useRef<HTMLInputElement | null>(null);
   useEffect(() => {
@@ -194,7 +240,6 @@ export function RailRecentRow({
     if (!menuOpen) return undefined;
     function close() {
       releasePopup(project.id, 'menu');
-      setConfirmingDelete(false);
     }
     function onDocPointerDown(event: PointerEvent) {
       const target = event.target as Node;
@@ -231,6 +276,9 @@ export function RailRecentRow({
     if (!next || next === project.name) return;
     onRename?.(project.id, next);
   }
+
+  const hasMenu = Boolean(onRename || onDuplicate || onDelete || (moveToTeamAvailable && onMoveToTeam));
+  const foreignTitle = ownedBySelf ? undefined : t('recentProjects.ownOnlyMutation');
 
   return (
     <div
@@ -307,7 +355,7 @@ export function RailRecentRow({
           <span className="entry-nav-rail__recent-name">{project.name}</span>
         </button>
       )}
-      {onRename || onDelete ? (
+      {hasMenu ? (
         <button
           type="button"
           className="entry-nav-rail__recent-more"
@@ -320,9 +368,6 @@ export function RailRecentRow({
              is what made it impossible to click through to. */
           onClick={(event) => {
             event.stopPropagation();
-            setConfirmingDelete(false);
-            const rect = rootRef.current?.getBoundingClientRect();
-            if (rect) setMenuAnchor({ top: rect.top + rect.height / 2, left: rect.right + POPUP_GAP_PX });
             if (menuOpen) releasePopup(project.id, 'menu');
             else claimPopup({ rowId: project.id, kind: 'menu' });
           }}
@@ -333,20 +378,26 @@ export function RailRecentRow({
       {/* Same slot as the hover preview — beside the row, clear of the rail
           (per product: 弹窗的位置就是预览图的位置). Portalled for the same
           reason the preview is: inside the rail it would sit behind the content
-          column whatever its z-index. */}
+          column whatever its z-index.
+
+          Items, in order: 重命名 / 复制 / 转入团队空间 (team workspaces only) /
+          删除 — the product's list for this menu (OPEND-2686, OPEND-2794). No
+          导出: a list row has no rendered file to export, and the whole-project
+          archive the old item offered is not what this menu is for. */}
       {menuOpen && menuAnchor && typeof document !== 'undefined' ? createPortal(
         <div
           ref={menuRef}
           className="entry-nav-rail__recent-menu"
           role="menu"
+          data-testid="entry-nav-recent-menu"
           style={{ top: menuAnchor.top, left: menuAnchor.left }}
-          /* The pointer arriving here is what cancels the close the ⋮ scheduled
-             when it left; leaving the menu closes it. */
         >
           {onRename ? (
             <button
               type="button"
               role="menuitem"
+              disabled={!ownedBySelf}
+              title={foreignTitle}
               onClick={() => {
                 releasePopup(project.id, 'menu');
                 setDraftName(project.name);
@@ -357,63 +408,73 @@ export function RailRecentRow({
               <span>{t('designs.menuRename')}</span>
             </button>
           ) : null}
-          {/* Export sits between Rename and Delete (per product: 增加一个导出，
-              在删除上边). It is the ONE export a list row can honestly offer:
-              the project is not open here, so there is no rendered file to turn
-              into a PDF / image / standalone HTML — those four rows in the
-              viewer all need a loaded source. The whole-project archive needs
-              nothing but the id, so that is what this is.
-              Calls the shared runtime helper directly rather than taking an
-              `onExport` prop like its neighbours: Rename and Delete mutate
-              state the parent owns, while this one is a download — no parent
-              has anything to do with it.
-              `preview.exportMenu` is the bare word "Export" already translated
-              in all 19 locales (导出 / 匯出 / Exporter …); same reasoning as the
-              `designs.renameSave` reuse below, rather than a 20th copy of one
-              word in every file. */}
-          <button
-            type="button"
-            role="menuitem"
-            onClick={() => {
-              releasePopup(project.id, 'menu');
-              // No file scope: an empty `filePath` leaves `root` off the
-              // archive URL, which is what asks for the whole project.
-              void exportProjectAsZip({
-                projectId: project.id,
-                filePath: '',
-                fallbackHtml: '',
-                fallbackTitle: project.name,
-                workspaceContext,
-              });
-            }}
-          >
-            {/* The viewer's Export button glyph (per product), from the same
-                shared set it uses there — `RemixIcon name="download-line"`,
-                sized to this menu's 14px marks. */}
-            <RemixIcon name="download-line" size={14} />
-            <span>{t('preview.exportMenu')}</span>
-          </button>
+          {onDuplicate ? (
+            <button
+              type="button"
+              role="menuitem"
+              disabled={!ownedBySelf}
+              title={foreignTitle}
+              onClick={() => {
+                releasePopup(project.id, 'menu');
+                onDuplicate(project);
+              }}
+            >
+              <Icon name="copy" size={14} />
+              <span>{t('designs.menuDuplicate')}</span>
+            </button>
+          ) : null}
+          {/* Hidden, not disabled, in a workspace with no team plane: there is
+              nowhere to move to, and a disabled 转入团队空间 would name a place
+              the workspace cannot have (OPEND-2794: 无可用团队空间时按产品规则
+              隐藏). A shared row and a foreign row keep the item and explain
+              themselves instead. */}
+          {moveToTeamAvailable && onMoveToTeam ? (
+            <button
+              type="button"
+              role="menuitem"
+              disabled={sharing || shared || !ownedBySelf}
+              title={foreignTitle}
+              data-testid="entry-nav-recent-move-to-team"
+              onClick={() => {
+                releasePopup(project.id, 'menu');
+                onMoveToTeam(project);
+              }}
+            >
+              <Icon name="share" size={14} />
+              <span>
+                {sharing
+                  ? t('recentProjects.shareInProgress')
+                  : shared
+                    ? t('recentProjects.sharedInTeam')
+                    : t('recentProjects.moveToTeam')}
+              </span>
+            </button>
+          ) : null}
+          {shareError ? (
+            <div className="entry-nav-rail__recent-menu-error" role="alert">
+              {t(
+                shareError === 'unshare'
+                  ? 'recentProjects.unshareFailed'
+                  : shareError === 'owner-conflict'
+                    ? 'recentProjects.shareOwnerConflict'
+                    : 'recentProjects.shareFailed',
+              )}
+            </div>
+          ) : null}
           {onDelete ? (
             <button
               type="button"
               role="menuitem"
-              className={confirmingDelete ? 'is-danger' : undefined}
+              className="is-danger"
+              disabled={!ownedBySelf}
+              title={foreignTitle}
               onClick={() => {
-                if (!confirmingDelete) {
-                  setConfirmingDelete(true);
-                  return;
-                }
                 releasePopup(project.id, 'menu');
-                setConfirmingDelete(false);
-                void onDelete(project.id);
+                onDelete(project);
               }}
             >
               <DeleteMark />
-              {/* `designs.renameSave` is the generic confirm word in every
-                  locale (确定 / OK) — it just happens to live under the rename
-                  dialog. Reused rather than adding a 20th copy of the same
-                  string to all 19 locale files. */}
-              <span>{confirmingDelete ? t('designs.renameSave') : t('designs.menuDelete')}</span>
+              <span>{t('designs.menuDelete')}</span>
             </button>
           ) : null}
         </div>,

--- a/apps/web/src/components/project-actions/ProjectDeleteConfirmDialog.tsx
+++ b/apps/web/src/components/project-actions/ProjectDeleteConfirmDialog.tsx
@@ -1,0 +1,72 @@
+import { useId } from 'react';
+import { Dialog, DialogDescription, DialogFooter, DialogTitle } from '@open-design/components';
+
+import { useT } from '../../i18n';
+
+/**
+ * The one delete confirmation every project entry point shows (OPEND-2797):
+ * the Home / 草稿 / 全部项目 cards and the rail's 最近项目 rows all open this
+ * same dialog, so a stray click can never destroy a project from any of them.
+ * Names the project, offers 取消 + a red 删除, closes on Esc / scrim / 取消,
+ * and locks both buttons while the request is in flight so a double click
+ * cannot submit twice. A failed request keeps it open and says so.
+ *
+ * State lives in {@link useProjectDeleteFlow}; this is only the surface.
+ */
+export function ProjectDeleteConfirmDialog({
+  projectName,
+  pending,
+  failed,
+  onCancel,
+  onConfirm,
+}: {
+  projectName: string;
+  pending: boolean;
+  failed: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const t = useT();
+  const titleId = useId();
+  return (
+    <Dialog
+      className="modal-confirm"
+      role="alertdialog"
+      onClose={() => {
+        if (pending) return;
+        onCancel();
+      }}
+      closeOnBackdrop={!pending}
+      closeOnEscape={!pending}
+      ariaLabelledBy={titleId}
+      data-testid="project-delete-confirm-dialog"
+    >
+      <DialogTitle id={titleId}>{t('designs.deleteTitle')}</DialogTitle>
+      <DialogDescription>{t('designs.deleteConfirm', { name: projectName })}</DialogDescription>
+      {failed ? (
+        <p className="recent-projects__card-menu-error" role="alert">
+          {t('ds.actionFailed')}
+        </p>
+      ) : null}
+      <DialogFooter className="row">
+        <button
+          type="button"
+          disabled={pending}
+          onClick={onCancel}
+          data-testid="project-delete-confirm-cancel"
+        >
+          {t('designs.renameCancel')}
+        </button>
+        <button
+          type="button"
+          className="primary danger"
+          disabled={pending}
+          onClick={onConfirm}
+          data-testid="project-delete-confirm-accept"
+        >
+          {t('designs.menuDelete')}
+        </button>
+      </DialogFooter>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/project-actions/ownership.ts
+++ b/apps/web/src/components/project-actions/ownership.ts
@@ -1,0 +1,22 @@
+import type { SharedProjectPredicate } from '../../collab/all-projects-list';
+
+/**
+ * Whether the signed-in member may mutate (rename / duplicate / move / delete)
+ * a project: the daemon's `canMutate` is privileged-or-self-created, and it
+ * 403s everything else. A project the team hub does not attribute to anyone
+ * is the member's own local one — unless it is shared, in which case the
+ * missing attribution means "someone else's" (the hub row simply has not
+ * arrived yet).
+ */
+export function projectOwnedBySelf(input: {
+  projectId: string;
+  ownerMemberIds: ReadonlyMap<string, string> | undefined;
+  selfMemberId: string | null | undefined;
+  isShared: SharedProjectPredicate;
+}): boolean {
+  const ownerMemberId = input.ownerMemberIds?.get(input.projectId) ?? null;
+  return (
+    ownerMemberId === (input.selfMemberId ?? null)
+    || (!ownerMemberId && !input.isShared(input.projectId))
+  );
+}

--- a/apps/web/src/components/project-actions/useProjectDeleteFlow.ts
+++ b/apps/web/src/components/project-actions/useProjectDeleteFlow.ts
@@ -1,0 +1,106 @@
+import { useCallback, useState } from 'react';
+import type { WorkspaceCollabContext } from '@open-design/contracts';
+import type { TrackingProjectCollectionPage } from '@open-design/contracts/analytics';
+
+import { useAnalytics } from '../../analytics/provider';
+import { trackWorkspaceProjectActionResult } from '../../analytics/events';
+import {
+  stableAnalyticsRequestErrorCode,
+  workspaceAnalyticsDimensions,
+} from '../../analytics/workspace';
+import type { Project } from '../../types';
+
+/** Return `false` (or reject) when the daemon refused or the request failed;
+ *  anything else means the project is gone. */
+export type ProjectDeleteHandler = (id: string) => Promise<boolean | void> | boolean | void;
+
+/**
+ * The confirm → request → settle state behind {@link ProjectDeleteConfirmDialog},
+ * shared by the project cards and the rail rows so both surfaces delete
+ * through one path with one analytics story.
+ *
+ * `commit` never runs twice for one confirmation (`pending` gates it), and a
+ * falsy result keeps the dialog open with `failed` set — a 403 or a dropped
+ * request must not close the dialog as if the project were gone
+ * (recvqbh189zBY6).
+ */
+export function useProjectDeleteFlow(input: {
+  onDelete?: ProjectDeleteHandler;
+  analyticsPage: TrackingProjectCollectionPage;
+  workspaceContext: WorkspaceCollabContext | null | undefined;
+}) {
+  const { onDelete, analyticsPage, workspaceContext } = input;
+  const analytics = useAnalytics();
+  const [target, setTarget] = useState<Project | null>(null);
+  const [pending, setPending] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  const request = useCallback((project: Project) => {
+    setFailed(false);
+    setTarget(project);
+  }, []);
+
+  const cancel = useCallback(() => {
+    if (pending) return;
+    setTarget(null);
+    setFailed(false);
+  }, [pending]);
+
+  const commit = useCallback(async () => {
+    if (!target || !onDelete || pending) return;
+    const startedAt = performance.now();
+    const workspaceDimensions = workspaceAnalyticsDimensions(workspaceContext);
+    setFailed(false);
+    setPending(true);
+    try {
+      const result = await onDelete(target.id);
+      if (result === false) {
+        trackWorkspaceProjectActionResult(analytics.track, {
+          page_name: analyticsPage,
+          area: 'project_collection',
+          action: 'delete',
+          result: 'failed',
+          requested_count: 1,
+          succeeded_count: 0,
+          failed_count: 1,
+          duration_ms: Math.round(performance.now() - startedAt),
+          error_code: 'request_failed',
+          ...workspaceDimensions,
+        });
+        setFailed(true);
+        return;
+      }
+      setTarget(null);
+      trackWorkspaceProjectActionResult(analytics.track, {
+        page_name: analyticsPage,
+        area: 'project_collection',
+        action: 'delete',
+        result: 'success',
+        requested_count: 1,
+        succeeded_count: 1,
+        failed_count: 0,
+        duration_ms: Math.round(performance.now() - startedAt),
+        ...workspaceDimensions,
+      });
+    } catch (err) {
+      console.warn('[useProjectDeleteFlow] delete project failed:', err);
+      setFailed(true);
+      trackWorkspaceProjectActionResult(analytics.track, {
+        page_name: analyticsPage,
+        area: 'project_collection',
+        action: 'delete',
+        result: 'failed',
+        requested_count: 1,
+        succeeded_count: 0,
+        failed_count: 1,
+        duration_ms: Math.round(performance.now() - startedAt),
+        error_code: stableAnalyticsRequestErrorCode(err),
+        ...workspaceDimensions,
+      });
+    } finally {
+      setPending(false);
+    }
+  }, [analytics.track, analyticsPage, onDelete, pending, target, workspaceContext]);
+
+  return { target, pending, failed, request, cancel, commit };
+}

--- a/apps/web/src/components/project-actions/useProjectDuplicateFlow.ts
+++ b/apps/web/src/components/project-actions/useProjectDuplicateFlow.ts
@@ -1,0 +1,59 @@
+import { useCallback } from 'react';
+import type { WorkspaceCollabContext } from '@open-design/contracts';
+import type { TrackingProjectCollectionPage } from '@open-design/contracts/analytics';
+
+import { useAnalytics } from '../../analytics/provider';
+import { trackWorkspaceProjectActionResult } from '../../analytics/events';
+import { workspaceAnalyticsDimensions } from '../../analytics/workspace';
+import type { Project } from '../../types';
+
+export type ProjectDuplicateHandler = (id: string) => Promise<void> | void;
+
+/**
+ * 复制项目 from a card or a rail row: hands the id to the shell's duplicate
+ * handler (which POSTs `/api/projects/:id/duplicate`, the same call
+ * `od project duplicate` makes) and reports the outcome once, so both
+ * surfaces tell one analytics story.
+ */
+export function useProjectDuplicateFlow(input: {
+  onDuplicate?: ProjectDuplicateHandler;
+  analyticsPage: TrackingProjectCollectionPage;
+  workspaceContext: WorkspaceCollabContext | null | undefined;
+}) {
+  const { onDuplicate, analyticsPage, workspaceContext } = input;
+  const analytics = useAnalytics();
+  const duplicate = useCallback(async (project: Project): Promise<void> => {
+    if (!onDuplicate) return;
+    const startedAt = performance.now();
+    const workspaceDimensions = workspaceAnalyticsDimensions(workspaceContext);
+    try {
+      await onDuplicate(project.id);
+      trackWorkspaceProjectActionResult(analytics.track, {
+        page_name: analyticsPage,
+        area: 'project_collection',
+        action: 'duplicate',
+        result: 'success',
+        requested_count: 1,
+        succeeded_count: 1,
+        failed_count: 0,
+        duration_ms: Math.round(performance.now() - startedAt),
+        ...workspaceDimensions,
+      });
+    } catch (err) {
+      console.warn('[useProjectDuplicateFlow] duplicate project failed:', err);
+      trackWorkspaceProjectActionResult(analytics.track, {
+        page_name: analyticsPage,
+        area: 'project_collection',
+        action: 'duplicate',
+        result: 'failed',
+        requested_count: 1,
+        succeeded_count: 0,
+        failed_count: 1,
+        duration_ms: Math.round(performance.now() - startedAt),
+        error_code: 'request_failed',
+        ...workspaceDimensions,
+      });
+    }
+  }, [analytics.track, analyticsPage, onDuplicate, workspaceContext]);
+  return { duplicate };
+}

--- a/apps/web/src/components/project-actions/useWorkspaceProjectMove.ts
+++ b/apps/web/src/components/project-actions/useWorkspaceProjectMove.ts
@@ -1,0 +1,174 @@
+import { useCallback, useState } from 'react';
+import type { WorkspaceCollabContext, WorkspaceProjectSummary } from '@open-design/contracts';
+import type { TrackingProjectCollectionPage } from '@open-design/contracts/analytics';
+
+import { useAnalytics } from '../../analytics/provider';
+import { trackWorkspaceProjectActionResult } from '../../analytics/events';
+import { workspaceAnalyticsDimensions } from '../../analytics/workspace';
+import { notifyTeamProjectsChanged } from '../../collab/useWorkspaceContext';
+import { moveWorkspaceProject, workspaceProjectMoveErrorCode } from '../../state/projects';
+import type { Project } from '../../types';
+
+export type ProjectMoveAction = 'to-team' | 'to-personal';
+
+/** 'owner-conflict' is the daemon's TEAM_PROJECT_OWNER_CONFLICT refusal: the
+ *  team hub already registers this project under another member's ownership.
+ *  That state is permanent until the registered owner unshares, so it gets its
+ *  own message instead of the retryable 'share' hint. */
+export type ProjectMoveErrorKind = 'share' | 'unshare' | 'owner-conflict';
+
+export interface ProjectMoveError {
+  projectId: string;
+  kind: ProjectMoveErrorKind;
+}
+
+/**
+ * 转入 / 移出团队空间 for one project, through the same workspace move endpoint
+ * the full project grid uses so cards, rail rows and in-file sharing cannot
+ * drift. Owns the in-flight ids, the last failure, the optimistic shared-state
+ * callbacks and the result analytics; the surface that calls it decides how to
+ * show those (the card menu stays open to say 分享中… / the failure; the rail
+ * re-opens its row menu for the same purpose).
+ *
+ * The daemon gates on `canShareProjects` (403 off-team / no rights), so the
+ * shared badge is only ever raised on success.
+ */
+export function useWorkspaceProjectMove(input: {
+  workspaceContext: WorkspaceCollabContext | null | undefined;
+  analyticsPage: TrackingProjectCollectionPage;
+  onProjectShared?: (project: WorkspaceProjectSummary) => void;
+  onProjectShareFailed?: (projectId: string) => void;
+  onProjectUnshared?: (projectId: string) => void;
+  /** The request is on its way: the host may open its progress surface. */
+  onMoveStart?: (project: Project, action: ProjectMoveAction) => void;
+  /** The request settled; `ok` false means `error` now names the project. */
+  onMoveSettled?: (project: Project, action: ProjectMoveAction, ok: boolean) => void;
+}) {
+  const {
+    workspaceContext,
+    analyticsPage,
+    onProjectShared,
+    onProjectShareFailed,
+    onProjectUnshared,
+    onMoveStart,
+    onMoveSettled,
+  } = input;
+  const analytics = useAnalytics();
+  const [sharingId, setSharingId] = useState<string | null>(null);
+  const [unsharingId, setUnsharingId] = useState<string | null>(null);
+  const [error, setError] = useState<ProjectMoveError | null>(null);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  const shareToTeam = useCallback(async (project: Project): Promise<boolean> => {
+    const startedAt = performance.now();
+    const workspaceDimensions = workspaceAnalyticsDimensions(workspaceContext);
+    setError(null);
+    onMoveStart?.(project, 'to-team');
+    setSharingId(project.id);
+    try {
+      const movedProject = await moveWorkspaceProject({
+        projectId: project.id,
+        visibility: 'team',
+        workspaceContext: workspaceContext ?? null,
+      });
+      onProjectShared?.(movedProject);
+      notifyTeamProjectsChanged();
+      trackWorkspaceProjectActionResult(analytics.track, {
+        page_name: analyticsPage,
+        area: 'project_collection',
+        action: 'move_to_team',
+        result: 'success',
+        requested_count: 1,
+        succeeded_count: 1,
+        failed_count: 0,
+        duration_ms: Math.round(performance.now() - startedAt),
+        ...workspaceDimensions,
+      });
+      onMoveSettled?.(project, 'to-team', true);
+      return true;
+    } catch (err) {
+      onProjectShareFailed?.(project.id);
+      console.warn('[useWorkspaceProjectMove] share project to team failed:', err);
+      setError({
+        projectId: project.id,
+        kind: workspaceProjectMoveErrorCode(err) === 'TEAM_PROJECT_OWNER_CONFLICT'
+          ? 'owner-conflict'
+          : 'share',
+      });
+      trackWorkspaceProjectActionResult(analytics.track, {
+        page_name: analyticsPage,
+        area: 'project_collection',
+        action: 'move_to_team',
+        result: 'failed',
+        requested_count: 1,
+        succeeded_count: 0,
+        failed_count: 1,
+        duration_ms: Math.round(performance.now() - startedAt),
+        error_code: workspaceProjectMoveErrorCode(err) ?? 'request_failed',
+        ...workspaceDimensions,
+      });
+      onMoveSettled?.(project, 'to-team', false);
+      return false;
+    } finally {
+      setSharingId(null);
+    }
+  }, [analytics.track, analyticsPage, onMoveSettled, onMoveStart, onProjectShareFailed, onProjectShared, workspaceContext]);
+
+  const unshareFromTeam = useCallback(async (project: Project): Promise<boolean> => {
+    const startedAt = performance.now();
+    const workspaceDimensions = workspaceAnalyticsDimensions(workspaceContext);
+    setError(null);
+    onMoveStart?.(project, 'to-personal');
+    setUnsharingId(project.id);
+    try {
+      await moveWorkspaceProject({
+        projectId: project.id,
+        visibility: 'personal',
+        workspaceContext: workspaceContext ?? null,
+      });
+      onProjectUnshared?.(project.id);
+      notifyTeamProjectsChanged();
+      trackWorkspaceProjectActionResult(analytics.track, {
+        page_name: analyticsPage,
+        area: 'project_collection',
+        action: 'move_to_personal',
+        result: 'success',
+        requested_count: 1,
+        succeeded_count: 1,
+        failed_count: 0,
+        duration_ms: Math.round(performance.now() - startedAt),
+        ...workspaceDimensions,
+      });
+      onMoveSettled?.(project, 'to-personal', true);
+      return true;
+    } catch (err) {
+      console.warn('[useWorkspaceProjectMove] unshare project from team failed:', err);
+      setError({ projectId: project.id, kind: 'unshare' });
+      trackWorkspaceProjectActionResult(analytics.track, {
+        page_name: analyticsPage,
+        area: 'project_collection',
+        action: 'move_to_personal',
+        result: 'failed',
+        requested_count: 1,
+        succeeded_count: 0,
+        failed_count: 1,
+        duration_ms: Math.round(performance.now() - startedAt),
+        error_code: workspaceProjectMoveErrorCode(err) ?? 'request_failed',
+        ...workspaceDimensions,
+      });
+      onMoveSettled?.(project, 'to-personal', false);
+      return false;
+    } finally {
+      setUnsharingId(null);
+    }
+  }, [analytics.track, analyticsPage, onMoveSettled, onMoveStart, onProjectUnshared, workspaceContext]);
+
+  const move = useCallback(
+    (project: Project, action: ProjectMoveAction) =>
+      action === 'to-team' ? shareToTeam(project) : unshareFromTeam(project),
+    [shareToTeam, unshareFromTeam],
+  );
+
+  return { sharingId, unsharingId, error, clearError, shareToTeam, unshareFromTeam, move };
+}

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -46,6 +46,13 @@
    to the right (it stays docked until the user collapses it again). */
 .entry-shell--no-header .entry {
   grid-template-columns: 0 minmax(0, 1fr);
+  /* The single row must be the shell's height and nothing more (OPEND-2757).
+     Without it the row is an implicit `auto` track, which sizes to its tallest
+     item — and the rail's column is content-sized, so a long 最近项目 list grew
+     the row past the window and carried the footer's Discord / X / mail links
+     off screen with it. `minmax(0, 1fr)` pins the track to the container, so
+     the rail's flex chain below actually has a height to shrink to. */
+  grid-template-rows: minmax(0, 1fr);
   /* Collapse: hold the horizontal squeeze until the rows have cascaded out
      top-to-bottom (see the staggered rail-row fade below), otherwise the
      0-width clip would swallow the lower rows before their turn. */
@@ -77,6 +84,11 @@
      visible surface is the floating `.entry-nav-rail__panel` inside it. */
   width: 100%;
   min-width: 0;
+  /* A grid item's automatic minimum is its content height; this is the top
+     of the flex chain that lets the recent list shrink (see
+     `.entry-nav-rail__recent-list`), so it has to opt out like every box
+     below it. */
+  min-height: 0;
   border-right: 0;
   background: transparent;
   display: flex;
@@ -1032,10 +1044,27 @@
   background: color-mix(in srgb, var(--text-strong) 10%, transparent);
   color: var(--text-strong);
 }
-/* Armed delete: the second click is the destructive one, so it says so. */
-.entry-nav-rail__recent-menu button.is-danger,
+/* 删除 reads as the destructive item (red ink, red-tinted hover), the same
+   treatment the project cards' menu gives theirs. It no longer arms in place:
+   the confirmation is the shared delete dialog (OPEND-2797). */
+.entry-nav-rail__recent-menu button.is-danger {
+  color: var(--red, #f04142);
+}
 .entry-nav-rail__recent-menu button.is-danger:hover:not(:disabled) {
   background: color-mix(in srgb, var(--red, #f04142) 12%, transparent);
+  color: var(--red, #f04142);
+}
+.entry-nav-rail__recent-menu button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+/* A failed move to the team space is reported inside the menu, under the item
+   that asked for it — the project cards keep theirs in the same place. */
+.entry-nav-rail__recent-menu-error {
+  padding: 4px 8px 6px;
+  max-width: 220px;
+  font-size: 12px;
+  line-height: 1.4;
   color: var(--red, #f04142);
 }
 /* The preview floats OUT of the rail, over the content column: the rail panel

--- a/apps/web/tests/components/EntryNavRail.recent-section.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.recent-section.test.tsx
@@ -22,6 +22,27 @@ const signedInContext = {
   permissions: { canInviteMembers: false, canViewWorkspaceSettings: false },
 } as unknown as WorkspaceCollabContext;
 
+const teamContext = {
+  ...signedInContext,
+  workspaceId: 'ws-team',
+  workspaceType: 'team',
+  permissions: {
+    canInviteMembers: false,
+    canViewWorkspaceSettings: false,
+    canShareProjects: true,
+  },
+} as unknown as WorkspaceCollabContext;
+
+/** What `POST …/projects/:id/move` answers; tests flip it to a refusal. */
+let MOVE_STATUS = 200;
+
+function moveRequests(): string[] {
+  return vi.mocked(fetch).mock.calls
+    .filter(([, init]) => init?.method === 'POST')
+    .map(([url]) => String(url))
+    .filter((url) => /\/projects\/[^/]+\/move$/.test(url));
+}
+
 function project(id: string, updatedAt: number, name = `Project ${id}`): Project {
   return {
     id,
@@ -48,8 +69,18 @@ let RUNS: Record<string, RunFixture> = { ...DEFAULT_RUNS };
 const originalFetch = globalThis.fetch;
 
 function stubFetch() {
-  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    const moveMatch = /^\/api\/workspaces\/[^/]+\/projects\/([^/]+)\/move$/.exec(url);
+    if (moveMatch && init?.method === 'POST') {
+      const id = decodeURIComponent(moveMatch[1]!);
+      return new Response(
+        JSON.stringify(MOVE_STATUS === 200
+          ? { id, name: `Project ${id}`, workspaceId: 'ws-team', visibility: 'team', project: { id } }
+          : { error: { code: 'FORBIDDEN', message: 'no' } }),
+        { status: MOVE_STATUS, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
     const match = /^\/api\/runs\?projectId=([^&]+)$/.exec(url);
     if (match) {
       const id = decodeURIComponent(match[1]!);
@@ -79,6 +110,7 @@ function renderRail(overrides: Partial<Parameters<typeof EntryNavRail>[0]> = {})
   const onOpen = vi.fn();
   const onRename = vi.fn();
   const onDelete = vi.fn(async () => true);
+  const onDuplicate = vi.fn(async () => {});
   render(
     <I18nProvider initial="en">
       <EntryNavRail
@@ -92,11 +124,12 @@ function renderRail(overrides: Partial<Parameters<typeof EntryNavRail>[0]> = {})
         onOpenRecentProject={onOpen}
         onRenameRecentProject={onRename}
         onDeleteRecentProject={onDelete}
+        onDuplicateRecentProject={onDuplicate}
         {...overrides}
       />
     </I18nProvider>,
   );
-  return { onOpen, onRename, onDelete };
+  return { onOpen, onRename, onDelete, onDuplicate };
 }
 
 let reportVisibleRows: (start: number, end: number) => void;
@@ -119,6 +152,7 @@ beforeEach(() => {
   vi.stubGlobal('IntersectionObserver', VisibleRowsObserver);
   window.localStorage.clear();
   RUNS = { ...DEFAULT_RUNS };
+  MOVE_STATUS = 200;
   stubFetch();
 });
 
@@ -257,20 +291,22 @@ describe('EntryNavRail 最近浏览过 section', () => {
     expect(screen.getByTestId('entry-nav-recent-toggle').getAttribute('aria-expanded')).toBe('false');
   });
 
-  it('offers rename and a two-step delete from the row menu', async () => {
-    const { onDelete, onRename } = renderRail();
-    const more = screen.getAllByTestId('entry-nav-recent-more')[0]!;
-    fireEvent.click(more);
+  it('offers rename / duplicate / delete in a personal workspace — no export, no team item', () => {
+    const { onDuplicate } = renderRail();
+    fireEvent.click(screen.getAllByTestId('entry-nav-recent-more')[0]!);
     const menu = screen.getByRole('menu');
-    const items = within(menu).getAllByRole('menuitem').map((item) => item.textContent);
-    expect(items).toEqual(['Rename', 'Export', 'Delete']);
+    // OPEND-2686: 导出 is gone; 复制 sits between 重命名 and 删除. OPEND-2794: a
+    // personal workspace has no team plane, so 转入团队空间 is hidden here.
+    expect(within(menu).getAllByRole('menuitem').map((item) => item.textContent)).toEqual(
+      ['Rename', 'Duplicate project', 'Delete'],
+    );
+    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Duplicate project' }));
+    expect(onDuplicate).toHaveBeenCalledWith('p1');
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
 
-    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Delete' }));
-    // First click only arms the destructive action.
-    expect(onDelete).not.toHaveBeenCalled();
-    fireEvent.click(within(screen.getByRole('menu')).getByRole('menuitem', { name: 'OK' }));
-    expect(onDelete).toHaveBeenCalledWith('p1');
-
+  it('renames inline from the row menu', async () => {
+    const { onRename } = renderRail();
     fireEvent.click(screen.getAllByTestId('entry-nav-recent-more')[1]!);
     fireEvent.click(within(screen.getByRole('menu')).getByRole('menuitem', { name: 'Rename' }));
     const input = screen.getByRole('textbox', { name: 'Rename' }) as HTMLInputElement;
@@ -280,5 +316,114 @@ describe('EntryNavRail 最近浏览过 section', () => {
       fireEvent.keyDown(input, { key: 'Enter' });
     });
     expect(onRename).toHaveBeenCalledWith('p2', 'Renamed');
+  });
+
+  it('confirms delete in the shared dialog: names the project, backs out on Esc / 取消, submits once', async () => {
+    let resolveDelete!: (value: boolean) => void;
+    const onDelete = vi.fn(() => new Promise<boolean>((resolve) => { resolveDelete = resolve; }));
+    renderRail({ onDeleteRecentProject: onDelete });
+    const openDelete = () => {
+      fireEvent.click(screen.getAllByTestId('entry-nav-recent-more')[0]!);
+      fireEvent.click(within(screen.getByRole('menu')).getByRole('menuitem', { name: 'Delete' }));
+      return screen.getByRole('alertdialog');
+    };
+    // OPEND-2797: the menu item no longer arms in place — nothing is deleted
+    // until the dialog's own red 删除 is pressed.
+    let dialog = openDelete();
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(within(dialog).getByText('Delete "Project p1"?')).toBeTruthy();
+    expect(within(dialog).getByRole('button', { name: 'Cancel' })).toBeTruthy();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('alertdialog')).toBeNull();
+    expect(onDelete).not.toHaveBeenCalled();
+
+    dialog = openDelete();
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByRole('alertdialog')).toBeNull();
+
+    dialog = openDelete();
+    const confirm = within(dialog).getByRole('button', { name: 'Delete' });
+    fireEvent.click(confirm);
+    fireEvent.click(confirm);
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onDelete).toHaveBeenCalledWith('p1');
+    // In flight: both buttons lock, and the scrim / Esc cannot dismiss it.
+    expect((confirm as HTMLButtonElement).disabled).toBe(true);
+    expect((within(dialog).getByRole('button', { name: 'Cancel' }) as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.getByRole('alertdialog')).toBe(dialog);
+    await act(async () => resolveDelete(true));
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
+  });
+
+  it('keeps the delete dialog open with a visible error when the request fails', async () => {
+    const onDelete = vi.fn(async () => false);
+    renderRail({ onDeleteRecentProject: onDelete });
+    fireEvent.click(screen.getAllByTestId('entry-nav-recent-more')[0]!);
+    fireEvent.click(within(screen.getByRole('menu')).getByRole('menuitem', { name: 'Delete' }));
+    const dialog = screen.getByRole('alertdialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }));
+    await waitFor(() => {
+      expect(onDelete).toHaveBeenCalledWith('p1');
+      expect(within(dialog).getByRole('alert')).toBeTruthy();
+    });
+    expect(screen.getByRole('alertdialog')).toBe(dialog);
+    expect((within(dialog).getByRole('button', { name: 'Delete' }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('offers 转入团队空间 in a team workspace through the shared confirm dialog and reports progress in the row menu', async () => {
+    const onProjectShared = vi.fn();
+    renderRail({
+      context: teamContext,
+      onRecentProjectShared: onProjectShared,
+      isSharedRecentProject: (id) => id === 'p2',
+    });
+    fireEvent.click(screen.getAllByTestId('entry-nav-recent-more')[0]!);
+    const menu = screen.getByRole('menu');
+    expect(within(menu).getAllByRole('menuitem').map((item) => item.textContent)).toEqual(
+      ['Rename', 'Duplicate project', 'Move to team space', 'Delete'],
+    );
+    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Move to team space' }));
+    // The same confirmation the project cards show — nothing moves yet.
+    const dialog = screen.getByRole('alertdialog', { name: 'Move to team space' });
+    expect(moveRequests()).toHaveLength(0);
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Confirm move' }));
+    await waitFor(() => expect(moveRequests()).toHaveLength(1));
+    expect(moveRequests()[0]).toBe('/api/workspaces/ws-team/projects/p1/move');
+    await waitFor(() => expect(onProjectShared).toHaveBeenCalledWith(expect.objectContaining({ id: 'p1' })));
+    // The row menu re-opened to say 分享中… and closes on success.
+    await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
+
+    // A project already in the team space says so and cannot be moved again.
+    fireEvent.click(screen.getAllByTestId('entry-nav-recent-more')[1]!);
+    const shared = within(screen.getByRole('menu')).getByRole('menuitem', { name: 'In team space' });
+    expect((shared as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('keeps the row menu open with the failure when the move is refused', async () => {
+    MOVE_STATUS = 403;
+    const onProjectShareFailed = vi.fn();
+    renderRail({ context: teamContext, onRecentProjectShareFailed: onProjectShareFailed });
+    fireEvent.click(screen.getAllByTestId('entry-nav-recent-more')[0]!);
+    fireEvent.click(within(screen.getByRole('menu')).getByRole('menuitem', { name: 'Move to team space' }));
+    fireEvent.click(
+      within(screen.getByRole('alertdialog', { name: 'Move to team space' })).getByRole('button', { name: 'Confirm move' }),
+    );
+    await waitFor(() => expect(onProjectShareFailed).toHaveBeenCalledWith('p1'));
+    const menu = await screen.findByRole('menu');
+    expect(within(menu).getByRole('alert').textContent).toBe('Could not move to team space. Try again.');
+  });
+
+  it('disables mutations on a row someone else shared', () => {
+    renderRail({
+      context: teamContext,
+      isSharedRecentProject: (id) => id === 'p1',
+      recentProjectOwnerMemberIds: new Map([['p1', 'wm-other']]),
+    });
+    fireEvent.click(screen.getAllByTestId('entry-nav-recent-more')[0]!);
+    const menu = screen.getByRole('menu');
+    for (const name of ['Rename', 'Duplicate project', 'In team space', 'Delete']) {
+      expect((within(menu).getByRole('menuitem', { name }) as HTMLButtonElement).disabled, name).toBe(true);
+    }
   });
 });

--- a/apps/web/tests/styles/entry-rail-recent.test.ts
+++ b/apps/web/tests/styles/entry-rail-recent.test.ts
@@ -99,6 +99,36 @@ describe('entry rail — 最近浏览过 rows', () => {
     expect(declarations('.entry-nav-rail__recent-menu button')).toMatch(/font-size:\s*13px/);
   });
 
+  it('gives the rail a height to shrink to, so the list scrolls instead of the footer leaving (OPEND-2757)', () => {
+    // The shell's single grid row is pinned to the container: an implicit
+    // `auto` row sized to the rail's content, which is what pushed the social
+    // links under the window in a short viewport.
+    expect(declarations('.entry-shell--no-header .entry')).toMatch(/grid-template-rows:\s*minmax\(0, 1fr\)/);
+    // Every box from the grid item down to the list opts out of the
+    // content-height minimum, and none of them GROWS to fill: a short list
+    // leaves the rail exactly as it was.
+    expect(declarations('.entry-nav-rail')).toMatch(/min-height:\s*0/);
+    expect(declarations('.entry-nav-rail__panel')).toMatch(/min-height:\s*0/);
+    expect(declarations('.entry-nav-rail__group')).toMatch(/min-height:\s*0/);
+    for (const selector of [
+      '.entry-nav-rail__team-section',
+      '.entry-nav-rail__recent',
+      '.entry-nav-rail__recent > .accordion-collapsible',
+    ]) {
+      const block = declarations(selector);
+      expect(block, selector).toMatch(/flex:\s*0 1 auto/);
+      expect(block, selector).toMatch(/min-height:\s*0/);
+    }
+    expect(declarations('.entry-nav-rail__recent > .accordion-collapsible > .accordion-collapsible-inner'))
+      .toMatch(/min-height:\s*0/);
+    // The list is the one scroll container, with the ~11-row desktop target as
+    // its ceiling rather than a fixed height.
+    const list = declarations('.entry-nav-rail__recent-list');
+    expect(list).toMatch(/min-height:\s*0/);
+    expect(list).toMatch(/max-height:\s*calc\(11 \* 38px \+ 10 \* 2px \+ 2px\)/);
+    expect(list).toMatch(/overflow-y:\s*auto/);
+  });
+
   it('keeps the inline rename inside the row box on the frosted panel', () => {
     const rename = declarations('.entry-nav-rail__recent-rename');
     expect(rename).toMatch(/height:\s*38px/);

--- a/e2e/ui/visual-entry-rail.test.ts
+++ b/e2e/ui/visual-entry-rail.test.ts
@@ -1,0 +1,173 @@
+// Entry rail layout under a signed-in workspace (OPEND-2757): the 最近项目 list
+// scrolls inside the rail's remaining height while the top destinations and
+// the bottom social links stay put — whatever the window height, and while it
+// changes. The signed-out visual home keeps the recent-projects grid on the
+// page instead, so this spec mocks the personal Workspace the rail section
+// needs and seeds enough projects to overflow a short window.
+import { expect, test } from '@/playwright/suite';
+import type { Locator, Page } from '@playwright/test';
+import { AMR_PERSONAL_WORKSPACE_ITEM, mockAmrPersonalWorkspace } from '@/playwright/amr';
+import { ensureRailOpen } from '@/playwright/rail';
+import { T } from '@/timeouts';
+import {
+  captureVisual,
+  configureVisualPage,
+  gotoVisualHome,
+  mockSignedInVelaAccount,
+  waitForVisualFonts,
+  type VisualProject,
+} from '@/playwright/visual';
+
+/** The desktop target the list stops growing at: ~11 rows of 38px plus the
+ *  2px rhythm between them and the list's 2px top padding. */
+const DESKTOP_LIST_CAP_PX = 11 * 38 + 10 * 2 + 2;
+
+const RAIL_PROJECTS: VisualProject[] = Array.from({ length: 24 }, (_, index) => {
+  const ordinal = String(index + 1).padStart(2, '0');
+  return {
+    id: `visual-rail-project-${ordinal}`,
+    name: `Rail project ${ordinal}`,
+    skillId: null,
+    designSystemId: null,
+    createdAt: 1_700_000_000_000 + index * 1_000,
+    updatedAt: 1_700_000_500_000 - index * 1_000,
+    metadata: {},
+  } as VisualProject;
+});
+
+async function expectInsideViewport(page: Page, locator: Locator): Promise<void> {
+  const viewport = page.viewportSize();
+  expect(viewport).not.toBeNull();
+  await expect.poll(async () => {
+    const box = await locator.boundingBox();
+    if (!box || !viewport) return null;
+    return {
+      left: Math.max(0, -box.x),
+      top: Math.max(0, -box.y),
+      right: Math.max(0, box.x + box.width - (viewport.width + 1)),
+      bottom: Math.max(0, box.y + box.height - (viewport.height + 1)),
+    };
+  }).toEqual({ left: 0, top: 0, right: 0, bottom: 0 });
+}
+
+/** The element under the locator's centre is the locator itself (or a child
+ *  of it): nothing that overflowed the rail is lying over the control. */
+async function expectHitTargetIsSelf(locator: Locator): Promise<void> {
+  await expect.poll(() => locator.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    const hit = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+    return hit !== null && (hit === element || element.contains(hit));
+  })).toBe(true);
+}
+
+/** A workspace-bound Home lists projects through the workspace-scoped
+ *  catalog (`GET /api/workspaces/:id/projects?view=drafts`), not the unscoped
+ *  `/api/projects` the visual fixture already answers; wrap the same rows in
+ *  the summary shape that read returns. */
+async function mockWorkspaceProjectList(page: Page, projects: readonly VisualProject[]): Promise<void> {
+  const summaries = projects.map((project) => ({
+    ...project,
+    workspaceId: AMR_PERSONAL_WORKSPACE_ITEM.workspaceId,
+    visibility: 'personal',
+    resourceState: 'active',
+    createdByWorkspaceMemberId: AMR_PERSONAL_WORKSPACE_ITEM.workspaceMemberId,
+    updatedByWorkspaceMemberId: AMR_PERSONAL_WORKSPACE_ITEM.workspaceMemberId,
+    resourceHubResourceId: null,
+    cloudTombstonedAt: null,
+    syncState: 'local_only',
+    currentUserAccess: {
+      canOpen: true,
+      canRename: true,
+      canDelete: true,
+      canDuplicate: true,
+      canMoveToTeam: true,
+      canMoveToPersonal: false,
+      canExport: true,
+      canSendTo: true,
+      canRestoreVersion: true,
+    },
+    project,
+  }));
+  await page.route('**/api/workspaces/*/projects**', async (route) => {
+    const request = route.request();
+    if (request.method() !== 'GET' || !new URL(request.url()).pathname.endsWith('/projects')) {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({ json: { projects: summaries } });
+  });
+}
+
+async function openRailWithRecentProjects(page: Page): Promise<void> {
+  await configureVisualPage(page, { projects: RAIL_PROJECTS });
+  await mockSignedInVelaAccount(page);
+  await mockAmrPersonalWorkspace(page);
+  await mockWorkspaceProjectList(page, RAIL_PROJECTS);
+  await gotoVisualHome(page);
+  await ensureRailOpen(page);
+  await expect(page.getByTestId('entry-nav-recent-item')).toHaveCount(RAIL_PROJECTS.length, {
+    timeout: T.medium,
+  });
+}
+
+test('[P1] keeps the rail footer reachable in a short window and lets the recent list scroll', async ({ page }) => {
+  test.setTimeout(T.xlong);
+  await page.setViewportSize({ width: 1280, height: 600 });
+  await openRailWithRecentProjects(page);
+
+  const list = page.locator('.entry-nav-rail__recent-list');
+  const rows = page.getByTestId('entry-nav-recent-item');
+  const social = page.getByTestId('entry-nav-rail-social');
+  const discord = page.getByTestId('entry-nav-rail-discord');
+  const settings = page.getByTestId('entry-settings-button');
+
+  // The fixed ends of the rail are on screen…
+  await expectInsideViewport(page, settings);
+  await expectInsideViewport(page, social);
+  await expectInsideViewport(page, discord);
+  await expectHitTargetIsSelf(discord);
+  await discord.hover();
+
+  // …because the list, not the rail, is what scrolls: it sits entirely above
+  // the social row and clips the rows it cannot fit.
+  await expect.poll(() => list.evaluate((el) => el.scrollHeight - el.clientHeight)).toBeGreaterThan(0);
+  const listBox = await list.boundingBox();
+  const socialBox = await social.boundingBox();
+  expect(listBox).not.toBeNull();
+  expect(socialBox).not.toBeNull();
+  expect(listBox!.y + listBox!.height).toBeLessThanOrEqual(socialBox!.y);
+  await expect(rows.last()).not.toBeInViewport();
+  await waitForVisualFonts(page);
+  await captureVisual(page, 'visual-entry-rail-short');
+
+  await list.evaluate((el) => el.scrollTo({ top: el.scrollHeight, behavior: 'instant' }));
+  await expect(rows.last()).toBeInViewport();
+  await expectInsideViewport(page, social);
+  await expectHitTargetIsSelf(discord);
+
+  // Growing the window hands the list more rows at once, live, and the footer
+  // still ends where the window does.
+  const shortListHeight = await list.evaluate((el) => el.clientHeight);
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await expect.poll(() => list.evaluate((el) => el.clientHeight)).toBeGreaterThan(shortListHeight);
+  expect(await list.evaluate((el) => el.clientHeight)).toBeLessThanOrEqual(DESKTOP_LIST_CAP_PX);
+  await expectInsideViewport(page, social);
+  await expectHitTargetIsSelf(discord);
+  await captureVisual(page, 'visual-entry-rail-tall');
+
+  // …and shrinking it again takes rows away without anything else moving.
+  await page.setViewportSize({ width: 1280, height: 600 });
+  await expect.poll(() => list.evaluate((el) => el.clientHeight)).toBeLessThan(shortListHeight + 1);
+  await expectInsideViewport(page, social);
+
+  // Collapsing and re-expanding the section restores the same layout.
+  const toggle = page.getByTestId('entry-nav-recent-toggle');
+  await toggle.click();
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  await expectInsideViewport(page, social);
+  await toggle.click();
+  await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+  await expect(rows.first()).toBeVisible();
+  await expectInsideViewport(page, social);
+  await expectHitTargetIsSelf(discord);
+});


### PR DESCRIPTION
## Why

OPEND-2553（首页链路 Demo #7635 一比一复刻）二轮验收里左栏「最近项目」暴露了三个 P0/P1 问题，这个 PR 一次收口（F1 批次，base 是 `feat/home-entry-refresh`，不进 main）：

- **OPEND-2757（验证不通过）** 窗口不够高时「最近项目」列表继续向下扩张，把左下角 Discord / X / 邮件按钮挤出视口。#7832 给列表加了 `min-height: 0` + 11 行上限的 flex 链，但链的最顶端断了：`.entry` 网格没有声明行轨道，隐式 `auto` 行按左栏内容撑高（1280×600 时行高 859px、容器只有 548px），下面的 flex 链再正确也无处可缩。
- **OPEND-2794 + OPEND-2686** 左栏行菜单只有「重命名 / 导出 / 删除」，历史版本的「转入团队空间」丢了（功能回退），产品要的「复制」也没有，「导出」不该在这里。
- **OPEND-2797** 删除的二次确认从独立弹窗变成了菜单内把「删除」变形为红色「确定」，QA 定性为防误触回退。

## What users will see

- 左栏「最近项目」按侧栏剩余高度滚动：顶部导航和左下角按钮任何窗口高度下都完整可见可点；拖动窗口高度时可见行数实时收缩/扩展；桌面大视口仍以约 11 行为上限，列表不足时不留空白。社区页等其它入口视图不受影响（内容列本来就是内部滚动）。
- 行菜单改为：个人空间「重命名 / 复制项目 / 删除」，团队空间「重命名 / 复制项目 / 转入团队空间 / 删除」。「导出」移除。
  - 「复制项目」走首页卡片同一个 `onDuplicateProject`（`POST /api/projects/:id/duplicate`，与 `od project duplicate` 同一接口）。
  - 「转入团队空间」复用首页卡片的流程：同一个 `MoveToTeamConfirmDialog`（含「不再提示」）、同一个 `moveWorkspaceProject` 请求与乐观共享标记；提交后行菜单自动重开显示「分享中…」，成功关闭并刷新所有列表，失败时菜单保留并显示原因。无团队空间（个人 workspace）隐藏该项；已在团队空间的显示「已在团队空间」置灰；他人分享的项目「重命名 / 复制 / 转入 / 删除」全部置灰并带「只能修改或删除自己创建的项目」提示，与卡片一致。
- 删除恢复独立确认弹窗：显示待删项目名，「取消」+ 红色「删除」，Esc / 遮罩 / 取消可退出，确认后按钮锁定防重复提交，失败时弹窗保留并显示错误。首页卡片与左栏两处删除入口现在用同一个 `ProjectDeleteConfirmDialog` + `useProjectDeleteFlow`。

## Surface area

- [x] **UI** — 左栏「最近项目」行菜单项、删除确认弹窗、左栏布局
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var** — 无新增：`od project duplicate <id> [--name] [--json]` 已存在（`apps/daemon/src/cli.ts`），与 UI 调同一 `/api/projects/:id/duplicate`；「转入团队空间」对应 `/api/workspaces/:id/projects/:pid/move`，本 PR 没有引入新能力
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — 无新增，全部复用 `designs.*` / `recentProjects.*` 现有键
- [ ] **New top-level dependency**
- [x] **Default behavior change** — 左栏行菜单去掉「导出」；删除改为弹窗确认
- [ ] **None**

## Screenshots

矮窗口 1280×600，改前 / 改后（改前左下角按钮在视口外 292px；改后列表内滚动，按钮可见）：

| 改前 | 改后 |
|---|---|
| ![before-short](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f1/before-short.png) | ![after-short](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f1/after-short.png) |

改后矮窗口滚到列表底部（底部按钮仍在原位）：

![after-short-scrolled](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f1/after-short-scrolled.png)

高窗口 1280×900，改前 / 改后：

| 改前 | 改后 |
|---|---|
| ![before-tall](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f1/before-tall.png) | ![after-tall](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f1/after-tall.png) |

行菜单（团队空间）改前 / 改后：

| 改前 | 改后 |
|---|---|
| ![before-menu-team](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f1/before-menu-team.png) | ![after-menu-team](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f1/after-menu-team.png) |

行菜单（个人空间，改后）与删除确认（改前菜单内变形为「确定」 / 改后独立弹窗）：

| 个人空间菜单 | 删除改前 | 删除改后 |
|---|---|---|
| ![after-menu-personal](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f1/after-menu-personal.png) | ![before-delete](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f1/before-delete.png) | ![after-delete](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f1/after-delete.png) |

## Bug fix verification

- OPEND-2757：`e2e/ui/visual-entry-rail.test.ts`（Playwright 视觉用例，1280×600 → 900 → 600，断言底部按钮在视口内且是命中目标、列表自身可滚动、行数随窗口实时变化、收起/展开、hover）——base 上红（social row bottom 溢出 292px），本分支绿；`apps/web/tests/styles/entry-rail-recent.test.ts` 新增 flex 链度量规格——base 红、本分支绿。
- OPEND-2794 / 2686 / 2797：`apps/web/tests/components/EntryNavRail.recent-section.test.tsx` 新增 6 条（个人/团队菜单项、复制、独立删除弹窗 Esc/取消/防重复/失败保留、转入团队空间确认与进度、失败留在菜单、他人项目置灰）——base 上 7 条红（含 CSS 规格），本分支 15/15 绿。

## Validation

- `pnpm guard`、`pnpm typecheck`、`pnpm i18n:check`、`pnpm --filter @open-design/e2e typecheck` 全绿
- `pnpm --filter @open-design/web test`：689 个文件、7319 条通过（1 expected fail、11 skipped 为既有）
- 视觉用例：CI 预构建后 `cd e2e && pnpm exec playwright test -c playwright.visual.config.ts ui/visual-entry-rail.test.ts` 通过
- 本地 `pnpm tools-dev run web --namespace f1-rail --daemon-port 17807 --web-port 17907` + Playwright 伪造登录态工作区，高/矮视口截图见上；社区页在 1280×600 下内容列内部滚动正常

## 与 Demo 的有意偏离 / 备注

- Demo（#7635）的行菜单是「重命名 / 导出 / 删除」+ 菜单内变形确认；本 PR 按产品（孙庆雨）与 QA 的规格改为上面的菜单与独立弹窗。变形按钮在 Demo 里没有其它用途，只是删除的二次确认。
- 「约 11 行」保留为桌面大视口的上限（`max-height`），不再是唯一限制：flex 链现在从 `.entry` 网格行一路通到列表。
- 抽了 `apps/web/src/components/project-actions/`（`ProjectDeleteConfirmDialog`、`useProjectDeleteFlow`、`useWorkspaceProjectMove`、`useProjectDuplicateFlow`、`ownership`），`RecentProjectsStrip` 改为消费这些 hook（行为不变，原 60 条卡片测试全绿），左栏与卡片共用一套删除/分享/复制流程。
