### PR TITLE
fix(amr): follow vela's test console onto the new cloud domain

### DIFF
--- a/apps/daemon/src/integrations/vela-console-origin.ts
+++ b/apps/daemon/src/integrations/vela-console-origin.ts
@@ -2,12 +2,25 @@ import { resolveAmrProfile } from './vela-profile.js';
 
 type EnvMap = NodeJS.ProcessEnv | Record<string, string | undefined>;
 
-// Publicly named console origins already used by the web client. feature-test
-// remains build-injected because its deployment hostname is intentionally not
-// part of the public repository.
+// Publicly named console origins already used by the web client. Each value is
+// a Cloud *base* that callers append a console path to (`/dashboard`,
+// `/settings`), so the `/cloud` segment belongs here rather than at each call
+// site — every consumer concatenates, none resolves against it as a URL base.
+//
+// The test entry moved off `vela.powerformer.net` onto
+// `open-design.powerformer.net/cloud` when vela cut the test Cloud domain over
+// (vela #1922 prepare, #1929 finalize). The new host serves the test Landing
+// page at `/` and hands `/cloud*` and `/amr*` to a test-only path proxy; the
+// legacy hostname is no longer a mapped test route and is scheduled for
+// decommissioning, so it must not be relied on for a compatibility redirect.
+//
+// feature-test is deliberately absent: this repository ships publicly and that
+// deployment's hostname is internal. It is supplied at packaging time through
+// OD_VELA_WEB_URLS / OD_VELA_WEB_URL, so an un-injected build resolves nothing
+// for it and the client falls back to the public console instead of guessing.
 const PUBLIC_ORIGINS: Partial<Record<string, string>> = {
   prod: 'https://open-design.ai/cloud',
-  test: 'https://vela.powerformer.net',
+  test: 'https://open-design.powerformer.net/cloud',
   local: 'http://localhost:5173',
 };
 

--- a/apps/daemon/tests/vela-console-origin.test.ts
+++ b/apps/daemon/tests/vela-console-origin.test.ts
@@ -40,6 +40,34 @@ describe('resolveVelaConsoleOrigin', () => {
     })).toBe('https://feature.example.invalid');
   });
 
