### PR TITLE
feat(web): seat the rail toggle first in the window chrome, before the search (OPEND-2553 F5)

### DIFF
--- a/apps/web/src/components/WorkspaceTabsBar.tsx
+++ b/apps/web/src/components/WorkspaceTabsBar.tsx
@@ -2078,20 +2078,55 @@ export function WorkspaceTabsBar({
             </div>
           );
         })}
-        {/* Search + the rail toggle, moved out of the rail and up into the
+        {/* The rail toggle + search, moved out of the rail and up into the
             chrome row (per product: 搜索和收起跟 home icon 一起放在顶部). They
             are this row's only controls now — the pinned Home pill is hidden
             here by CSS (routines.css), so the toggle owns BOTH directions: it
             stays rendered while the rail is collapsed, where the pill used to
-            be the expand control. Only the undocked (entry) chrome shows them,
-            and only on routes that actually mount EntryShell — in chat the
-            strip lives in the column dock and there is no entry rail to
-            toggle, and full-page settings replaces the rail outright
-            (settingsPageChrome). Both targets live in EntryShell's tree, so the
-            clicks travel as window events (see entryRailBridge). The classes
-            are the rail's own, so the controls keep their look. */}
+            be the expand control. The toggle takes the FIRST slot after the
+            traffic-light space (OPEND-2685: the sidebar switch sits where a
+            macOS sidebar switch is expected, right beside the window
+            controls, and stays put across open/collapsed so the expand entry
+            is the same target as the collapse one); the search follows it.
+            Only the undocked (entry) chrome shows them, and only on routes
+            that actually mount EntryShell — in chat the strip lives in the
+            column dock and there is no entry rail to toggle, and full-page
+            settings replaces the rail outright (settingsPageChrome). Both
+            targets live in EntryShell's tree, so the clicks travel as window
+            events (see entryRailBridge). The classes are the rail's own, so
+            the controls keep their look. */}
         {!tabsDockEl && !settingsPageChrome ? (
           <div className="entry-nav-rail__search-row workspace-tabs-rail-actions">
+            <button
+              type="button"
+              className="entry-nav-rail__collapse od-tooltip"
+              aria-label={entryRailOpen ? t('entry.navCollapse') : t('entry.navExpand')}
+              aria-expanded={entryRailOpen}
+              aria-keyshortcuts={isMacPlatform() ? 'Meta+B' : 'Control+B'}
+              title={entryRailOpen ? collapseHint : expandHint}
+              data-tooltip={entryRailOpen ? collapseHint : expandHint}
+              data-tooltip-placement="bottom"
+              data-testid="entry-rail-collapse"
+              onClick={() => {
+                window.dispatchEvent(new CustomEvent(ENTRY_RAIL_TOGGLE_EVENT));
+              }}
+            >
+              {/* The bar sits on the side the rail is on while it is open, and
+                  flips out of the frame once it is collapsed. Both glyphs stay
+                  mounted, stacked, so the swap cross-fades (CSS keys it off
+                  `is-current`) instead of popping — an unmount would skip the
+                  exit transition. */}
+              <Icon
+                name="layout-left"
+                size={16}
+                className={`entry-nav-rail__collapse-glyph${entryRailOpen ? ' is-current' : ''}`}
+              />
+              <Icon
+                name="layout-right"
+                size={16}
+                className={`entry-nav-rail__collapse-glyph${entryRailOpen ? '' : ' is-current'}`}
+              />
+            </button>
             <button
               type="button"
               className="entry-nav-rail__search od-tooltip"
@@ -2121,24 +2156,6 @@ export function WorkspaceTabsBar({
               }}
             >
               <Icon name="search" size={16} />
-            </button>
-            <button
-              type="button"
-              className="entry-nav-rail__collapse od-tooltip"
-              aria-label={entryRailOpen ? t('entry.navCollapse') : t('entry.navExpand')}
-              aria-expanded={entryRailOpen}
-              aria-keyshortcuts={isMacPlatform() ? 'Meta+B' : 'Control+B'}
-              title={entryRailOpen ? collapseHint : expandHint}
-              data-tooltip={entryRailOpen ? collapseHint : expandHint}
-              data-tooltip-placement="bottom"
-              data-testid="entry-rail-collapse"
-              onClick={() => {
-                window.dispatchEvent(new CustomEvent(ENTRY_RAIL_TOGGLE_EVENT));
-              }}
-            >
-              {/* The bar sits on the side the rail is on while it is open, and
-                  flips out of the frame once it is collapsed. */}
-              <Icon name={entryRailOpen ? 'layout-left' : 'layout-right'} size={16} />
             </button>
           </div>
         ) : null}

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -1323,6 +1323,32 @@
   border-radius: var(--radius-large, 8px);
   background: transparent;
   color: var(--text-muted);
