### PR TITLE
chore(release): stop blocking stable releases on missing release notes

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -245,7 +245,10 @@ jobs:
           GITHUB_REF_NAME: ${{ inputs.ref != '' && inputs.ref || github.ref_name }}
         run: pnpm exec tools-release prepare stable
 
-      - name: Validate stable release note policy
+      # Reports missing or partial stable release notes as a run annotation and
+      # a job-summary entry. It is deliberately not a gate: see
+      # docs/CHANGELOG/README.md.
+      - name: Check stable release note coverage
         env:
           RELEASE_CHANNEL: stable
           RELEASE_NOTE_PLAN_PATH: ${{ runner.temp }}/release-note-preflight/plan.json

--- a/docs/CHANGELOG/README.md
+++ b/docs/CHANGELOG/README.md
@@ -12,9 +12,14 @@ Each locale file must:
   strings; and
 - contain a non-empty Markdown body after the front matter.
 
-The `en` locale is required whenever a release-note directory is supplied.
-Stable releases additionally require `zh-CN`. Other channels may omit the
-version directory entirely.
+The `en` locale is required whenever a release-note directory is supplied,
+because every consumer falls back to it. Everything else is a recommendation,
+not a gate: any channel may omit the version directory entirely, and a stable
+release that is missing its notes — or missing `zh-CN` — still publishes. The
+gap is reported as a GitHub Actions warning and a job-summary entry on the
+release run rather than failing it, so an editorial omission never forces a new
+prerelease round trip. Stable releases are still expected to ship `en` and
+`zh-CN`; treat the warning as a to-do, not as permission to skip them.
 
 `tools-release` retains the front matter in the uploaded file and publishes it
 as an immutable object at

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -2501,7 +2501,9 @@ process.stdin.on("end", () => {
     }
 
     const stableWorkflow = workflows[2] ?? "";
-    expect(stableWorkflow).toContain("Validate stable release note policy");
+    // Stable still runs the release-note preflight in `metadata`, but it
+    // reports coverage instead of gating on it (docs/CHANGELOG/README.md).
+    expect(stableWorkflow).toContain("Check stable release note coverage");
     expect(stableWorkflow).toContain(
       "RELEASE_PUBLISH_SIDE_EFFECTS: ${{ needs.metadata.outputs.publish_side_effects_enabled }}",
     );

--- a/tools/release/src/release-note/policy.ts
+++ b/tools/release/src/release-note/policy.ts
@@ -1,23 +1,75 @@
+import { appendFileSync } from "node:fs";
+
 import type { ReleaseChannel } from "@open-design/release";
 
 import type { ReleaseNotePlan } from "./source.ts";
 
-const STABLE_REQUIRED_LOCALES = ["en", "zh-CN"] as const;
+const STABLE_RECOMMENDED_LOCALES = ["en", "zh-CN"] as const;
 
-export function assertReleaseNotePlanPolicy(plan: ReleaseNotePlan, channel: ReleaseChannel): void {
+export type ReleaseNotePolicyWarning = {
+  code: "stable-release-note-absent" | "stable-release-note-locale-missing";
+  message: string;
+};
+
+/**
+ * Release note policy invariant: a release note that exists must be usable,
+ * but a release with no note still ships.
+ *
+ * Throwing is reserved for a plan that is internally broken — a channel that
+ * disagrees with the caller, or a plan with notes that omits the default
+ * locale every consumer falls back to. Content that is merely missing (a
+ * stable release with no notes, or one without every recommended locale) comes
+ * back as a warning for the caller to surface, because a missing changelog is
+ * an editorial gap and blocking on it costs a whole prerelease round trip: the
+ * stable promotion gate pins `github.commit` to the promoted prerelease, so a
+ * commit that adds notes invalidates the artifact being promoted.
+ */
+export function reviewReleaseNotePlanPolicy(
+  plan: ReleaseNotePlan,
+  channel: ReleaseChannel,
+): ReleaseNotePolicyWarning[] {
   if (plan.channel !== channel) {
     throw new Error(`release note plan channel mismatch: expected ${channel}, got ${plan.channel}`);
   }
   if (plan.state === "ready" && !plan.entries.some((entry) => entry.locale === plan.defaultLocale)) {
     throw new Error(`release notes require the default locale: ${plan.defaultLocale}`);
   }
-  if (channel !== "stable") return;
+  if (channel !== "stable") return [];
   if (plan.state === "absent") {
-    throw new Error("release notes are required for stable releases");
+    return [{
+      code: "stable-release-note-absent",
+      message: `stable ${plan.releaseVersion} has no release notes; publishing without them. `
+        + `Add ${STABLE_RECOMMENDED_LOCALES.map((locale) => `${locale}.md`).join(" and ")} under ${plan.sourceDirectory} to include one.`,
+    }];
   }
   const locales = new Set(plan.entries.map((entry) => entry.locale));
-  const missing = STABLE_REQUIRED_LOCALES.filter((locale) => !locales.has(locale));
-  if (missing.length > 0) {
-    throw new Error(`stable release notes require locales: ${missing.join(", ")}`);
+  const missing = STABLE_RECOMMENDED_LOCALES.filter((locale) => !locales.has(locale));
+  if (missing.length === 0) return [];
+  return [{
+    code: "stable-release-note-locale-missing",
+    message: `stable ${plan.releaseVersion} release notes are missing ${missing.join(", ")}; `
+      + `publishing ${[...locales].join(", ")} only. Consumers fall back to ${plan.defaultLocale}.`,
+  }];
+}
+
+/**
+ * Make a skipped release note impossible to miss on the run page: one Actions
+ * annotation per warning plus a job summary block. Outside Actions, and when
+ * there is nothing to report, this stays quiet.
+ */
+export function reportReleaseNotePolicyWarnings(
+  warnings: readonly ReleaseNotePolicyWarning[],
+  summaryPath = process.env.GITHUB_STEP_SUMMARY ?? "",
+): void {
+  if (warnings.length === 0) return;
+  for (const warning of warnings) {
+    // Actions annotations are single-line; the messages above never wrap.
+    console.warn(`::warning title=Release notes missing::${warning.message}`);
   }
+  if (summaryPath.length === 0) return;
+  appendFileSync(
+    summaryPath,
+    `${["### :warning: Release notes", "", ...warnings.map((warning) => `- ${warning.message}`), ""].join("\n")}\n`,
+    "utf8",
+  );
 }

--- a/tools/release/src/release-note/prepare.ts
+++ b/tools/release/src/release-note/prepare.ts
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 import { releaseChannelDescriptor } from "@open-design/release";
 
 import { optional, required, writeJson } from "../storage/common.ts";
-import { assertReleaseNotePlanPolicy } from "./policy.ts";
+import { reportReleaseNotePolicyWarnings, reviewReleaseNotePlanPolicy } from "./policy.ts";
 import { discoverReleaseNotePlan } from "./source.ts";
 
 const channel = releaseChannelDescriptor(required("RELEASE_CHANNEL")).channel;
@@ -12,7 +12,10 @@ const sourceRoot = resolve(optional("RELEASE_NOTE_SOURCE_ROOT", "docs/CHANGELOG"
 const planPath = required("RELEASE_NOTE_PLAN_PATH");
 
 const plan = discoverReleaseNotePlan({ channel, releaseVersion, sourceRoot });
-assertReleaseNotePlanPolicy(plan, channel);
+// prepare owns the reporting: it is the first release-note command every
+// channel runs, so publish/verify enforce the same policy without repeating
+// the annotation.
+reportReleaseNotePolicyWarnings(reviewReleaseNotePlanPolicy(plan, channel));
 writeJson(planPath, plan);
 
 if (plan.state === "absent") {

--- a/tools/release/src/release-note/publish.ts
+++ b/tools/release/src/release-note/publish.ts
@@ -5,7 +5,7 @@ import { releaseChannelDescriptor } from "@open-design/release";
 
 import { optional, required, storageConfigFromEnv, writeJson } from "../storage/common.ts";
 import { getStorageObject, putStorageObjectWithStatus } from "../storage/s3-upload.ts";
-import { assertReleaseNotePlanPolicy } from "./policy.ts";
+import { reviewReleaseNotePlanPolicy } from "./policy.ts";
 import { createReleaseNotePublication } from "./publication.ts";
 import { parseReleaseNotePlan } from "./source.ts";
 
@@ -21,7 +21,7 @@ const plan = parseReleaseNotePlan(JSON.parse(readFileSync(planPath, "utf8")) as 
 if (plan.channel !== channel || plan.releaseVersion !== releaseVersion) {
   throw new Error(`release note plan identity mismatch for ${channel} ${releaseVersion}`);
 }
-assertReleaseNotePlanPolicy(plan, channel);
+reviewReleaseNotePlanPolicy(plan, channel);
 
 const storage = publishSideEffectsEnabled && plan.state === "ready" ? storageConfigFromEnv() : null;
 

--- a/tools/release/src/release-note/verify.ts
+++ b/tools/release/src/release-note/verify.ts
@@ -5,7 +5,7 @@ import { releaseChannelDescriptor } from "@open-design/release";
 
 import { optional, required, storageConfigFromEnv } from "../storage/common.ts";
 import { getStorageObject } from "../storage/s3-upload.ts";
-import { assertReleaseNotePlanPolicy } from "./policy.ts";
+import { reviewReleaseNotePlanPolicy } from "./policy.ts";
 import { parseReleaseNotePublication, verifyReleaseNotePublication } from "./publication.ts";
 import { parseReleaseNotePlan } from "./source.ts";
 
@@ -22,7 +22,7 @@ const publication = parseReleaseNotePublication(JSON.parse(readFileSync(publicat
 if (plan.channel !== channel || plan.releaseVersion !== releaseVersion) {
   throw new Error(`release note plan identity mismatch for ${channel} ${releaseVersion}`);
 }
-assertReleaseNotePlanPolicy(plan, channel);
+reviewReleaseNotePlanPolicy(plan, channel);
 verifyReleaseNotePublication(plan, publication, {
   publicOrigin,
   requirePublished: publishSideEffectsEnabled && plan.state === "ready",

--- a/tools/release/src/storage/publish-metadata.ts
+++ b/tools/release/src/storage/publish-metadata.ts
@@ -114,9 +114,10 @@ function readReleaseNoteMetadata(): ReturnType<typeof releaseNoteMetadataFromPub
   if (publication.channel !== releaseChannel || publication.releaseVersion !== releaseVersion) {
     throw new Error(`release note publication identity mismatch for ${releaseChannel} ${releaseVersion}`);
   }
-  if (releaseChannel === "stable" && publication.state === "absent") {
-    throw new Error("release note publication is required for stable metadata");
-  }
+  // An absent publication is a complete outcome, not a half-built one: the
+  // metadata simply omits its releaseNote block and verify-metadata asserts
+  // that same absence. prepare-release-note reports the editorial gap; blocking
+  // here would only move the stable hard-failure past the GitHub draft release.
   if (publication.state !== "absent") {
     const expectedState = publishSideEffectsEnabled ? "published" : "planned";
     if (publication.state !== expectedState) {

--- a/tools/release/tests/release-note.test.ts
+++ b/tools/release/tests/release-note.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -7,10 +7,11 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   createReleaseNotePublication,
+  parseReleaseNotePublication,
   releaseNoteMetadataFromPublication,
   verifyReleaseNotePublication,
 } from "../src/release-note/publication.js";
-import { assertReleaseNotePlanPolicy } from "../src/release-note/policy.js";
+import { reportReleaseNotePolicyWarnings, reviewReleaseNotePlanPolicy } from "../src/release-note/policy.js";
 import { discoverReleaseNotePlan } from "../src/release-note/source.js";
 
 const roots: string[] = [];
@@ -116,7 +117,10 @@ describe("release note source discovery", () => {
 });
 
 describe("release note channel policy", () => {
-  it("keeps discovery channel-neutral and makes stable require en and zh-CN", async () => {
+  // The invariant: missing release notes never block a release. A note that
+  // exists but cannot be consumed (wrong channel, no default locale) still
+  // fails, because that is a broken artifact rather than an absent one.
+  it("keeps discovery channel-neutral and warns instead of failing when stable notes are partial", async () => {
     const root = await temporaryRoot();
     await writeNote(root, "1.2.3", "en");
     const plan = discoverReleaseNotePlan({
@@ -125,20 +129,121 @@ describe("release note channel policy", () => {
       sourceRoot: root,
     });
 
-    expect(() => assertReleaseNotePlanPolicy(plan, "stable")).toThrow(/zh-CN/);
-    expect(() => assertReleaseNotePlanPolicy({ ...plan, channel: "beta" }, "beta")).not.toThrow();
+    const warnings = reviewReleaseNotePlanPolicy(plan, "stable");
+    expect(warnings.map((warning) => warning.code)).toEqual(["stable-release-note-locale-missing"]);
+    expect(warnings[0]?.message).toMatch(/zh-CN/);
+    expect(reviewReleaseNotePlanPolicy({ ...plan, channel: "beta" }, "beta")).toEqual([]);
   });
 
-  it("allows absent notes outside stable and rejects them for stable", async () => {
+  it("reports nothing when a stable release carries every recommended locale", async () => {
     const root = await temporaryRoot();
-    const absent = discoverReleaseNotePlan({
-      channel: "prerelease",
-      releaseVersion: "1.2.3-prerelease.1",
+    await writeNote(root, "1.2.3", "en");
+    await writeNote(root, "1.2.3", "zh-CN");
+    const plan = discoverReleaseNotePlan({
+      channel: "stable",
+      releaseVersion: "1.2.3",
       sourceRoot: root,
     });
 
-    expect(() => assertReleaseNotePlanPolicy(absent, "prerelease")).not.toThrow();
-    expect(() => assertReleaseNotePlanPolicy({ ...absent, channel: "stable" }, "stable")).toThrow(/required/i);
+    expect(reviewReleaseNotePlanPolicy(plan, "stable")).toEqual([]);
+  });
+
+  it("lets a stable release ship with no notes at all and reports the gap", async () => {
+    const root = await temporaryRoot();
+    const absent = discoverReleaseNotePlan({
+      channel: "stable",
+      releaseVersion: "1.2.3",
+      sourceRoot: root,
+    });
+
+    expect(absent.state).toBe("absent");
+    const warnings = reviewReleaseNotePlanPolicy(absent, "stable");
+    expect(warnings.map((warning) => warning.code)).toEqual(["stable-release-note-absent"]);
+    expect(warnings[0]?.message).toContain("1.2.3");
+  });
+
+  it("leaves non-stable channels silent when notes are absent", async () => {
+    const root = await temporaryRoot();
+    for (const [channel, releaseVersion] of [
+      ["beta", "1.2.3-beta.1"],
+      ["prerelease", "1.2.3-prerelease.1"],
+      ["preview", "1.2.3-preview.1"],
+    ] as const) {
+      const absent = discoverReleaseNotePlan({ channel, releaseVersion, sourceRoot: root });
+      expect(absent.state).toBe("absent");
+      expect(reviewReleaseNotePlanPolicy(absent, channel)).toEqual([]);
+    }
+  });
+
+  it("still rejects a plan that has notes but omits the default locale", async () => {
+    const root = await temporaryRoot();
+    await writeNote(root, "1.2.3", "zh-CN");
+    const plan = discoverReleaseNotePlan({
+      channel: "stable",
+      releaseVersion: "1.2.3",
+      sourceRoot: root,
+    });
+
+    expect(plan.state).toBe("ready");
+    expect(() => reviewReleaseNotePlanPolicy(plan, "stable")).toThrow(/default locale/i);
+    expect(() => reviewReleaseNotePlanPolicy({ ...plan, channel: "beta" }, "beta")).toThrow(/default locale/i);
+  });
+
+  it("still rejects a plan whose channel disagrees with the caller", async () => {
+    const root = await temporaryRoot();
+    await writeNote(root, "1.2.3", "en");
+    const plan = discoverReleaseNotePlan({
+      channel: "stable",
+      releaseVersion: "1.2.3",
+      sourceRoot: root,
+    });
+
+    expect(() => reviewReleaseNotePlanPolicy(plan, "beta")).toThrow(/channel mismatch/i);
+  });
+});
+
+describe("release note policy reporting", () => {
+  // Not blocking only works if the gap is loud. A skipped stable note must land
+  // on the run page as an annotation and in the job summary.
+  it("annotates the run and appends to the job summary", async () => {
+    const root = await temporaryRoot();
+    const summaryPath = join(root, "step-summary.md");
+    await writeFile(summaryPath, "", "utf8");
+    const absent = discoverReleaseNotePlan({
+      channel: "stable",
+      releaseVersion: "1.2.3",
+      sourceRoot: root,
+    });
+    const warned: string[] = [];
+    const restore = console.warn;
+    console.warn = (message: string) => void warned.push(message);
+    try {
+      reportReleaseNotePolicyWarnings(reviewReleaseNotePlanPolicy(absent, "stable"), summaryPath);
+    } finally {
+      console.warn = restore;
+    }
+
+    expect(warned).toHaveLength(1);
+    expect(warned[0]).toMatch(/^::warning title=Release notes missing::/);
+    expect(warned[0]).not.toContain("\n");
+    expect(await readFile(summaryPath, "utf8")).toContain("### :warning: Release notes");
+  });
+
+  it("stays quiet and leaves the summary untouched when there is nothing to report", async () => {
+    const root = await temporaryRoot();
+    const summaryPath = join(root, "step-summary.md");
+    await writeFile(summaryPath, "", "utf8");
+    const warned: string[] = [];
+    const restore = console.warn;
+    console.warn = (message: string) => void warned.push(message);
+    try {
+      reportReleaseNotePolicyWarnings([], summaryPath);
+    } finally {
+      console.warn = restore;
+    }
+
+    expect(warned).toEqual([]);
+    expect(await readFile(summaryPath, "utf8")).toBe("");
   });
 });
 
@@ -180,5 +285,49 @@ describe("release note publication contract", () => {
         },
       },
     });
+  });
+
+  // A stable release that skipped its notes must produce a whole artifact, not
+  // half of one: an absent publication, no releaseNote metadata block, and a
+  // verification pass that agrees with both.
+  it("projects an absent stable plan into an absent publication carrying no metadata", async () => {
+    const root = await temporaryRoot();
+    const plan = discoverReleaseNotePlan({
+      channel: "stable",
+      releaseVersion: "1.2.3",
+      sourceRoot: root,
+    });
+    const publication = createReleaseNotePublication(plan, {
+      publicOrigin: "https://releases.example.test",
+      published: true,
+      versionPrefix: "stable/versions/1.2.3",
+    });
+
+    expect(publication.state).toBe("absent");
+    expect(publication.entries).toEqual([]);
+    expect(releaseNoteMetadataFromPublication(publication)).toBeNull();
+    expect(() => verifyReleaseNotePublication(plan, publication, { requirePublished: true })).not.toThrow();
+    expect(() => parseReleaseNotePublication(JSON.parse(JSON.stringify(publication)) as unknown)).not.toThrow();
+  });
+
+  it("projects a partial stable plan into a publication carrying only the locales that exist", async () => {
+    const root = await temporaryRoot();
+    await writeNote(root, "1.2.3", "en");
+    const plan = discoverReleaseNotePlan({
+      channel: "stable",
+      releaseVersion: "1.2.3",
+      sourceRoot: root,
+    });
+    const publication = createReleaseNotePublication(plan, {
+      publicOrigin: "https://releases.example.test",
+      published: true,
+      versionPrefix: "stable/versions/1.2.3",
+    });
+
+    expect(publication.state).toBe("published");
+    expect(publication.entries.map((entry) => entry.locale)).toEqual(["en"]);
+    expect(Object.keys(releaseNoteMetadataFromPublication(publication)?.content.locales ?? {})).toEqual(["en"]);
+    expect(() => verifyReleaseNotePublication(plan, publication, { requirePublished: true })).not.toThrow();
+    expect(() => parseReleaseNotePublication(JSON.parse(JSON.stringify(publication)) as unknown)).not.toThrow();
   });
 });

--- a/tools/serve/tests/release-metadata-publish.test.ts
+++ b/tools/serve/tests/release-metadata-publish.test.ts
@@ -345,4 +345,97 @@ describe("shared release metadata publisher", () => {
     expect(metadata.dryRun).toBe(true);
     expect(Object.keys(metadata.releaseNote?.content?.locales ?? {})).toEqual(["en", "zh-CN"]);
   });
+
+  // Missing release notes must not stop a stable release. The whole chain has
+  // to agree that "no notes" is a complete outcome: an absent plan, an absent
+  // publication, metadata without a releaseNote block, and a verify pass.
+  it("publishes stable metadata when the release has no release notes at all", async () => {
+    const repoRoot = resolve(import.meta.dirname, "../../..");
+    const root = await mkdtemp(join(tmpdir(), "od-release-metadata-no-notes-"));
+    const version = "1.2.3";
+    const manifestDir = join(root, "manifests");
+    const metadataDir = join(root, "metadata");
+    const releaseNoteRoot = join(root, "CHANGELOG");
+    const releaseNotePlanPath = join(metadataDir, "release-note-plan.json");
+    const releaseNoteManifestPath = join(metadataDir, "release-note-publication.json");
+    const summaryPath = join(root, "step-summary.md");
+    await mkdir(manifestDir, { recursive: true });
+    await mkdir(releaseNoteRoot, { recursive: true });
+    await writeFile(summaryPath, "", "utf8");
+    await writeFile(
+      join(manifestDir, "mac_arm64.json"),
+      JSON.stringify({
+        artifacts: { payload: { url: "https://releases.example.test/mac-payload" } },
+        channel: "stable",
+        enabled: true,
+        github: { commit: "nonote1", runId: 78 },
+        legacyPlatformKey: "mac",
+        platformKey: "mac_arm64",
+        r2: { versionPrefix: `stable/versions/${version}` },
+        releaseTarget: "mac_arm64",
+        releaseVersion: version,
+        signed: true,
+        status: "published",
+      }),
+      "utf8",
+    );
+
+    const env = {
+      ...process.env,
+      BASE_VERSION: version,
+      ENABLE_LINUX_X64: "false",
+      ENABLE_MAC_ARM64: "true",
+      ENABLE_MAC_X64: "false",
+      ENABLE_WIN_X64: "false",
+      GITHUB_STEP_SUMMARY: summaryPath,
+      MAC_ARM64_RESULT: "success",
+      RELEASE_CHANNEL: "stable",
+      RELEASE_COMMIT: "nonote1",
+      RELEASE_DRY_RUN_MODE: "prepublish",
+      RELEASE_MANIFEST_DIR: manifestDir,
+      RELEASE_METADATA_DIR: metadataDir,
+      RELEASE_NOTE_MANIFEST_PATH: releaseNoteManifestPath,
+      RELEASE_NOTE_PLAN_PATH: releaseNotePlanPath,
+      RELEASE_NOTE_SOURCE_ROOT: releaseNoteRoot,
+      RELEASE_OUTPUTS_PATH: join(metadataDir, "outputs.json"),
+      RELEASE_PUBLIC_ORIGIN: "https://releases.example.test",
+      RELEASE_PUBLISH_SIDE_EFFECTS: "false",
+      RELEASE_RUN_ID: "78",
+      RELEASE_SIGNED: "true",
+      RELEASE_VERSION: version,
+      STATE_SOURCE: "local-no-notes",
+      STABLE_VERSION: version,
+    };
+
+    for (const script of [
+      "tools/release/src/release-note/prepare.ts",
+      "tools/release/src/release-note/publish.ts",
+      "tools/release/src/release-note/verify.ts",
+      "tools/release/src/storage/publish-metadata.ts",
+    ]) {
+      await runNode(["--experimental-strip-types", script], { cwd: repoRoot, env });
+    }
+    await runNode(["--experimental-strip-types", "tools/release/src/storage/verify-metadata.ts"], {
+      cwd: repoRoot,
+      env: { ...env, RELEASE_METADATA_PATH: join(metadataDir, "metadata.json") },
+    });
+
+    const plan = JSON.parse(await readFile(releaseNotePlanPath, "utf8")) as { entries?: unknown[]; state?: string };
+    const publication = JSON.parse(await readFile(releaseNoteManifestPath, "utf8")) as {
+      entries?: unknown[];
+      state?: string;
+    };
+    const metadata = JSON.parse(await readFile(join(metadataDir, "metadata.json"), "utf8")) as {
+      releaseNote?: unknown;
+      releaseState?: string;
+    };
+    expect(plan.state).toBe("absent");
+    expect(plan.entries).toEqual([]);
+    expect(publication.state).toBe("absent");
+    expect(publication.entries).toEqual([]);
+    expect(metadata.releaseNote).toBeUndefined();
+    expect(metadata.releaseState).toBe("complete");
+    // The skipped note has to be visible on the run page, not silent.
+    expect(await readFile(summaryPath, "utf8")).toMatch(/release note/i);
+  });
 });


### PR DESCRIPTION
## Why

**My use case.** A stable release was blocked today by a missing changelog. `docs/CHANGELOG/v0.22.0/` did not exist, so the `Validate stable release note policy` step in `release-stable.yml` — the first step of the first job — threw `release notes are required for stable releases` and the release stopped before a single artifact was built.

**The pain.** The cost of that gate is not "write two markdown files". Fixing it mid-release is a ~27-minute detour:

1. `prepare-stable.ts` validates the promoted prerelease with `expectStringFieldIfPresent(github, "commit", options.commit, …)` — the prerelease's `github.commit` must equal the current release branch HEAD.
2. Adding the changelog moves HEAD.
3. HEAD moving invalidates the prerelease being promoted, so a whole new prerelease has to be cut and validated (~27 min) before stable can be attempted again.

So an editorial omission — the kind of thing anyone can forget on release day — costs half an hour of pipeline time at exactly the moment nobody has half an hour. Meanwhile the thing the gate protects (users can read what changed) is achievable without blocking: warn loudly, publish anyway, add the note in the next release.

Worth stating plainly, because it changes how much this gate was actually buying: **`metadata.releaseNote` has no product-side reader today.** Nothing in `apps/`, `packages/`, or `e2e/` consumes it. The What's New popup users actually see reads `https://whatsnew.open-design.ai/whats-new.json`, a separately-uploaded R2 object (`apps/daemon/src/services/whats-new.ts`). The gate was blocking releases to protect a transport descriptor that only `tools-release` reads back.

Note that `docs/CHANGELOG/` has no `v0.20.x` directory either — the gate has been a recurring cost, not a one-off.

## What users will see

Nothing in the product. This changes release-pipeline behavior only:

- A stable release with no `docs/CHANGELOG/v<version>/` directory now completes instead of failing. Its published metadata simply carries no `releaseNote` block.
- The release run shows a `::warning::` annotation and a **Release notes** entry in the job summary naming the version and the exact directory to add, so the gap is visible on the run page rather than silent.
- Non-stable channels (beta / prerelease / preview) are byte-for-byte unchanged.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — release tooling, its tests, and the release-note source contract doc.

## Design notes

The four questions this change had to answer.

### 1. What happens downstream of `plan.state === "absent"`

Nothing new — and that is the point. `absent` is already the normal beta/prerelease outcome, so the chain below the policy was built for it and needed no change:

| Stage | Behavior when `absent` |
|---|---|
| `createReleaseNotePublication` | `state: "absent"`, `entries: []` |
| `publish-release-note` | `storage` stays `null`, the entry loop is empty — no partial upload |
| `verifyReleaseNotePublication` | `expectedState` derives from `plan.state`, so it expects `absent` and passes |
| `releaseNoteMetadataFromPublication` | returns `null` |
| `publish-metadata` | `...(releaseNote == null ? {} : { releaseNote })` — the key is simply omitted |
| `verify-metadata` | asserts `metadata.releaseNote == null`, which matches |

The one real risk was **moving the hard failure instead of removing it**, and that risk was concrete: `publish-metadata.ts` carried a *second* stable gate on the same condition (`release note publication is required for stable metadata`). Removing only the policy throw would have relocated the failure from the first step of the first job to *after* the GitHub draft release was created and its assets uploaded — strictly worse, and it would have exercised the rollback path. Both gates are gone in this PR, and the end-to-end spec below exists specifically to keep them gone together.

Two `RELEASE_NOTE_MANIFEST_PATH is required` throws remain in `publish-metadata.ts` / `verify-metadata.ts`. Those are wiring invariants (the workflow must pass the env var), not content gates, so they stay.

### 2. Partial locales: `en.md` present, `zh-CN.md` missing

**Choice: publish the locales that exist, warn about the ones that do not.**

- The metadata shape is a locale map (`content.locales`), and a map with one entry is a complete, valid artifact. Publishing `en` only is strictly better for users than publishing nothing.
- `parseReleaseNotePublication` already enforces "entries non-empty ⇒ must contain `en`", so the only *structurally* invalid partial is the one still rejected by the default-locale check below. Everything else round-trips.
- Treating `en`-only as `absent` would mean discarding written content — the worst of both worlds. It would also be internally inconsistent: `parseReleaseNotePlan` throws when `state === "absent"` disagrees with a non-empty `entries`, so we would have to drop the entries too.

### 3. The `defaultLocale` check (old line 11) — kept

Agreed with the stated preference, and there is a mechanical reason beyond the editorial one. "You wrote a note but omitted `en`" is a different failure from "you wrote no note": consumers fall back to `defaultLocale`, so a note without it is unreadable for anyone outside that one locale. And `parseReleaseNotePublication` independently rejects a non-empty publication lacking `en` — dropping this check would just produce a manifest that fails to parse one stage later. It stays a throw, on every channel.

`channel mismatch` stays a throw too, for the same reason: it means the caller and the plan disagree about what is being released.

### 4. Non-stable channels

Unchanged. `reviewReleaseNotePlanPolicy` returns `[]` for any non-stable channel before reaching the stable branches, and `leaves non-stable channels silent when notes are absent` pins that across beta / prerelease / preview.

## Follow-up (evaluated, deliberately not in this PR)

The real fix for the underlying pain is catching the gap **before** release day. Two options, cheapest first:

1. **Warn from the prerelease lane.** `release-prerelease.yml` already runs `prepare-release-note`, and a prerelease version like `0.22.0-prerelease.3` carries its stable base version. Having the prerelease run check whether `docs/CHANGELOG/v<baseVersion>/` exists and annotate when it does not would surface the gap days early, at zero risk — the prerelease itself never needed notes and still would not. This is the option I would pick.
2. **Warn on the release branch.** A check on `release/v*` branches that annotates a missing `docs/CHANGELOG/v<version>/` gives even earlier notice, but adds a new workflow surface for a problem option 1 already covers.

Not doing either here: this PR should stay a single-purpose "stop blocking" change, and option 1 touches the prerelease lane during a release freeze.

**Adjacent issue, not fixed here:** `expectStringFieldIfPresent(github, "commit", …)` in `prepare-stable.ts:384` is what turns *any* late release-branch commit into a full prerelease round trip, not just changelog commits. Whether a documentation-only commit should invalidate a promoted prerelease is a real question, but it is a promotion-gate decision with its own risk profile and belongs in its own PR.

## Bug fix verification

Not a bug fix, but the change was driven red-first per AGENTS.md → Bug follow-up workflow.

**Red specs, written and confirmed red before any source change:**

- `tools/release/tests/release-note.test.ts` — 4 of the new policy cases went red on `main`, on behavior rather than on a missing import (the red pass deliberately used the old exported name). Key one: `lets a stable release ship with no notes at all and reports the gap` failed with `Error: release notes are required for stable releases` at `policy.ts:16`.
- `tools/serve/tests/release-metadata-publish.test.ts` → `publishes stable metadata when the release has no release notes at all` — end-to-end through the real scripts (`prepare` → `publish` → `verify` → `publish-metadata` → `verify-metadata`). Red on `main` at `prepare-release-note`, exit 1.

**Verified red again by removing each part of the implementation** (all three branches proven load-bearing, none is dead code):

| Reverted | Result |
|---|---|
| `policy.ts` absent branch → throw | 2 failed (`lets a stable release ship with no notes at all`, `annotates the run and appends to the job summary`) |
| `policy.ts` missing-locale branch → throw | 1 failed (`warns instead of failing when stable notes are partial`) |
| `publish-metadata.ts` stable gate restored | end-to-end spec failed — proving the second gate was load-bearing and that fixing `policy.ts` alone would only have relocated the failure |

**Existing tests changed** (rewritten as the new invariant, not deleted):

- `tools/release/tests/release-note.test.ts` → `keeps discovery channel-neutral and makes stable require en and zh-CN`. Pinned `expect(...).toThrow(/zh-CN/)` for an `en`-only stable plan. Now `keeps discovery channel-neutral and warns instead of failing when stable notes are partial`, asserting a `stable-release-note-locale-missing` warning.
- `tools/release/tests/release-note.test.ts` → `allows absent notes outside stable and rejects them for stable`. Pinned `expect(...).toThrow(/required/i)` for an absent stable plan. Split into `lets a stable release ship with no notes at all and reports the gap` (stable, warns) and `leaves non-stable channels silent when notes are absent` (beta / prerelease / preview, unchanged) — the non-stable half of the old assertion is preserved, and broadened from one channel to three.
- `e2e/tests/packaged-smoke-workflow.test.ts` → `[P2] publishes release notes through one channel-neutral tools-release pipeline`. Its `Validate stable release note policy` string assertion follows the workflow step rename to `Check stable release note coverage`. The preflight step still exists and still runs; only its name and its role (report, not gate) changed.

**Coverage added**, matching the requested matrix: no notes at all / `en` only / `zh-CN` only / both / non-stable channel with no notes — plus channel mismatch, the reporter's annotation and summary output, the reporter's silence when there is nothing to say, and the absent-plan and partial-plan projections through publication → metadata.

## Validation

- `pnpm guard` — exit 0
- `pnpm typecheck` — exit 0
- `pnpm --filter @open-design/tools-release test` — 107 passed (11 files)
- `pnpm --filter @open-design/tools-serve test` — 29 passed, 2 failed. Both failures are in `tests/dsh-bootstrap-publish.test.ts` (`install-dsh.cmd must contain exactly one landing PS1 URL`), pre-existing on `origin/main` and unrelated: `git diff --stat origin/main` over the whole DSH chain (`dsh-bootstrap-bundle.ts`, `publish-dsh-bootstrap.ts`, `dsh-bootstrap-publish.test.ts`, `install-dsh.cmd`) is empty. The file this PR touches in that package, `release-metadata-publish.test.ts`, passes 4/4.
- `e2e` → `tests/packaged-smoke-workflow.test.ts` — 81 passed, 1 skipped
- `tools/pack` → `tests/release-workflows.test.ts` — 8 passed
- `actionlint` v1.7.12 (the CI-pinned version) — exit 0, zero findings

Not backported. `release/v0.22.0` is in release freeze; this lands on `main` only and rides the next version naturally.
