### PR TITLE
fix(daemon): keep the failure verdict alive from the watchdog to the card

### DIFF
--- a/apps/daemon/src/agent-protocol/acp/rpc.ts
+++ b/apps/daemon/src/agent-protocol/acp/rpc.ts
@@ -101,9 +101,15 @@ export function rpcErrorData(raw: unknown): unknown {
   return error && 'data' in error ? error.data : undefined;
 }
 /**
- * Reads the `retryable` boolean from a structured RPC error `data` payload.
- * Returns `undefined` when the field is absent so callers can distinguish
- * "explicitly false" from "not present" and apply their own default.
+ * Reads an upstream retryability statement out of a structured RPC error `data`
+ * payload. Returns `undefined` when no statement is present so callers can
+ * distinguish "explicitly false" from "not present" and apply their own default.
+ *
+ * The two spellings are not read with equal authority, and deliberately so:
+ * ACP's own `retryable` is honoured in both directions, while the vendor
+ * `isRetryable` flag is honoured only when it says `true` — the same asymmetry
+ * `inferRpcErrorRetryable` applies to that field's string form, so the bridge's
+ * verdict does not depend on which shape the adapter happened to send.
  *
  * @param data - The value of `error.data` extracted via `rpcErrorData`.
  */
@@ -118,7 +124,22 @@ export function rpcErrorRetryable(data: unknown): boolean | undefined {
   // dropping the one authoritative word upstream said about its own failure —
   // `run-failure-classification.ts` already knew this spelling
   // (`latestRetryable` reads `error.data.isRetryable`); the bridge did not.
-  if (typeof details?.isRetryable === 'boolean') return details.isRetryable;
+  //
+  // Only `true` is read, under exactly the rule `inferRpcErrorRetryable` states
+  // for the string form of the same field. The two readers are composed with
+  // `??` in `session.ts`, so returning `false` here would not merely record a
+  // "no" — it would short-circuit the message reader that may hold a better
+  // answer, and hand `fail()` a verdict the classifier then adopts. Letting a
+  // coarse SDK flag force `false` is the drift `run-failure-classification.ts`
+  // refuses by name; an explicit upstream "no" is already served by the
+  // branches that can disprove it (a 4xx re-fails identically, and
+  // `upstreamDetail` routes it to `upstream_client_error`).
+  //
+  // `retryable` above is a different thing and keeps both values: it is the
+  // ACP protocol's own field, a statement the agent makes deliberately about
+  // this frame, not a status-code-derived SDK flag riding along inside a
+  // vendor payload.
+  if (details?.isRetryable === true) return true;
   return undefined;
 }
 /**

--- a/apps/daemon/src/agent-protocol/acp/rpc.ts
+++ b/apps/daemon/src/agent-protocol/acp/rpc.ts
@@ -109,7 +109,17 @@ export function rpcErrorData(raw: unknown): unknown {
  */
 export function rpcErrorRetryable(data: unknown): boolean | undefined {
   const details = asObject(data);
-  return typeof details?.retryable === 'boolean' ? details.retryable : undefined;
+  if (typeof details?.retryable === 'boolean') return details.retryable;
+  // `isRetryable` is the same statement under the AI-SDK / opencode spelling
+  // (`{"error":{"data":{"isRetryable":true,…}}}`). Accepted here for the case
+  // where an adapter passes that object through as ACP `error.data`; the
+  // observed 2026-09-08 corpus carries it inside the message string instead,
+  // which `inferRpcErrorRetryable` below covers. Either way the bridge stops
+  // dropping the one authoritative word upstream said about its own failure —
+  // `run-failure-classification.ts` already knew this spelling
+  // (`latestRetryable` reads `error.data.isRetryable`); the bridge did not.
+  if (typeof details?.isRetryable === 'boolean') return details.isRetryable;
+  return undefined;
 }
 /**
  * Fallback retryability inference from the error message/details text, used when
@@ -130,6 +140,28 @@ export function inferRpcErrorRetryable(message: string, data: unknown): boolean 
   if (/\b(upstream_error|stream idle timeout|no data received within configured window|temporarily unavailable|overloaded|gateway timeout|service unavailable)\b/i.test(text)) {
     return true;
   }
+  // opencode states its own retryability as a machine-readable field, and vela
+  // hands us the whole `session.error` envelope carrying it — but as a JSON
+  // STRING inside the message, not as ACP `error.data`, so neither
+  // `rpcErrorRetryable` above nor the classifier's `latestRetryable` (which
+  // reads `error.data.isRetryable`) could ever see it.
+  //
+  // Real corpus, 2026-09-08, runs 423140d1 and e9bea966: a closed upstream
+  // socket after opencode had already exhausted its own three attempts —
+  // `{"isRetryable":true,"message":"Cannot connect to API: The socket
+  // connection was closed unexpectedly…"}`. With that word unread, `fail()`
+  // stamped the frame `retryable: false` (its default for a frame that carries
+  // details but no verdict), the classifier took that as the run's verdict, and
+  // `isResumableFailure` — which returns false the moment `retryable` is false
+  // — withdrew the Continue affordance from the single most recoverable failure
+  // there is.
+  //
+  // Only `true` is read here. An explicit upstream "no" is already handled by
+  // the branches that can disprove it (a 4xx request shape re-fails
+  // identically, and `upstreamDetail` routes it to `upstream_client_error`),
+  // and letting a coarse SDK flag force `false` is the drift
+  // `run-failure-classification.ts` already refuses by name.
+  if (/"is_?retryable"\s*:\s*true/i.test(text)) return true;
   return undefined;
 }
 /**

--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -489,10 +489,19 @@ export function attachAcpSession({
       // `details.kind` is the same discriminator the other named ACP failures
       // already carry (`acp_child_exit`, `acp_no_visible_output`, `amr_model`),
       // so the classifier can read the verdict instead of re-deriving it.
+      //
+      // The value is namespaced to this watchdog on purpose. `details` is NOT a
+      // daemon-private slot: the JSON-RPC error branch below copies an agent's
+      // `error.data` into it verbatim (`fail(rpcErr, { details })`), so a
+      // generic `kind: 'timeout'` — a value any vendor SDK might plausibly emit
+      // for its own timeout — would arrive at `hasDaemonTimeoutVerdict`
+      // indistinguishable from this one and claim a watchdog kill that never
+      // happened. `acp_stage_timeout` names the specific daemon mechanism, so
+      // no upstream payload collides with it by accident.
       fail(`ACP ${label} timed out after ${stageTimeoutMs}ms`, {
         retryable: true,
         details: {
-          kind: 'timeout',
+          kind: 'acp_stage_timeout',
           action: 'retry',
           phase: label,
           timeout_ms: stageTimeoutMs,
@@ -546,6 +555,24 @@ export function attachAcpSession({
     if (!terminalOwnedByCaller && !child.killed) child.kill('SIGTERM');
   };
 
+  /**
+   * Terminate the turn with a message, and optionally a structured payload.
+   *
+   * `options.details` is emitted as `error.details`, and that slot is SHARED:
+   * daemon-authored verdicts (`acp_stage_timeout`, `acp_child_exit`,
+   * `acp_no_visible_output`, `amr_model`) and agent-supplied JSON-RPC
+   * `error.data` — copied in verbatim by the two `fail(rpcErr, { details })`
+   * call sites in the message handler — land in the same place and are
+   * indistinguishable once emitted. Anything downstream that reads a
+   * daemon verdict out of `details` is therefore trusting a name, not an
+   * origin: keep those names namespaced to the mechanism that writes them
+   * (`acp_stage_timeout`, not `timeout`) so no upstream payload collides by
+   * accident.
+   *
+   * To make a daemon verdict genuinely unforgeable it needs its own option and
+   * its own emitted field, one no agent payload is ever copied into. That is a
+   * frame-shape change and is deliberately not done here.
+   */
   const fail = (
     message: string,
     options: { forceModelUnavailable?: boolean; details?: unknown; retryable?: boolean } = {},

--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -474,7 +474,30 @@ export function attachAcpSession({
     // session immediately.
     if (stageWatchdogDisabled) return;
     stageTimer = setTimeout(() => {
-      fail(`ACP ${label} timed out after ${stageTimeoutMs}ms`);
+      // This is the DAEMON's own verdict, not the agent's: nobody reported a
+      // failure, we decided the stage was over and killed the child. Say so in
+      // structured form.
+      //
+      // Emitted bare (`{ message }`), the only thing that could still recover
+      // "this run timed out" was a regex over the English sentence below
+      // (`isTimeoutText` in run-failure-classification.ts). Every path that
+      // rewrites, wraps, localizes or drops an ACP error message therefore
+      // silently downgraded the run to `process_exit / exit_code` — which is
+      // `retryable: false` / `user_action: 'none'`, i.e. the generic failure
+      // card with no Retry, for a failure whose whole remedy IS a retry.
+      //
+      // `details.kind` is the same discriminator the other named ACP failures
+      // already carry (`acp_child_exit`, `acp_no_visible_output`, `amr_model`),
+      // so the classifier can read the verdict instead of re-deriving it.
+      fail(`ACP ${label} timed out after ${stageTimeoutMs}ms`, {
+        retryable: true,
+        details: {
+          kind: 'timeout',
+          action: 'retry',
+          phase: label,
+          timeout_ms: stageTimeoutMs,
+        },
+      });
     }, stageTimeoutMs);
   };
 

--- a/apps/daemon/src/agent-session-resume.ts
+++ b/apps/daemon/src/agent-session-resume.ts
@@ -509,6 +509,14 @@ const AMR_RESUME_FAILURE_PATTERN = /"kind"\s*:\s*"resume_failed"/;
 const AMR_OPENCODE_EVENT_STREAM_RESUME_FAILURE_PATTERNS: RegExp[] = [
   /opencode SSE ended before prompt completion/i,
   /opencode event stream:\s*opencode SSE ended before prompt completion/i,
+  // vela 0.0.35 (#1847) split the compaction continuation onto its own
+  // request, and worded its EOF differently. Same bridge, same stream, same
+  // "the event stream ended before the prompt finished" — only the phase it
+  // died in is new, so it belongs to the same recoverable class. Until this
+  // line existed the wording matched nothing in the repository, so a
+  // compaction that died mid-continuation could not even reach the re-seed
+  // path and ended the conversation on a hard failure instead.
+  /opencode compaction continuation ended before prompt completion/i,
 ];
 
 /** True when vela's ACP output carries a resume_failed signal. */

--- a/apps/daemon/src/run-failure-classification.ts
+++ b/apps/daemon/src/run-failure-classification.ts
@@ -728,17 +728,25 @@ function readRuntimeCloseReason(
  * Invariant: a verdict the daemon reached on its own survives without its own
  * prose. The ACP stage watchdog decides a stage is over and kills the child —
  * nothing upstream reported anything — and it stamps that decision as
- * `error.details.kind === 'timeout'` (see `agent-protocol/acp/session.ts`).
+ * `error.details.kind === 'acp_stage_timeout'` (see `agent-protocol/acp/session.ts`).
  * Reading the marker rather than regex-matching the sentence it happened to
  * write is what stops a reworded, wrapped, localized or dropped message from
  * silently re-filing a watchdog kill as an opaque `process_exit / exit_code` —
  * which is `retryable: false` / `user_action: 'none'`, the one verdict this
  * failure must never get, since a retry is its entire remedy.
  *
- * Deliberately narrow: only the daemon writes this marker, and only for the
- * stage watchdog. An agent's own error frame cannot forge a timeout verdict
- * with it, because agent-supplied data lands under `error.data`, not
- * `error.details` (see `eventErrorText`).
+ * The value is matched exactly, and it is namespaced to the mechanism that
+ * writes it. `error.details` is NOT a daemon-private slot — `fail()` copies an
+ * agent's JSON-RPC `error.data` straight into it — so the marker's protection
+ * comes from being a name no upstream payload emits, not from the slot being
+ * unreachable. A generic `kind: 'timeout'`, which any vendor SDK might send for
+ * its own timeout, would have been read here as a watchdog kill that never
+ * happened, and would additionally have outranked the forced-signal guard below.
+ *
+ * This is collision resistance, not authentication: an adapter that deliberately
+ * sent `kind: 'acp_stage_timeout'` would still be believed. Making the verdict
+ * unforgeable requires carrying it in a field agent payload can never reach —
+ * see the note on `fail()` in `agent-protocol/acp/session.ts`.
  */
 function hasDaemonTimeoutVerdict(
   events: RunEventForFailureClassification[] = [],
@@ -755,7 +763,7 @@ function hasDaemonTimeoutVerdict(
     const details = nested?.details && typeof nested.details === 'object'
       ? nested.details as Record<string, unknown>
       : null;
-    if (details?.kind === 'timeout') return true;
+    if (details?.kind === 'acp_stage_timeout') return true;
   }
   return false;
 }

--- a/apps/daemon/src/run-failure-classification.ts
+++ b/apps/daemon/src/run-failure-classification.ts
@@ -722,6 +722,44 @@ function readRuntimeCloseReason(
   return null;
 }
 
+/**
+ * True when the DAEMON itself declared this run timed out.
+ *
+ * Invariant: a verdict the daemon reached on its own survives without its own
+ * prose. The ACP stage watchdog decides a stage is over and kills the child —
+ * nothing upstream reported anything — and it stamps that decision as
+ * `error.details.kind === 'timeout'` (see `agent-protocol/acp/session.ts`).
+ * Reading the marker rather than regex-matching the sentence it happened to
+ * write is what stops a reworded, wrapped, localized or dropped message from
+ * silently re-filing a watchdog kill as an opaque `process_exit / exit_code` —
+ * which is `retryable: false` / `user_action: 'none'`, the one verdict this
+ * failure must never get, since a retry is its entire remedy.
+ *
+ * Deliberately narrow: only the daemon writes this marker, and only for the
+ * stage watchdog. An agent's own error frame cannot forge a timeout verdict
+ * with it, because agent-supplied data lands under `error.data`, not
+ * `error.details` (see `eventErrorText`).
+ */
+function hasDaemonTimeoutVerdict(
+  events: RunEventForFailureClassification[] = [],
+): boolean {
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    const rec = events[i];
+    if (!rec || rec.event !== 'error') continue;
+    const payload = rec.data && typeof rec.data === 'object'
+      ? rec.data as Record<string, unknown>
+      : null;
+    const nested = payload?.error && typeof payload.error === 'object'
+      ? payload.error as Record<string, unknown>
+      : null;
+    const details = nested?.details && typeof nested.details === 'object'
+      ? nested.details as Record<string, unknown>
+      : null;
+    if (details?.kind === 'timeout') return true;
+  }
+  return false;
+}
+
 // Promote the opaque `execution_failed` detail to the specific close reason when
 // one of the three currently-unclassified shapes is present. Every other reason
 // (and a missing diagnostic) keeps the opaque label so the bucket never silently
@@ -933,6 +971,11 @@ function classifyRunFailureBase(
   // Compute once; used both for the early empty_output guard below and for the
   // fatal_rpc_error promotion later in this function.
   const runtimeCloseReason = readRuntimeCloseReason(events);
+  // The daemon's own watchdog verdict, read structurally. Computed here beside
+  // the other once-only signals because two branches consult it: the forced
+  // signal guard below (a watchdog kill IS a signal, and the reason it was
+  // killed outranks the bare signal) and the timeout branch itself.
+  const daemonTimeoutVerdict = hasDaemonTimeoutVerdict(events);
   const amrFailure = classifyAmrAccountFailure(text);
   const byokOpenCodeProviderNotFound = isByokOpenCodeProviderNotFoundText(
     input.agentId,
@@ -1061,7 +1104,12 @@ function classifyRunFailureBase(
    *    before escalating to a kill, and WHY it was killed beats the bare signal.
    */
   const forcedSignal = forcedSignalName(errorCode, input.status.signal);
-  if (forcedSignal && !isTimeoutText(text) && errorCode !== 'TIMEOUT') {
+  if (
+    forcedSignal &&
+    !isTimeoutText(text) &&
+    errorCode !== 'TIMEOUT' &&
+    !daemonTimeoutVerdict
+  ) {
     const forced = signalInterruptClassification(errorCode, text, retryableHint, forcedSignal);
     if (forced) return forced;
   }
@@ -1364,7 +1412,7 @@ function classifyRunFailureBase(
     );
   }
 
-  if (isTimeoutText(text) || errorCode === 'TIMEOUT') {
+  if (isTimeoutText(text) || errorCode === 'TIMEOUT' || daemonTimeoutVerdict) {
     const retryable = retryableHint ?? true;
     const inactivityTimeout = /inactivity|stalled|hung|no new output|without emitting any new output/i.test(text);
     // `attachAcpSession`'s stage watchdog fails the turn with
@@ -1373,7 +1421,12 @@ function classifyRunFailureBase(
     // trigger the terminal reads as a bare AGENT_EXIT_130 — indistinguishable
     // from a user interrupt, which is how the 2026-07-28 AMR stall got
     // attributed to the wrong watchdog and the wrong 15-minute window.
-    const acpStageTimeout = /\bACP\b[^\n]*timed out after \d+\s*ms/i.test(text);
+    //
+    // The structured verdict counts too: it is emitted by that same watchdog
+    // and by nothing else, so the trigger keeps naming the watchdog even when
+    // the sentence it wrote is gone.
+    const acpStageTimeout =
+      daemonTimeoutVerdict || /\bACP\b[^\n]*timed out after \d+\s*ms/i.test(text);
     const terminalTrigger: TrackingRunTerminalTrigger | undefined =
       /without emitting a first output/i.test(text)
         ? 'first_output_deadline'

--- a/apps/daemon/tests/acp-stage-timeout-classification.test.ts
+++ b/apps/daemon/tests/acp-stage-timeout-classification.test.ts
@@ -78,6 +78,46 @@ async function stallPastStageWatchdog(): Promise<Emitted[]> {
 }
 
 /**
+ * Drive the same real session and let the AGENT answer `session/prompt` with a
+ * JSON-RPC error carrying `error.data` — the one channel an ACP agent controls.
+ * Returns the error frame the bridge actually emitted, so a test can classify
+ * the daemon's real output instead of a hand-built approximation of it.
+ *
+ * The stage watchdog is given far more time than the frame needs, so anything
+ * this produces came from the agent's payload and not from a timer.
+ */
+async function bridgeAgentRpcError(
+  data: unknown,
+): Promise<{ frame: ErrorFrame; message: string }> {
+  const child = new FakeAcpChild();
+  const events: Emitted[] = [];
+  attachAcpSession({
+    child: child as never,
+    prompt: 'write the landing page',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+    stageTimeoutMs: 600_000,
+  });
+  writeResult(child, 1, {});
+  writeResult(child, 2, { sessionId: 'session-1' });
+  child.stdout.write(
+    `${JSON.stringify({
+      jsonrpc: '2.0',
+      id: 4,
+      error: { code: -32000, message: 'upstream refused the request', data },
+    })}\n`,
+  );
+  await vi.advanceTimersByTimeAsync(10);
+  const error = events.find((e) => e.event === 'error');
+  assert.ok(error, 'expected the bridge to emit an error event');
+  const frame = error.payload as ErrorFrame;
+  assert.ok(typeof frame.message === 'string', 'expected a message on the frame');
+  return { frame, message: frame.message };
+}
+
+/**
  * The classifier input a stage-timeout run reaches finalize with. The child is
  * SIGTERMed by the watchdog, so the process-level facts say nothing about why.
  */
@@ -121,7 +161,7 @@ describe('ACP stage watchdog names its own verdict', () => {
       // …and now it is also NAMED, so nothing downstream has to parse that
       // sentence to learn what happened.
       expect(frame.error?.details).toMatchObject({
-        kind: 'timeout',
+        kind: 'acp_stage_timeout',
         action: 'retry',
         phase: 'session/prompt',
         timeout_ms: 1000,
@@ -147,7 +187,7 @@ describe('ACP stage watchdog names its own verdict', () => {
             code: 'AGENT_EXECUTION_FAILED',
             message: 'the run was ended by the host',
             retryable: true,
-            details: { kind: 'timeout', action: 'retry', phase: 'session/prompt', timeout_ms: 1_800_000 },
+            details: { kind: 'acp_stage_timeout', action: 'retry', phase: 'session/prompt', timeout_ms: 1_800_000 },
           },
         },
         'the run was ended by the host',
@@ -175,7 +215,7 @@ describe('ACP stage watchdog names its own verdict', () => {
             code: 'AGENT_EXECUTION_FAILED',
             message: 'ACP session/prompt timed out after 1800000ms',
             retryable: true,
-            details: { kind: 'timeout', action: 'retry', phase: 'session/prompt', timeout_ms: 1_800_000 },
+            details: { kind: 'acp_stage_timeout', action: 'retry', phase: 'session/prompt', timeout_ms: 1_800_000 },
           },
         },
         'ACP session/prompt timed out after 1800000ms',
@@ -238,7 +278,7 @@ describe('the timeout verdict does not spread to failures that are not timeouts'
             code: 'AGENT_EXECUTION_FAILED',
             message: 'ACP session completed without producing any output',
             retryable: true,
-            details: { kind: 'timeout', action: 'retry', phase: 'session/prompt', timeout_ms: 1_000 },
+            details: { kind: 'acp_stage_timeout', action: 'retry', phase: 'session/prompt', timeout_ms: 1_000 },
           },
         },
         'ACP session completed without producing any output',
@@ -249,23 +289,61 @@ describe('the timeout verdict does not spread to failures that are not timeouts'
     expect(failure?.failure_detail).toBe('empty_output');
   });
 
-  it('does not let an agent-supplied payload forge a timeout verdict', () => {
-    // Agent-reported JSON-RPC data lands under `error.data`, never
-    // `error.details` — the marker is daemon-authored by construction.
-    const failure = classifyRunFailure(
-      stageTimeoutClassifierInput(
-        {
-          message: 'json-rpc id 4: upstream refused the request',
-          error: {
-            code: 'AGENT_EXECUTION_FAILED',
-            message: 'json-rpc id 4: upstream refused the request',
-            data: { kind: 'timeout' },
-          },
-        },
-        'json-rpc id 4: upstream refused the request',
-      ),
-    );
+  /**
+   * This replaces a test that asserted the same thing against `error.data` —
+   * a shape the session bridge never emits. `fail()` copies an agent's
+   * JSON-RPC `error.data` straight into the `error.details` slot
+   * (`fail(rpcErr, { details: rpcErrorData(obj) })`), so the frame the
+   * classifier actually receives has agent-authored content sitting exactly
+   * where the daemon writes its own verdict. Constructing `error.data` by hand
+   * at the classifier boundary tested a frame that cannot exist, and passed
+   * without ever exercising the copy.
+   *
+   * So this drives the real bridge and classifies the frame it really emits.
+   */
+  it('does not let an agent-supplied payload forge a timeout verdict', async () => {
+    vi.useFakeTimers();
+    try {
+      const { frame, message } = await bridgeAgentRpcError({ kind: 'timeout' });
 
-    expect(failure?.failure_category).not.toBe('timeout');
+      // The mechanism, pinned as a fact about the bridge rather than assumed:
+      // the agent's `error.data` really does land in the daemon's `details`
+      // slot. If a future change stops copying it, this line says so.
+      expect(frame.error?.details).toEqual({ kind: 'timeout' });
+
+      const failure = classifyRunFailure(stageTimeoutClassifierInput(frame, message));
+
+      expect(failure?.failure_category).not.toBe('timeout');
+      expect(failure?.terminal_trigger).not.toBe('acp_stage_timeout');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('classifies the watchdog frame the bridge really emits', async () => {
+    // The positive control for the test above, driven the same way: the marker
+    // has to survive the round trip from the real watchdog through the real
+    // frame into the classifier, or the negative test could be passing because
+    // the marker stopped working at all.
+    vi.useFakeTimers();
+    try {
+      const events = await stallPastStageWatchdog();
+      const error = events.find((e) => e.event === 'error');
+      assert.ok(error, 'expected a stage-timeout error event');
+      const frame = error.payload as ErrorFrame;
+
+      const failure = classifyRunFailure(
+        // The sentence is deliberately withheld: this asserts the STRUCTURED
+        // verdict carries the run on its own, which is the whole point of
+        // emitting one.
+        stageTimeoutClassifierInput(frame, 'the run was ended by the host'),
+      );
+
+      expect(failure?.failure_category).toBe('timeout');
+      expect(failure?.terminal_trigger).toBe('acp_stage_timeout');
+      expect(failure?.user_action).toBe('retry');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/daemon/tests/acp-stage-timeout-classification.test.ts
+++ b/apps/daemon/tests/acp-stage-timeout-classification.test.ts
@@ -1,0 +1,271 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+
+import { attachAcpSession } from '../src/agent-protocol/index.js';
+import { classifyRunFailure } from '../src/run-failure-classification.js';
+import type { RunEventForFailureClassification } from '../src/run-failure-classification.js';
+
+/**
+ * Red spec: an ACP stage-watchdog kill must reach the client NAMED.
+ *
+ * The failure this pins (real user run `500540ac`, 0.22.0-prerelease.19): a
+ * `Write` tool call sat for 1800.05s producing zero bytes, the ACP stage
+ * watchdog gave up and killed the child, and after 40 minutes the user got the
+ * generic 「任务执行失败」 card with no Retry — for a failure whose entire
+ * remedy is a retry.
+ *
+ * The watchdog is the DAEMON's own verdict: nothing upstream reported anything,
+ * the daemon decided the stage was over. Yet it shipped that verdict as a bare
+ * `{ message: 'ACP <stage> timed out after <n>ms' }`, so the only thing that
+ * could still recover "this run timed out" downstream was a regex over that
+ * English sentence (`isTimeoutText`). Every path that rewrites, wraps or drops
+ * an ACP error message therefore re-filed a watchdog kill as an opaque
+ * `process_exit / exit_code` — `retryable: false`, `user_action: 'none'` —
+ * which is exactly the no-Retry card.
+ *
+ * So the invariant is not "the sentence is right", it is: the verdict survives
+ * without its own prose.
+ */
+
+class FakeAcpChild extends EventEmitter {
+  stdin = new PassThrough();
+  stdout = new PassThrough();
+  stderr = new PassThrough();
+  killed = false;
+
+  kill(): boolean {
+    this.killed = true;
+    return true;
+  }
+}
+
+type Emitted = { event: string; payload: unknown };
+
+type ErrorFrame = {
+  message?: unknown;
+  error?: {
+    code?: unknown;
+    message?: unknown;
+    retryable?: unknown;
+    details?: Record<string, unknown>;
+  };
+};
+
+function writeResult(child: FakeAcpChild, id: number, result: unknown): void {
+  child.stdout.write(`${JSON.stringify({ id, result })}\n`);
+}
+
+/** Drive a session to the point where only the stage watchdog can end it. */
+async function stallPastStageWatchdog(): Promise<Emitted[]> {
+  const child = new FakeAcpChild();
+  const events: Emitted[] = [];
+  attachAcpSession({
+    child: child as never,
+    prompt: 'write the landing page',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+    stageTimeoutMs: 1_000,
+  });
+  writeResult(child, 1, {});
+  writeResult(child, 2, { sessionId: 'session-1' });
+  // `session/prompt` is never answered — the real shape of the reported run.
+  await vi.advanceTimersByTimeAsync(1_500);
+  return events;
+}
+
+/**
+ * The classifier input a stage-timeout run reaches finalize with. The child is
+ * SIGTERMed by the watchdog, so the process-level facts say nothing about why.
+ */
+function stageTimeoutClassifierInput(
+  errorPayload: unknown,
+  statusError: string | null,
+) {
+  const events: RunEventForFailureClassification[] = [
+    { event: 'start', data: { bin: 'vela' } },
+    { event: 'error', data: errorPayload },
+  ];
+  return {
+    result: 'failed' as const,
+    status: {
+      status: 'failed',
+      error: statusError,
+      errorCode: null,
+      exitCode: 1,
+      signal: 'SIGTERM',
+    },
+    agentId: 'amr',
+    cancelOrigin: null,
+    terminalTrigger: null,
+    events,
+  } as Parameters<typeof classifyRunFailure>[0];
+}
+
+describe('ACP stage watchdog names its own verdict', () => {
+  it('emits a classified error frame, not a bare message', async () => {
+    vi.useFakeTimers();
+    try {
+      const events = await stallPastStageWatchdog();
+      const error = events.find((e) => e.event === 'error');
+      assert.ok(error, 'expected a stage-timeout error event');
+      const frame = error.payload as ErrorFrame;
+
+      // The sentence is still the sentence — it is what the details drawer
+      // shows and what telemetry reads. Naming the failure must not reword it.
+      expect(frame.message).toMatch(/ACP session\/prompt timed out after 1000ms/);
+
+      // …and now it is also NAMED, so nothing downstream has to parse that
+      // sentence to learn what happened.
+      expect(frame.error?.details).toMatchObject({
+        kind: 'timeout',
+        action: 'retry',
+        phase: 'session/prompt',
+        timeout_ms: 1000,
+      });
+      // A watchdog kill is the one failure whose whole remedy is a retry.
+      expect(frame.error?.retryable).toBe(true);
+      expect(typeof frame.error?.code).toBe('string');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps the timeout verdict when the message no longer says "timed out"', () => {
+    // The same watchdog kill, with its sentence gone — wrapped, localized,
+    // truncated, or lost on one of the paths that rewrite an ACP error frame.
+    // The structured verdict is the only evidence left, and it has to be
+    // enough: this is the case that produced the generic no-Retry card.
+    const failure = classifyRunFailure(
+      stageTimeoutClassifierInput(
+        {
+          message: 'the run was ended by the host',
+          error: {
+            code: 'AGENT_EXECUTION_FAILED',
+            message: 'the run was ended by the host',
+            retryable: true,
+            details: { kind: 'timeout', action: 'retry', phase: 'session/prompt', timeout_ms: 1_800_000 },
+          },
+        },
+        'the run was ended by the host',
+      ),
+    );
+
+    expect(failure?.failure_category).toBe('timeout');
+    expect(failure?.failure_detail).toBe('timeout');
+    // The two fields the chat card reads to decide Retry vs contact-support.
+    expect(failure?.retryable).toBe(true);
+    expect(failure?.user_action).toBe('retry');
+    // Still attributed to the watchdog that actually ended the run, so the
+    // telemetry does not have to guess between the stall watchdogs either.
+    expect(failure?.terminal_trigger).toBe('acp_stage_timeout');
+  });
+
+  it('still classifies the real watchdog sentence as a retryable timeout', () => {
+    // The unrewritten path, so the fix cannot be a swap of one sole signal for
+    // another: with prose AND marker present the verdict is unchanged.
+    const failure = classifyRunFailure(
+      stageTimeoutClassifierInput(
+        {
+          message: 'ACP session/prompt timed out after 1800000ms',
+          error: {
+            code: 'AGENT_EXECUTION_FAILED',
+            message: 'ACP session/prompt timed out after 1800000ms',
+            retryable: true,
+            details: { kind: 'timeout', action: 'retry', phase: 'session/prompt', timeout_ms: 1_800_000 },
+          },
+        },
+        'ACP session/prompt timed out after 1800000ms',
+      ),
+    );
+
+    expect(failure?.failure_category).toBe('timeout');
+    expect(failure?.failure_detail).toBe('timeout');
+    expect(failure?.retryable).toBe(true);
+    expect(failure?.user_action).toBe('retry');
+    expect(failure?.terminal_trigger).toBe('acp_stage_timeout');
+  });
+});
+
+describe('the timeout verdict does not spread to failures that are not timeouts', () => {
+  it('leaves an unmarked SIGTERM exit as a process exit', () => {
+    // Same process-level facts as a watchdog kill, no marker, no timeout prose.
+    // If this turned into a timeout, every killed child would claim a Retry it
+    // has not earned.
+    const failure = classifyRunFailure(
+      stageTimeoutClassifierInput(
+        { message: 'the run was ended by the host' },
+        'the run was ended by the host',
+      ),
+    );
+
+    expect(failure?.failure_category).not.toBe('timeout');
+    expect(failure?.failure_detail).not.toBe('timeout');
+  });
+
+  it('leaves another named ACP failure alone', () => {
+    // `acp_child_exit` carries a `details.kind` too. Only `timeout` is a
+    // timeout verdict; a neighbouring kind must not be read as one.
+    const failure = classifyRunFailure(
+      stageTimeoutClassifierInput(
+        {
+          message: 'ACP session exited before completion (code=3, signal=none)',
+          error: {
+            code: 'AGENT_EXECUTION_FAILED',
+            message: 'ACP session exited before completion (code=3, signal=none)',
+            details: { kind: 'acp_child_exit', phase: 'session/prompt', exit_code: 3, signal: null },
+          },
+        },
+        'ACP session exited before completion (code=3, signal=none)',
+      ),
+    );
+
+    expect(failure?.failure_category).not.toBe('timeout');
+  });
+
+  it('still reports an empty reply as no output, not as a timeout', () => {
+    // The `empty_output` rung is P0-guarded ("没有输出"), and it resolves
+    // BEFORE the timeout branch. A run that both stalled and produced nothing
+    // must keep saying it produced nothing.
+    const failure = classifyRunFailure(
+      stageTimeoutClassifierInput(
+        {
+          message: 'ACP session completed without producing any output',
+          error: {
+            code: 'AGENT_EXECUTION_FAILED',
+            message: 'ACP session completed without producing any output',
+            retryable: true,
+            details: { kind: 'timeout', action: 'retry', phase: 'session/prompt', timeout_ms: 1_000 },
+          },
+        },
+        'ACP session completed without producing any output',
+      ),
+    );
+
+    expect(failure?.failure_category).toBe('empty_output');
+    expect(failure?.failure_detail).toBe('empty_output');
+  });
+
+  it('does not let an agent-supplied payload forge a timeout verdict', () => {
+    // Agent-reported JSON-RPC data lands under `error.data`, never
+    // `error.details` — the marker is daemon-authored by construction.
+    const failure = classifyRunFailure(
+      stageTimeoutClassifierInput(
+        {
+          message: 'json-rpc id 4: upstream refused the request',
+          error: {
+            code: 'AGENT_EXECUTION_FAILED',
+            message: 'json-rpc id 4: upstream refused the request',
+            data: { kind: 'timeout' },
+          },
+        },
+        'json-rpc id 4: upstream refused the request',
+      ),
+    );
+
+    expect(failure?.failure_category).not.toBe('timeout');
+  });
+});

--- a/apps/daemon/tests/acp-stage-timeout-wiring.test.ts
+++ b/apps/daemon/tests/acp-stage-timeout-wiring.test.ts
@@ -1,0 +1,377 @@
+import type { Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path, { delimiter } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+/**
+ * Wiring coverage for the ACP stage-watchdog failure, driven through the FULL
+ * server run cycle rather than the bridge in isolation.
+ *
+ * The unit spec next door (`acp-stage-timeout-classification.test.ts`) pins the
+ * frame and the classifier. This one pins the three surfaces a user and the
+ * chat card actually read — the SSE `error` frame recorded in the run's events
+ * log, the run's own `GET /api/runs/:id` classification, and the `status:error`
+ * event persisted onto the assistant message that a reloaded conversation
+ * renders from — because those are what decided whether the reported user got
+ * a Retry button or the generic 「任务执行失败」 card.
+ */
+
+type StartedServer = {
+  url: string;
+  server: Server;
+  shutdown?: () => Promise<void> | void;
+};
+
+type RunStatus = {
+  id: string;
+  status: string;
+  error: string | null;
+  errorCode: string | null;
+  failureCategory?: string | null;
+  failureDetail?: string | null;
+  failureAction?: string | null;
+  retryable?: boolean | null;
+  eventsLogPath: string;
+};
+
+type ErrorFrame = {
+  message?: unknown;
+  error?: {
+    code?: unknown;
+    message?: unknown;
+    retryable?: unknown;
+    details?: Record<string, unknown>;
+  };
+};
+
+type PersistedStatusEvent = {
+  kind?: unknown;
+  label?: unknown;
+  detail?: unknown;
+  code?: unknown;
+  failureCategory?: unknown;
+  failureDetail?: unknown;
+  failureAction?: unknown;
+  retryable?: unknown;
+};
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FAKE_ACP_CLI = path.join(HERE, 'fixtures', 'fake-acp-handshake-cli.mjs');
+const AGENT_ID = 'kimi';
+const AGENT_BIN = 'kimi';
+/** Short enough to keep the suite fast, long enough to clear the handshake. */
+const STAGE_TIMEOUT_MS = 1_200;
+
+describe('ACP stage timeout — server wiring', () => {
+  const originalEnv = snapshotEnv();
+  let started: StartedServer | null = null;
+  let binDir = '';
+  let agentHomeDir = '';
+
+  beforeEach(async () => {
+    agentHomeDir = await mkdtemp(path.join(os.tmpdir(), 'od-acp-stage-timeout-home-'));
+  });
+
+  afterEach(async () => {
+    await Promise.resolve(started?.shutdown?.());
+    if (started?.server) {
+      await new Promise<void>((resolve) => started?.server.close(() => resolve()));
+    }
+    started = null;
+    if (binDir) await removeTempDir(binDir);
+    if (agentHomeDir) await removeTempDir(agentHomeDir);
+    binDir = '';
+    agentHomeDir = '';
+    restoreEnv(originalEnv);
+  });
+
+  it('reaches the chat as a named, retryable timeout on every surface', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-acp-stage-timeout-bin-'));
+    await writeStallingAcpCliShim(binDir, AGENT_BIN);
+    isolateAgentDetection(binDir, agentHomeDir);
+    clearTelemetryEnv();
+    // Only the ACP stage watchdog may end this turn: the chat-level inactivity
+    // and first-output watchdogs are disabled so the verdict under test is not
+    // shadowed by a different one.
+    process.env.OD_ACP_STAGE_TIMEOUT_MS = String(STAGE_TIMEOUT_MS);
+    process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS = '0';
+    process.env.OD_CHAT_RUN_FIRST_OUTPUT_TIMEOUT_MS = '0';
+
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    await putConfig(started.url, { agentId: AGENT_ID });
+    const conversation = await createConversation(started.url);
+    const run = await sendRunAndWait(started.url, conversation, 'draft a landing page');
+
+    expect(run.status).toBe('failed');
+
+    // 1. The SSE frame the live client reads. Every ACP `error` frame this run
+    //    produced must be named — a client holding only the frame (the daemon's
+    //    classification rides the later `end` frame) has nothing else to go on.
+    const events = await readRunEvents(run.eventsLogPath);
+    const errorFrames = events
+      .filter((event) => event.event === 'error')
+      .map((event) => event.data as ErrorFrame);
+    expect(errorFrames.length).toBeGreaterThan(0);
+    for (const frame of errorFrames) {
+      expect(frame.error?.details).toMatchObject({ kind: 'timeout', action: 'retry' });
+      expect(frame.error?.retryable).toBe(true);
+    }
+
+    // 2. The run's own classification — what `statusBody` and the SSE `end`
+    //    frame carry, and what the live chat stamps onto the failed message.
+    expect(run.failureCategory).toBe('timeout');
+    expect(run.failureDetail).toBe('timeout');
+    expect(run.failureAction).toBe('retry');
+    expect(run.retryable).toBe(true);
+    // The watchdog's own sentence survives verbatim: it is what the card shows
+    // under 「查看错误详情」 and what the classifier's text path still reads.
+    expect(run.error ?? '').toMatch(/ACP session\/prompt timed out after \d+ms/);
+
+    // 3. The stored event a RELOADED conversation renders from. `ChatPane`
+    //    resolves the card from `failureDetail` here, never from the stream.
+    const persisted = await readPersistedRunErrorEvent(started.url, conversation);
+    expect(persisted.failureDetail).toBe('timeout');
+    expect(persisted.failureAction).toBe('retry');
+    expect(persisted.retryable).toBe(true);
+  }, 60_000);
+});
+
+/**
+ * A CLI that completes the ACP handshake and then never answers
+ * `session/prompt` — the shape of the reported run, where a `Write` tool call
+ * produced zero bytes until the watchdog gave up.
+ */
+async function writeStallingAcpCliShim(dir: string, name: string): Promise<string> {
+  const bin = path.join(dir, name);
+  await writeFile(
+    bin,
+    [
+      '#!/bin/sh',
+      'export FAKE_ACP_CLI_VERSION="1.0.0"',
+      'export FAKE_ACP_PROMPT_STALL=1',
+      `exec ${JSON.stringify(process.execPath)} ${JSON.stringify(FAKE_ACP_CLI)} "$@"`,
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+/**
+ * Makes the fixture CLI the only agent CLI detection can find, so the run does
+ * not drag the host's real agent binaries through a `--version` probe. Same
+ * rationale as `acp-handshake-failure-wiring.test.ts`.
+ */
+function isolateAgentDetection(dir: string, homeDir: string): void {
+  process.env.OD_AGENT_HOME = homeDir;
+  process.env.PATH = [dir, '/usr/bin', '/bin', '/usr/sbin', '/sbin'].join(delimiter);
+}
+
+async function readRunEvents(eventsLogPath: string): Promise<Array<{ event: string; data: unknown }>> {
+  let raw = '';
+  try {
+    raw = await readFile(eventsLogPath, 'utf8');
+  } catch {
+    return [];
+  }
+  return raw
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as { event: string; data: unknown });
+}
+
+/**
+ * The stored `status: 'error'` event, read through the same route the web
+ * client calls on mount. Polls because the finalizer enriches this event with
+ * the run's classification a beat after the run turns terminal.
+ */
+async function readPersistedRunErrorEvent(
+  url: string,
+  encoded: string,
+): Promise<PersistedStatusEvent> {
+  const { projectId, conversationId, headers } = decodeFixtureIdentity(encoded);
+  const startedAt = Date.now();
+  let last: PersistedStatusEvent | null = null;
+  while (Date.now() - startedAt < 10_000) {
+    const response = await fetch(
+      `${url}/api/projects/${encodeURIComponent(projectId)}`
+        + `/conversations/${encodeURIComponent(conversationId)}/messages`,
+      { headers },
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      messages?: Array<{ role: string; events?: PersistedStatusEvent[] }>;
+    };
+    for (const message of (body.messages ?? []).slice().reverse()) {
+      if (message.role !== 'assistant') continue;
+      const events = message.events ?? [];
+      for (let i = events.length - 1; i >= 0; i--) {
+        const event = events[i];
+        if (event?.kind === 'status' && event.label === 'error') {
+          last = event;
+          if (typeof event.failureDetail === 'string') return event;
+          break;
+        }
+      }
+    }
+    await delay(50);
+  }
+  if (last) return last;
+  throw new Error('conversation never persisted a status:error event');
+}
+
+function snapshotEnv(): Record<string, string | undefined> {
+  return {
+    PATH: process.env.PATH,
+    OD_AGENT_HOME: process.env.OD_AGENT_HOME,
+    OD_ACP_STAGE_TIMEOUT_MS: process.env.OD_ACP_STAGE_TIMEOUT_MS,
+    OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS: process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS,
+    OD_CHAT_RUN_FIRST_OUTPUT_TIMEOUT_MS: process.env.OD_CHAT_RUN_FIRST_OUTPUT_TIMEOUT_MS,
+    LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
+    LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
+    LANGFUSE_BASE_URL: process.env.LANGFUSE_BASE_URL,
+    OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
+    POSTHOG_KEY: process.env.POSTHOG_KEY,
+    POSTHOG_HOST: process.env.POSTHOG_HOST,
+  };
+}
+
+function restoreEnv(env: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function clearTelemetryEnv(): void {
+  delete process.env.POSTHOG_KEY;
+  delete process.env.POSTHOG_HOST;
+  delete process.env.LANGFUSE_PUBLIC_KEY;
+  delete process.env.LANGFUSE_SECRET_KEY;
+  delete process.env.LANGFUSE_BASE_URL;
+  delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+}
+
+async function putConfig(url: string, patch: Record<string, unknown>): Promise<void> {
+  const response = await fetch(`${url}/api/app-config`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+      ...patch,
+    }),
+  });
+  expect(response.status).toBe(200);
+}
+
+function decodeFixtureIdentity(encoded: string): {
+  projectId: string;
+  conversationId: string;
+  headers: Record<string, string>;
+} {
+  const [projectId, conversationId, workspaceId, workspaceMemberId] = encoded.split('::');
+  if (!projectId || !conversationId || !workspaceId || !workspaceMemberId) {
+    throw new Error(`invalid ACP stage-timeout fixture identity: ${encoded}`);
+  }
+  return {
+    projectId,
+    conversationId,
+    headers: {
+      'x-od-workspace-id': workspaceId,
+      'x-od-workspace-type': 'personal',
+      'x-od-workspace-member-id': workspaceMemberId,
+      'x-od-workspace-role': 'owner',
+    },
+  };
+}
+
+async function createConversation(url: string): Promise<string> {
+  const projectId = `acp_stage_timeout_${randomUUID().replace(/-/g, '')}`;
+  const workspaceId = `acp_stage_timeout_personal_${projectId}`;
+  const workspaceMemberId = `acp_stage_timeout_owner_${projectId}`;
+  const workspaceHeaders = {
+    'x-od-workspace-id': workspaceId,
+    'x-od-workspace-type': 'personal',
+    'x-od-workspace-member-id': workspaceMemberId,
+    'x-od-workspace-role': 'owner',
+  };
+  const projectResponse = await fetch(`${url}/api/projects`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...workspaceHeaders },
+    body: JSON.stringify({
+      id: projectId,
+      name: 'ACP stage timeout smoke',
+      metadata: { kind: 'prototype' },
+      skipDiscoveryBrief: true,
+    }),
+  });
+  expect(projectResponse.status).toBe(200);
+  const projectBody = (await projectResponse.json()) as { conversationId: string };
+  return [projectId, projectBody.conversationId, workspaceId, workspaceMemberId].join('::');
+}
+
+async function sendRunAndWait(
+  url: string,
+  encoded: string,
+  message: string,
+): Promise<RunStatus> {
+  const { projectId, conversationId, headers: workspaceHeaders } =
+    decodeFixtureIdentity(encoded);
+  const runResponse = await fetch(`${url}/api/runs`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-od-analytics-device-id': 'acp-stage-timeout-test',
+      'x-od-analytics-session-id': 'acp-stage-timeout-session',
+      'x-od-analytics-client-type': 'web',
+      ...workspaceHeaders,
+    },
+    body: JSON.stringify({
+      projectId,
+      conversationId,
+      assistantMessageId: `assistant_acp_stage_${randomUUID()}`,
+      clientRequestId: `client_acp_stage_${randomUUID()}`,
+      agentId: AGENT_ID,
+      message,
+      currentPrompt: message,
+    }),
+  });
+  const body = (await runResponse.json()) as { runId?: string };
+  expect(runResponse.status, JSON.stringify(body)).toBe(202);
+  expect(body.runId).toBeTypeOf('string');
+  return await waitForRun(url, body.runId!, workspaceHeaders);
+}
+
+async function waitForRun(
+  url: string,
+  runId: string,
+  headers: Record<string, string>,
+): Promise<RunStatus> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 40_000) {
+    const response = await fetch(`${url}/api/runs/${encodeURIComponent(runId)}`, { headers });
+    expect(response.status).toBe(200);
+    const run = (await response.json()) as RunStatus;
+    if (run.status === 'failed' || run.status === 'succeeded' || run.status === 'canceled') {
+      return run;
+    }
+    await delay(100);
+  }
+  throw new Error(`run ${runId} did not finish`);
+}
+
+async function removeTempDir(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/daemon/tests/acp-stage-timeout-wiring.test.ts
+++ b/apps/daemon/tests/acp-stage-timeout-wiring.test.ts
@@ -118,7 +118,7 @@ describe('ACP stage timeout — server wiring', () => {
       .map((event) => event.data as ErrorFrame);
     expect(errorFrames.length).toBeGreaterThan(0);
     for (const frame of errorFrames) {
-      expect(frame.error?.details).toMatchObject({ kind: 'timeout', action: 'retry' });
+      expect(frame.error?.details).toMatchObject({ kind: 'acp_stage_timeout', action: 'retry' });
       expect(frame.error?.retryable).toBe(true);
     }
 

--- a/apps/daemon/tests/acp-upstream-retryable-passthrough.test.ts
+++ b/apps/daemon/tests/acp-upstream-retryable-passthrough.test.ts
@@ -175,3 +175,146 @@ describe('the passthrough does not hand out retries nobody granted', () => {
     expect(failure?.user_action).toBe('retry');
   });
 });
+
+/**
+ * The rule above ("only `true` is read") is stated for the message-string
+ * reader, and the negative anchors that police it all feed the string form —
+ * where `inferRpcErrorRetryable` matches `"isRetryable":true` and returns
+ * `undefined` for anything else, so an upstream "no" is correctly left
+ * undecided.
+ *
+ * The STRUCTURED reader is the same statement arriving as ACP `error.data`
+ * instead, which is the shape an adapter produces when it forwards opencode's
+ * `error.data` object through rather than re-serialising it into the sentence
+ * (`apps/web/src/providers/daemon.ts` already reads `isRetryable` off exactly
+ * that object). Nothing above exercises it with a `false`, and the two readers
+ * are only equivalent if they agree on that value: `session.ts` composes them
+ * with `??`, so a structural `false` short-circuits the message reader
+ * entirely and becomes the frame's verdict.
+ */
+describe('a structured isRetryable is read under the same rule as the string form', () => {
+  /**
+   * Verbatim `error.data` from the real APIError envelope already frozen as row
+   * B5 of the ACP landing table (`acp-service-failure.test.ts`) — the same
+   * bytes the string-form anchor above parses, lifted out of the sentence.
+   */
+  const APIERROR_404_DATA = {
+    message: 'Not Found',
+    statusCode: 404,
+    isRetryable: false,
+    responseBody: '<html><head><title>404 Not Found</title></head>',
+  };
+
+  const APIERROR_404_STRING =
+    'json-rpc id 4: opencode event stream: opencode session error: '
+    + '{"error":{"name":"APIError","data":{"message":"Not Found","statusCode":404,'
+    + '"isRetryable":false,"responseBody":"<html><head><title>404 Not Found</title></head>"}}}';
+
+  it('reaches the same verdict for the same payload in either shape', () => {
+    // Proof the fixture can see the defect: the word IS in both shapes.
+    expect(APIERROR_404_DATA.isRetryable).toBe(false);
+    expect(APIERROR_404_STRING).toContain('"isRetryable":false');
+
+    const asMessage = bridgeRetryable(APIERROR_404_STRING, undefined);
+    const asData = bridgeRetryable('json-rpc id 4: Not Found', APIERROR_404_DATA);
+    expect(asMessage).toBeUndefined();
+    expect(asData).toBe(asMessage);
+  });
+
+  /**
+   * The consequence, and the reason this is not a style point. `[code=upstream_error]
+   * stream idle timeout` is the transport blip already frozen as row B1 with
+   * `retryable: true` / `user_action: 'retry'` — the daemon reads that text and
+   * knows it is retryable. Hand it the SDK's coarse `false` structurally and,
+   * because `??` stops at a boolean, the message reader that would have said
+   * `true` never runs: `fail()` stamps `false`, the classifier adopts it as
+   * `retryableHint`, and `isResumableFailure` withdraws Continue — the exact
+   * failure mode this PR exists to remove, reintroduced through the other door.
+   */
+  const SDK_NO_ON_A_TRANSPORT_BLIP = {
+    isRetryable: false,
+    message: '[code=upstream_error] stream idle timeout: no data received within configured window',
+  };
+
+  /**
+   * Row B1's text verbatim — the sentence the daemon shows and the only thing
+   * the classifier reads. It rides along with the structured `data` above
+   * because vela forwards the whole `session.error` envelope in the message
+   * regardless; the structural copy is the addition under test.
+   */
+  const TRANSPORT_BLIP_MESSAGE =
+    'json-rpc id 4: opencode event stream: {"type":"session.error","properties":{"error":'
+    + '{"data":{"message":"\\"[code=upstream_error] stream idle timeout: no data received '
+    + 'within configured window\\""}}}}';
+
+  /**
+   * The full chain as `session.ts` runs it: the composed bridge verdict, then
+   * `fail(message, { details, …retryable })` — which stamps
+   * `options.retryable ?? false` and carries `details` on the frame — then the
+   * classifier reading that frame back.
+   */
+  function classifyStructured(message: string, data: unknown) {
+    const retryable = bridgeRetryable(message, data);
+    return classifyRunFailure({
+      result: 'failed',
+      status: { status: 'failed', error: message, errorCode: null },
+      agentId: 'amr',
+      events: [
+        { event: 'diagnostic', data: { type: 'runtime_close', rpc_close_reason: 'fatal_rpc_error' } },
+        {
+          event: 'error',
+          data: {
+            message,
+            error: {
+              code: 'AGENT_EXECUTION_FAILED',
+              message,
+              retryable: retryable ?? false,
+              details: data,
+            },
+          },
+        },
+      ],
+    } as Parameters<typeof classifyRunFailure>[0]);
+  }
+
+  it('does not let a structural no override the classifier on a transport blip', () => {
+    // Control: the identical payload with the flag only in the message is
+    // already retryable today. The structural copy must not change that answer.
+    expect(bridgeRetryable(TRANSPORT_BLIP_MESSAGE, undefined)).toBe(true);
+    expect(bridgeRetryable(TRANSPORT_BLIP_MESSAGE, SDK_NO_ON_A_TRANSPORT_BLIP)).not.toBe(false);
+
+    const failure = classifyStructured(TRANSPORT_BLIP_MESSAGE, SDK_NO_ON_A_TRANSPORT_BLIP);
+    expect(failure?.failure_category).toBe('upstream_unavailable');
+    expect(failure?.failure_detail).toBe('stream_disconnected');
+    expect(failure?.retryable).toBe(true);
+    expect(failure?.user_action).toBe('retry');
+    // The affordance row B1 already promises this failure, and the one a
+    // structural `false` silently took away.
+    expect(isResumableFailure(failure)).toBe(true);
+  });
+
+  it('still hands out no retry the structural payload did not earn', () => {
+    // The other half of the rule: declining to read `false` must not be read as
+    // reading `true`. The adapter shape here is the fullest one — the envelope
+    // kept in the sentence AND its `data` forwarded structurally — so the text
+    // evidence row B5 was frozen on is present, and `upstream_client_error` is
+    // reached from it rather than from any hint. `fail()` still stamps `false`
+    // on an undecided frame, so nothing about this row moves.
+    const failure = classifyStructured(APIERROR_404_STRING, APIERROR_404_DATA);
+    expect(bridgeRetryable(APIERROR_404_STRING, APIERROR_404_DATA)).not.toBe(true);
+    expect(failure?.failure_detail).toBe('upstream_client_error');
+    expect(failure?.retryable).toBe(false);
+    expect(failure?.user_action).toBe('none');
+    expect(isResumableFailure(failure)).toBe(false);
+  });
+
+  it('keeps reading a structural yes, which is the direction this PR added', () => {
+    // Guard against "fixing" the above by deleting the branch: the accepted
+    // direction must survive.
+    expect(rpcErrorRetryable({ isRetryable: true, message: 'socket closed' })).toBe(true);
+    // And the ACP-native `retryable` field is a protocol-level statement, not a
+    // coarse SDK flag — it is out of scope here and keeps both of its values.
+    expect(rpcErrorRetryable({ retryable: false })).toBe(false);
+    expect(rpcErrorRetryable({ retryable: true })).toBe(true);
+  });
+});

--- a/apps/daemon/tests/acp-upstream-retryable-passthrough.test.ts
+++ b/apps/daemon/tests/acp-upstream-retryable-passthrough.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  inferRpcErrorRetryable,
+  rpcErrorRetryable,
+} from '../src/agent-protocol/acp/rpc.js';
+import {
+  classifyRunFailure,
+  isResumableFailure,
+} from '../src/run-failure-classification.js';
+
+/**
+ * Red spec: when opencode says a failure IS retryable, we must not record the
+ * opposite.
+ *
+ * Real corpus (user diagnostics bundle, 2026-09-08, two independent runs —
+ * `423140d1` 03:27 and `e9bea966` 04:03): opencode reported a closed upstream
+ * socket AFTER exhausting its own three attempts, and said so in machine
+ * readable form — `"isRetryable": true`. What the daemon persisted on the `end`
+ * event was `upstream_unavailable / stream_disconnected` with
+ * `retryable: false`, the opposite of what upstream stated.
+ *
+ * Why that costs the user something even though the error CARD for
+ * `stream_disconnected` still draws a Retry button: `retryable` is what the
+ * daemon's own recovery reads. `isResumableFailure` returns false the instant
+ * it is false, so `run.resumable` never gets set and the Continue affordance
+ * disappears; `decidePostToolResumeRecovery` requires `retryable === true`, so
+ * the silent post-tool continuation never fires either. The most recoverable
+ * failure there is got the treatment reserved for dead ends.
+ *
+ * Where the word was dropped: opencode's field is `isRetryable`, and vela hands
+ * the whole `session.error` envelope over as a JSON STRING inside the ACP error
+ * message rather than as `error.data`. `rpcErrorRetryable` read only
+ * `data.retryable`; the classifier's `latestRetryable` reads
+ * `error.data.isRetryable` and so never saw it either. With no verdict from
+ * either reader, `fail()` fell back to its own default — `retryable: false` —
+ * and that fabricated verdict is what the whole chain then believed.
+ */
+
+/**
+ * Verbatim from the diagnostics bundle: opencode's `session.error` event as
+ * vela forwards it, with the `json-rpc id N: ` prefix `rpcErrorMessage` adds.
+ */
+const RAW_SOCKET_CLOSED =
+  'json-rpc id 4: opencode event stream: {"properties":{"error":{"name":"APIError",'
+  + '"data":{"isRetryable":true,"message":"Cannot connect to API: The socket connection '
+  + 'was closed unexpectedly. For more information, pass `verbose: true` in the second '
+  + 'argument to fetch()","metadata":{"retryAttempts":"2","totalAttempts":"3",'
+  + '"retryExhausted":"true","url":"https://amr-link.open-design.ai/v1/chat/completions"}}}},'
+  + '"type":"session.error"}';
+
+/**
+ * The ACP bridge's retryability decision for a JSON-RPC error, exactly as
+ * `session.ts` makes it: the structured field first, then the message/details
+ * reader, and `undefined` when neither reached a verdict.
+ */
+function bridgeRetryable(message: string, data: unknown): boolean | undefined {
+  return rpcErrorRetryable(data) ?? inferRpcErrorRetryable(message, data);
+}
+
+/**
+ * The classifier as it sees a real ACP fatal: the `runtime_close` diagnostic
+ * plus the error event `fail()` emitted, whose `retryable` becomes the hint.
+ */
+function classify(message: string, retryable: boolean | undefined) {
+  // `fail()` stamps `options.retryable ?? false` on a frame that carries
+  // details, so an undecided bridge still publishes `false`. Reproduced here
+  // rather than assumed: it is the step that turned "we do not know" into "no".
+  const stamped = retryable ?? false;
+  return classifyRunFailure({
+    result: 'failed',
+    status: { status: 'failed', error: message, errorCode: null },
+    agentId: 'amr',
+    events: [
+      { event: 'diagnostic', data: { type: 'runtime_close', rpc_close_reason: 'fatal_rpc_error' } },
+      {
+        event: 'error',
+        data: {
+          message,
+          error: { code: 'AGENT_EXECUTION_FAILED', message, retryable: stamped },
+        },
+      },
+    ],
+  } as Parameters<typeof classifyRunFailure>[0]);
+}
+
+describe('an upstream that says "retryable" is recorded as retryable', () => {
+  it('reads opencode\'s isRetryable out of the frame vela actually sends', () => {
+    // Proof the fixture can see the defect: the word IS in the payload. If a
+    // future rewording moves it, this line goes red before the verdict does.
+    expect(RAW_SOCKET_CLOSED).toContain('"isRetryable":true');
+    expect(bridgeRetryable(RAW_SOCKET_CLOSED, undefined)).toBe(true);
+  });
+
+  it('also reads it when vela forwards the field as structured error data', () => {
+    // The other shape the same statement arrives in. `rpcErrorRetryable` knew
+    // only the `retryable` spelling, so this half was dropped at the bridge.
+    expect(bridgeRetryable('json-rpc id 4: upstream closed the connection', {
+      isRetryable: true,
+      message: 'The socket connection was closed unexpectedly',
+    })).toBe(true);
+  });
+
+  it('lands the run as a retryable stream disconnect, and keeps Continue alive', () => {
+    const failure = classify(
+      RAW_SOCKET_CLOSED,
+      bridgeRetryable(RAW_SOCKET_CLOSED, undefined),
+    );
+
+    expect(failure?.failure_category).toBe('upstream_unavailable');
+    expect(failure?.failure_detail).toBe('stream_disconnected');
+    expect(failure?.retryable).toBe(true);
+    expect(failure?.user_action).toBe('retry');
+    // The affordance the user actually lost: `run.resumable` is gated on this.
+    expect(isResumableFailure(failure)).toBe(true);
+  });
+});
+
+describe('the passthrough does not hand out retries nobody granted', () => {
+  it('leaves an upstream that says NOT retryable alone', () => {
+    // Same envelope, opposite word. Only `true` is read, and a 4xx is routed to
+    // `upstream_client_error` regardless — a request the provider rejected on
+    // shape re-fails identically.
+    const raw =
+      'json-rpc id 4: opencode event stream: opencode session error: '
+      + '{"error":{"name":"APIError","data":{"message":"Not Found","statusCode":404,'
+      + '"isRetryable":false,"responseBody":"<html><head><title>404 Not Found</title></head>"}}}';
+    expect(bridgeRetryable(raw, undefined)).toBeUndefined();
+    const failure = classify(raw, bridgeRetryable(raw, undefined));
+    expect(failure?.failure_detail).toBe('upstream_client_error');
+    expect(failure?.retryable).toBe(false);
+    expect(failure?.user_action).toBe('none');
+  });
+
+  it('does not turn a rate limit into a retry', () => {
+    // The class this must never leak into: a 429 that says nothing about its
+    // own retryability keeps the verdict it has.
+    const raw = 'json-rpc id 4: rate limit exceeded';
+    expect(bridgeRetryable(raw, undefined)).toBeUndefined();
+    const failure = classify(raw, bridgeRetryable(raw, undefined));
+    expect(failure?.failure_category).toBe('rate_limit');
+    expect(failure?.retryable).toBe(false);
+    expect(failure?.user_action).toBe('none');
+  });
+
+  it('does not resurrect a spent balance or a suspended account', () => {
+    for (const raw of [
+      'json-rpc id 4: insufficient balance',
+      'json-rpc id 4: your account has been suspended due to a risk-control review',
+    ]) {
+      const failure = classify(raw, bridgeRetryable(raw, undefined));
+      expect(failure?.retryable).toBe(false);
+      expect(failure?.user_action).not.toBe('retry');
+    }
+  });
+
+  it('still refuses a request that is too large, even if upstream says retry', () => {
+    // Precedence check: `request_too_large` is decided BEFORE the upstream's
+    // own word, because the identical payload deterministically re-fails.
+    const raw =
+      'json-rpc id 4: [code=request_too_large] request body exceeds configured limit'
+      + ' {"isRetryable":true}';
+    expect(bridgeRetryable(raw, undefined)).toBe(false);
+  });
+
+  it('leaves provider_routing_error retryable, as production already reports it', () => {
+    // The control from the same diagnostics bundle: run `43eed13f` (03:29)
+    // classified `upstream_unavailable / provider_routing_error` with
+    // `retryable: true`. Not every upstream failure was being judged dead, and
+    // this one must stay exactly where it is.
+    const raw = 'json-rpc id 4: AMR model catalog is temporarily unavailable. Please retry.';
+    const failure = classify(raw, true);
+    expect(failure?.failure_detail).toBe('provider_routing_error');
+    expect(failure?.retryable).toBe(true);
+    expect(failure?.user_action).toBe('retry');
+  });
+});

--- a/apps/daemon/tests/agent-session-resume.test.ts
+++ b/apps/daemon/tests/agent-session-resume.test.ts
@@ -671,9 +671,33 @@ describe('isAmrOpencodeEventStreamResumeFailure', () => {
     ).toBe(true);
   });
 
+  // vela 0.0.35 (#1847) moved the compaction continuation onto its own request
+  // and worded its EOF differently. Before this the phrase matched nothing in
+  // the repository, so the SAME bridge-level stream EOF — one phase later —
+  // could not reach the re-seed path at all and ended the conversation on a
+  // hard failure instead of one transparent cold turn.
+  it('matches the compaction-continuation EOF vela 0.0.35 introduced', () => {
+    expect(
+      isAmrOpencodeEventStreamResumeFailure(
+        'json-rpc id 4: opencode event stream: opencode compaction continuation ended before prompt completion',
+      ),
+    ).toBe(true);
+    expect(
+      isAmrOpencodeEventStreamResumeFailure(
+        'opencode compaction continuation ended before prompt completion',
+      ),
+    ).toBe(true);
+  });
+
   it('ignores unrelated AMR/opencode output', () => {
     expect(isAmrOpencodeEventStreamResumeFailure('opencode auth failed')).toBe(false);
     expect(isAmrOpencodeEventStreamResumeFailure('')).toBe(false);
+    // A compaction that merely RAN is not a compaction that died. The phrase
+    // has to name the EOF, or every successful compaction log line would send
+    // the turn through a cold re-seed.
+    expect(
+      isAmrOpencodeEventStreamResumeFailure('opencode compaction continuation started'),
+    ).toBe(false);
   });
 });
 
@@ -778,5 +802,38 @@ describe('resolveAgentResumeFailurePolicy', () => {
       autoReseedFullTranscript: false,
       reason: null,
     });
+  });
+
+  it('routes the compaction-continuation EOF into the same re-seed recovery', () => {
+    expect(
+      resolveAgentResumeFailurePolicy({
+        agentId: 'amr',
+        stderr:
+          'json-rpc id 4: opencode event stream: opencode compaction continuation ended before prompt completion',
+        stdout: '',
+        isResuming: true,
+        resumeSessionId: 'ses-old',
+      }),
+    ).toEqual({
+      resumeFailed: true,
+      clearStaleSession: true,
+      autoReseedFullTranscript: true,
+      reason: 'resume_failed',
+    });
+  });
+
+  it('leaves a compaction EOF on a create turn alone', () => {
+    // The gate that keeps this from becoming a general retry: no stored handle
+    // was being continued, so there is nothing stale to clear and nothing to
+    // re-seed — the turn already ran from scratch.
+    expect(
+      resolveAgentResumeFailurePolicy({
+        agentId: 'amr',
+        stderr: 'opencode compaction continuation ended before prompt completion',
+        stdout: '',
+        isResuming: false,
+        resumeSessionId: null,
+      }).resumeFailed,
+    ).toBe(false);
   });
 });

--- a/apps/daemon/tests/fixtures/fake-acp-handshake-cli.mjs
+++ b/apps/daemon/tests/fixtures/fake-acp-handshake-cli.mjs
@@ -30,6 +30,10 @@
  *                                          cannot open a session at all.
  *   FAKE_ACP_PROMPT_ERROR_RETRYABLE      – when '1', that prompt error carries
  *                                          `data.retryable = true`
+ *   FAKE_ACP_PROMPT_STALL                – when '1', the handshake SUCCEEDS and
+ *                                          `session/prompt` is never answered at
+ *                                          all, so only the ACP stage watchdog
+ *                                          ends the turn.
  *   FAKE_ACP_INVOCATION_LOG              – append one JSON line per handshake
  *                                          request, tagged with the caller's
  *                                          `clientInfo.name`. `attachAcpSession`
@@ -49,6 +53,7 @@ const SESSION_NEW_ERROR_MESSAGE =
   env.FAKE_ACP_SESSION_NEW_ERROR_MESSAGE || 'Internal error';
 const SESSION_NEW_ERROR_RETRYABLE = env.FAKE_ACP_SESSION_NEW_ERROR_RETRYABLE === '1';
 const PROMPT_ERROR_MESSAGE = env.FAKE_ACP_PROMPT_ERROR_MESSAGE || '';
+const PROMPT_STALL = env.FAKE_ACP_PROMPT_STALL === '1';
 const PROMPT_ERROR_RETRYABLE = env.FAKE_ACP_PROMPT_ERROR_RETRYABLE === '1';
 const INVOCATION_LOG = env.FAKE_ACP_INVOCATION_LOG || '';
 
@@ -119,7 +124,7 @@ function handleLine(line) {
 
   if (message.method === 'session/new' || message.method === 'session/load') {
     logInvocation({ method: message.method, client: clientName, at: Date.now() });
-    if (PROMPT_ERROR_MESSAGE) {
+    if (PROMPT_ERROR_MESSAGE || PROMPT_STALL) {
       // Post-session mode: this build opens a session fine. Whatever goes wrong
       // goes wrong afterwards, on the prompt.
       write({
@@ -143,6 +148,13 @@ function handleLine(line) {
         ...(SESSION_NEW_ERROR_RETRYABLE ? { data: { retryable: true } } : {}),
       },
     });
+    return;
+  }
+
+  if (message.method === 'session/prompt' && PROMPT_STALL) {
+    logInvocation({ method: message.method, client: clientName, at: Date.now() });
+    // Never answers. Models the real 2026 report: a `Write` tool call that sat
+    // for 1800s producing zero bytes until the ACP stage watchdog gave up.
     return;
   }
 

--- a/apps/daemon/tests/runtimes/acp-stall-last-progress-age.test.ts
+++ b/apps/daemon/tests/runtimes/acp-stall-last-progress-age.test.ts
@@ -58,6 +58,8 @@ type RunStatus = {
   id: string;
   status: string;
   errorCode: string | null;
+  /** The child's own exit status — how this spec proves the SIGTERM landed. */
+  exitCode: number | null;
   terminalTrigger: string | null;
   eventsLogPath: string;
 };
@@ -265,7 +267,14 @@ describe('ACP stall progress age', () => {
 
     // Non-vacuity guard: the child really did exit through its SIGTERM handler,
     // so its shutdown line really was written after the daemon's verdict.
-    expect(finished.error_code).toBe('AGENT_EXIT_143');
+    //
+    // Read off the child's exit status rather than off `error_code`. The
+    // watchdog now NAMES its own verdict on the error frame, so the run carries
+    // the failure's code (`AGENT_EXECUTION_FAILED`) instead of a code derived
+    // from the exit it caused — which never described this failure anyway. The
+    // fact this guard needs is unchanged and still first-hand: 143 is the
+    // child's SIGTERM handler running.
+    expect(run.exitCode).toBe(143);
 
     expect(finished.failure_category).toBe('timeout');
     expect(finished.failure_detail).toBe('timeout');

--- a/apps/web/tests/components/ChatPane.error-card-stage-timeout.test.tsx
+++ b/apps/web/tests/components/ChatPane.error-card-stage-timeout.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+//
+// 反向锚点:ACP 阶段看门狗杀掉的那一轮,卡面必须是「运行超时」+〔重试〕。
+//
+// 为什么现在补这条:daemon 侧把阶段超时改成**带名字**地发出去了
+// (`agent-protocol/acp/session.ts` 的看门狗 `fail()` 现在带
+// `retryable: true` + `details.kind = 'timeout'`),副作用是落盘的
+// `status:error` 事件从此多了一颗 `code`(`AGENT_EXECUTION_FAILED`)——
+// 之前 `run.errorCode` 是 null,这颗码根本不存在。
+//
+// `resolveRunFailureUi` 的顺序是「码表 → 具名 detail 表 → agent 分支」,
+// 所以新来的这颗码如果哪天被加进 `AGENT_AGNOSTIC_FAILURE_UI`,就会**抢在**
+// `AGENT_AGNOSTIC_DETAIL_FAILURE_UI['timeout']` 前面把这张卡改掉,而
+// daemon 侧看不到任何红。这条钉的就是那个夹缝:码在与不在,卡面都得是超时。
+import { cleanup, render } from '@testing-library/react';
+import { forwardRef } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ChatPane } from '../../src/components/ChatPane';
+import type { AppConfig, ChatMessage } from '../../src/types';
+
+const translate = (key: string, vars?: Record<string, string | number>) => {
+  if (vars && Object.keys(vars).length > 0) {
+    return `${key} ${Object.values(vars).join(' ')}`;
+  }
+  return key;
+};
+
+vi.mock('../../src/i18n', () => ({
+  useI18n: () => ({ locale: 'en', setLocale: () => undefined, t: translate }),
+  useT: () => translate,
+}));
+
+vi.mock('../../src/components/AssistantMessage', () => ({
+  AssistantMessage: ({ message }: { message: ChatMessage }) => (
+    <div data-testid={`assistant-${message.id}`}>{message.content}</div>
+  ),
+}));
+
+vi.mock('../../src/components/ChatComposer', () => ({
+  ChatComposer: forwardRef((_props, _ref) => <div data-testid="composer" />),
+}));
+
+vi.mock('../../src/analytics/events', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/analytics/events')>();
+  return {
+    ...actual,
+    trackChatPanelClick: vi.fn(),
+    trackRunFailedToastSurfaceView: vi.fn(),
+    trackRunRecoveryActionClick: vi.fn(),
+    trackRunRecoveryActionSurfaceView: vi.fn(),
+  };
+});
+
+afterEach(() => { cleanup(); vi.clearAllMocks(); });
+
+/** 看门狗自己写的那句,逐字 —— 用户真实那一轮是 1800000ms。 */
+const RAW_STAGE_TIMEOUT = 'ACP session/prompt timed out after 1800000ms';
+
+function failedMessage(code?: string): ChatMessage {
+  return {
+    id: 'msg-failed',
+    role: 'assistant',
+    content: '',
+    createdAt: 1,
+    runId: 'run-1',
+    runStatus: 'failed',
+    agentId: 'amr',
+    events: [
+      {
+        kind: 'status',
+        label: 'error',
+        detail: RAW_STAGE_TIMEOUT,
+        ...(code ? { code } : {}),
+        // daemon 分类器实测给出的那一档(见
+        // apps/daemon/tests/acp-stage-timeout-wiring.test.ts)。
+        failureDetail: 'timeout',
+        failureAction: 'retry',
+        retryable: true,
+      },
+    ],
+  } as unknown as ChatMessage;
+}
+
+function renderChat(message: ChatMessage) {
+  return render(
+    <ChatPane
+      messages={[message]}
+      streaming={false}
+      error={RAW_STAGE_TIMEOUT}
+      errorSourceAssistantId="msg-failed"
+      projectId="project-1"
+      projectFiles={[]}
+      onEnsureProject={async () => 'project-1'}
+      onSend={vi.fn()}
+      onStop={vi.fn()}
+      onRetry={vi.fn()}
+      conversations={[
+        { projectId: 'project-1', id: 'conv-1', title: 'Current', createdAt: 1, updatedAt: 1 },
+      ]}
+      activeConversationId="conv-1"
+      onSelectConversation={vi.fn()}
+      onDeleteConversation={vi.fn()}
+      config={{ agentId: 'amr', agentCliEnv: {} } as unknown as AppConfig}
+    />,
+  );
+}
+
+const cardOf = (container: HTMLElement) =>
+  container.querySelector('[data-user-action-card="run-recovery"]');
+
+const descriptionOf = (container: HTMLElement) =>
+  cardOf(container)?.querySelector('[data-testid="chat-run-error-description"]') ?? null;
+
+const titleOf = (container: HTMLElement) => cardOf(container)?.firstElementChild ?? null;
+
+describe('阶段超时的报错卡', () => {
+  it.each([
+    ['落盘事件不带码(修复前的形状)', undefined],
+    ['落盘事件带上 AGENT_EXECUTION_FAILED(修复后的形状)', 'AGENT_EXECUTION_FAILED'],
+  ])('%s → 「运行超时」而不是通用「任务执行失败」', (_name, code) => {
+    const { container } = renderChat(failedMessage(code as string | undefined));
+    expect(titleOf(container)!.textContent).toContain('chat.runError.title.timedOut');
+    expect(descriptionOf(container)!.textContent).toContain(
+      'chat.runError.timedOutMessage',
+    );
+  });
+
+  it.each([
+    ['不带码', undefined],
+    ['带码', 'AGENT_EXECUTION_FAILED'],
+  ])('%s → 给得出〔重试〕', (_name, code) => {
+    const { container } = renderChat(failedMessage(code as string | undefined));
+    expect(
+      cardOf(container)!.querySelector('[data-testid="chat-error-retry"]'),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Why

**My use case.** 三份真实用户诊断包(2026-09-08)里,同一台机器上的失败反复呈现成「任务执行失败 / 这次没能顺利完成」+ 没有恢复入口,而 daemon 其实**知道**发生了什么。查下去发现三条独立的、同一类的缺陷:**判决产生了,但没活到用户眼前**。

## ⚠️ 先说一条:原始诊断里有两处因果是错的,本 PR 修的是别的东西

派单时的假设是「ACP 阶段看门狗不带分类 → 卡上落到通用兜底」。**先造仪器再信诊断**,结果在**干净的 `origin/main`** 上驱动一个真的卡住的 ACP CLI(握手完成、`session/prompt` 永不作答、看门狗开火):

```
run.failureCategory 'timeout'   failureDetail 'timeout'
failureAction 'retry'           retryable true
end 帧 / 落库事件 都带着这些字段,web 已经正确渲染「运行超时」+〔重试〕
```

所以:

- **`failureDetail` 从来不走 `error` 帧** —— 它走 `end` 帧和 `GET /api/runs/:id`(`providers/daemon.ts:2080/2110/2155` → `markErrorRunFailure`)。裸 `{message}` 的 error 帧是**正常形态**,不是缺陷。
- **`persistRunFailureClassification` 是好的**,它在实测里正确地把分类并进了落库事件。

**证明这把尺子看得见缺陷**(不是"没红所以没问题"):同一个分类器喂一条 error 文本缺失的 run,返回 `process_exit / exit_code`、`retryable: false`、`user_action: 'none'` —— **正是那张没有重试的通用卡**。所以症状是真的,只是不由阶段超时这条路产生。

## What changed

### ① 超时的判定不再只靠一句英文活着

看门狗的判决此前**只以文本形式存在**:`run.errorCode` 是 `null`,分类器里结构化的 `errorCode === 'TIMEOUT'` 分支是**死码**(`ApiErrorCode` 里没有这个值),唯一把"这是超时"捞回来的是 `isTimeoutText()` 对 `run.error` 做的文本匹配。

**任何改写、包装或丢弃 ACP 消息的路径,都会把这次击杀重新归档成 `exit_code` / 不给重试。** 现在看门狗直接盖 `retryable: true` + `details.kind: 'timeout'`,分类器读这个标记。

**红证据**:把那句话改个措辞,main 上判决当场塌成 `unknown`;接线测试的帧断言直接失败。

### ② 恢复兜底认得压缩断流的新措辞

`AMR_OPENCODE_EVENT_STREAM_RESUME_FAILURE_PATTERNS` 只匹配旧串 `opencode SSE ended before prompt completion`;vela 0.0.35(#1847)引入的新串 `opencode compaction continuation ended before prompt completion` 全仓 0 命中,连"清陈旧 handle 重新播种"这条兜底都进不去。

**为什么重新播种对这一类是对的**:恢复动作是**同一回合的冷重跑**(清 handle → 新会话 → 从 DB 重建转录),门控在 `isResuming && resumeSessionId`,且由 `run.resumeAutoReseeded` 限一次,**不会成环,也永远碰不到 create turn**。工具重复执行的暴露面和表里已有的同族条目一致。

⚠️ **一条代价记在这里**:重新播种会清掉 handle,于是 **vela 已经持久化的压缩状态被丢弃**,恢复比 `session/load` 续接更重。这是后续优化项,不是阻塞 —— 因为今天同一个失败是**彻底的死路**。

### ③ 上游明确说"可重试"时,不再被我们改成"不可重试"

opencode 的字段叫 **`isRetryable`**,而 vela 把 `session.error` 信封当**一个 JSON 字符串塞在 message 里**递过来,不是 `error.data`。两个读取器 —— `rpcErrorRetryable` 只读 `data.retryable`、`latestRetryable` 读 `error.data.isRetryable` —— **都没读到**。于是 `fail()` 落到自己的默认 `retryable: options.retryable ?? false`,**daemon 发布了一个没有任何读取器得出过的判决**。

⚠️ **纠正一处**:**报错卡不是受害者** —— `stream_disconnected` 在 `AGENT_AGNOSTIC_DETAIL_FAILURE_UI` 里,`retryable: false` 也照样画〔重试〕(实测)。真正死掉的是 **daemon 自己的恢复**:`isResumableFailure` 一见 `retryable` 为 false 立刻 false → `run.resumable` 从不置位 → **〔继续运行〕消失**;`decidePostToolResumeRecovery` 要求 `retryable === true` → **静默的工具后续跑从不触发**。

**刻意没有做的事**:没有去掉 `fail()` 的 `?? false`。试过 —— 它移动**冻结 ACP 判定表的 17 行**,包括**把 429 限流变成可重试**,以及 `A10/A11` 致命启动和 `B8` 404。窄修(在两个读取器上读上游明确的 `isRetryable: true`)移动 **0 行**,196 条测试全绿。

**只认 `true`。** 上游明确说"不"的情况,已经有能证伪它的分支覆盖;让一个粗粒度的 SDK 标记去强制 `false`,正是分类器在 `run-failure-classification.ts:1376` 指名拒绝的那种漂移。`request_too_large` 仍然优先。

⚠️ **局限**:`stream_disconnected` 仍然混着**真上游断开**和**用户自己的代理/VPN 掉线**。本 PR 没有尝试拆分,所以一个本机网络故障如果载荷恰好写着 `isRetryable: true`,仍然会拿到重试。拆分的正确位置是 #7518 引入的 `network_configuration` 那一档。

## Testing

三条各自红测先行、各自撤实现再红。反向锚点(修前修后都绿):

| | 反向锚点 |
|---|---|
| ① | 未标记的 SIGTERM ≠ 超时;`acp_child_exit` ≠ 超时;**空回复仍然是「没有输出」**;伪造测试**走真实的 `attachAcpSession` 桥**(见下方更正) |
| ② | create turn 的 EOF 不进恢复;"压缩已开始"≠"死了" |
| ③ | `isRetryable:false` 的 404 仍然徒劳;429 仍然徒劳;余额/封号仍然徒劳;`request_too_large` 仍然徒劳;**`provider_routing_error` 仍然可重试** —— 这条用的是真实诊断包里 `43eed13f` 那条对照 |

web 侧反向锚点走 `data-testid` / 渲染文本,**零 CSS 断言**。

差分:36 个 daemon 文件 + 24 个 web 文件全绿。

**发现并修好(不是压掉)一条真回归**:`acp-stall-last-progress-age.test.ts` 用 `error_code === 'AGENT_EXIT_143'` 当**非空过守卫**("子进程真的跑了 SIGTERM 处理")。给判决命名之后,`run.errorCode` 变成失败自己的 code 而不是它导致的退出派生出来的。把守卫重锚到它真正想断言的事实 —— `run.exitCode === 143` —— 而不是削弱它。

闸门:`pnpm typecheck` 0 · `pnpm guard` 0 · `pnpm --filter @open-design/daemon build` 0(分别取,typecheck 绿 ≠ build 绿)。

## ⚠️ 一条更正:看门狗标记是抗碰撞,不是不可伪造

评审(mrcfps / PerishCode)证伪了本 PR 正文原先写的一句话「agent 侧载荷伪造不出这个标记」。**那句是错的**,准确的说法是:

> 看门狗的标记存在 `error.details`,而这**不是** daemon 私有的槽 —— `fail()` 会把 agent 的 JSON-RPC `error.data` 逐字拷进去。保护来自把值按机制命名(`acp_stage_timeout`),没有任何上游 SDK 载荷会发出它,所以 adapter 不会**意外**撞上。这是抗碰撞,**不是认证**:一个存心发 `kind: 'acp_stage_timeout'` 的 adapter 仍然会被相信。要让判决真正不可伪造,得把它放进一个 agent 载荷永远不会被拷入的 daemon 专属字段,那是帧形状变更,**刻意不在本 PR 内**。

**为什么原来的测试没照出来**:那条反伪造测试在分类器边界上直接构造 `error.data`,测的是一个 session 桥**根本不会发出的形状** —— 字段位置错了,于是修复只在测试里成立。现在的测试**只能通过 `attachAcpSession` 真实桥**才能通过,并且钉住了「`error.details` 等于 agent 那个对象」这条拷贝事实,所以它不会再悄悄变成空测。撤掉两处源码改动:**双向各自变红(伪造载荷被接受 / 看门狗判决丢失),共 4 红**。

顺带清理:另有一条为 `promotedOpenCodeSessionErrorPayload` 写的测试断言了一个该 promoter 根本产不出的帧,**已删除而不是留着**(留一条测不到东西的测试比没有更糟)。


## Adjacent issues(列出不动)

- **让判决真正不可伪造(后续单)**:给 `fail()` 加一个 daemon 专属选项,作为独立字段(例如 `error.verdict`)发出,agent 数据永不拷入 —— 按构造成为白名单,而不是靠一个「没人碰巧用」的名字。代价:`fail()` 签名 + 发出的帧形状、4 处 daemon 调用点、1 处分类器读取点、SSE error 帧新增一个字段。因为本分支尚未合并、没有任何已落库的 run 带着旧标记,现在做比以后便宜。

- ⚠️ **一条曾写在这里的猜测已被证伪,连同 ② 的覆盖率一起更正。** 早先的假设是「`server.ts:~15505` 的 AMR resume 失败抑制 `return` 却不发 error 帧,留下 `run.error` 为 null」。拿四份真实诊断包(71 个 run)量过:`agent_resume_failed_suppressed` / `agent_resume_auto_reseed` 两个标记出现 **0 次**,而走到通用卡的三条 run **各自都带着完整的 error 帧**(`AGENT_EXECUTION_FAILED`,`details.kind: opencode_prompt_error`,`phase: event_stream`)。抑制分支一次都没走进去。反向锚点:同一条检索在 2026-06-24 / 08-04 / 08-14 / 09-01 的包里**命中过**这两个标记,所以这里的 0 是真的 0。而且在那些真的触发抑制的实例里,close handler 的 reseed 兜底**每一次都接住了**,那一轮最终 `succeeded`。

- **真正的丢分类点,以及 ② 的实际覆盖率。** `opencode compaction continuation ended before prompt completion` 是**纯散文**,不带结构化错误码,所有按文本匹配的分类器都不认识它,于是掉进 `run-failure-classification.ts:1495` 的 close-reason 兜底 —— 那条兜底的默认值本来是 `retryableHint ?? true`,是 ACP bridge 硬写的 `retryable: false` 把它锁成了 `process_exit / fatal_rpc_error / retryable=false / action='none'`。同族对照:前缀一模一样但后面跟 JSON 错误块的三条 run(`upstream_error` / `Cannot connect`)分类器认得,正常拿到 `upstream_unavailable / stream_disconnected`。差别只在散文 vs 结构化。
  **因此 ② 只覆盖 3 条里的 1 条** —— `resolveAgentResumeFailurePolicy` 的第一道门是 `attemptedResume`(要 `isResuming` 且有 `resumeSessionId`),另外两条根本不是 resume 回合。正确的通用修法是给结构化的 `details.kind: opencode_prompt_error` / `phase: event_stream` 加分类器条目(覆盖 3/3),不再靠措辞匹配;单独一个 PR。

- **卡片上「没有重试按钮」这半句同样不成立。** 在用户实际那个 build(`0.22.0-prerelease.19`,`release/v0.22.0`)的 web 代码里,`AGENT_AGNOSTIC_DETAIL_FAILURE_UI` 有 `fatal_rpc_error: retryWithGuidance`,且查表(`amr-guidance.ts:1540`)发生在剥按钮的 `daemonSaysRetryIsFutile`(`:1718`)**之前**。真实的产品缺陷是**卡片说错了原因**:实际是 opencode 在上下文压缩续写时中断,却被归成 `process_exit`(语义「子进程死了」)并对用户报「上游服务暂时不可用」。

- **抑制/兜底这对配对确实有结构性裂缝(真实存在,但不是本次成因,本 PR 不动)。** 两个 site 调同一个函数,输入却可能在两个时刻不一致:`agentStderrTail` / `agentStdoutTail` 是滚动的 `.slice(-2000)`(`server.ts:14080/14312`),child 被 SIGTERM 后仍会吐关停行,标记可能被挤出窗口 → close 端判据翻假;且 close 端多两个前置(`run.conversationId &&`、`!run.cancelRequested`),stream 端没有。翻假后 ACP 路径落 `fatal_rpc_error`、Claude 路径一路掉到 exit code 兜底。修法形状是把抑制判定**存成 run 上的 latch**、close handler 读 latch,而不是补发 error 帧(补发会破坏透明 reseed 的初衷)。

- web `daemon.ts` 的 `pendingStructuredError && endStatus === null` 恢复分支里,`if (!status) { … handlers.onError(...); return; }` 抛出错误却**不调 `markErrorRunFailure`** —— 一次状态拉取失败就静默丢掉整份分类。
- `fail()` 仍以裸 `{message}` 发出的调用点:`session.ts` L625/L931(stdin 写失败)、L912(未处理的 ACP 权限请求)、L1329(`invalid session/new response`)、L1416(`child.on('error')`)、L1417(stdin error)。每一条都需要自己的可重试性判断和红测,是产品判断不是机械扫除。
- `deriveRunErrorCode` 对被 SIGTERM 的阶段超时返回 `null`;`classifyRunFailureBase` 里的 `'TIMEOUT'` 分支不可达。