+  /* Anchors the stacked glyph pair below. */
+  position: relative;
+}
+/* Open/collapsed glyphs are both mounted and stacked in the toggle; the
+   current one is shown, the other waits at 90% behind it. The swap is a
+   cross-fade + settle rather than a pop: enter ~200ms, exit ~140ms, both on the
+   ease-out curve (AGENTS.md "UI animation philosophy"), never from scale(0). */
+.entry-nav-rail__collapse-glyph {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  opacity: 0;
+  transform: scale(0.9);
+  transition:
+    opacity 140ms cubic-bezier(0.23, 1, 0.32, 1),
+    transform 140ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+.entry-nav-rail__collapse-glyph.is-current {
+  opacity: 1;
+  transform: none;
+  transition-duration: 200ms, 200ms;
+}
+@media (prefers-reduced-motion: reduce) {
+  .entry-nav-rail__collapse-glyph {
+    transition: none;
+  }
 }
 /* Search + collapse take the SAME fill as the rail's selected nav row —
    `--text-strong` at 10% (per product: 这几个 icon 的选中和 hover 都和首页的
@@ -1356,10 +1382,12 @@
 .workspace-tabs-rail-actions {
   flex: 0 0 auto;
   gap: 4px;
-  /* The search glyph sits on the same vertical axis as the rail's 首页 icon
-     below it (per product). The strip already insets this cluster 10px, and
-     the search's own 34px hit box centres its glyph 17px in, so the remainder
-     lives here. */
+  /* The cluster's first glyph sits on the same vertical axis as the rail's
+     首页 icon below it (per product). Since OPEND-2685 that first control is
+     the rail toggle (search second), so the toggle is what lines up with the
+     column — and, on macOS, what sits right after the traffic lights. The
+     strip already insets this cluster 10px, and the control's own 34px hit box
+     centres its glyph 17px in, so the remainder lives here. */
   margin: 0 0 0 14.8px;
 }
 .workspace-tabs-rail-actions .entry-nav-rail__collapse {

--- a/apps/web/tests/components/WorkspaceTabsBar.test.tsx
+++ b/apps/web/tests/components/WorkspaceTabsBar.test.tsx
@@ -373,6 +373,69 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     expect(screen.queryByRole('button', { name: 'Search tabs' })).toBeNull();
   });
 