+  // The publicly named profiles resolve without any build injection, so their
+  // literals in PUBLIC_ORIGINS are the shipped value. vela moved the test Cloud
+  // entry off `vela.powerformer.net` onto `open-design.powerformer.net/cloud`
+  // (vela #1922 prepare / #1929 finalize); that host maps `/cloud*` and `/amr*`
+  // to the Web origin, and the legacy hostname is explicitly no longer a mapped
+  // test route, so a stale value here sends every console link off-environment.
+  it('resolves the public console origin for a runtime profile selection', () => {
+    expect(resolveVelaConsoleOrigin({}, { OPEN_DESIGN_AMR_PROFILE: 'test' })).toBe(
+      'https://open-design.powerformer.net/cloud',
+    );
+    expect(resolveVelaConsoleOrigin({}, { OPEN_DESIGN_AMR_PROFILE: 'prod' })).toBe(
+      'https://open-design.ai/cloud',
+    );
+    expect(resolveVelaConsoleOrigin({}, { OPEN_DESIGN_AMR_PROFILE: 'local' })).toBe(
+      'http://localhost:5173',
+    );
+  });
+
+  // feature-test is deliberately NOT in the public table: its deployment
+  // hostname is internal, and this repository ships publicly. It arrives only
+  // through OD_VELA_WEB_URLS / OD_VELA_WEB_URL at packaging time, so with no
+  // injection the runtime reports nothing rather than guessing a hostname.
+  it('has no public origin for the internal feature-test profile', () => {
+    expect(
+      resolveVelaConsoleOrigin({}, { OPEN_DESIGN_AMR_PROFILE: 'feature-test' }),
+    ).toBeUndefined();
+  });
+
   it('never reuses the packaged origin after switching to an unmapped profile', () => {
     expect(resolveVelaConsoleOrigin({
       OPEN_DESIGN_AMR_PROFILE: 'test',

--- a/apps/web/src/runtime/amr-guidance.ts
+++ b/apps/web/src/runtime/amr-guidance.ts
@@ -78,9 +78,18 @@ export const AMR_CONSOLE_UPGRADE_INTENT = 'plan';
  */
 export const AMR_CONSOLE_AUTO_RECHARGE_INTENT = 'auto-recharge';
 
+// The test entry moved off `vela.powerformer.net` onto
+// `open-design.powerformer.net/cloud` when vela cut the test Cloud domain over
+// (vela #1922 prepare, #1929 finalize). That host serves the test Landing page
+// at `/` and routes `/cloud*` to the AMR web origin; the legacy hostname is no
+// longer a mapped test route and must not be relied on for a redirect.
+//
+// feature-test has no row on purpose — see the note at the bottom of this file:
+// an internal hostname must not be a literal in a publicly shipped bundle, so
+// it arrives through the daemon's runtime console origin instead.
 const AMR_CONSOLE_URL_BY_PROFILE: Record<string, string> = {
   prod: DEFAULT_AMR_RECHARGE_URL,
-  test: 'https://vela.powerformer.net/dashboard?source=open_design',
+  test: 'https://open-design.powerformer.net/cloud/dashboard?source=open_design',
   local: 'http://localhost:5173/dashboard?source=open_design',
 };
 

--- a/apps/web/tests/components/AmrLoginPill.test.tsx
+++ b/apps/web/tests/components/AmrLoginPill.test.tsx
@@ -279,7 +279,7 @@ describe('AmrLoginPill', () => {
     expect(screen.getByText('leaf@example.com')).toBeTruthy();
     expect(screen.getByText('TEST')).toBeTruthy();
     expect(screen.getByRole('link', { name: 'Manage' }).getAttribute('href')).toBe(
-      'https://vela.powerformer.net/dashboard?source=open_design',
+      'https://open-design.powerformer.net/cloud/dashboard?source=open_design',
     );
   });
 

--- a/apps/web/tests/components/ChatPane.conversation-title.test.tsx
+++ b/apps/web/tests/components/ChatPane.conversation-title.test.tsx
@@ -266,7 +266,7 @@ describe('ChatPane session switcher', () => {
     const parsedConsoleUrl = new URL(String(consoleUrl));
     // Top-up reports on the console dashboard now, not a wallet page.
     expect(`${parsedConsoleUrl.origin}${parsedConsoleUrl.pathname}`).toBe(
-      'https://vela.powerformer.net/dashboard',
+      'https://open-design.powerformer.net/cloud/dashboard',
     );
     // The plain top-up entry must NOT carry the upgrade intent — it opens the
     // console to add credit, not the plan catalog.
@@ -312,7 +312,7 @@ describe('ChatPane session switcher', () => {
     // non-prod build sent people to production checkout.
     const parsedPlansUrl = new URL(String(plansUrl));
     expect(`${parsedPlansUrl.origin}${parsedPlansUrl.pathname}`).toBe(
-      'https://vela.powerformer.net/dashboard',
+      'https://open-design.powerformer.net/cloud/dashboard',
     );
     expect(parsedPlansUrl.searchParams.get('billing')).toBe('plan');
     expect(parsedPlansUrl.searchParams.get('od_entry_source')).toBe('chat_error_upgrade');

--- a/apps/web/tests/components/InlineModelSwitcher.test.tsx
+++ b/apps/web/tests/components/InlineModelSwitcher.test.tsx
@@ -664,8 +664,8 @@ describe('InlineModelSwitcher AMR row', () => {
     // The point of this case is the PROFILE: a signed-in test-profile account
     // must not be handed a production upgrade link. While the plans URL ignored
     // its profile argument this assertion read the prod host (T54).
-    expect(parsed.origin).toBe('https://vela.powerformer.net');
-    expect(parsed.pathname).toBe('/dashboard');
+    expect(parsed.origin).toBe('https://open-design.powerformer.net');
+    expect(parsed.pathname).toBe('/cloud/dashboard');
     expect(parsed.searchParams.get('billing')).toBe('plan');
     expect(parsed.searchParams.get('od_entry_source')).toBe('inline_amr_upgrade');
     expect(parsed.searchParams.get('od_device_id')).toBe('od-install-abc');

--- a/apps/web/tests/runtime/amr-guidance.test.ts
+++ b/apps/web/tests/runtime/amr-guidance.test.ts
@@ -33,7 +33,7 @@ describe('amrRechargeUrlForProfile', () => {
     );
     expect(amrRechargeUrlForProfile('prod')).toBe(DEFAULT_AMR_RECHARGE_URL);
     expect(amrRechargeUrlForProfile('test')).toBe(
-      'https://vela.powerformer.net/dashboard?source=open_design',
+      'https://open-design.powerformer.net/cloud/dashboard?source=open_design',
     );
     expect(amrRechargeUrlForProfile('local')).toBe(
       'http://localhost:5173/dashboard?source=open_design',

--- a/apps/web/tests/runtime/amr-plans-console-deeplink.test.ts
+++ b/apps/web/tests/runtime/amr-plans-console-deeplink.test.ts
@@ -35,7 +35,7 @@ describe('升级按钮的落点:console 的套餐页', () => {
 
   it('test profile 落在 test console,不再落在生产 Pricing', () => {
     expect(amrPlansUrlForProfile('test')).toBe(
-      'https://vela.powerformer.net/dashboard?source=open_design&billing=plan',
+      'https://open-design.powerformer.net/cloud/dashboard?source=open_design&billing=plan',
     );
   });
 


### PR DESCRIPTION
## Why

**My use case.** vela 把 test 环境的域名切了(`#1922` prepare + `#1929` finalize,两条都在 vela `main` 上),OD 客户端这边还指着旧域名。

**The pain.** vela 的 `specs/current/envs.md:33-34` 明写旧入口**不再是 canonical**、且「下线另行处理,**不要依赖它做兼容重定向**」。所以 test 环境的控制台链接和充值入口现在是靠一个随时会消失的旧部署活着。

## What users will see

在 test 环境里点「切换到 Cloud」/ 充值 / 控制台入口,落到新域名 `open-design.powerformer.net/cloud`,而不是即将下线的 `vela.powerformer.net`。生产不受影响。

## What changed

两处运行时字面量:

| 文件 | 旧 | 新 |
|---|---|---|
| `apps/daemon/src/integrations/vela-console-origin.ts` | `https://vela.powerformer.net` | `https://open-design.powerformer.net/cloud` |
| `apps/web/src/runtime/amr-guidance.ts` | `https://vela.powerformer.net/dashboard?source=open_design` | `https://open-design.powerformer.net/cloud/dashboard?source=open_design` |

`/cloud` 放在 **origin** 里而不是路径里,因为所有消费者都是**字符串拼接**(`${origin}/dashboard`、`${origin}/settings`),没有任何一处用 `new URL(path, base)` —— 后者会把 `/cloud` 静默吃掉。这样 test 也和既有的 prod(`https://open-design.ai/cloud`)对称。

## 三处刻意**没有**改

1. **生产不动。** OD 生产用的是 `https://open-design.ai/amr/dashboard?source=open_design`,既不是 `/cloud/wallet` 也不是 `/cloud/dashboard`(OD 早在 vela #1055 就搬离 wallet 了,代码里有记录)。实测 `/amr/dashboard` → **302 → `/cloud/dashboard`**,路径与 query 都保留,`source=open_design` 归因不丢;`/cloud/wallet` 仍返回 **200**。
2. **`feature-test` 不加进 URL 表。** 这不是遗漏:既有注释和既有测试都钉着「非公开的环境主机名不能作为字面量出现在公开仓库里」,它由打包期的 `OD_VELA_WEB_URLS` / `OD_VELA_WEB_URL` 注入。本 PR 只把回落写明,并补了一条断言它解析为 `undefined` 的 daemon 测试。
3. **`specs/current/chat-panel-ai-handoff.md:245` 的旧域名不动** —— 那是过去一次排查的历史记录,不是运行时值。

## Testing

红测先行:先只改测试 → daemon `1 failed | 5 passed`、web `5 files failed, 6 failed | 122 passed`(exit=1);改完两处字面量 → daemon 6/6、web 128/128;**只把那两个字面量撤回去** → 两边重新 exit=1、同样 6 条失败。

⚠️ daemon 那张公开 origin 表**此前零测试覆盖** —— 本 PR 补上了 test / prod / local 三档的值,以及 feature-test 的缺席。

差分:按 grep 出的并集点名跑,daemon 4 文件 108 条、web 9 文件 307 条,全绿。根 `pnpm typecheck` 0、`pnpm guard` 0。

## Adjacent issues(本 PR 不做)

OD 生产的两个面**前缀不一致**:`vela-console-origin.ts` 用 `/cloud`,`amr-guidance.ts` 用 `/amr`。vela `monorepo.md:51` 把 `/amr*` 称为**兼容重定向**,所以生产的控制台链接现在白走一跳 302。统一到 `/cloud` 要动约 15 个文件(contracts 埋点、e2e、设置页 URL、landing 模板),且是发布前夕的生产行为改动 —— 范围不对,只记不做。
