### PR TITLE
feat(web): sync #7635 run-status glyphs and zh-CN headline, fix template preview chrome and reference rows (OPEND-2553 PR-F3)

### DIFF
--- a/apps/web/src/components/CommunityTemplatePreview.tsx
+++ b/apps/web/src/components/CommunityTemplatePreview.tsx
@@ -191,12 +191,15 @@ export function buildCommunityTemplates(
 export function TemplatePreviewModal({
   template,
   onClose,
-  onUse,
-  busy,
 }: {
   template: TemplateDemo;
   onClose: () => void;
-  onUse: () => void;
+  /* The footer bar that carried the Remix / 使用 action is gone (per product:
+     去掉下边的 remix 那一条; OPEND-2692), so nothing consumes these any more.
+     Kept — and made optional — so the call sites that still pass them
+     type-check unchanged; drop them there whenever those files are touched
+     next. */
+  onUse?: () => void;
   busy?: boolean;
 }) {
   const t = useT();
@@ -234,12 +237,6 @@ export function TemplatePreviewModal({
             ? { src: template.previewSrc }
             : { srcDoc: templatePreviewHtml(template) })}
         />
-        <footer className="community-template-preview__foot">
-          <span>{template.meta}</span>
-          <button type="button" disabled={busy} onClick={onUse}>
-            {busy ? t('common.loading') : templateActionLabel(template)}
-          </button>
-        </footer>
       </section>
     </div>
   );

--- a/apps/web/src/components/ProjectReferenceModal.module.css
+++ b/apps/web/src/components/ProjectReferenceModal.module.css
@@ -117,12 +117,23 @@
   grid-template-columns: auto 1fr auto;
   gap: 10px;
   align-items: center;
-  padding: 10px;
+  /* The row is a <button>, so the global primitive (styles/primitives.css)
+     hands it `height: 36px; line-height: 1; white-space: nowrap`. Two lines of
+     text plus the 28px icon need ~54px, so the box was shorter than its
+     content: the content overflowed evenly above and below, the border
+     framed only the title band, and the overflow drew over the neighbouring
+     rows' meta text (OPEND-2787). The row must size to its content, and the
+     three states below share this one box — hover and selected only recolour
+     it, so nothing shifts when a row is picked. */
+  height: auto;
+  min-height: 0;
+  padding: 8px 10px;
   border: 1px solid transparent;
   border-radius: var(--radius);
   background: transparent;
   color: var(--text);
   font: inherit;
+  line-height: normal;
   text-align: left;
   cursor: pointer;
 }
@@ -163,6 +174,7 @@
   color: var(--text-strong);
   font-size: 13.5px;
   font-weight: 600;
+  line-height: 18px;
 }
 
 .itemMeta {
@@ -171,14 +183,20 @@
   white-space: nowrap;
   color: var(--text-muted);
   font-size: 12px;
+  line-height: 16px;
 }
 