+  it('puts the rail toggle first in the entry chrome cluster and mirrors the rail state on it', async () => {
+    // OPEND-2685: the sidebar switch is the FIRST control after the window's
+    // traffic-light space — where a macOS sidebar toggle is expected — and the
+    // search follows it. It stays mounted in both rail states, so the
+    // collapsed rail's expand entry is the same target as the collapse one;
+    // only its label, aria-expanded and glyph flip.
+    render(<WorkspaceTabsBar route={homeRoute} projects={[project]} />);
+
+    const cluster = document.querySelector('.workspace-tabs-rail-actions');
+    expect(cluster).not.toBeNull();
+    const order = Array.from(cluster!.querySelectorAll('[data-testid]')).map(
+      (el) => (el as HTMLElement).dataset.testid,
+    );
+    expect(order).toEqual(['entry-rail-collapse', 'entry-nav-search']);
+
+    const toggle = screen.getByTestId('entry-rail-collapse');
+    // Fresh storage: the rail is collapsed, so the toggle reads as "expand".
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(toggle.getAttribute('aria-label')).toBe('entry.navExpand');
+    const currentGlyph = () =>
+      toggle.querySelectorAll('.entry-nav-rail__collapse-glyph.is-current').length;
+    expect(toggle.querySelectorAll('.entry-nav-rail__collapse-glyph')).toHaveLength(2);
+    expect(currentGlyph()).toBe(1);
+
+    // Clicking asks EntryShell (a sibling tree) to flip the rail via the
+    // bridge event; the button itself owns no state.
+    const toggled = vi.fn();
+    window.addEventListener('od:entry-rail-toggle', toggled);
+    fireEvent.click(toggle);
+    expect(toggled).toHaveBeenCalledTimes(1);
+    window.removeEventListener('od:entry-rail-toggle', toggled);
+
+    // EntryShell answers with the state event; the toggle mirrors it in place
+    // (same element, same slot) and flips to the collapse affordance.
+    act(() => {
+      window.dispatchEvent(new CustomEvent('od:entry-rail-state', { detail: { open: true } }));
+    });
+    expect(screen.getByTestId('entry-rail-collapse')).toBe(toggle);
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(toggle.getAttribute('aria-label')).toBe('entry.navCollapse');
+    expect(currentGlyph()).toBe(1);
+    expect(
+      Array.from(cluster!.querySelectorAll('[data-testid]')).map(
+        (el) => (el as HTMLElement).dataset.testid,
+      ),
+    ).toEqual(['entry-rail-collapse', 'entry-nav-search']);
+  });
+
+  it('shows no rail toggle in the docked (project) chrome — there is no entry rail to switch', async () => {
+    const dock = document.createElement('div');
+    document.body.appendChild(dock);
+    setWorkspaceTabsDock(dock);
+    try {
+      render(<WorkspaceTabsBar route={projectRoute} projects={[project]} />);
+      expect(screen.queryByTestId('entry-rail-collapse')).toBeNull();
+      expect(screen.queryByTestId('entry-nav-search')).toBeNull();
+      // The docked chrome keeps the brand-logo Home button in that first slot.
+      expect(screen.getByTestId('workspace-home-chrome')).toBeTruthy();
+    } finally {
+      dock.remove();
+    }
+  });
+
   it('collapses every entry section into the single leftmost tab (no new tab per section)', async () => {
     const { rerender } = render(
       <WorkspaceTabsBar route={{ kind: 'home', view: 'home' }} projects={[project]} />,

--- a/apps/web/tests/styles/workspace-tabs-chrome.test.ts
+++ b/apps/web/tests/styles/workspace-tabs-chrome.test.ts
@@ -430,6 +430,23 @@ describe('workspace tabs chrome styles', () => {
     expect(ruleValue(cluster, 'margin')).toBe('0 0 0 14.8px');
   });
 
+  it('cross-fades the rail toggle glyphs on the ease-out curve (enter 200ms, exit 140ms)', () => {
+    // OPEND-2685: both glyphs stay mounted; the swap is a fade + settle from
+    // scale(0.9), never a pop or a scale(0) start (AGENTS.md animation rules).
+    const glyph = cssDeclarations(entryLayoutCss, '.entry-nav-rail__collapse-glyph');
+    const current = cssDeclarations(entryLayoutCss, '.entry-nav-rail__collapse-glyph.is-current');
+    expect(ruleValue(glyph, 'position')).toBe('absolute');
+    expect(ruleValue(glyph, 'opacity')).toBe('0');
+    expect(ruleValue(glyph, 'transform')).toBe('scale(0.9)');
+    expect(ruleValue(glyph, 'transition')).toContain('opacity 140ms cubic-bezier(0.23, 1, 0.32, 1)');
+    expect(ruleValue(glyph, 'transition')).toContain('transform 140ms cubic-bezier(0.23, 1, 0.32, 1)');
+    expect(ruleValue(current, 'opacity')).toBe('1');
+    expect(ruleValue(current, 'transform')).toBe('none');
+    expect(ruleValue(current, 'transition-duration')).toBe('200ms, 200ms');
+    const toggle = cssDeclarations(entryLayoutCss, '.entry-nav-rail__collapse');
+    expect(ruleValue(toggle, 'position')).toBe('relative');
+  });
+
   it('caps the docked tab dropdown at six rows and scrolls the rest', () => {
     const menu = cssDeclarations(routinesCss, '.workspace-tabs-dropdown__menu');
     const row = cssDeclarations(routinesCss, '.workspace-tabs-dropdown__row-main');

--- a/e2e/ui/entry-chrome-flows.test.ts
+++ b/e2e/ui/entry-chrome-flows.test.ts
@@ -443,6 +443,11 @@ test('[P1] entry top navigation matches the current home tab structure', async (
   await expect(page.getByTestId('entry-nav-collapse')).toHaveCount(0);
   await expect(page.locator('.entry-nav-rail').getByTestId('entry-nav-search')).toHaveCount(0);
   await expect(page.locator('.workspace-tabs-rail-actions').getByTestId('entry-nav-search')).toBeVisible();
+  // OPEND-2685: the rail toggle is the cluster's FIRST control (right after
+  // the traffic-light space on macOS), the search second.
+  await expect(
+    page.locator('.workspace-tabs-rail-actions > [data-testid]').first(),
+  ).toHaveAttribute('data-testid', 'entry-rail-collapse');
   await expect(page.getByTestId('entry-nav-home')).toHaveAttribute('aria-current', 'page');
   await expect(page.getByTestId('entry-nav-community')).toBeVisible();
   await expect(page.locator('.entry-nav-rail__group').getByTestId('entry-nav-design-systems')).toBeVisible();


### PR DESCRIPTION
Plane: OPEND-2685（OPEND-2553 首页链路一期 · PR-F5）。Base 是 `feat/home-entry-refresh`，不打到 `main`。

## Why

QA 在 OPEND-2685 里指出左栏折叠按钮没有按新设计移到窗口顶部：工单截图（C1 合入前的 main）里它还在侧栏搜索框右侧，红色箭头指向红绿灯右侧原 home 徽标的位置。C1（#7832）已经把搜索与折叠一起挪进顶部 chrome，但顺序是「搜索 → 折叠」，折叠按钮落在第二个槽位，与箭头所指的第一槽位（红绿灯之后）不符。产品已认可「放到红绿灯右侧的顶部 chrome 区域」这个方案，本 PR 把折叠按钮调到 chrome 最左的第一个槽位，搜索紧随其后。

顺带把图标切换从瞬时替换改成符合 AGENTS.md 动效规范的交叉淡入淡出（进入 200ms、退出 140ms、ease-out、从 scale(0.9) 起）。

## What users will see

- 首页顶栏最左（macOS 上紧贴红绿灯留白之后，Windows / 浏览器上贴左侧内边距）是「收起侧栏」按钮，搜索按钮在它右边；按钮图标与左栏「首页」图标处在同一竖直轴线上。
- 左栏收起后按钮留在原位，图标翻转为「展开侧栏」、tooltip 文案随之切换（⌘B / Ctrl+B 快捷键不变），展开入口与收起入口是同一个目标。
- 点击切换时图标做轻微的淡入淡出而不是突变；`prefers-reduced-motion` 下无动画。
- 项目页（chat）的 chrome 没有左栏可折叠，该槽位仍是 Home 徽标按钮，与首页的折叠按钮同轴（glyph 中心 x≈110px），因此两种壳的顶栏第一槽位视觉一致；项目页不加折叠按钮。

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

CLI 不适用：这是纯壳层 chrome 布局，不涉及 `/api/*` 能力。

## Screenshots

工单标注图（改动前的 main）：

![ticket](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f5/ticket-2685-annotated.png)

三种平台 × 展开/收起 × 改前/改后（顶栏左上 420×160 CSS px 裁切；macOS 为 webContents 截图，不含原生红绿灯，红绿灯占位 64px + 4px 留白，按钮从 x=92.8px 起）：

![compare](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f5/f5-compare-sheet.png)

macOS 桌面端整窗（改后，展开 / 收起）：

![mac open](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f5/mac-after-open.png)
![mac collapsed](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f5/mac-after-collapsed.png)

项目页 chrome（同一槽位是 Home 徽标）：

![mac project](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f5/f5-mac-project-chrome.png)

桌面端实测（`tools-dev inspect desktop eval`，1402px 宽窗口）：

| 元素 | x | 宽 | app-region |
| --- | --- | --- | --- |
| 红绿灯占位 | 0 | 64 | — |
| 折叠按钮（改后） | 92.8 | 34 | no-drag |
| 搜索按钮（改后） | 130.8 | 34 | no-drag |
| 项目页 Home 徽标 | 78 | 64 | no-drag |

顶栏其余区域仍为 `drag`，窗口可拖动；`.entry-rail-resizer` 与自动折叠逻辑未改动。

## Bug fix verification

- `apps/web/tests/components/WorkspaceTabsBar.test.tsx`「puts the rail toggle first in the entry chrome cluster and mirrors the rail state on it」：在基线上顺序为 `[entry-nav-search, entry-rail-collapse]`，用例红；本分支绿。
- `apps/web/tests/styles/workspace-tabs-chrome.test.ts` 钉住 glyph 交叉淡入淡出的时长与曲线。
- `e2e/ui/entry-chrome-flows.test.ts`「[P1] entry top navigation」增加簇内首个控件为 `entry-rail-collapse` 的断言。

## Validation

- `pnpm guard`、`pnpm typecheck`、`pnpm --filter @open-design/e2e typecheck` 通过。
- `pnpm --filter @open-design/web test`：692 文件、7348 通过、1 expected fail、11 skipped。
- 新增两条用例在基线源码上红（`git checkout HEAD~1 -- <两处源文件>` 后：cluster 顺序断言与 `.entry-nav-rail__collapse-glyph` 缺失），本分支绿。
- Playwright（本地，`pnpm exec playwright test -c playwright.config.ts ui/entry-chrome-flows.test.ts ui/critical-smoke.test.ts`）：「[P1] entry top navigation」等全部通过。首轮与 web 全量 vitest 并行时 4 条因 harness 预热超时失败，单独复跑后 `critical-smoke:21` 与 `entry-chrome-flows:84` 在本分支与基线（549b2703ec 的独立 worktree）上均通过；CI 的 `UI P0 (entry-settings)` 与 `workspace-restoration` 分片也覆盖并通过。
- 本地 `pnpm tools-dev run web --namespace f5-toggle --daemon-port 17811 --web-port 17911` + `tools-dev start desktop` 人工核对 mac 桌面端（`inspect desktop eval / click / screenshot`）；浏览器下以 `data-host-platform=win32` 模拟 Windows。

## Adjacent issues

- 桌面端 webContents 截图不含原生红绿灯（本机无屏幕录制权限，`screencapture -l` 失败），红绿灯相对位置以上表数值为准。
- `WorkspaceTabsBar.tsx` 里隐藏的 pinned Home pill 注释仍写着「COLLAPSE control moved into the rail」，该 pill 在入口 chrome 已被 CSS 隐藏，本 PR 未动。