+/* Sits in the third grid column, centred by the row's `align-items`; it is
+   shorter than the two text lines so it never sets the row's height. */
 .currentTag {
+  flex: 0 0 auto;
   padding: 2px 7px;
   border-radius: 999px;
   background: var(--bg-subtle);
   color: var(--text-muted);
   font-size: 11px;
+  line-height: 16px;
+  white-space: nowrap;
 }
 
 .empty {

--- a/apps/web/src/components/ProjectRunStatusIcon.tsx
+++ b/apps/web/src/components/ProjectRunStatusIcon.tsx
@@ -1,29 +1,45 @@
 /**
  * The one place a `ProjectDisplayStatus` becomes a glyph.
  *
- * Finished work is a static badge; anything still moving — or stalled in a way
- * the user has to act on — is the same rotating orb in a different colour, so
- * the row reads as one object changing state rather than four unrelated icons.
+ * A run that has stopped is a static badge; a run still moving — or paused on a
+ * question the user has to answer — is the same rotating orb in a different
+ * colour, so the row reads as one object changing state rather than a handful
+ * of unrelated icons. The split is "is it still going", not "did it go well":
+ * spinning a stopped run's orb is the one thing this component must never do,
+ * because the rotation itself is what says "working".
  *
- * Returns `null` for the statuses that have nothing to say (`not_started`,
- * `canceled`). Callers must still reserve the slot so names stay aligned; that
- * is the caller's layout concern, not this component's.
+ * Speed carries only one distinction, and it is not urgency: `queued` turns
+ * slowly because it has not started. Everything else that is live — running
+ * and awaiting a reply alike — turns at the same rate, so a colour change
+ * never reads as a change of pace.
+ *
+ * Returns `null` only for `not_started`, which has nothing to say. Callers must
+ * still reserve the slot so names stay aligned; that is the caller's layout
+ * concern, not this component's.
  */
 import type { ProjectDisplayStatus } from '@open-design/contracts';
 import { SiriOrb } from './SiriOrb';
 
 /**
- * Recolouring the orb means moving BOTH accent slots, not just `--c1`.
- * `--c2` is the second accent and the outer glow, and the stock palette pairs
- * green `#00FF08` with spring-green `#00FFAE` — a neighbouring hue. Leaving it
- * green while `--c1` turns orange mixes the two into a muddy red-green dot; the
- * pairs below keep each state's two slots in one hue family, the way the
- * original does. Both stay chromatic, as `--c2` requires.
+ * Awaiting a reply: still live, but it is the user's move.
+ *
+ * A three-step warm ramp, ordered by the role each slot plays rather than by
+ * hue: orange is the base, amber the second accent AND the outer bloom, gold
+ * the narrow specular glint. Lightness climbs across them — OKLCH L 75.2 →
+ * 83.1 → 85.0 — so the brightest slot is the one that draws the highlight,
+ * which is what makes the dot read as a sphere at 14px.
+ *
+ * Gold in `c5` is what buys the glint back: `literal` bans the stock white
+ * highlights because screen-blending white raises this accent's mid green
+ * channel into yellow, but a lighter tone named outright is a colour the
+ * design chose, not one the compositor invented.
+ *
+ * `literal` is not optional here. Without it the orb edits whatever it is
+ * given — three slots still hold green, and the highlight, saturation and
+ * texture passes each push a mid-channel accent off its hue. Not theoretical:
+ * this palette came out green, then yellow, then red as each was found.
  */
-/** Awaiting a reply, or finished with declared work left undone. */
-const ATTENTION = { c1: '#EDC337', c2: '#FFE066' };
-/** The run failed. */
-const FAILED = { c1: '#F8672F', c2: '#FFA94D' };
+const ATTENTION = { c1: '#FF8D02', c2: '#EDC337', c5: '#FFC400' };
 
 /**
  * Whether this status draws anything at all.
@@ -33,7 +49,7 @@ const FAILED = { c1: '#F8672F', c2: '#FFA94D' };
  * indented past an empty gutter.
  */
 export function hasRunStatusGlyph(status: ProjectDisplayStatus | undefined): boolean {
-  return status !== undefined && status !== 'not_started' && status !== 'canceled';
+  return status !== undefined && status !== 'not_started';
 }
 
 interface Props {
@@ -78,23 +94,60 @@ function SucceededBadge({ size, label }: { size: number; label?: string }) {
   );
 }
 
+/**
+ * Interrupted: the run stopped before it delivered — it failed, it was
+ * canceled, or it ended with declared work still undone. One mark for all
+ * three, because the row only has to say "this did not finish"; the reason
+ * belongs to the status text next to it, not to a colour the user has to
+ * decode.
+ *
+ * Built as the succeeded badge's twin — same disc, same knocked-out glyph, same
+ * cropped viewBox so `size` means the same drawn pixels in a mixed column —
+ * with the mark itself carried by the counter rather than the disc. The rect
+ * backs ONLY that counter; the disc paints everything else, so its bounds never
+ * need to match the artwork.
+ */
+function InterruptedBadge({ size, label }: { size: number; label?: string }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="2 2 20 20"
+      fill="none"
+      focusable="false"
+      {...(label ? { role: 'img', 'aria-label': label } : { 'aria-hidden': true })}
+    >
+      <rect x="7" y="6" width="10" height="13" fill="#121212" />
+      <path
+        d="M12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22ZM12 9.5C12.8284 9.5 13.5 8.82843 13.5 8C13.5 7.17157 12.8284 6.5 12 6.5C11.1716 6.5 10.5 7.17157 10.5 8C10.5 8.82843 11.1716 9.5 12 9.5ZM14 15H13V10.5H10V12.5H11V15H10V17H14V15Z"
+        fill="#F34801"
+      />
+    </svg>
+  );
+}
+
 export function ProjectRunStatusIcon({ status, size = 14, label }: Props) {
   switch (status) {
     case 'succeeded':
       return <SucceededBadge size={size} label={label} />;
+    case 'failed':
+    case 'canceled':
+    case 'incomplete':
+      return <InterruptedBadge size={size} label={label} />;
     case 'running':
       return <SiriOrb size={size} state="thinking" label={label} />;
     case 'queued':
-      // Same green: it is the same "not finished" family. Only the speed says
-      // this one has not actually started turning over yet.
+      // Same green as running: it is the same "not finished" family. The
+      // slower turn is the only thing saying this one has not started yet, so
+      // `idle` here is load-bearing.
       return <SiriOrb size={size} state="idle" label={label} />;
     case 'awaiting_input':
-    case 'incomplete':
-      return <SiriOrb size={size} state="idle" colors={ATTENTION} label={label} />;
-    case 'failed':
-      return <SiriOrb size={size} state="idle" colors={FAILED} label={label} />;
+      // Running's speed, deliberately (per product). A pending question is not
+      // a paused run — the agent is live and the work is mid-flight, so the
+      // orb keeps working; colour alone carries "your move". Slowing it here
+      // would say "stalled", which is what `queued` means.
+      return <SiriOrb size={size} state="thinking" colors={ATTENTION} literal label={label} />;
     case 'not_started':
-    case 'canceled':
       return null;
     default:
       return null;

--- a/apps/web/src/components/SiriOrb.module.css
+++ b/apps/web/src/components/SiriOrb.module.css
@@ -145,6 +145,78 @@
   --bg: color-mix(in srgb, var(--c1) 24%, #101010);
 }
 
+/* Literal build: the orb shows the accents it was given and nothing else.
+ *
+ * The stock build is tuned around `#00FF08` specifically, and six separate
+ * things assume it. Three hardcode green in slots the `colors` prop cannot
+ * reach — `--c4`, `--c5`, `--fill` — plus `.isTiny`, which mixes `--c4`
+ * against a green-black. The other three push whatever hue they are given:
+ * the white highlights, the saturate/contrast pair, and the texture pass (see
+ * the three rules below). None of them disturb `#00FF08`, whose R sits at 0.00
+ * and G at 1.00 — pinned at the channel bounds, it has nowhere to move. An
+ * accent with a mid channel does move: `#FF8D02` (G 141) came out green, then
+ * yellow, then red as each was fixed in turn.
+ *
+ * So this is not "recolour" — it is "stop the build from editing the colour".
+ * The slots below default to `--c1`, and a caller that passes its own `c2` or
+ * `c5` keeps it (the component sets those inline, which outranks this rule);
+ * either way nothing but the dark side is left over.
+ *
+ * The original's structural constraints all still hold: `--c3` is untouched
+ * and still exactly 2 of the 8 layers, `--c2` stays chromatic, and `--c4` is
+ * still a distinct layer — it just no longer bridges a hue, only the lightness
+ * the `contrast()` pass needs. Declared after `.isTiny` because both are
+ * single-class selectors and `--c4` is set by both. */
+.isLiteral {
+  --c2: var(--c1);
+  --c4: var(--c1);
+  --c5: var(--c1);
+  --fill: var(--c1);
+  /* The stock 1.12 is a compensation tuned for `#00FF08`, whose R and B are
+     already pinned at the channel bounds — saturating it cannot move the hue.
+     A mid-channel accent has room to move, and 1.12 walks `#FF8D02` (G 141)
+     visibly toward red. Single-hue means the orb IS the colour, so no filter
+     may push it off. `--contrast` is set inline by the component and is
+     neutralised there for the same reason. */
+  --sat: 1;
+}
+
+/* Nothing may lighten a literal orb, only darken it.
+ *
+ * Every highlight in the stock build is white, screen-blended. Screening white
+ * over `#00FF08` just raises R and B toward a paler green — the hue holds
+ * because G is already 255. Screening it over `#FF8D02` raises G from 141
+ * toward 255 with R already pinned, and that IS the definition of yellow: the
+ * highlight reads as a different colour rather than a brighter one. Screening
+ * the accent over itself does the same thing, so there is no "tint the
+ * highlight instead" fix at the blend level — the top-lit modelling simply has
+ * to go, leaving the dark side to do the shaping. A caller that wants the
+ * glint back names a colour for it in `c5` instead; a chosen lighter tone is a
+ * hue the designer picked, not one the compositor invented. The disc still
+ * turns, so the orb still reads as working. */
+.isLiteral .sheen {
+  display: none;
+}
+
+.isLiteral .rim {
+  box-shadow: inset 0 calc(var(--rim) * -1.2) calc(var(--rim) * 2.4) hsl(0 0% 0% / 0.4);
+}
+
+/* The dot texture is the single biggest hue-pusher, and it has to go too.
+ *
+ * It composites `mix-blend-mode: overlay` over a `contrast(2)` backdrop, and
+ * overlay branches per channel on 0.5: below it multiplies, at or above it
+ * screens. `#00FF08` sits nowhere near that seam — R is 0.00 and G is 1.00, so
+ * both channels take the same branch every time and the green only gets darker
+ * or lighter. `#FF8D02` puts G at 0.553, a hair over the seam, so the texture
+ * drives G down while R stays pinned at 1.0 and the whole orb reads as red
+ * rather than orange. Measured at 14px: the accent came out around `#E03A08`.
+ *
+ * The texture only ever added grain, and at 14px there is no grain to see. */
+.isLiteral .disc::after {
+  display: none;
+}
+
 /* Drifting specular sheen — keeps the highlight from reading as printed on. */
 .sheen {
   background:

--- a/apps/web/src/components/SiriOrb.tsx
+++ b/apps/web/src/components/SiriOrb.tsx
@@ -19,10 +19,20 @@ interface Props {
   size?: number;
   state?: SiriOrbState;
   /**
-   * Palette overrides. Only `c1` (and `c2`, the bloom) are meant to change —
-   * see the constraints documented in the stylesheet before touching the rest.
+   * Palette overrides, by role: `c1` is the base accent, `c2` the second
+   * accent AND the outer bloom, `c5` the narrow specular glint. Those are the
+   * three slots a caller has any business setting — `c3` is the dark side and
+   * must never go chromatic, and `c4` only bridges the lightness between them.
+   * Anything left unset follows `c1` under `literal`; see the constraints
+   * documented in the stylesheet before reaching past these.
    */
-  colors?: { c1?: string; c2?: string };
+  colors?: { c1?: string; c2?: string; c5?: string };
+  /**
+   * Render the given accents literally — nothing lightens them and nothing
+   * pushes their hue. Required to recolour the orb at all: the stock build is
+   * tuned around `#00FF08` in six places. See `.isLiteral` in the stylesheet.
+   */
+  literal?: boolean;
   className?: string;
   /** Announced to assistive tech; omit to keep the orb decorative. */
   label?: string;
@@ -55,6 +65,7 @@ export function SiriOrb({
   size = 24,
   state = 'thinking',
   colors,
+  literal = false,
   className,
   label,
 }: Props) {
@@ -62,18 +73,28 @@ export function SiriOrb({
   const style = {
     '--size': `${size}px`,
     '--blur': m.blur,
-    '--contrast': m.contrast,
+    // `contrast()` stretches the gap between channels. On `#00FF08` — R and B
+    // already at the bounds — that only changes lightness; on a mid-channel
+    // accent it shifts the hue, which a literal orb cannot afford.
+    '--contrast': literal ? 1 : m.contrast,
     '--dot': m.dot,
     '--shadow': m.shadow,
     '--rim': m.rim,
     '--mask': m.mask,
     ...(colors?.c1 ? { '--c1': colors.c1 } : {}),
     ...(colors?.c2 ? { '--c2': colors.c2 } : {}),
+    ...(colors?.c5 ? { '--c5': colors.c5 } : {}),
   } as CSSProperties;
 
   return (
     <span
-      className={[styles.orb, STATE_CLASS[state], m.tiny ? styles.isTiny : '', className]
+      className={[
+        styles.orb,
+        STATE_CLASS[state],
+        m.tiny ? styles.isTiny : '',
+        literal ? styles.isLiteral : '',
+        className,
+      ]
         .filter(Boolean)
         .join(' ')}
       style={style}

--- a/apps/web/src/components/home-hero/RotatingTitleWord.tsx
+++ b/apps/web/src/components/home-hero/RotatingTitleWord.tsx
@@ -4,8 +4,7 @@ import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import styles from './RotatingTitleWord.module.css';
 
 /**
- * The headline's rotating noun: 「我们来设计点 __？」 cycles 文档 → 幻灯片 →
- * 原型 → 幻灯片 → 文档.
+ * The headline's rotating noun: 「让我们创建 __」 cycles 原型 → 幻灯片 → 文档.
  *
  * This is 21st.dev's `@satoriui/typewriter-loop`, ported rather than copied:
  * the original is a shadcn/Tailwind component (`@/components/ui`, `cn()` from

--- a/apps/web/src/hooks/useModalWindowDragGuard.ts
+++ b/apps/web/src/hooks/useModalWindowDragGuard.ts
@@ -14,6 +14,7 @@ export const MODAL_WINDOW_DRAG_BACKDROP_SELECTOR = [
   '.project-ds-picker-fullscreen',
   '.staged-preview-modal',
   '.qs-overlay',
+  '.community-template-preview',
 ].join(',');
 
 export function eventHitsModalWindowDragStrip(event: MouseEvent | PointerEvent): boolean {

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -877,7 +877,7 @@ export const zhCN: Dict = {
   "workspaceTabs.project": "项目",
   "workspaceTabs.pluginDetails": "插件详情",
   "workspaceTabs.marketplace": "插件市场",
-  "homeHero.title": "我们来设计点{word}",
+  "homeHero.title": "让我们创建{word}",
   "homeHero.titleWords": "原型,幻灯片,文档",
   "homeHero.subtitle": "好的作品，从这里开始",
   "homeHero.startWithTemplate": "从模板开始…",

--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -138,7 +138,7 @@
 
      Georgia carries no CJK glyphs (1111 codepoints, zero Han), so the Chinese
      headline would fall straight through to the UI sans and look unchanged.
-     The two Song faces behind it are what actually make 我们来设计点什么？read
+     The two Song faces behind it are what actually make 让我们创建原型 read
      as a serif; drop them if the headline should stay sans in Chinese. */
   font-family: Georgia, "Songti SC", STSong, SimSun, serif;
   font-weight: 600;

--- a/apps/web/src/styles/home/plugin-marketplace-demo.css
+++ b/apps/web/src/styles/home/plugin-marketplace-demo.css
@@ -1637,6 +1637,10 @@
 }
 
 .community-template-preview {
+  /* Room above the panel. 28px matches the other three sides; the macOS
+     desktop host raises it below so the panel clears the native traffic
+     lights (see the darwin block after `__panel`). */
+  --community-template-preview-inset-top: 28px;
   position: fixed;
   inset: 0;
   /* Modal-layer z, matching .ds-modal-backdrop (composio.css): the scrim must
@@ -1648,7 +1652,7 @@
   z-index: 1700;
   display: grid;
   place-items: center;
-  padding: 28px;
+  padding: var(--community-template-preview-inset-top) 28px 28px;
   /* The app's one scrim material (styles/material.css). This REPLACES the
      earlier "shaped blur, not a flat frost" treatment: that one tinted the
      scrim #000 at 30% and painted four pastel wash blobs in a ::before, so the
@@ -1659,9 +1663,14 @@
 }
 .community-template-preview__panel {
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  /* Two rows: head + stage. The third (the footer bar with Remix) is gone
+     (per product: 去掉下边的 remix 那一条; OPEND-2692). */
+  grid-template-rows: auto minmax(0, 1fr);
   width: min(1120px, calc(100vw - 56px));
-  height: min(760px, calc(100vh - 56px));
+  /* The fit-to-window clamp subtracts the overlay's actual padding, so a
+     taller top inset shrinks the panel instead of pushing it back under the
+     traffic lights it was meant to clear. */
+  height: min(760px, calc(100vh - 28px - var(--community-template-preview-inset-top)));
   overflow: hidden;
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
@@ -1669,16 +1678,27 @@
   box-shadow: var(--shadow-md);
 }
 
-.community-template-preview__head,
-.community-template-preview__foot {
+/* macOS desktop: the window is `titleBarStyle: hiddenInset` with the traffic
+   lights drawn by the OS at x:12 y:20 (apps/desktop runtime.ts), i.e. over
+   the top ~32px of the web content. The overlay covers the whole window, so
+   the panel's top edge sat at 28px and cut straight through the buttons
+   (OPEND-2691). 56px is the same band the shared modal drag strip reserves
+   (`--modal-window-drag-strip-height`, styles/modal-window-drag.css): the
+   panel starts below the chrome row, and the uncovered band above it is where
+   the window can still be dragged. Keyed off the host marks App.tsx stamps
+   (`data-client-type` / `data-host-platform`) so browsers and Windows keep the
+   even 28px. `html:has()` because the overlay is portalled to <body>, outside
+   `.workspace-shell`. */
+html:has(.workspace-shell--desktop[data-host-platform='darwin']) .community-template-preview {
+  --community-template-preview-inset-top: 56px;
+}
+
+.community-template-preview__head {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 18px;
   padding: 16px 18px;
-}
-
-.community-template-preview__head {
   border-bottom: 1px solid var(--border);
 }
 
@@ -1716,49 +1736,6 @@
   height: 100%;
   border: 0;
   background: #fff;
-}
-
-.community-template-preview__foot {
-  border-top: 1px solid var(--border);
-}
-
-.community-template-preview__foot span {
-  color: var(--text-muted);
-  font-size: 13px;
-}
-
-/* Remix + Prompt sit side by side on the right, mirroring the card footer. */
-.community-template-preview__actions {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  flex: 0 0 auto;
-}
-
-/* Same treatment as `.community-template-card__foot button`: borderless gray
-   pill at rest, hover fills black with brand-green ink. */
-.community-template-preview__foot button {
-  appearance: none;
-  min-height: 36px;
-  padding: 0 16px;
-  border: 1px solid transparent;
-  border-radius: var(--radius-pill);
-  background: var(--bg-panel);
-  color: var(--text);
-  font: inherit;
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  transition:
-    background-color 140ms var(--ease-out),
-    color 140ms var(--ease-out),
-    border-color 140ms var(--ease-out);
-}
-.community-template-preview__foot button:hover:not(:disabled) {
-  background: var(--text-strong);
-  border-color: transparent;
-  color: var(--brand, #87ea5c);
-  filter: none;
 }
 
 @media (max-width: 980px) {

--- a/apps/web/src/styles/modal-window-drag.css
+++ b/apps/web/src/styles/modal-window-drag.css
@@ -12,7 +12,8 @@
   .home-hero-confirm__backdrop,
   .project-ds-picker-fullscreen,
   .staged-preview-modal,
-  .qs-overlay
+  .qs-overlay,
+  .community-template-preview
 ) {
   --modal-window-drag-strip-height: 56px;
 }
@@ -28,7 +29,8 @@
   .home-hero-confirm__backdrop,
   .project-ds-picker-fullscreen,
   .staged-preview-modal,
-  .qs-overlay
+  .qs-overlay,
+  .community-template-preview
 )::before {
   content: '';
   position: absolute;

--- a/apps/web/tests/components/ProjectRunStatusIcon.test.tsx
+++ b/apps/web/tests/components/ProjectRunStatusIcon.test.tsx
@@ -8,7 +8,7 @@ import { ProjectRunStatusIcon } from '../../src/components/ProjectRunStatusIcon'
 
 afterEach(cleanup);
 
-/** The orb is a span tree; the succeeded badge is an svg. */
+/** The orb is a span tree; the badges are svg. */
 function shapeOf(status: ProjectDisplayStatus) {
   const { container } = render(<ProjectRunStatusIcon status={status} />);
   const root = container.firstElementChild;
@@ -26,12 +26,46 @@ describe('ProjectRunStatusIcon', () => {
     expect(fills).toEqual(['#202020', '#00FF08']);
   });
 
-  it.each<[ProjectDisplayStatus]>([['running'], ['queued'], ['awaiting_input'], ['incomplete'], ['failed']])(
+  it.each<[ProjectDisplayStatus]>([['running'], ['queued'], ['awaiting_input']])(
     'draws %s as the orb',
     (status) => {
       expect(shapeOf(status).kind).toBe('orb');
     },
   );
+
+  it.each<[ProjectDisplayStatus]>([['failed'], ['canceled'], ['incomplete']])(
+    'draws %s as the interrupted badge, not the orb',
+    (status) => {
+      // A stopped run must not spin: the rotation is what says "working".
+      const result = shapeOf(status);
+      expect(result.kind).toBe('badge');
+      expect(result.root!.querySelector('path')?.getAttribute('fill')).toBe('#F34801');
+      // The glyph is a knockout, so it needs the dark plate behind it.
+      expect(result.root!.querySelector('rect')?.getAttribute('fill')).toBe('#121212');
+    },
+  );
+
+  it('gives every interrupted status the identical mark', () => {
+    // One mark for all three; the reason is carried by the status text.
+    const marks = (['failed', 'canceled', 'incomplete'] as const).map(
+      (status) => (shapeOf(status) as { root: Element }).root.innerHTML,
+    );
+    expect(new Set(marks).size).toBe(1);
+  });
+
+  it('turns the attention orb at running speed', () => {
+    // A pending question is a live run, not a stalled one. Only `queued` may
+    // turn slowly, and only because it has not started.
+    const speedOf = (status: ProjectDisplayStatus) => {
+      const { root } = shapeOf(status) as { root: HTMLElement };
+      return root.className
+        .split(' ')
+        .find((c) => c.includes('isThinking') || c.includes('isIdle'));
+    };
+
+    expect(speedOf('awaiting_input')).toBe(speedOf('running'));
+    expect(speedOf('queued')).not.toBe(speedOf('running'));
+  });
 
   it('leaves running and queued on the default green', () => {
     // Same family, same colour — only the speed differs, so neither may set a
@@ -42,32 +76,42 @@ describe('ProjectRunStatusIcon', () => {
     }
   });
 
-  it('recolours the orb per the states that need attention', () => {
+  it('recolours the orb for the state that needs attention', () => {
     const attention = (shapeOf('awaiting_input') as { root: HTMLElement }).root;
-    const incomplete = (shapeOf('incomplete') as { root: HTMLElement }).root;
-    const failed = (shapeOf('failed') as { root: HTMLElement }).root;
 
-    expect(attention.style.getPropertyValue('--c1')).toBe('#EDC337');
-    expect(incomplete.style.getPropertyValue('--c1')).toBe('#EDC337');
-    expect(failed.style.getPropertyValue('--c1')).toBe('#F8672F');
+    expect(attention.style.getPropertyValue('--c1')).toBe('#FF8D02');
+  });
+
+  it('renders the attention orb literally', () => {
+    // Without this the orb edits the colour it is given: three slots still
+    // hold green, and the highlight/saturation/texture passes push a
+    // mid-channel accent off its hue.
+    const { root } = shapeOf('awaiting_input') as { root: HTMLElement };
+    expect(root.className).toContain('isLiteral');
+    // `contrast()` is one of those passes and is set inline, so a class rule
+    // cannot neutralise it — the component has to.
+    expect(root.style.getPropertyValue('--contrast')).toBe('1');
   });
 
   it('moves the second accent with the first', () => {
     // `--c2` is the other accent AND the glow. Left on the stock spring-green
     // it blends with an orange `--c1` into a muddy red-green dot, which is
     // exactly what the first pass shipped.
-    for (const status of ['awaiting_input', 'incomplete', 'failed'] as const) {
-      const { root } = shapeOf(status) as { root: HTMLElement };
-      const c2 = root.style.getPropertyValue('--c2');
-      expect(c2).not.toBe('');
-      expect(c2.toLowerCase()).not.toBe('#00ffae');
-    }
+    const { root } = shapeOf('awaiting_input') as { root: HTMLElement };
+    const c2 = root.style.getPropertyValue('--c2');
+    expect(c2).not.toBe('');
+    expect(c2.toLowerCase()).not.toBe('#00ffae');
+    // Amber to the accent's orange: a second hue, but the warm neighbour of
+    // the first, the way the stock green/spring-green pair is.
+    expect(c2).toBe('#EDC337');
+    // Gold in the glint slot. `literal` strips the white highlights, so the
+    // orb has no lit side at all unless one is named here.
+    expect(root.style.getPropertyValue('--c5')).toBe('#FFC400');
   });
 
-  it('renders nothing for the statuses with nothing to say', () => {
+  it('renders nothing for the status with nothing to say', () => {
     // The caller reserves the slot; this must not fill it with a placeholder.
     expect(shapeOf('not_started').kind).toBe('none');
-    expect(shapeOf('canceled').kind).toBe('none');
   });
 
   it('is decorative unless given a label', () => {

--- a/apps/web/tests/components/template-modal-mapping.test.tsx
+++ b/apps/web/tests/components/template-modal-mapping.test.tsx
@@ -6,7 +6,8 @@
 //   • the FULL plugin details modal (PluginDetailsModal → PreviewModal):
 //     top-right Use split action + Share menu + close;
 //   • the LIGHTWEIGHT template preview (TemplatePreviewModal): header
-//     title/category + close, footer category + Remix.
+//     title/category + close; no footer (the Remix bar is gone per product,
+//     OPEND-2692).
 //
 // Product mapping: the Community gallery card opens the FULL modal, and the
 // creation page's active template chip opens the LIGHTWEIGHT preview. This
@@ -156,7 +157,7 @@ describe('Community template card → full details modal', () => {
 });
 
 describe('creation page active template chip → lightweight preview', () => {
-  it('opens the lightweight template preview (footer category + Remix), not the full details modal', async () => {
+  it('opens the lightweight template preview (header only, no Remix footer), not the full details modal', async () => {
     stubAnimationFrame();
     render(
       <HomeView
@@ -174,13 +175,16 @@ describe('creation page active template chip → lightweight preview', () => {
 
     fireEvent.click(screen.getByTitle('Plugin: Seed Round Pitch'));
 
-    // Lightweight preview: header + footer category with the Remix action.
+    // Lightweight preview: the header carries title + category, and that is
+    // the whole chrome — the footer bar that used to hold the Remix action is
+    // gone (per product, OPEND-2692).
     await waitFor(() => {
       expect(document.querySelector('.community-template-preview')).not.toBeNull();
     });
-    const foot = document.querySelector('.community-template-preview__foot');
-    expect(foot?.textContent).toContain('Slides');
-    expect(foot?.textContent).toContain('Remix');
+    const head = document.querySelector('.community-template-preview__head');
+    expect(head?.textContent).toContain('Slides');
+    expect(document.querySelector('.community-template-preview__foot')).toBeNull();
+    expect(document.querySelector('.community-template-preview')?.textContent).not.toContain('Remix');
 
     // The full modal's Use split action + Share menu must NOT appear here.
     expect(screen.queryByTestId('plugin-details-use-example-fundraising-deck')).toBeNull();

--- a/apps/web/tests/styles/community-template-preview-chrome.test.ts
+++ b/apps/web/tests/styles/community-template-preview-chrome.test.ts
@@ -1,0 +1,78 @@
+// Measurement spec for the community template preview overlay's chrome
+// (OPEND-2691 / OPEND-2692).
+//
+// On the macOS desktop host the window is `hiddenInset` and the OS draws the
+// traffic lights over the top ~32px of the web content; the overlay covers the
+// whole window, so a panel starting 28px down cut straight through them. The
+// darwin host reserves the same 56px band the shared modal drag strip owns;
+// every other host keeps the even 28px inset. The footer bar that carried the
+// Remix action is gone, so the panel is two rows and no `__foot` rule remains.
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { MODAL_WINDOW_DRAG_BACKDROP_SELECTOR } from '../../src/hooks/useModalWindowDragGuard';
+
+const marketplaceCss = readFileSync(
+  new URL('../../src/styles/home/plugin-marketplace-demo.css', import.meta.url),
+  'utf8',
+);
+const dragStripCss = readFileSync(
+  new URL('../../src/styles/modal-window-drag.css', import.meta.url),
+  'utf8',
+);
+
+const DARWIN_OVERLAY_SELECTOR =
+  "html:has(.workspace-shell--desktop[data-host-platform='darwin']) .community-template-preview";
+
+function declarations(css: string, selector: string): string {
+  const cssWithoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  const blocks: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  return blocks.join('\n');
+}
+
+describe('community template preview — window chrome', () => {
+  it('insets the panel from the top through one variable that defaults to 28px', () => {
+    const overlay = declarations(marketplaceCss, '.community-template-preview');
+    expect(overlay).toMatch(/--community-template-preview-inset-top:\s*28px/);
+    expect(overlay).toMatch(/padding:\s*var\(--community-template-preview-inset-top\) 28px 28px/);
+    expect(overlay).toMatch(/position:\s*fixed/);
+  });
+
+  it('reserves the 56px traffic-light band on the macOS desktop host only', () => {
+    const darwin = declarations(marketplaceCss, DARWIN_OVERLAY_SELECTOR);
+    expect(darwin).toMatch(/--community-template-preview-inset-top:\s*56px/);
+    expect(dragStripCss).toMatch(/--modal-window-drag-strip-height:\s*56px/);
+
+    // No other selector may raise the inset: browsers and Windows keep 28px.
+    const setters = marketplaceCss
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .match(/[^{}]+\{[^}]*--community-template-preview-inset-top:[^}]*\}/g)
+      ?.map((rule) => rule.slice(0, rule.indexOf('{')).trim()) ?? [];
+    expect(setters).toEqual(['.community-template-preview', DARWIN_OVERLAY_SELECTOR]);
+  });
+
+  it('shrinks the fit-to-window clamp by the top inset so the panel cannot slide back under the lights', () => {
+    const panel = declarations(marketplaceCss, '.community-template-preview__panel');
+    expect(panel).toMatch(
+      /height:\s*min\(760px, calc\(100vh - 28px - var\(--community-template-preview-inset-top\)\)\)/,
+    );
+    expect(panel).toMatch(/width:\s*min\(1120px, calc\(100vw - 56px\)\)/);
+  });
+
+  it('lets the uncovered top band drag the window like every other full-screen backdrop', () => {
+    expect(MODAL_WINDOW_DRAG_BACKDROP_SELECTOR.split(',')).toContain('.community-template-preview');
+    expect(dragStripCss.match(/\.community-template-preview\b/g)?.length).toBe(2);
+  });
+
+  it('is two rows — head and stage — with no Remix footer left in the stylesheet', () => {
+    const panel = declarations(marketplaceCss, '.community-template-preview__panel');
+    expect(panel).toMatch(/grid-template-rows:\s*auto minmax\(0, 1fr\);/);
+    expect(marketplaceCss).not.toMatch(/community-template-preview__foot/);
+    expect(marketplaceCss).not.toMatch(/community-template-preview__actions/);
+  });
+});

--- a/apps/web/tests/styles/project-reference-modal-rows.test.ts
+++ b/apps/web/tests/styles/project-reference-modal-rows.test.ts
@@ -1,0 +1,74 @@
+// Measurement spec for the 引用其他项目 dialog's project rows (OPEND-2787).
+//
+// Each row is a <button>, so the global primitive (styles/primitives.css) hands
+// it `height: 36px; line-height: 1; white-space: nowrap`. Two lines of text
+// beside a 28px icon need more than that, and a box shorter than its content
+// overflows evenly above and below: the selected border framed only the title
+// band and the overflow drew over the neighbouring rows' meta text. These pins
+// hold the row to its content and keep hover / selected from touching the box.
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const moduleCss = readFileSync(
+  new URL('../../src/components/ProjectReferenceModal.module.css', import.meta.url),
+  'utf8',
+);
+
+function declarations(selector: string): string {
+  const cssWithoutComments = moduleCss.replace(/\/\*[\s\S]*?\*\//g, '');
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  const blocks: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  return blocks.join('\n');
+}
+
+describe('project reference modal — rows', () => {
+  it('sizes the row to its two lines instead of the 36px button primitive', () => {
+    const item = declarations('.item');
+    expect(item).toMatch(/height:\s*auto/);
+    expect(item).toMatch(/min-height:\s*0/);
+    expect(item).toMatch(/line-height:\s*normal/);
+    expect(item).toMatch(/padding:\s*8px 10px/);
+    expect(item).toMatch(/align-items:\s*center/);
+    // The border is always drawn (transparent at rest) so selecting a row
+    // recolours it rather than adding 1px to the box.
+    expect(item).toMatch(/border:\s*1px solid transparent/);
+  });
+
+  it('keeps hover and selected on the same box as the resting row', () => {
+    for (const selector of ['.item:hover', '.item:focus-visible', '.itemSelected']) {
+      const state = declarations(selector);
+      expect(state, selector).not.toMatch(/(?<![a-z-])(?:min-|max-)?height\s*:/);
+      expect(state, selector).not.toMatch(/\bpadding(?:-[a-z]+)?\s*:/);
+      expect(state, selector).not.toMatch(/\bmargin(?:-[a-z]+)?\s*:/);
+      expect(state, selector).not.toMatch(/\bborder-width\s*:/);
+      expect(state, selector).not.toMatch(/\bborder\s*:/);
+      expect(state, selector).not.toMatch(/\btransform\s*:/);
+    }
+    expect(declarations('.itemSelected')).toMatch(/border-color:/);
+    expect(declarations('.itemSelected')).toMatch(/background:/);
+  });
+
+  it('pins the two text lines and the 已选 tag so the row height is stable', () => {
+    expect(declarations('.itemTitle')).toMatch(/line-height:\s*18px/);
+    expect(declarations('.itemTitle')).toMatch(/white-space:\s*nowrap/);
+    expect(declarations('.itemTitle')).toMatch(/text-overflow:\s*ellipsis/);
+    expect(declarations('.itemMeta')).toMatch(/line-height:\s*16px/);
+    expect(declarations('.itemMeta')).toMatch(/white-space:\s*nowrap/);
+    expect(declarations('.itemText')).toMatch(/gap:\s*2px/);
+    const tag = declarations('.currentTag');
+    expect(tag).toMatch(/line-height:\s*16px/);
+    expect(tag).toMatch(/white-space:\s*nowrap/);
+    expect(tag).not.toMatch(/(?<![a-z-])(?:min-)?height\s*:/);
+  });
+
+  it('separates rows with a fixed gap so no row can paint over its neighbour', () => {
+    const list = declarations('.list');
+    expect(list).toMatch(/gap:\s*4px/);
+    expect(list).toMatch(/flex-direction:\s*column/);
+  });
+});

--- a/e2e/ui/community-template-modal-mapping.test.ts
+++ b/e2e/ui/community-template-modal-mapping.test.ts
@@ -4,8 +4,8 @@
 //   • the Community gallery card opens the FULL plugin details modal
 //     (Use split action + Share menu + close);
 //   • the creation page's active template chip opens the LIGHTWEIGHT
-//     community preview (header title/category + close, footer category +
-//     Remix).
+//     community preview (header title/category + close; no footer — the Remix
+//     bar is gone per product, OPEND-2692).
 // Before the swap the two entries were reversed. These specs pin the
 // corrected mapping end-to-end through the real entry shell.
 
@@ -170,12 +170,13 @@ test('[P0] signed-out Local setup can use a Community template on Home', async (
   await page.getByTestId(`plugin-details-use-${DECK_PLUGIN.id}`).click();
   await expect(page.getByTestId('home-hero-active-plugin')).toBeVisible();
 
-  // The chip's detail entry opens the LIGHTWEIGHT preview: footer category +
-  // Remix, no Use split action, no Share menu.
+  // The chip's detail entry opens the LIGHTWEIGHT preview: header category
+  // + close only — no Remix footer, no Use split action, no Share menu.
   await page.getByTestId('home-hero-active-plugin').locator('.home-hero__active-chip-body').click();
   await expect(page.locator('.community-template-preview')).toBeVisible();
-  const foot = page.locator('.community-template-preview__foot');
-  await expect(foot).toContainText('Remix');
+  await expect(page.locator('.community-template-preview__head')).toContainText('Slides');
+  await expect(page.locator('.community-template-preview__foot')).toHaveCount(0);
+  await expect(page.locator('.community-template-preview')).not.toContainText('Remix');
   await expect(page.getByTestId(`plugin-details-use-${DECK_PLUGIN.id}`)).toHaveCount(0);
   await expect(page.locator('.template-share-trigger')).toHaveCount(0);
 


### PR DESCRIPTION
## Why

OPEND-2553 phase one, PR-F3. Two things made this PR: the Demo (#7635) gained two commits after our last sync — the run-status glyph rework that answers the QA finding that running / awaiting / failed are hard to tell apart at 18px (OPEND-2743, with product's spec "绿色运行、黄色意图澄清 loading，红色报错不 loading"), and the Chinese home headline reword — and QA filed three visual defects on the feature branch that are cheap to fix together because they all sit in modal chrome: the template preview overlapping the macOS traffic lights (OPEND-2691), the preview's Remix footer that product removed (OPEND-2692), and the 引用其它项目 dialog's selected row framing only the title and painting over its neighbours (OPEND-2787).

The pain: every one of these is on the acceptance list for the phase-one branch, and the status-glyph half of OPEND-2744 (a pending question must read as a live run, not a finished one) is settled by the same Demo commit.

## What users will see

- **Left rail 最近项目 rows and the project switcher dropdown**: a run that stopped without delivering — failed, canceled, or finished with declared work undone — shows one static orange-red badge (it no longer spins; canceled had no glyph at all before). A project waiting on the user's answer shows a warm orange orb turning at running's speed instead of a slow amber one. Only queued still turns slowly. Succeeded keeps the check.
- **Home headline (zh-CN only)**: 「我们来设计点{word}」 → 「让我们创建{word}」, rotating 原型 → 幻灯片 → 文档. This is the wording the design side gave; other locales are untouched.
- **Template preview (Home active-template chip → preview)**: the footer bar with 「Remix」 is gone; the header still names the category. On the macOS desktop app the panel now starts below the title-bar band, so it no longer cuts through the traffic lights on windows shorter than ~816px; browsers and Windows keep the previous even inset.
- **引用其它项目 dialog**: each project row is as tall as its two lines; the selected frame wraps icon, title, type and the 已选 tag, and rows no longer overlap each other on hover / selection / search.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow) — no new key; the existing `homeHero.title` value changes in `zh-CN` only (design-supplied Chinese copy; other locales deliberately untouched)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install) — the run-status glyphs and the Chinese headline change for everyone on this branch
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Left rail 最近项目 rows, six statuses faked through `/api/runs` (running · awaiting_input · failed · canceled · queued · succeeded), before → after. Awaiting now turns at running's speed; failed / canceled / incomplete share the static badge:

![rail before/after](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f3/cmp-rail.png)

Hovered row:

![rail hover before/after](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f3/cmp-rail-hover.png)

引用其它项目 dialog after selecting the second row and hovering the third (OPEND-2787). Before: rows are the 36px button primitive, text overflows the frame and the next row paints over it. After: 54px rows, one box for default / hover / selected:

![reference before/after](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f3/cmp-reference.png)

Same dialog with a search filter and a long title:

![reference search before/after](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f3/cmp-reference-search.png)

Template preview on the macOS desktop app (`tools-dev inspect desktop screenshot`, window 1205×767 so the fit-to-window clamp is active). `capturePage` does not draw the native traffic lights; they sit at x 12–64 / y 20–32 of the window, where the before panel's top edge (y = 28) cuts through and the after panel (y = 56) does not. The Remix footer is gone (OPEND-2691 / OPEND-2692):

![desktop preview before/after](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f3/cmp-preview-desktop.png)

Same preview in a browser (no traffic lights, even 28px inset kept; only the footer changes):

![web preview before/after](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f3/cmp-preview-web.png)

## Bug fix verification

- OPEND-2787: `apps/web/tests/styles/project-reference-modal-rows.test.ts` pins the row box (`height: auto`, fixed line heights) and forbids hover / selected from touching it. Red on `feat/home-entry-refresh` (the module never overrode the primitive's 36px), green here. Measured in the running app: row height 36 → 54, text no longer extends past the row box (before: text 302–339 inside a 291–327 box).
- OPEND-2691 / OPEND-2692: `apps/web/tests/styles/community-template-preview-chrome.test.ts` pins the darwin-only 56px inset, the panel clamp subtracting it, the two-row panel and the absence of any `__foot` rule. Red on the base branch, green here. Verified in the desktop app: overlay padding-top 28 → 56, panel top 28 → 56, footer present → absent.
- OPEND-2743: `apps/web/tests/components/ProjectRunStatusIcon.test.tsx` (from the Demo commit) covers the glyph per status and the speed split.
- `apps/web/tests/components/template-modal-mapping.test.tsx` and `e2e/ui/community-template-modal-mapping.test.ts` asserted the Remix footer; both now assert the header carries the category and no footer exists.

## Validation

- `pnpm guard`, `pnpm typecheck`, `pnpm i18n:check`, `pnpm --filter @open-design/e2e typecheck`: pass
- `pnpm --filter @open-design/web test`: 691 files, 7333 passed, 1 expected fail, 11 skipped
- `cd e2e && pnpm exec playwright test ui/community-template-modal-mapping.test.ts`: 3 passed
- Manual: two isolated `tools-dev` runtimes (base branch vs this branch) driven by an ad-hoc Playwright script for the rail / dialog / preview captures above; `tools-dev start desktop` + `inspect desktop eval` / `screenshot` on macOS for the traffic-light check.

## Notes for review

- Both Demo commits (`79be3bc321`, `997a0a08f3`) cherry-picked with zero conflicts; commit messages rewritten without trailers.
- The community preview overlay joins `MODAL_WINDOW_DRAG_BACKDROP_SELECTOR`, so its uncovered top band drags the window like every other full-screen backdrop. In a browser this means a click in the top 56px of the scrim no longer dismisses the preview — the same trade every backdrop in that list already makes.
- `TemplatePreviewModal`'s `onUse` / `busy` props are kept optional so the HomeView call site is untouched (per the Demo); the Demo's other preview changes (8% scale, radius, Esc handling) belong to 阶段三 and are not in this PR.
- OPEND-2744's other half (top-of-chat copy while a question is pending) is a product call and stays open.
