### PR TITLE
feat(web,daemon): enter the pending project frame on send and bound create preparation

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -7206,6 +7206,23 @@ Common options:
             data:    data.error.data,
           });
         }
+        // The daemon bounds create preparation (15s by default) and answers
+        // 504 PROJECT_CREATE_PREPARATION_TIMEOUT without committing anything.
+        // Surface that code the same way the Web does so an embedding agent
+        // can retry the identical request instead of parsing a log line.
+        if (flags.json && typeof data?.error?.code === 'string') {
+          return exitWithStructuredError({
+            code:    data.error.code,
+            message: typeof data.error.message === 'string'
+              ? data.error.message
+              : `POST /api/projects failed: ${resp.status}`,
+            data:    {
+              status:    resp.status,
+              retryable: data.error.retryable === true,
+              ...(data.error.details !== undefined ? { details: data.error.details } : {}),
+            },
+          });
+        }
         console.error(`POST /api/projects failed: ${resp.status} ${JSON.stringify(data)}`);
         process.exit(1);
       }

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -4153,10 +4153,14 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
         // `/api/plugins/:id/apply-local` uses, then read the example's bytes
         // from the record's own path. The request body contributes an identity
         // claim only; it never contributes content.
-        const resolvedExample = await ctx.pluginScope?.getLocalPluginBySource?.(
-          examplePluginId,
-          exampleSource,
-        ) ?? null;
+        const resolvedExample = await awaitProjectCreatePreparation(
+          ctx.pluginScope?.getLocalPluginBySource?.(
+            examplePluginId,
+            exampleSource,
+          ) ?? Promise.resolve(null),
+          projectCreatePreparationDeadline,
+          'resolving the selected example',
+        );
         const resolvedExampleRecord = resolvedExample as
           { id?: unknown; source?: unknown; fsPath?: unknown } | null;
         if (
@@ -4172,8 +4176,10 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
           exampleBinding = createProjectExampleBinding({
             pluginId: examplePluginId,
             pluginSource: exampleSource,
-            manifestSourceDigest: await digestExampleSkillManifest(
-              resolvedExampleRecord.fsPath,
+            manifestSourceDigest: await awaitProjectCreatePreparation(
+              digestExampleSkillManifest(resolvedExampleRecord.fsPath),
+              projectCreatePreparationDeadline,
+              'reading the selected example',
             ),
             boundAt: now,
           });

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -270,7 +270,69 @@ function sameLocalCatalogScopes(left: unknown, right: unknown): boolean {
   return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
 }
 
+/**
+ * Upper bound for every asynchronous read POST /api/projects performs before
+ * its project/conversation transaction. The Web enters an optimistic project
+ * surface the moment it sends the request, so a stalled catalogue scan must
+ * turn into a definite 504 the client can roll back from rather than an
+ * open-ended wait; see `PROJECT_CREATE_PREPARATION_TIMEOUT` in contracts.
+ */
+export const DEFAULT_PROJECT_CREATE_PREPARATION_TIMEOUT_MS = 15_000;
+
+class ProjectCreatePreparationTimeoutError extends Error {
+  constructor(readonly stage: string) {
+    super(`Project preparation timed out while ${stage}. Please try again.`);
+    this.name = 'ProjectCreatePreparationTimeoutError';
+  }
+}
+
+/**
+ * Bound the read-only work that must finish before the project/conversation
+ * transaction starts. A rejected race never continues into that transaction,
+ * so a stalled local catalogue scan cannot leave the Web on an endless
+ * optimistic project route or create a half-initialized project later.
+ */
+async function awaitProjectCreatePreparation<T>(
+  promise: Promise<T>,
+  deadlineMs: number,
+  stage: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  try {
+    const remainingMs = Math.max(0, deadlineMs - Date.now());
+    if (remainingMs === 0) {
+      throw new ProjectCreatePreparationTimeoutError(stage);
+    }
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new ProjectCreatePreparationTimeoutError(stage)),
+          remainingMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function assertProjectCreatePreparationWithinDeadline(
+  deadlineMs: number,
+  stage: string,
+): void {
+  if (Date.now() >= deadlineMs) {
+    throw new ProjectCreatePreparationTimeoutError(stage);
+  }
+}
+
 export interface RegisterProjectRoutesDeps extends RouteDeps<'db' | 'design' | 'http' | 'paths' | 'projectStore' | 'projectFiles' | 'conversations' | 'templates' | 'status' | 'events' | 'ids' | 'telemetry' | 'appConfig' | 'agents' | 'validation' | 'collabSync'> {
+  /**
+   * Request-wide deadline for the read-only preparation POST /api/projects
+   * runs before its transaction. Production keeps the 15s default; tests and
+   * the `OD_PROJECT_CREATE_PREPARATION_TIMEOUT_MS` env seam may shorten it.
+   */
+  projectCreatePreparationTimeoutMs?: number;
   pluginScope?: {
     loadRegistry: (options: {
       workspaceId?: string | null;
@@ -2072,6 +2134,12 @@ function buildDesignSystemCopyPendingPrompt(input: {
 
 export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDeps) {
   const { db, design } = ctx;
+  const projectCreatePreparationTimeoutMs =
+    typeof ctx.projectCreatePreparationTimeoutMs === 'number'
+    && Number.isFinite(ctx.projectCreatePreparationTimeoutMs)
+    && ctx.projectCreatePreparationTimeoutMs > 0
+      ? ctx.projectCreatePreparationTimeoutMs
+      : DEFAULT_PROJECT_CREATE_PREPARATION_TIMEOUT_MS;
   const projectTelemetry = ctx.telemetry;
   const { sendApiError, createSseResponse } = ctx.http;
   const { DESIGN_SYSTEMS_DIR, PROJECTS_DIR, SKILLS_DIR, BRANDS_DIR, USER_DESIGN_SYSTEMS_DIR } = ctx.paths;
@@ -3748,6 +3816,11 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
 
   app.post('/api/projects', async (req, res) => {
     try {
+      // One request-wide deadline covers every asynchronous read before the
+      // transaction. Resetting a full timeout for each stage would still let a
+      // sequence of merely slow reads outlive the Web's optimistic route.
+      const projectCreatePreparationDeadline =
+        Date.now() + projectCreatePreparationTimeoutMs;
       // Ordinary project creation is local. Capture any complete identity that
       // the Web already has for local attribution, but do not turn Workspace
       // directory availability into a Send dependency. Remote share/sync/move
@@ -3837,9 +3910,15 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       // snapshot while a Workspace switch is loading. Use the partition that
       // produced that exact selection for local lookup only. It does not bind
       // this local project to that Workspace or prove current membership.
-      const designSystemValidation = await validateProjectDesignSystemId(
-        designSystemId,
-        designSystemCatalogScope ?? creationWorkspaceScope,
+      const designSystemValidation = await awaitProjectCreatePreparation<
+        Awaited<ReturnType<typeof validateProjectDesignSystemId>>
+      >(
+        validateProjectDesignSystemId(
+          designSystemId,
+          designSystemCatalogScope ?? creationWorkspaceScope,
+        ),
+        projectCreatePreparationDeadline,
+        'validating the selected design system',
       );
       if (!designSystemValidation.ok) {
         return sendApiError(
@@ -3850,9 +3929,15 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
         );
       }
       const normalizedDesignSystemId = designSystemValidation.id;
-      const skillValidation = await validateProjectSkillId(
-        skillId,
-        skillCatalogScope ?? creationWorkspaceScope,
+      const skillValidation = await awaitProjectCreatePreparation<
+        Awaited<ReturnType<typeof validateProjectSkillId>>
+      >(
+        validateProjectSkillId(
+          skillId,
+          skillCatalogScope ?? creationWorkspaceScope,
+        ),
+        projectCreatePreparationDeadline,
+        'validating the selected skill',
       );
       if (!skillValidation.ok) {
         return sendApiError(res, 400, skillValidation.code, skillValidation.message);
@@ -3871,10 +3956,14 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       // Home already reconciles staged selections against its current local
       // catalogue, and this project is local until a later share/sync/move.
       const selectedLocalPlugin = requestedPluginId && requestedPluginSource
-        ? await ctx.pluginScope?.getLocalPluginBySource?.(
-            requestedPluginId,
-            requestedPluginSource,
-          ) ?? null
+        ? await awaitProjectCreatePreparation(
+            ctx.pluginScope?.getLocalPluginBySource?.(
+              requestedPluginId,
+              requestedPluginSource,
+            ) ?? Promise.resolve(null),
+            projectCreatePreparationDeadline,
+            'resolving the selected plugin',
+          )
         : null;
       if (requestedPluginId) {
         // Once a source is supplied, never substitute a same-id Personal or
@@ -3883,16 +3972,29 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
         const visiblePlugin = requestedPluginSource
           ? selectedLocalPlugin
           : ctx.pluginScope
-            ? await ctx.pluginScope.getPlugin(requestedPluginId, creationWorkspaceScope)
+            ? await awaitProjectCreatePreparation(
+                ctx.pluginScope.getPlugin(requestedPluginId, creationWorkspaceScope),
+                projectCreatePreparationDeadline,
+                'resolving the selected plugin',
+              )
             : getInstalledPlugin(db, requestedPluginId);
         if (!visiblePlugin) {
           return sendApiError(res, 404, 'PLUGIN_NOT_FOUND', 'plugin not found');
         }
       }
-      const selectedLocationId = await resolveCreateProjectLocationId(projectLocationId);
+      const selectedLocationId = await awaitProjectCreatePreparation(
+        resolveCreateProjectLocationId(projectLocationId),
+        projectCreatePreparationDeadline,
+        'resolving the project location',
+      );
       let externalProjectDir: string | null = null;
       if (selectedLocationId !== BUILT_IN_PROJECT_LOCATION_ID) {
-        const location = (await configuredProjectLocations()).find((loc: any) => loc.id === selectedLocationId);
+        const locations = await awaitProjectCreatePreparation(
+          configuredProjectLocations(),
+          projectCreatePreparationDeadline,
+          'reading project locations',
+        );
+        const location = locations.find((loc: any) => loc.id === selectedLocationId);
         if (!location || location.builtIn) {
           return sendApiError(res, 400, 'BAD_REQUEST', 'unknown project location');
         }
@@ -4127,6 +4229,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
         }
       }
       let project;
+      let managedTemplateDirPrepared = false;
       const pluginResolutionState: {
         snapshot: ResolveSnapshotOk | null;
         failure: ResolveSnapshotError | null;
@@ -4144,10 +4247,14 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
           });
         }
         const registry = resolveBody
-          ? await loadPluginRegistryView(
-              selectedLocalPlugin
-                ? localPluginRegistryScope(selectedLocalPlugin)
-                : creationWorkspaceScope,
+          ? await awaitProjectCreatePreparation(
+              loadPluginRegistryView(
+                selectedLocalPlugin
+                  ? localPluginRegistryScope(selectedLocalPlugin)
+                  : creationWorkspaceScope,
+              ),
+              projectCreatePreparationDeadline,
+              'loading plugin resources',
             )
           : null;
         let pluginForSnapshot = selectedLocalPlugin;
@@ -4157,16 +4264,81 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
           // reconciliation tombstone cannot leave a project/conversation or
           // snapshot behind. This is local catalogue freshness only: do not
           // turn it into a remote membership or current-Workspace gate.
-          pluginForSnapshot = await ctx.pluginScope?.getLocalPluginBySource?.(
-            requestedPluginId,
-            requestedPluginSource,
-          ) ?? null;
+          pluginForSnapshot = await awaitProjectCreatePreparation(
+            ctx.pluginScope?.getLocalPluginBySource?.(
+              requestedPluginId,
+              requestedPluginSource,
+            ) ?? Promise.resolve(null),
+            projectCreatePreparationDeadline,
+            'confirming the selected plugin',
+          );
           if (!pluginForSnapshot) {
             if (externalProjectDir) {
               await rm(externalProjectDir, { recursive: true, force: true }).catch(() => {});
             }
             return sendApiError(res, 404, 'PLUGIN_NOT_FOUND', 'plugin not found');
           }
+        }
+        // Seed saved-template files before the atomic database commit. The
+        // first Chat turn must never race a project row whose initial files are
+        // still being copied. Managed directories are compensated below if a
+        // later deadline, disconnect, or transaction failure prevents commit.
+        if (
+          metadata
+          && typeof metadata === 'object'
+          && metadata.kind === 'template'
+          && typeof metadata.templateId === 'string'
+        ) {
+          const tpl = getTemplate(db, metadata.templateId);
+          if (tpl && Array.isArray(tpl.files) && tpl.files.length > 0) {
+            assertProjectCreatePreparationWithinDeadline(
+              projectCreatePreparationDeadline,
+              'preparing template files',
+            );
+            managedTemplateDirPrepared = externalProjectDir == null;
+            await ensureProject(PROJECTS_DIR, id, projectMetadata);
+            for (const f of tpl.files) {
+              if (
+                !f
+                || typeof f.name !== 'string'
+                || typeof f.content !== 'string'
+              ) {
+                continue;
+              }
+              try {
+                await writeProjectFile(
+                  PROJECTS_DIR,
+                  id,
+                  f.name,
+                  Buffer.from(f.content, 'utf8'),
+                  {},
+                  projectMetadata,
+                );
+              } catch {
+                // The template is also embedded in the agent prompt. Preserve
+                // the existing best-effort behavior for individual bad files.
+              }
+            }
+          }
+        }
+        // Filesystem preparation is not raced because those writes cannot be
+        // cancelled safely. If it was slow, stop here and let the catch below
+        // compensate the external directory before any SQLite row is written.
+        assertProjectCreatePreparationWithinDeadline(
+          projectCreatePreparationDeadline,
+          'finalizing project preparation',
+        );
+        // The Web proxy propagates an aborted optimistic create to this
+        // request. Never cross the persistence boundary after its caller has
+        // gone away, even if the final catalogue read happened to settle at
+        // the same moment as the disconnect.
+        if (req.aborted || res.destroyed) {
+          if (externalProjectDir) {
+            await rm(externalProjectDir, { recursive: true, force: true }).catch(() => {});
+          } else if (managedTemplateDirPrepared) {
+            await removeProjectDir(PROJECTS_DIR, id).catch(() => {});
+          }
+          return;
         }
         project = db.transaction(() => {
           let createdProject = insertProject(db, {
@@ -4241,11 +4413,13 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
           return createdProject;
         })();
       } catch (err) {
-        // External directories cannot participate in SQLite's transaction.
-        // Treat their creation as a recoverable side effect and compensate on
-        // any manifest or database transaction failure.
+        // Filesystem preparation cannot participate in SQLite's transaction.
+        // Compensate external locations and managed template staging on any
+        // deadline, disconnect, or database transaction failure.
         if (externalProjectDir) {
           await rm(externalProjectDir, { recursive: true, force: true }).catch(() => {});
+        } else if (managedTemplateDirPrepared) {
+          await removeProjectDir(PROJECTS_DIR, id).catch(() => {});
         }
         if (pluginResolutionState.failure) {
           return res
@@ -4253,43 +4427,6 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
             .json(pluginResolutionState.failure.body);
         }
         throw err;
-      }
-      // For "from template" projects, seed the chosen template's snapshot
-      // HTML into the new project folder so the agent can Read/edit files
-      // on disk (the system prompt also embeds them, but a real on-disk
-      // copy lets the agent treat them as the project's working state).
-      if (
-        metadata &&
-        typeof metadata === 'object' &&
-        metadata.kind === 'template' &&
-        typeof metadata.templateId === 'string'
-      ) {
-        const tpl = getTemplate(db, metadata.templateId);
-        if (tpl && Array.isArray(tpl.files) && tpl.files.length > 0) {
-          await ensureProject(PROJECTS_DIR, id, projectMetadata);
-          for (const f of tpl.files) {
-            if (
-              !f ||
-              typeof f.name !== 'string' ||
-              typeof f.content !== 'string'
-            ) {
-              continue;
-            }
-            try {
-              await writeProjectFile(
-                PROJECTS_DIR,
-                id,
-                f.name,
-                Buffer.from(f.content, 'utf8'),
-                {},
-                projectMetadata,
-              );
-            } catch {
-              // Skip individual file failures — the template snapshot is
-              // best-effort; the agent still has the embedded copy.
-            }
-          }
-        }
       }
       /** @type {import('@open-design/contracts').CreateProjectResponse} */
       const createdProject = pluginResolutionState.snapshot
@@ -4311,6 +4448,15 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       };
       res.json(body);
     } catch (err: any) {
+      if (err instanceof ProjectCreatePreparationTimeoutError) {
+        return sendApiError(
+          res,
+          504,
+          'PROJECT_CREATE_PREPARATION_TIMEOUT',
+          err.message,
+          { retryable: true, details: { stage: err.stage } },
+        );
+      }
       sendApiError(res, 400, 'BAD_REQUEST', String(err));
     }
   });

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1156,6 +1156,18 @@ import {
 import { renderOAuthResultPage } from './http/oauth-result-page.js';
 import { bearerTokenFromRequest, createToolRequestAuth } from './http/tool-request-auth.js';
 
+/**
+ * `OD_PROJECT_CREATE_PREPARATION_TIMEOUT_MS` shortens the POST /api/projects
+ * preparation deadline for end-to-end tests. Only a positive finite number is
+ * honoured; anything else leaves the route on its production default.
+ */
+function projectCreatePreparationTimeoutMsFromEnv(): number | null {
+  const raw = process.env.OD_PROJECT_CREATE_PREPARATION_TIMEOUT_MS;
+  if (raw == null || raw.trim() === '') return null;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
 /** @typedef {import('@open-design/contracts').ApiErrorCode} ApiErrorCode */
 /** @typedef {import('@open-design/contracts').ApiError} ApiError */
 /** @typedef {import('@open-design/contracts').ApiErrorResponse} ApiErrorResponse */
@@ -8246,9 +8258,15 @@ export async function startServer({
     });
   });
   registerSocialShareRoutes(app, { http: httpDeps });
+  const projectCreatePreparationTimeoutMs = projectCreatePreparationTimeoutMsFromEnv();
   registerProjectRoutes(app, {
     db,
     design,
+    // Test seam for the POST /api/projects preparation deadline; production
+    // keeps the route's 15s default when the variable is unset or invalid.
+    ...(projectCreatePreparationTimeoutMs != null
+      ? { projectCreatePreparationTimeoutMs }
+      : {}),
     http: httpDeps,
     paths: pathDeps,
     projectStore: projectStoreDeps,

--- a/apps/daemon/tests/routes/project-create-preparation-deadline.test.ts
+++ b/apps/daemon/tests/routes/project-create-preparation-deadline.test.ts
@@ -1,0 +1,217 @@
+import type http from 'node:http';
+
+import express from 'express';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { registerProjectRoutes } from '../../src/routes/project/index.js';
+
+// POST /api/projects must answer within one request-wide deadline (15s in
+// production) and commit nothing when it cannot: the Web enters an optimistic
+// project surface the moment it sends the request, so a stalled catalogue
+// read has to become a definite, retryable 504 the client can roll back from.
+
+const servers: http.Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  })));
+});
+
+function noop() {}
+
+function functionProxy(overrides: Record<string, unknown> = {}) {
+  return new Proxy(overrides, {
+    get(target, property) {
+      return property in target ? target[property as string] : noop;
+    },
+  });
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+function buildDeps(input: {
+  insertProject: ReturnType<typeof vi.fn>;
+  insertConversation: ReturnType<typeof vi.fn>;
+  projectCreatePreparationTimeoutMs: number;
+  designSystemDelayMs?: number;
+  skillDelayMs?: number;
+}) {
+  return {
+    projectCreatePreparationTimeoutMs: input.projectCreatePreparationTimeoutMs,
+    db: {
+      transaction: (fn: (...args: unknown[]) => unknown) => (...args: unknown[]) => fn(...args),
+    },
+    design: {},
+    http: {
+      createSseResponse: noop,
+      sendApiError: (
+        res: express.Response,
+        status: number,
+        code: string,
+        message: string,
+        init: Record<string, unknown> = {},
+      ) => res.status(status).json({ error: { code, message, ...init } }),
+    },
+    paths: {
+      DESIGN_SYSTEMS_DIR: '',
+      PROJECTS_DIR: '',
+      SKILLS_DIR: '',
+      BRANDS_DIR: '',
+      USER_DESIGN_SYSTEMS_DIR: '',
+    },
+    projectStore: functionProxy({
+      insertProject: input.insertProject,
+      updateProject: vi.fn(),
+      validateLinkedDirs: () => ({ dirs: [] }),
+      getProject: () => null,
+      getWorkspaceProject: () => null,
+      getWorkspaceProjectByProjectId: () => null,
+      listWorkspaceProjects: () => [],
+      listProjects: () => [],
+    }),
+    projectFiles: functionProxy({
+      listFiles: () => [],
+      listTabs: () => [],
+      resolveProjectDir: () => '',
+    }),
+    conversations: functionProxy({ insertConversation: input.insertConversation }),
+    templates: functionProxy({ listTemplates: () => [] }),
+    status: functionProxy({
+      listLatestProjectRunStatuses: () => new Map(),
+      listProjectsAwaitingInput: () => new Set(),
+      listProjects: () => [],
+      listUnboundProjects: () => [],
+    }),
+    events: functionProxy({ activeProjectEventSinks: new Map() }),
+    ids: { randomId: () => 'conversation-id' },
+    telemetry: { reportFinalizedMessage: noop },
+    appConfig: { readAppConfig: async () => ({}), writeAppConfig: noop },
+    agents: {},
+    validation: {
+      validateProjectDesignSystemId: vi.fn(async (id: string | null) => {
+        if (input.designSystemDelayMs) await sleep(input.designSystemDelayMs);
+        return { ok: true, id };
+      }),
+      validateProjectSkillId: vi.fn(async (id: string | null) => {
+        if (input.skillDelayMs) await sleep(input.skillDelayMs);
+        return { ok: true, id };
+      }),
+    },
+    collabSync: functionProxy(),
+    authorizeProjectRequest: vi.fn(async () => true),
+    fetchProjectCreationWorkspaceDirectory: vi.fn(async () => ({ ok: false, items: [] })),
+    pluginScope: {
+      loadRegistry: vi.fn(async () => ({
+        skills: [],
+        designSystems: [],
+        craft: [],
+        atoms: [],
+        scenarios: [],
+      })),
+      getPlugin: vi.fn(async () => ({})),
+    },
+  } as unknown as Parameters<typeof registerProjectRoutes>[1];
+}
+
+async function start(deps: Parameters<typeof registerProjectRoutes>[1]) {
+  const app = express();
+  app.use(express.json());
+  registerProjectRoutes(app, deps);
+  const server = app.listen(0);
+  servers.push(server);
+  await new Promise<void>((resolve) => server.once('listening', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('server did not bind');
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function post(baseUrl: string) {
+  return fetch(`${baseUrl}/api/projects`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      id: 'deadline-project',
+      name: 'Deadline project',
+      skillId: null,
+      designSystemId: null,
+      metadata: { kind: 'prototype' },
+      // The automatic OD Next route keeps this scaffold off the default
+      // scenario plugin lookup, which needs a real SQLite handle.
+      conversationMode: 'design',
+      automaticStrategyTaskProfile: 'prototype',
+      pendingPrompt: 'Make a landing page',
+    }),
+  });
+}
+
+describe('POST /api/projects preparation deadline', () => {
+  it('answers 504 PROJECT_CREATE_PREPARATION_TIMEOUT and commits nothing when one read stalls', async () => {
+    const insertProject = vi.fn();
+    const insertConversation = vi.fn();
+    const baseUrl = await start(buildDeps({
+      insertProject,
+      insertConversation,
+      projectCreatePreparationTimeoutMs: 40,
+      designSystemDelayMs: 400,
+    }));
+
+    const response = await post(baseUrl);
+    expect(response.status).toBe(504);
+    expect(await response.json()).toMatchObject({
+      error: {
+        code: 'PROJECT_CREATE_PREPARATION_TIMEOUT',
+        retryable: true,
+        details: { stage: 'validating the selected design system' },
+      },
+    });
+    expect(insertProject).not.toHaveBeenCalled();
+    expect(insertConversation).not.toHaveBeenCalled();
+  });
+
+  it('shares one deadline across stages instead of restarting it per read', async () => {
+    const insertProject = vi.fn();
+    const insertConversation = vi.fn();
+    // Each stage alone fits inside the deadline; together they do not.
+    const baseUrl = await start(buildDeps({
+      insertProject,
+      insertConversation,
+      projectCreatePreparationTimeoutMs: 60,
+      designSystemDelayMs: 40,
+      skillDelayMs: 40,
+    }));
+
+    const response = await post(baseUrl);
+    expect(response.status).toBe(504);
+    expect(await response.json()).toMatchObject({
+      error: {
+        code: 'PROJECT_CREATE_PREPARATION_TIMEOUT',
+        details: { stage: 'validating the selected skill' },
+      },
+    });
+    expect(insertProject).not.toHaveBeenCalled();
+  });
+
+  it('still creates the project when preparation finishes inside the deadline', async () => {
+    const insertProject = vi.fn((_: unknown, project: Record<string, unknown>) => project);
+    const insertConversation = vi.fn();
+    const baseUrl = await start(buildDeps({
+      insertProject,
+      insertConversation,
+      projectCreatePreparationTimeoutMs: 2_000,
+      designSystemDelayMs: 5,
+    }));
+
+    const response = await post(baseUrl);
+    const happyBody = await response.json();
+    expect([response.status, happyBody]).toEqual([
+      200,
+      expect.objectContaining({
+        project: expect.objectContaining({ id: 'deadline-project', name: 'Deadline project' }),
+        conversationId: 'conversation-id',
+      }),
+    ]);
+    expect(insertProject).toHaveBeenCalledTimes(1);
+    expect(insertConversation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/daemon/tests/routes/project-create-preparation-deadline.test.ts
+++ b/apps/daemon/tests/routes/project-create-preparation-deadline.test.ts
@@ -36,6 +36,7 @@ function buildDeps(input: {
   projectCreatePreparationTimeoutMs: number;
   designSystemDelayMs?: number;
   skillDelayMs?: number;
+  getLocalPluginBySource?: ReturnType<typeof vi.fn>;
 }) {
   return {
     projectCreatePreparationTimeoutMs: input.projectCreatePreparationTimeoutMs,
@@ -110,6 +111,9 @@ function buildDeps(input: {
         scenarios: [],
       })),
       getPlugin: vi.fn(async () => ({})),
+      ...(input.getLocalPluginBySource
+        ? { getLocalPluginBySource: input.getLocalPluginBySource }
+        : {}),
     },
   } as unknown as Parameters<typeof registerProjectRoutes>[1];
 }
@@ -126,11 +130,12 @@ async function start(deps: Parameters<typeof registerProjectRoutes>[1]) {
   return `http://127.0.0.1:${address.port}`;
 }
 
-async function post(baseUrl: string) {
+async function post(baseUrl: string, overrides: Record<string, unknown> = {}) {
   return fetch(`${baseUrl}/api/projects`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({
+      ...overrides,
       id: 'deadline-project',
       name: 'Deadline project',
       skillId: null,
@@ -190,6 +195,35 @@ describe('POST /api/projects preparation deadline', () => {
       },
     });
     expect(insertProject).not.toHaveBeenCalled();
+  });
+
+  it('bounds the example-card lookup that runs after the catalogue validations', async () => {
+    const insertProject = vi.fn();
+    const insertConversation = vi.fn();
+    // Home Send takes this path when an official example card was picked under
+    // an automatic OD Next route; the lookup must not escape the deadline.
+    const getLocalPluginBySource = vi.fn(() => new Promise<never>(() => undefined));
+    const baseUrl = await start(buildDeps({
+      insertProject,
+      insertConversation,
+      projectCreatePreparationTimeoutMs: 60,
+      getLocalPluginBySource,
+    }));
+
+    const response = await post(baseUrl, {
+      exampleReference: { pluginId: 'example-web-prototype', source: '/tmp/example-web-prototype' },
+    });
+    expect(response.status).toBe(504);
+    expect(await response.json()).toMatchObject({
+      error: {
+        code: 'PROJECT_CREATE_PREPARATION_TIMEOUT',
+        retryable: true,
+        details: { stage: 'resolving the selected example' },
+      },
+    });
+    expect(getLocalPluginBySource).toHaveBeenCalledTimes(1);
+    expect(insertProject).not.toHaveBeenCalled();
+    expect(insertConversation).not.toHaveBeenCalled();
   });
 
   it('still creates the project when preparation finishes inside the deadline', async () => {

--- a/apps/daemon/tests/runtimes/run-failure-telemetry-smoke.test.ts
+++ b/apps/daemon/tests/runtimes/run-failure-telemetry-smoke.test.ts
@@ -494,7 +494,6 @@ describe('run failure telemetry smoke', () => {
     delete process.env.POSTHOG_KEY;
 
     started = await startIsolatedServer();
-    restoreSetTimeout = accelerateLangfuseTerminalFallbackDelay();
     await putConfig(started.url, {
       agentId: 'claude',
       agentCliEnv: { claude: { CLAUDE_BIN: path.join(binDir, 'claude-terminal-failure') } },
@@ -504,7 +503,12 @@ describe('run failure telemetry smoke', () => {
       odNextStrategyMode: 'active',
     });
 
-    const run = await createAndWaitForRun(started.url, {
+    // Create the project before accelerating 15s timers: POST /api/projects
+    // races its own 15s preparation deadline, and the blunt setTimeout stub
+    // would fire that deadline immediately and answer 504 instead of 200.
+    const project = await createSmokeProject(started.url, 'headerless_terminal_fallback');
+    restoreSetTimeout = accelerateLangfuseTerminalFallbackDelay();
+    const run = await startAndWaitForRun(started.url, project, {
       caseId: 'headerless_terminal_fallback',
       agentId: 'claude',
       message: 'od-failure-smoke-headerless-terminal-fallback',
@@ -529,7 +533,6 @@ describe('run failure telemetry smoke', () => {
     delete process.env.POSTHOG_KEY;
 
     started = await startIsolatedServer();
-    restoreSetTimeout = accelerateLangfuseTerminalFallbackDelay(1000);
     await putConfig(started.url, {
       agentId: 'claude',
       agentCliEnv: { claude: { CLAUDE_BIN: path.join(binDir, 'claude-buffered-fallback') } },
@@ -539,7 +542,11 @@ describe('run failure telemetry smoke', () => {
       odNextStrategyMode: 'active',
     });
 
-    const run = await createAndWaitForRun(started.url, {
+    // Same ordering as above: keep the create's own 15s deadline out of the
+    // accelerated window so a cold catalogue read cannot answer 504.
+    const project = await createSmokeProject(started.url, 'buffered_unfinalized_failed_message');
+    restoreSetTimeout = accelerateLangfuseTerminalFallbackDelay(1000);
+    const run = await startAndWaitForRun(started.url, project, {
       caseId: 'buffered_unfinalized_failed_message',
       agentId: 'claude',
       message: 'od-failure-smoke-buffered-unfinalized-message',
@@ -792,31 +799,47 @@ async function putConfig(url: string, patch: Record<string, unknown>): Promise<v
   expect(response.status).toBe(200);
 }
 
-async function createAndWaitForRun(url: string, input: {
-  caseId: string;
-  agentId: string;
-  message: string;
-}): Promise<RunStatus> {
-  const projectId = `failure_smoke_${input.caseId}_${randomUUID()}`;
+type SmokeProject = { projectId: string; conversationId: string };
+
+async function createSmokeProject(url: string, caseId: string): Promise<SmokeProject> {
+  const projectId = `failure_smoke_${caseId}_${randomUUID()}`;
   const projectResponse = await fetch(`${url}/api/projects`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({
       id: projectId,
-      name: `Failure smoke ${input.caseId}`,
+      name: `Failure smoke ${caseId}`,
       metadata: { kind: 'prototype' },
       skipDiscoveryBrief: true,
     }),
   });
   expect(projectResponse.status).toBe(200);
   const projectBody = await projectResponse.json() as { conversationId: string };
+  return { projectId, conversationId: projectBody.conversationId };
+}
+
+async function createAndWaitForRun(url: string, input: {
+  caseId: string;
+  agentId: string;
+  message: string;
+}): Promise<RunStatus> {
+  const project = await createSmokeProject(url, input.caseId);
+  return await startAndWaitForRun(url, project, input);
+}
+
+async function startAndWaitForRun(url: string, project: SmokeProject, input: {
+  caseId: string;
+  agentId: string;
+  message: string;
+}): Promise<RunStatus> {
+  const { projectId } = project;
   const assistantMessageId = `assistant_${input.caseId}_${randomUUID()}`;
   const runResponse = await fetch(`${url}/api/runs`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({
       projectId,
-      conversationId: projectBody.conversationId,
+      conversationId: project.conversationId,
       assistantMessageId,
       clientRequestId: `client_${input.caseId}_${randomUUID()}`,
       agentId: input.agentId,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -88,6 +88,9 @@ import {
 } from './components/SettingsDialog';
 import { PrivacyConsentModal } from './components/PrivacyConsentModal';
 import {
+  stashHomeComposerAttachments,
+} from './state/home-composer-stash';
+import {
   daemonIsLive,
   fetchAppVersionInfo,
   fetchAgentsStream,
@@ -208,6 +211,7 @@ import {
   duplicatePluginAsProject,
   patchProject,
   resolvedWorkspaceContextForWrite,
+  ProjectCreateError,
 } from './state/projects';
 import { useModalWindowDragGuard } from './hooks/useModalWindowDragGuard';
 import { resumeThumbnailLoads, suspendThumbnailLoads } from './lib/thumbnail-load-gate';
@@ -269,9 +273,18 @@ type AppCreateProjectInput = Omit<CreateInput, 'metadata'> & {
   onboardingEntry?: OnboardingEntry;
 };
 
+/**
+ * Everything the optimistic project surface shows while POST /api/projects is
+ * in flight. It is self-contained on purpose: the pending frame must render on
+ * the tick the request is sent and keep rendering even if a project-list
+ * refresh drops the optimistic row before the daemon confirms the id.
+ */
 interface PendingProjectCreation {
   projectId: string;
+  name: string;
   prompt: string;
+  /** Home composer attachments; uploaded only after the project exists. */
+  attachments: File[];
 }
 
 const APP_CONFIG_CHANGED_EVENT = 'open-design:app-config-changed';
@@ -2922,6 +2935,9 @@ function AppInner() {
         kind === 'template' ? 'template' : 'blank';
       let createWorkspaceContext: WorkspaceCollabContext | null = null;
       let optimisticProjectId: string | null = null;
+      const stagedHomeAttachments = Array.isArray(input.pendingFiles)
+        ? input.pendingFiles.filter((file): file is File => file instanceof File)
+        : [];
       let result;
       try {
         // PRODUCT INVARIANT: ordinary project creation is local. Reuse a
@@ -2971,7 +2987,9 @@ function AppInner() {
           flushSync(() => {
             setPendingProjectCreation({
               projectId: optimisticProjectId!,
+              name: optimisticProject.name,
               prompt: derivedPendingPrompt ?? '',
+              attachments: stagedHomeAttachments,
             });
             setProjects((current) => [
               optimisticProject,
@@ -3039,13 +3057,22 @@ function AppInner() {
           setProjects((current) => current.filter((project) => project.id !== optimisticProjectId));
           setPendingProjectCreation((current) =>
             current?.projectId === optimisticProjectId ? null : current);
+          // Home remounts on the way back and restores its prompt draft on its
+          // own; the staged File objects have no persisted draft, so hand them
+          // back explicitly and the retry sends the same payload.
+          stashHomeComposerAttachments(stagedHomeAttachments);
           if (
             routeRef.current.kind === 'project'
             && routeRef.current.projectId === optimisticProjectId
           ) {
             navigate({ kind: 'home', view: 'home' });
           }
-          setProjectCreateError(errorCode);
+          setProjectCreateError(
+            err instanceof ProjectCreateError
+            && err.code === 'PROJECT_CREATE_PREPARATION_TIMEOUT'
+              ? t('home.createTimedOut')
+              : errorCode,
+          );
           return false;
         }
         throw err;
@@ -3283,7 +3310,7 @@ function AppInner() {
       }
       return true;
     },
-    [analytics.track, clearLocalProject, rememberLocalProject],
+    [analytics.track, clearLocalProject, rememberLocalProject, t],
   );
 
   const handleCreateProjectFromDesignSystem = useCallback(
@@ -5124,8 +5151,11 @@ function AppInner() {
   } else if (route.kind === 'home' && route.view === 'settings') {
     appMain = renderSettingsSurface('page');
   } else if (route.kind === 'project') {
+    // Keyed on the route, not on `activeProject`: the pending frame is built
+    // from the creation record alone so it shows on the tick the create request
+    // leaves, and survives a list refresh that has not seen the new row yet.
     const pendingCreation =
-      activeProject && pendingProjectCreation?.projectId === activeProject.id
+      pendingProjectCreation?.projectId === route.projectId
         ? pendingProjectCreation
         : null;
     const routeSurfaceState = projectRouteSurfaceState({
@@ -5137,7 +5167,7 @@ function AppInner() {
           ? deepLinkResolutionFailure.failure
           : undefined,
     });
-    if (pendingCreation && activeProject) {
+    if (pendingCreation) {
       // Same `div.app` element as the ProjectView branch below, deliberately.
       // React reconciles one element across the pending -> real hand-off, so
       // the `.app` entrance animation plays once for the whole transition
@@ -5147,8 +5177,9 @@ function AppInner() {
       appMain = (
         <div className="app">
           <ProjectCreationPendingView
-            project={activeProject}
+            projectName={activeProject?.name ?? pendingCreation.name}
             prompt={pendingCreation.prompt}
+            attachments={pendingCreation.attachments}
             agentId={config.agentId}
             onBack={handleBack}
           />

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -88,6 +88,7 @@ import {
 } from './components/SettingsDialog';
 import { PrivacyConsentModal } from './components/PrivacyConsentModal';
 import {
+  clearHomeComposerAttachments,
   stashHomeComposerAttachments,
 } from './state/home-composer-stash';
 import {
@@ -2984,6 +2985,9 @@ function AppInner() {
               : {}),
           };
           rememberLocalProject(optimisticProjectId);
+          // A previous rollback's snapshot must not outlive the retry that
+          // carries the same files; the new attempt owns them from here.
+          clearHomeComposerAttachments();
           flushSync(() => {
             setPendingProjectCreation({
               projectId: optimisticProjectId!,
@@ -3103,6 +3107,9 @@ function AppInner() {
           }
         : result.project;
       if (optimisticProjectId) {
+        // The files now belong to this project (uploaded below); a later Home
+        // visit must not revive them into the composer.
+        clearHomeComposerAttachments();
         rememberLocalProject(project.id);
         flushSync(() => {
           setProjects((curr) => [

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -55,6 +55,7 @@ import {
   renderPluginBriefTemplate,
   resolvePluginQueryFallback,
 } from '../state/projects';
+import { takeHomeComposerAttachments } from '../state/home-composer-stash';
 import { FigmaImportModal } from './FigmaImportModal';
 import { fetchMcpServers } from '../state/mcp';
 import { takeHomeComposerAssetSeed } from '../state/libraryHandoff';
@@ -638,7 +639,11 @@ export function HomeView({
   const [selectedMcpContexts, setSelectedMcpContexts] = useState<SelectedMcpContext[]>([]);
   const [selectedConnectorContexts, setSelectedConnectorContexts] = useState<SelectedConnectorContext[]>([]);
   const [contextWorkspaceItems, setContextWorkspaceItems] = useState<WorkspaceContextItem[]>([]);
-  const [stagedFiles, setStagedFiles] = useState<File[]>([]);
+  // A failed optimistic create hands the staged attachments back through the
+  // stash (App owns the rollback); a plain mount takes an empty list.
+  const [stagedFiles, setStagedFiles] = useState<File[]>(() =>
+    ownsComposerDraft ? takeHomeComposerAttachments() : [],
+  );
   const [workingDir, setWorkingDir] = useState<string | null>(null);
   // Token paired with `workingDir` when picked through the desktop host's
   // native dialog. Spent on the post-creation working-dir POST so the

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -55,7 +55,10 @@ import {
   renderPluginBriefTemplate,
   resolvePluginQueryFallback,
 } from '../state/projects';
-import { takeHomeComposerAttachments } from '../state/home-composer-stash';
+import {
+  HOME_COMPOSER_ATTACHMENTS_EVENT,
+  takeHomeComposerAttachments,
+} from '../state/home-composer-stash';
 import { FigmaImportModal } from './FigmaImportModal';
 import { fetchMcpServers } from '../state/mcp';
 import { takeHomeComposerAssetSeed } from '../state/libraryHandoff';
@@ -783,6 +786,20 @@ export function HomeView({
     window.addEventListener(HOME_COMPOSER_SEED_EVENT, onSeed);
     return () => window.removeEventListener(HOME_COMPOSER_SEED_EVENT, onSeed);
   }, [variant]);
+  // The attachment hand-off's second consumer: a failed optimistic create that
+  // lands while this page composer is already mounted (the user pressed Back on
+  // the pending frame mid-create) cannot rely on the mount initializer above,
+  // so take the stash on the event instead. Page variant only, like the draft.
+  useEffect(() => {
+    if (!ownsComposerDraft) return;
+    function onAttachmentsHandedBack() {
+      const files = takeHomeComposerAttachments();
+      if (files.length === 0) return;
+      setStagedFiles((current) => [...current, ...files]);
+    }
+    window.addEventListener(HOME_COMPOSER_ATTACHMENTS_EVENT, onAttachmentsHandedBack);
+    return () => window.removeEventListener(HOME_COMPOSER_ATTACHMENTS_EVENT, onAttachmentsHandedBack);
+  }, [ownsComposerDraft]);
   const [figmaModalOpen, setFigmaModalOpen] = useState(false);
   const examplePromptInfoRef = useRef<ExamplePromptInfo | null>(null);
   const handleExamplePromptStatusChange = useCallback((info: ExamplePromptInfo | null) => {

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -57,7 +57,8 @@ import {
 } from '../state/projects';
 import {
   HOME_COMPOSER_ATTACHMENTS_EVENT,
-  takeHomeComposerAttachments,
+  clearHomeComposerAttachments,
+  peekHomeComposerAttachments,
 } from '../state/home-composer-stash';
 import { FigmaImportModal } from './FigmaImportModal';
 import { fetchMcpServers } from '../state/mcp';
@@ -643,10 +644,16 @@ export function HomeView({
   const [selectedConnectorContexts, setSelectedConnectorContexts] = useState<SelectedConnectorContext[]>([]);
   const [contextWorkspaceItems, setContextWorkspaceItems] = useState<WorkspaceContextItem[]>([]);
   // A failed optimistic create hands the staged attachments back through the
-  // stash (App owns the rollback); a plain mount takes an empty list.
+  // stash (App owns the rollback); a plain mount starts empty. `peek` is
+  // side-effect free on purpose: StrictMode invokes this initializer twice and
+  // keeps only one result, so consuming here would hand the files to the
+  // discarded call. The effect below clears the slot once they are in state.
   const [stagedFiles, setStagedFiles] = useState<File[]>(() =>
-    ownsComposerDraft ? takeHomeComposerAttachments() : [],
+    ownsComposerDraft ? peekHomeComposerAttachments() : [],
   );
+  useEffect(() => {
+    if (ownsComposerDraft) clearHomeComposerAttachments();
+  }, [ownsComposerDraft]);
   const [workingDir, setWorkingDir] = useState<string | null>(null);
   // Token paired with `workingDir` when picked through the desktop host's
   // native dialog. Spent on the post-creation working-dir POST so the
@@ -793,8 +800,9 @@ export function HomeView({
   useEffect(() => {
     if (!ownsComposerDraft) return;
     function onAttachmentsHandedBack() {
-      const files = takeHomeComposerAttachments();
+      const files = peekHomeComposerAttachments();
       if (files.length === 0) return;
+      clearHomeComposerAttachments();
       setStagedFiles((current) => [...current, ...files]);
     }
     window.addEventListener(HOME_COMPOSER_ATTACHMENTS_EVENT, onAttachmentsHandedBack);

--- a/apps/web/src/components/ProjectCreationPendingView.module.css
+++ b/apps/web/src/components/ProjectCreationPendingView.module.css
@@ -9,6 +9,12 @@
   background: var(--veil-panel);
 }
 
+.pendingComposer {
+  min-width: 0;
+  pointer-events: none;
+  user-select: none;
+}
+
 .workspace {
   grid-column: 3;
 }

--- a/apps/web/src/components/ProjectCreationPendingView.tsx
+++ b/apps/web/src/components/ProjectCreationPendingView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useState } from 'react';
 
 import { AgentIcon } from './AgentIcon';
 import { ChatComposer } from './ChatComposer';
@@ -30,6 +30,24 @@ function attachmentKind(file: File): 'image' | 'file' {
   return file.type.startsWith('image/') ? 'image' : 'file';
 }
 
+/** Object URL for an image chip, or null where unavailable (e.g. jsdom). */
+function createPreviewUrl(file: File): string | null {
+  try {
+    if (typeof URL === 'undefined' || typeof URL.createObjectURL !== 'function') return null;
+    return URL.createObjectURL(file);
+  } catch {
+    return null;
+  }
+}
+
+function revokePreviewUrl(url: string): void {
+  try {
+    URL.revokeObjectURL?.(url);
+  } catch {
+    /* no-op */
+  }
+}
+
 /**
  * Immediate, read-free handoff shown while POST /api/projects is still
  * settling. It deliberately mirrors the first ProjectView frame without
@@ -55,24 +73,21 @@ export function ProjectCreationPendingView({
   const agentName = agentDisplayName(agentId) ?? t('assistant.role');
   const iconId = agentIconId(agentId);
   // Image chips preview the staged file itself; the upload has not happened
-  // yet, so there is no project raw URL to point at.
-  const previewUrls = useMemo(
-    () =>
-      attachments.map((file) =>
-        attachmentKind(file) === 'image' && typeof URL.createObjectURL === 'function'
-          ? URL.createObjectURL(file)
-          : null,
-      ),
-    [attachments],
-  );
-  useEffect(
-    () => () => {
-      for (const url of previewUrls) {
-        if (url && typeof URL.revokeObjectURL === 'function') URL.revokeObjectURL(url);
-      }
-    },
-    [previewUrls],
-  );
+  // yet, so there is no project raw URL to point at. Creation and revocation
+  // are paired inside one `attachments`-keyed effect (the StrictMode-safe
+  // shape from DesignSystemAssetDropzone): the cleanup revokes exactly the
+  // URLs its own setup created, so StrictMode's simulated unmount cannot leave
+  // a memoized list of dead blob: links for the remount to hand to <img>.
+  const [previewUrls, setPreviewUrls] = useState<ReadonlyArray<string | null>>([]);
+  useEffect(() => {
+    const next = attachments.map((file) =>
+      attachmentKind(file) === 'image' ? createPreviewUrl(file) : null,
+    );
+    setPreviewUrls(next);
+    return () => {
+      for (const url of next) if (url) revokePreviewUrl(url);
+    };
+  }, [attachments]);
 
   // The `.app` shell belongs to App.tsx, which wraps this view and ProjectView
   // in the same element so React reconciles one `div.app` across the hand-off
@@ -111,7 +126,7 @@ export function ProjectCreationPendingView({
                       >
                         {attachments.map((file, index) => {
                           const kind = attachmentKind(file);
-                          const previewUrl = previewUrls[index];
+                          const previewUrl = previewUrls[index] ?? null;
                           return (
                             <button
                               type="button"

--- a/apps/web/src/components/ProjectCreationPendingView.tsx
+++ b/apps/web/src/components/ProjectCreationPendingView.tsx
@@ -1,15 +1,33 @@
+import { useEffect, useMemo } from 'react';
+
 import { AgentIcon } from './AgentIcon';
+import { ChatComposer } from './ChatComposer';
 import { Icon } from './Icon';
 import { useI18n } from '../i18n';
 import { agentDisplayName, agentIconId } from '../utils/agentLabels';
-import type { Project } from '../types';
 import styles from './ProjectCreationPendingView.module.css';
 
 interface Props {
-  project: Project;
+  projectName: string;
   prompt: string;
+  /** Home composer attachments that will upload once the project exists. */
+  attachments?: readonly File[];
   agentId?: string | null;
   onBack: () => void;
+}
+
+const EMPTY_ATTACHMENTS: readonly File[] = [];
+const ensureNoPendingProject = () => Promise.resolve(null);
+const ignorePendingComposerAction = () => undefined;
+const makePendingComposerInert = (node: HTMLDivElement | null) => {
+  // React 18's DOM runtime drops the boolean `inert` attribute even though
+  // current React typings expose it. Set the standards-based attribute on the
+  // node so keyboard focus is blocked as well as pointer interaction.
+  node?.setAttribute('inert', '');
+};
+
+function attachmentKind(file: File): 'image' | 'file' {
+  return file.type.startsWith('image/') ? 'image' : 'file';
 }
 
 /**
@@ -18,16 +36,43 @@ interface Props {
  * mounting ProjectView itself: an optimistic project has not been authorized
  * or persisted yet, so no project-owned API, SSE, file, or presence reads may
  * start from this surface.
+ *
+ * Everything it shows comes from the creation record itself (name, prompt,
+ * staged attachments), so the surface renders on the very tick the request is
+ * sent and does not depend on the optimistic row surviving a project-list
+ * refresh. The composer at the bottom is the real ChatComposer made inert:
+ * the frame already looks like the project the user is about to land in, and
+ * ProjectView's own composer takes over in place once the id is confirmed.
  */
 export function ProjectCreationPendingView({
-  project,
+  projectName,
   prompt,
+  attachments = EMPTY_ATTACHMENTS,
   agentId,
   onBack,
 }: Props) {
   const { t } = useI18n();
   const agentName = agentDisplayName(agentId) ?? t('assistant.role');
   const iconId = agentIconId(agentId);
+  // Image chips preview the staged file itself; the upload has not happened
+  // yet, so there is no project raw URL to point at.
+  const previewUrls = useMemo(
+    () =>
+      attachments.map((file) =>
+        attachmentKind(file) === 'image' && typeof URL.createObjectURL === 'function'
+          ? URL.createObjectURL(file)
+          : null,
+      ),
+    [attachments],
+  );
+  useEffect(
+    () => () => {
+      for (const url of previewUrls) {
+        if (url && typeof URL.revokeObjectURL === 'function') URL.revokeObjectURL(url);
+      }
+    },
+    [previewUrls],
+  );
 
   // The `.app` shell belongs to App.tsx, which wraps this view and ProjectView
   // in the same element so React reconciles one `div.app` across the hand-off
@@ -50,18 +95,53 @@ export function ProjectCreationPendingView({
               <span className="chat-project-header-title">
                 <span className="chat-project-title-line">
                   <span className="title" data-testid="pending-project-title">
-                    {project.name}
+                    {projectName}
                   </span>
                 </span>
               </span>
             </div>
             <div className="chat-log-wrap">
               <div className="chat-log" aria-busy="true">
-                {prompt ? (
+                {prompt || attachments.length > 0 ? (
                   <div className="msg user">
-                    <div className="user-text-wrap">
-                      <div className="user-text user-bubble">{prompt}</div>
-                    </div>
+                    {attachments.length > 0 ? (
+                      <div
+                        className="user-attachments"
+                        data-testid="pending-user-attachments"
+                      >
+                        {attachments.map((file, index) => {
+                          const kind = attachmentKind(file);
+                          const previewUrl = previewUrls[index];
+                          return (
+                            <button
+                              type="button"
+                              key={`${file.name}:${file.size}:${index}`}
+                              className={`user-attachment staged-${kind}`}
+                              disabled
+                              title={file.name}
+                            >
+                              <span
+                                className="staged-order"
+                                aria-label={`Attachment ${index + 1}`}
+                              >
+                                {index + 1}
+                              </span>
+                              {previewUrl ? (
+                                <img src={previewUrl} alt={file.name} />
+                              ) : (
+                                <Icon name="file" size={14} />
+                              )}
+                              <span className="staged-name">{file.name}</span>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    ) : null}
+                    {prompt ? (
+                      <div className="user-text-wrap">
+                        <div className="user-text user-bubble">{prompt}</div>
+                      </div>
+                    ) : null}
                   </div>
                 ) : null}
                 <div className="msg assistant">
@@ -83,6 +163,24 @@ export function ProjectCreationPendingView({
                   </div>
                 </div>
               </div>
+            </div>
+            <div
+              className={`chat-composer-slot ${styles.pendingComposer}`}
+              data-testid="pending-chat-composer-shell"
+              ref={makePendingComposerInert}
+              aria-disabled="true"
+            >
+              <ChatComposer
+                projectId={null}
+                projectFiles={[]}
+                streaming={false}
+                sendDisabled
+                inputDisabled
+                composerPlaceholder={t('chat.composerPlaceholder')}
+                onEnsureProject={ensureNoPendingProject}
+                onSend={ignorePendingComposerAction}
+                onStop={ignorePendingComposerAction}
+              />
             </div>
           </div>
         </div>

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -836,6 +836,7 @@ export const ar: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.createTimedOut': 'انتهت مهلة تجهيز المشروع قبل أن يبدأ. حاول الإرسال مرة أخرى.',
   'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "سجّل الدخول لاستخدام OpenDesign Cloud والتعاون عبر السحابة",
   "entry.cloudCalloutDismissAria": "إغلاق ملاحظة OpenDesign Cloud",

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -836,6 +836,7 @@ export const de: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.createTimedOut': 'Die Projektvorbereitung hat zu lange gedauert und wurde nicht gestartet. Bitte erneut senden.',
   'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "Melden Sie sich an, um OpenDesign Cloud zu nutzen und in der Cloud zusammenzuarbeiten",
   "entry.cloudCalloutDismissAria": "OpenDesign Cloud-Hinweis schließen",

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -836,6 +836,7 @@ export const en: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.createTimedOut': 'Project setup timed out before it could start. Try sending again.',
   'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "Sign in to use OpenDesign Cloud and collaborate in the cloud",
   "entry.cloudCalloutDismissAria": "Dismiss OpenDesign Cloud note",

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -836,6 +836,7 @@ export const esES: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.createTimedOut': 'La preparación del proyecto ha superado el tiempo de espera y no se ha iniciado. Vuelve a enviar.',
   'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "Inicia sesión para usar OpenDesign Cloud y colaborar en la nube",
   "entry.cloudCalloutDismissAria": "Cerrar el aviso de OpenDesign Cloud",

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -836,6 +836,7 @@ export const fa: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.createTimedOut': 'آماده‌سازی پروژه پیش از شروع به پایان مهلت رسید. دوباره ارسال کنید.',
   'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "برای استفاده از OpenDesign Cloud و همکاری در فضای ابری وارد شوید",
   "entry.cloudCalloutDismissAria": "بستن یادداشت OpenDesign Cloud",

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -836,6 +836,7 @@ export const fr: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.createTimedOut': 'La préparation du projet a expiré avant de démarrer. Réessayez d’envoyer.',
   'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "Connectez-vous pour utiliser OpenDesign Cloud et collaborer dans le cloud",
   "entry.cloudCalloutDismissAria": "Fermer la note OpenDesign Cloud",

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -836,6 +836,7 @@ export const hu: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.createTimedOut': 'A projekt előkészítése túllépte az időkorlátot, és nem indult el. Küldd el újra.',
   'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "Jelentkezzen be az OpenDesign Cloud használatához és a felhőalapú együttműködéshez",
   "entry.cloudCalloutDismissAria": "OpenDesign Cloud értesítés bezárása",

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -836,6 +836,7 @@ export const id: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.createTimedOut': 'Persiapan proyek melebihi batas waktu sebelum dimulai. Coba kirim lagi.',
   'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "Masuk untuk menggunakan OpenDesign Cloud dan berkolaborasi di cloud",
   "entry.cloudCalloutDismissAria": "Tutup catatan OpenDesign Cloud",

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -836,6 +836,7 @@ export const it: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.createTimedOut': 'La preparazione del progetto è scaduta prima di iniziare. Prova a inviare di nuovo.',
   'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "Accedi per usare OpenDesign Cloud e collaborare nel cloud",
   "entry.cloudCalloutDismissAria": "Chiudi l'avviso di OpenDesign Cloud",

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -836,6 +836,7 @@ export const ja: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.createTimedOut': 'プロジェクトの準備がタイムアウトし、開始できませんでした。もう一度送信してください。',
   'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "サインインして OpenDesign Cloud を利用し、クラウドでコラボレーションしましょう",
   "entry.cloudCalloutDismissAria": "OpenDesign Cloud の案内を閉じる",

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -836,6 +836,7 @@ export const ko: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.createTimedOut': '프로젝트 준비 시간이 초과되어 시작하지 못했습니다. 다시 보내 주세요.',
   'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "로그인하여 OpenDesign Cloud를 사용하고 클라우드에서 협업하세요",
   "entry.cloudCalloutDismissAria": "OpenDesign Cloud 안내 닫기",

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -836,6 +836,7 @@ export const pl: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.createTimedOut': 'Przygotowanie projektu przekroczyło limit czasu i nie zostało rozpoczęte. Wyślij ponownie.',
   'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "Zaloguj się, aby korzystać z OpenDesign Cloud i współpracować w chmurze",
   "entry.cloudCalloutDismissAria": "Zamknij powiadomienie OpenDesign Cloud",

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -836,6 +836,7 @@ export const ptBR: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.createTimedOut': 'A preparação do projeto expirou antes de começar. Tente enviar novamente.',
   'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "Entre para usar o OpenDesign Cloud e colaborar na nuvem",
   "entry.cloudCalloutDismissAria": "Dispensar o aviso do OpenDesign Cloud",

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -836,6 +836,7 @@ export const ru: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.createTimedOut': 'Подготовка проекта не уложилась в отведённое время и не была запущена. Отправьте ещё раз.',
   'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "Войдите, чтобы использовать OpenDesign Cloud и работать совместно в облаке",
   "entry.cloudCalloutDismissAria": "Закрыть уведомление OpenDesign Cloud",

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -836,6 +836,7 @@ export const th: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.createTimedOut': 'การเตรียมโปรเจกต์หมดเวลาก่อนจะเริ่มได้ โปรดส่งอีกครั้ง',
   'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "ลงชื่อเข้าใช้เพื่อใช้ OpenDesign Cloud และทำงานร่วมกันบนคลาวด์",
   "entry.cloudCalloutDismissAria": "ปิดข้อความ OpenDesign Cloud",

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -836,6 +836,7 @@ export const tr: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.createTimedOut': 'Proje hazırlığı zaman aşımına uğradı ve başlatılamadı. Lütfen yeniden gönderin.',
   'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "OpenDesign Cloud'u kullanmak ve bulutta iş birliği yapmak için oturum açın",
   "entry.cloudCalloutDismissAria": "OpenDesign Cloud notunu kapat",

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -836,6 +836,7 @@ export const uk: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.createTimedOut': 'Підготовка проєкту перевищила ліміт часу й не розпочалася. Надішліть ще раз.',
   'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "Увійдіть, щоб використовувати OpenDesign Cloud і співпрацювати в хмарі",
   "entry.cloudCalloutDismissAria": "Закрити повідомлення OpenDesign Cloud",

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -841,6 +841,7 @@ export const zhCN: Dict = {
   'entry.authExpiredBody': '登录状态已过期。登录后即可继续使用 OpenDesign Cloud。',
   'home.createFailed': '启动任务失败，请重试。',
   'home.daemonRecovering': '本地服务连接中断，正在自动恢复…',
+  'home.createTimedOut': '项目准备超时，任务尚未开始。请重新发送。',
   'home.bundledScenarioMissing': '内置场景“{scenarioId}”未安装。请重新安装 OpenDesign，以恢复默认插件。',
   "entry.cloudCalloutBody": "登录即可享受云端协作",
   "entry.cloudCalloutDismissAria": "关闭 OpenDesign Cloud 版说明",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -843,6 +843,7 @@ export const zhTW: Dict = {
   'entry.authExpiredBody': '登入狀態已過期。登入後即可繼續使用 OpenDesign Cloud。',
   'home.createFailed': '啟動任務失敗，請再試一次。',
   'home.daemonRecovering': '本機服務連線中斷，正在自動恢復…',
+  'home.createTimedOut': '專案準備逾時，任務尚未開始。請重新傳送。',
   'home.bundledScenarioMissing': '內建場景「{scenarioId}」未安裝。請重新安裝 OpenDesign，以還原預設外掛。',
   "entry.cloudCalloutBody": "登入即可享受雲端協作",
   "entry.cloudCalloutDismissAria": "關閉 OpenDesign Cloud 版說明",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -1225,6 +1225,8 @@ export interface Dict {
   'entry.authExpiredBody': string;
   'home.createFailed': string;
   'home.daemonRecovering': string;
+  /** Toast after POST /api/projects answered PROJECT_CREATE_PREPARATION_TIMEOUT. */
+  'home.createTimedOut': string;
   'home.bundledScenarioMissing': string;
   'entry.cloudCalloutBody': string;
   'entry.cloudCalloutDismissAria': string;

--- a/apps/web/src/state/home-composer-stash.ts
+++ b/apps/web/src/state/home-composer-stash.ts
@@ -5,14 +5,27 @@
  * Sending from Home unmounts `HomeView` the moment the optimistic project
  * route takes over, so the staged `File` objects (which cannot live in the
  * persisted prompt draft) would be lost if the create later fails. App
- * stashes them here while rolling back to Home; the next `HomeView` mount
- * takes them back into its staged-file band so the user can retry with the
- * same payload. The slot holds one hand-off at a time and is emptied on read.
+ * stashes them here while rolling back to Home. Two consumers exist because
+ * Home may or may not be mounted at that moment:
+ *
+ * - a `HomeView` that mounts afterwards takes the slot in its state
+ *   initializer (the stay-on-pending-until-failure path);
+ * - a `HomeView` that is already mounted — the user pressed Back on the
+ *   pending frame while the create was still in flight — hears
+ *   `HOME_COMPOSER_ATTACHMENTS_EVENT` and takes the slot right away.
+ *
+ * The slot holds one hand-off at a time and is emptied on read, so whichever
+ * consumer runs first wins and the other sees nothing.
  */
+export const HOME_COMPOSER_ATTACHMENTS_EVENT = 'open-design:home-composer:attachments';
+
 let stashedAttachments: File[] | null = null;
 
 export function stashHomeComposerAttachments(files: readonly File[]): void {
   stashedAttachments = files.length > 0 ? [...files] : null;
+  if (stashedAttachments && typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(HOME_COMPOSER_ATTACHMENTS_EVENT));
+  }
 }
 
 export function takeHomeComposerAttachments(): File[] {

--- a/apps/web/src/state/home-composer-stash.ts
+++ b/apps/web/src/state/home-composer-stash.ts
@@ -8,14 +8,18 @@
  * stashes them here while rolling back to Home. Two consumers exist because
  * Home may or may not be mounted at that moment:
  *
- * - a `HomeView` that mounts afterwards takes the slot in its state
- *   initializer (the stay-on-pending-until-failure path);
+ * - a `HomeView` that mounts afterwards seeds its staged band from the
+ *   snapshot (the stay-on-pending-until-failure path);
  * - a `HomeView` that is already mounted — the user pressed Back on the
  *   pending frame while the create was still in flight — hears
- *   `HOME_COMPOSER_ATTACHMENTS_EVENT` and takes the slot right away.
+ *   `HOME_COMPOSER_ATTACHMENTS_EVENT` and appends the snapshot right away.
  *
- * The slot holds one hand-off at a time and is emptied on read, so whichever
- * consumer runs first wins and the other sees nothing.
+ * Reading is side-effect free (`peek`): React StrictMode double-invokes state
+ * initializers, so a consume-on-read slot would hand the files to the
+ * discarded call and leave the kept one empty. The consumer clears the slot
+ * explicitly once the files are in state, and App clears it when a create
+ * succeeds or a new optimistic create starts, so a later Home visit never
+ * revives attachments that already belong to a project.
  */
 export const HOME_COMPOSER_ATTACHMENTS_EVENT = 'open-design:home-composer:attachments';
 
@@ -28,8 +32,11 @@ export function stashHomeComposerAttachments(files: readonly File[]): void {
   }
 }
 
-export function takeHomeComposerAttachments(): File[] {
-  const files = stashedAttachments ?? [];
+/** The current snapshot; never mutates the slot. */
+export function peekHomeComposerAttachments(): File[] {
+  return stashedAttachments ? [...stashedAttachments] : [];
+}
+
+export function clearHomeComposerAttachments(): void {
   stashedAttachments = null;
-  return files;
 }

--- a/apps/web/src/state/home-composer-stash.ts
+++ b/apps/web/src/state/home-composer-stash.ts
@@ -1,0 +1,22 @@
+/**
+ * Hand-off slot for Home composer attachments across the optimistic project
+ * surface.
+ *
+ * Sending from Home unmounts `HomeView` the moment the optimistic project
+ * route takes over, so the staged `File` objects (which cannot live in the
+ * persisted prompt draft) would be lost if the create later fails. App
+ * stashes them here while rolling back to Home; the next `HomeView` mount
+ * takes them back into its staged-file band so the user can retry with the
+ * same payload. The slot holds one hand-off at a time and is emptied on read.
+ */
+let stashedAttachments: File[] | null = null;
+
+export function stashHomeComposerAttachments(files: readonly File[]): void {
+  stashedAttachments = files.length > 0 ? [...files] : null;
+}
+
+export function takeHomeComposerAttachments(): File[] {
+  const files = stashedAttachments ?? [];
+  stashedAttachments = null;
+  return files;
+}

--- a/apps/web/tests/components/App.project-create-race.test.tsx
+++ b/apps/web/tests/components/App.project-create-race.test.tsx
@@ -45,7 +45,9 @@ import {
   listProjects,
   listTemplates,
   patchProject,
+  ProjectCreateError,
 } from '../../src/state/projects';
+import { takeHomeComposerAttachments } from '../../src/state/home-composer-stash';
 import {
   WORKSPACE_CONTEXT_REFRESH_EVENT,
   notifyWorkspaceContextRefresh,
@@ -1285,6 +1287,66 @@ describe('App project creation routing', () => {
     expect(screen.queryByTestId(`entry-project-${requestedProjectId}`)).toBeNull();
     expect(workspaceTabsHarness.projectIds.has(requestedProjectId!)).toBe(false);
     expect(screen.getByRole('alert').textContent).toContain('Could not create project');
+  });
+
+  it('shows the staged attachment and an inert composer on the pending frame', async () => {
+    mockedListProjects.mockResolvedValue([]);
+    const creation = deferred<{
+      project: Project;
+      conversationId: string;
+    }>();
+    mockedCreateProject.mockImplementation(() => creation.promise);
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Create prompted project' }));
+
+    // Synchronous on purpose: the optimistic hand-off is flushed inside the
+    // click, so the frame exists before the create request can even settle.
+    const pending = screen.getByTestId('project-creation-pending-view');
+    expect(pending.querySelector('[data-testid="pending-user-attachments"]')?.textContent)
+      .toContain('brief.txt');
+    const composerShell = screen.getByTestId('pending-chat-composer-shell');
+    expect(composerShell.hasAttribute('inert')).toBe(true);
+    expect(composerShell.querySelector('[data-testid="chat-composer"]')).toBeTruthy();
+    expect((screen.getByTestId('chat-send') as HTMLButtonElement).disabled).toBe(true);
+
+    creation.reject(new Error('Could not create project'));
+    await screen.findByTestId('entry-home-surface');
+  });
+
+  it('maps a create preparation timeout to a localized retry toast and hands attachments back', async () => {
+    mockedListProjects.mockResolvedValue([]);
+    const creation = deferred<{
+      project: Project;
+      conversationId: string;
+    }>();
+    let requestedProjectId: string | undefined;
+    mockedCreateProject.mockImplementation((input) => {
+      requestedProjectId = (input as typeof input & { id?: string }).id;
+      return creation.promise;
+    });
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Create prompted project' }));
+    await screen.findByTestId('project-creation-pending-view');
+
+    creation.reject(new ProjectCreateError(
+      'Project preparation timed out while validating the selected design system. Please try again.',
+      504,
+      'PROJECT_CREATE_PREPARATION_TIMEOUT',
+      true,
+      null,
+    ));
+
+    await screen.findByTestId('entry-home-surface');
+    expect(window.location.pathname).toBe('/');
+    expect(screen.queryByTestId('project-creation-pending-view')).toBeNull();
+    expect(screen.queryByTestId(`entry-project-${requestedProjectId}`)).toBeNull();
+    expect(screen.getByRole('alert').textContent)
+      .toContain('Project setup timed out before it could start. Try sending again.');
+    // Home remounts on the way back; the staged File objects ride the stash
+    // so the retry can resend the same payload.
+    expect(takeHomeComposerAttachments().map((file) => file.name)).toEqual(['brief.txt']);
   });
 
   it('releases a persisted project when attachment setup fails after creation', async () => {

--- a/apps/web/tests/components/App.project-create-race.test.tsx
+++ b/apps/web/tests/components/App.project-create-race.test.tsx
@@ -47,7 +47,10 @@ import {
   patchProject,
   ProjectCreateError,
 } from '../../src/state/projects';
-import { takeHomeComposerAttachments } from '../../src/state/home-composer-stash';
+import {
+  HOME_COMPOSER_ATTACHMENTS_EVENT,
+  takeHomeComposerAttachments,
+} from '../../src/state/home-composer-stash';
 import {
   WORKSPACE_CONTEXT_REFRESH_EVENT,
   notifyWorkspaceContextRefresh,
@@ -1347,6 +1350,50 @@ describe('App project creation routing', () => {
     // Home remounts on the way back; the staged File objects ride the stash
     // so the retry can resend the same payload.
     expect(takeHomeComposerAttachments().map((file) => file.name)).toEqual(['brief.txt']);
+  });
+
+  it('hands attachments to an already-mounted Home when the user backed out before the create failed', async () => {
+    mockedListProjects.mockResolvedValue([]);
+    const creation = deferred<{
+      project: Project;
+      conversationId: string;
+    }>();
+    mockedCreateProject.mockImplementation(() => creation.promise);
+    // Stands in for the mounted page HomeView (EntryView is mocked here): the
+    // real listener in HomeView.attachment-stash.test.tsx takes the slot on
+    // this event and appends the files to its staged band.
+    const handedBack: string[] = [];
+    const onHandedBack = () => {
+      handedBack.push(...takeHomeComposerAttachments().map((file) => file.name));
+    };
+    window.addEventListener(HOME_COMPOSER_ATTACHMENTS_EVENT, onHandedBack);
+    try {
+      render(<App />);
+      fireEvent.click(await screen.findByRole('button', { name: 'Create prompted project' }));
+      await screen.findByTestId('project-creation-pending-view');
+
+      // Back during the in-flight create: Home is on screen before the 504.
+      fireEvent.click(screen.getByRole('button', { name: 'Back to projects' }));
+      await screen.findByTestId('entry-home-surface');
+      expect(handedBack).toEqual([]);
+
+      creation.reject(new ProjectCreateError(
+        'Project preparation timed out while loading plugin resources. Please try again.',
+        504,
+        'PROJECT_CREATE_PREPARATION_TIMEOUT',
+        true,
+        null,
+      ));
+
+      await waitFor(() => expect(handedBack).toEqual(['brief.txt']));
+      expect(window.location.pathname).toBe('/');
+      expect(screen.getByRole('alert').textContent)
+        .toContain('Project setup timed out before it could start. Try sending again.');
+      // Consumed by the mounted composer, so nothing is left for a later mount.
+      expect(takeHomeComposerAttachments()).toEqual([]);
+    } finally {
+      window.removeEventListener(HOME_COMPOSER_ATTACHMENTS_EVENT, onHandedBack);
+    }
   });
 
   it('releases a persisted project when attachment setup fails after creation', async () => {

--- a/apps/web/tests/components/App.project-create-race.test.tsx
+++ b/apps/web/tests/components/App.project-create-race.test.tsx
@@ -49,7 +49,8 @@ import {
 } from '../../src/state/projects';
 import {
   HOME_COMPOSER_ATTACHMENTS_EVENT,
-  takeHomeComposerAttachments,
+  clearHomeComposerAttachments,
+  peekHomeComposerAttachments,
 } from '../../src/state/home-composer-stash';
 import {
   WORKSPACE_CONTEXT_REFRESH_EVENT,
@@ -1349,7 +1350,8 @@ describe('App project creation routing', () => {
       .toContain('Project setup timed out before it could start. Try sending again.');
     // Home remounts on the way back; the staged File objects ride the stash
     // so the retry can resend the same payload.
-    expect(takeHomeComposerAttachments().map((file) => file.name)).toEqual(['brief.txt']);
+    expect(peekHomeComposerAttachments().map((file) => file.name)).toEqual(['brief.txt']);
+    clearHomeComposerAttachments();
   });
 
   it('hands attachments to an already-mounted Home when the user backed out before the create failed', async () => {
@@ -1364,7 +1366,8 @@ describe('App project creation routing', () => {
     // this event and appends the files to its staged band.
     const handedBack: string[] = [];
     const onHandedBack = () => {
-      handedBack.push(...takeHomeComposerAttachments().map((file) => file.name));
+      handedBack.push(...peekHomeComposerAttachments().map((file) => file.name));
+      clearHomeComposerAttachments();
     };
     window.addEventListener(HOME_COMPOSER_ATTACHMENTS_EVENT, onHandedBack);
     try {
@@ -1390,7 +1393,7 @@ describe('App project creation routing', () => {
       expect(screen.getByRole('alert').textContent)
         .toContain('Project setup timed out before it could start. Try sending again.');
       // Consumed by the mounted composer, so nothing is left for a later mount.
-      expect(takeHomeComposerAttachments()).toEqual([]);
+      expect(peekHomeComposerAttachments()).toEqual([]);
     } finally {
       window.removeEventListener(HOME_COMPOSER_ATTACHMENTS_EVENT, onHandedBack);
     }

--- a/apps/web/tests/components/HomeView.attachment-stash.test.tsx
+++ b/apps/web/tests/components/HomeView.attachment-stash.test.tsx
@@ -7,6 +7,7 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { act, cleanup, render, screen } from '@testing-library/react';
+import { StrictMode } from 'react';
 
 vi.mock('../../src/components/home-hero/PlaceholderCarousel', () => ({
   PlaceholderCarousel: () => null,
@@ -27,8 +28,9 @@ vi.mock('../../src/collab/useWorkspaceContext', async (importOriginal) => {
 import { HomeView } from '../../src/components/HomeView';
 import { I18nProvider } from '../../src/i18n';
 import {
+  clearHomeComposerAttachments,
+  peekHomeComposerAttachments,
   stashHomeComposerAttachments,
-  takeHomeComposerAttachments,
 } from '../../src/state/home-composer-stash';
 import { writeHomeGuideStage } from '../../src/components/home-hero/firstRunGuide';
 
@@ -36,7 +38,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
   cleanup();
   window.localStorage.clear();
-  takeHomeComposerAttachments();
+  clearHomeComposerAttachments();
 });
 
 function stubPluginsFetch() {
@@ -51,10 +53,10 @@ function stubPluginsFetch() {
   }));
 }
 
-function renderHome(variant: 'page' | 'dock' = 'page') {
+function renderHome(variant: 'page' | 'dock' = 'page', strict = false) {
   writeHomeGuideStage('done');
   stubPluginsFetch();
-  return render(
+  const tree = (
     <I18nProvider initial="en">
       <HomeView
         projects={[]}
@@ -63,8 +65,9 @@ function renderHome(variant: 'page' | 'dock' = 'page') {
         onOpenProject={() => undefined}
         onViewAllProjects={() => undefined}
       />
-    </I18nProvider>,
+    </I18nProvider>
   );
+  return render(strict ? <StrictMode>{tree}</StrictMode> : tree);
 }
 
 describe('home composer attachment stash', () => {
@@ -76,7 +79,22 @@ describe('home composer attachment stash', () => {
     const band = await screen.findByTestId('home-hero-staged-files');
     expect(band.textContent).toContain('brief.txt');
     // The stash is a one-shot hand-off: nothing is left for a later mount.
-    expect(takeHomeComposerAttachments()).toEqual([]);
+    expect(peekHomeComposerAttachments()).toEqual([]);
+  });
+
+  it('keeps the restored attachments through a StrictMode double mount', async () => {
+    // apps/web runs with reactStrictMode: the state initializer runs twice and
+    // effects mount twice. A consume-on-read slot handed the files to the
+    // discarded initializer call, leaving the kept state empty (this is the
+    // stay-on-pending-until-timeout path, where Home mounts fresh).
+    stashHomeComposerAttachments([new File(['brief'], 'brief.txt', { type: 'text/plain' })]);
+
+    renderHome('page', true);
+
+    const band = await screen.findByTestId('home-hero-staged-files');
+    expect(band.textContent).toContain('brief.txt');
+    expect(band.querySelectorAll('.home-hero__active-label').length).toBe(1);
+    expect(peekHomeComposerAttachments()).toEqual([]);
   });
 
   it('takes attachments handed back while it is already mounted', async () => {
@@ -93,7 +111,7 @@ describe('home composer attachment stash', () => {
 
     const band = await screen.findByTestId('home-hero-staged-files');
     expect(band.textContent).toContain('brief.txt');
-    expect(takeHomeComposerAttachments()).toEqual([]);
+    expect(peekHomeComposerAttachments()).toEqual([]);
   });
 
   it('leaves the stash alone when nothing was handed back', async () => {
@@ -111,13 +129,13 @@ describe('home composer attachment stash', () => {
 
     await screen.findByTestId('home-hero-input');
     expect(screen.queryByTestId('home-hero-staged-files')).toBeNull();
-    expect(takeHomeComposerAttachments()).toEqual([file]);
+    expect(peekHomeComposerAttachments()).toEqual([file]);
 
     // Nor while mounted: the event is addressed to the page composer only.
     act(() => {
       stashHomeComposerAttachments([file]);
     });
     expect(screen.queryByTestId('home-hero-staged-files')).toBeNull();
-    expect(takeHomeComposerAttachments()).toEqual([file]);
+    expect(peekHomeComposerAttachments()).toEqual([file]);
   });
 });

--- a/apps/web/tests/components/HomeView.attachment-stash.test.tsx
+++ b/apps/web/tests/components/HomeView.attachment-stash.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+// A failed optimistic create rolls the user back to Home (OPEND-2617). The
+// prompt survives through the persisted draft; the staged File objects cannot,
+// so App hands them back through the composer stash and the remounted Home
+// must pick them up so the retry sends the same payload.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+vi.mock('../../src/components/home-hero/PlaceholderCarousel', () => ({
+  PlaceholderCarousel: () => null,
+}));
+
+vi.mock('../../src/collab/useWorkspaceContext', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/collab/useWorkspaceContext')>();
+  return {
+    ...actual,
+    useWorkspaceContext: () => ({
+      context: null,
+      loading: false,
+      failure: 'unsupported' as const,
+    }),
+  };
+});
+
+import { HomeView } from '../../src/components/HomeView';
+import { I18nProvider } from '../../src/i18n';
+import {
+  stashHomeComposerAttachments,
+  takeHomeComposerAttachments,
+} from '../../src/state/home-composer-stash';
+import { writeHomeGuideStage } from '../../src/components/home-hero/firstRunGuide';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  cleanup();
+  window.localStorage.clear();
+  takeHomeComposerAttachments();
+});
+
+function stubPluginsFetch() {
+  vi.stubGlobal('fetch', vi.fn(async (url: RequestInfo | URL) => {
+    if (typeof url === 'string' && url === '/api/plugins') {
+      return new Response(JSON.stringify({ plugins: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  }));
+}
+
+function renderHome(variant: 'page' | 'dock' = 'page') {
+  writeHomeGuideStage('done');
+  stubPluginsFetch();
+  return render(
+    <I18nProvider initial="en">
+      <HomeView
+        projects={[]}
+        variant={variant}
+        onSubmit={() => Promise.resolve(true)}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+      />
+    </I18nProvider>,
+  );
+}
+
+describe('home composer attachment stash', () => {
+  it('restores stashed attachments into the staged-file band on mount', async () => {
+    stashHomeComposerAttachments([new File(['brief'], 'brief.txt', { type: 'text/plain' })]);
+
+    renderHome();
+
+    const band = await screen.findByTestId('home-hero-staged-files');
+    expect(band.textContent).toContain('brief.txt');
+    // The stash is a one-shot hand-off: nothing is left for a later mount.
+    expect(takeHomeComposerAttachments()).toEqual([]);
+  });
+
+  it('leaves the stash alone when nothing was handed back', async () => {
+    renderHome();
+
+    await screen.findByTestId('home-hero-input');
+    expect(screen.queryByTestId('home-hero-staged-files')).toBeNull();
+  });
+
+  it('does not let a non-page surface consume the page composer hand-off', async () => {
+    const file = new File(['brief'], 'brief.txt', { type: 'text/plain' });
+    stashHomeComposerAttachments([file]);
+
+    renderHome('dock');
+
+    await screen.findByTestId('home-hero-input');
+    expect(screen.queryByTestId('home-hero-staged-files')).toBeNull();
+    expect(takeHomeComposerAttachments()).toEqual([file]);
+  });
+});

--- a/apps/web/tests/components/HomeView.attachment-stash.test.tsx
+++ b/apps/web/tests/components/HomeView.attachment-stash.test.tsx
@@ -6,7 +6,7 @@
 // must pick them up so the retry sends the same payload.
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, render, screen } from '@testing-library/react';
 
 vi.mock('../../src/components/home-hero/PlaceholderCarousel', () => ({
   PlaceholderCarousel: () => null,
@@ -79,6 +79,23 @@ describe('home composer attachment stash', () => {
     expect(takeHomeComposerAttachments()).toEqual([]);
   });
 
+  it('takes attachments handed back while it is already mounted', async () => {
+    // The user pressed Back on the pending frame mid-create, so Home is on
+    // screen when the create later fails: no remount, no initializer. The
+    // hand-off has to reach the live instance through the event.
+    renderHome();
+    await screen.findByTestId('home-hero-input');
+    expect(screen.queryByTestId('home-hero-staged-files')).toBeNull();
+
+    act(() => {
+      stashHomeComposerAttachments([new File(['brief'], 'brief.txt', { type: 'text/plain' })]);
+    });
+
+    const band = await screen.findByTestId('home-hero-staged-files');
+    expect(band.textContent).toContain('brief.txt');
+    expect(takeHomeComposerAttachments()).toEqual([]);
+  });
+
   it('leaves the stash alone when nothing was handed back', async () => {
     renderHome();
 
@@ -93,6 +110,13 @@ describe('home composer attachment stash', () => {
     renderHome('dock');
 
     await screen.findByTestId('home-hero-input');
+    expect(screen.queryByTestId('home-hero-staged-files')).toBeNull();
+    expect(takeHomeComposerAttachments()).toEqual([file]);
+
+    // Nor while mounted: the event is addressed to the page composer only.
+    act(() => {
+      stashHomeComposerAttachments([file]);
+    });
     expect(screen.queryByTestId('home-hero-staged-files')).toBeNull();
     expect(takeHomeComposerAttachments()).toEqual([file]);
   });

--- a/apps/web/tests/components/ProjectCreationPendingView.test.tsx
+++ b/apps/web/tests/components/ProjectCreationPendingView.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+// The optimistic project frame shown between Send and the daemon's create
+// response (OPEND-2617). It must be built from the creation record alone —
+// name, prompt, staged attachments — carry an inert copy of the real composer
+// so the frame already reads as the project page, and start no project-owned
+// request while the project does not exist yet.
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ProjectCreationPendingView } from '../../src/components/ProjectCreationPendingView';
+import { I18nProvider } from '../../src/i18n';
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn(async () =>
+    new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } }));
+  vi.stubGlobal('fetch', fetchMock);
+  Object.assign(URL, {
+    createObjectURL: vi.fn(() => 'blob:preview'),
+    revokeObjectURL: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  cleanup();
+});
+
+function renderPending(overrides: Partial<Parameters<typeof ProjectCreationPendingView>[0]> = {}) {
+  return render(
+    <I18nProvider initial="en">
+      <ProjectCreationPendingView
+        projectName="Coffee shop landing page"
+        prompt="Make a landing page for a coffee shop"
+        agentId="claude"
+        onBack={() => undefined}
+        {...overrides}
+      />
+    </I18nProvider>,
+  );
+}
+
+describe('ProjectCreationPendingView', () => {
+  it('shows the sent prompt and the project name from the creation record alone', () => {
+    renderPending();
+
+    expect(screen.getByTestId('pending-project-title').textContent).toBe('Coffee shop landing page');
+    expect(screen.getByText('Make a landing page for a coffee shop')).toBeTruthy();
+    expect(screen.getByText('Preparing...')).toBeTruthy();
+  });
+
+  it('lists staged attachments as user-message chips in send order', () => {
+    renderPending({
+      attachments: [
+        new File(['brief'], 'brief.txt', { type: 'text/plain' }),
+        new File(['png'], 'mood.png', { type: 'image/png' }),
+      ],
+    });
+
+    const chips = screen.getByTestId('pending-user-attachments').querySelectorAll('.user-attachment');
+    expect(Array.from(chips).map((chip) => chip.textContent)).toEqual(['1brief.txt', '2mood.png']);
+    expect(chips[1]!.className).toContain('staged-image');
+    expect(chips[1]!.querySelector('img')?.getAttribute('src')).toBe('blob:preview');
+    // The chips are labels, not openable files: nothing has been uploaded.
+    expect(Array.from(chips).every((chip) => (chip as HTMLButtonElement).disabled)).toBe(true);
+  });
+
+  it('renders the real composer as an inert, non-sendable shell', () => {
+    renderPending();
+
+    const shell = screen.getByTestId('pending-chat-composer-shell');
+    // React 18 drops the boolean `inert` prop, so the view sets the attribute
+    // on the node itself; the assertion is on the DOM, not on props.
+    expect(shell.hasAttribute('inert')).toBe(true);
+    expect(shell.getAttribute('aria-disabled')).toBe('true');
+    expect(shell.querySelector('.chat-composer, [data-testid="chat-composer"], form, textarea, [contenteditable]')).toBeTruthy();
+    // The send affordance is present so the frame matches ProjectView, but
+    // it can never fire: no project exists to send into.
+    expect((screen.getByTestId('chat-send') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('starts no project-owned request while the project is unconfirmed', async () => {
+    renderPending({ attachments: [new File(['brief'], 'brief.txt', { type: 'text/plain' })] });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const projectReads = fetchMock.mock.calls
+      .map(([input]) => String(input))
+      .filter((url) => url.includes('/api/projects/'));
+    expect(projectReads).toEqual([]);
+  });
+});

--- a/apps/web/tests/components/ProjectCreationPendingView.test.tsx
+++ b/apps/web/tests/components/ProjectCreationPendingView.test.tsx
@@ -7,20 +7,31 @@
 // request while the project does not exist yet.
 
 import { cleanup, render, screen } from '@testing-library/react';
+import { StrictMode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ProjectCreationPendingView } from '../../src/components/ProjectCreationPendingView';
 import { I18nProvider } from '../../src/i18n';
 
 let fetchMock: ReturnType<typeof vi.fn>;
+let createdUrls: string[];
+let revokedUrls: string[];
 
 beforeEach(() => {
   fetchMock = vi.fn(async () =>
     new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } }));
   vi.stubGlobal('fetch', fetchMock);
+  createdUrls = [];
+  revokedUrls = [];
   Object.assign(URL, {
-    createObjectURL: vi.fn(() => 'blob:preview'),
-    revokeObjectURL: vi.fn(),
+    createObjectURL: vi.fn(() => {
+      const url = `blob:preview-${createdUrls.length + 1}`;
+      createdUrls.push(url);
+      return url;
+    }),
+    revokeObjectURL: vi.fn((url: string) => {
+      revokedUrls.push(url);
+    }),
   });
 });
 
@@ -63,9 +74,34 @@ describe('ProjectCreationPendingView', () => {
     const chips = screen.getByTestId('pending-user-attachments').querySelectorAll('.user-attachment');
     expect(Array.from(chips).map((chip) => chip.textContent)).toEqual(['1brief.txt', '2mood.png']);
     expect(chips[1]!.className).toContain('staged-image');
-    expect(chips[1]!.querySelector('img')?.getAttribute('src')).toBe('blob:preview');
+    expect(chips[1]!.querySelector('img')?.getAttribute('src')).toBe('blob:preview-1');
     // The chips are labels, not openable files: nothing has been uploaded.
     expect(Array.from(chips).every((chip) => (chip as HTMLButtonElement).disabled)).toBe(true);
+  });
+
+  it('keeps image previews alive through a StrictMode double mount', () => {
+    // apps/web runs with reactStrictMode: the simulated unmount fires the
+    // preview cleanup, and the remount must mint fresh URLs rather than reuse
+    // revoked ones (the useMemo + separate-cleanup split did exactly that).
+    render(
+      <StrictMode>
+        <I18nProvider initial="en">
+          <ProjectCreationPendingView
+            projectName="Coffee shop landing page"
+            prompt="Make a landing page"
+            attachments={[new File(['png'], 'mood.png', { type: 'image/png' })]}
+            onBack={() => undefined}
+          />
+        </I18nProvider>
+      </StrictMode>,
+    );
+
+    const src = screen.getByTestId('pending-user-attachments').querySelector('img')?.getAttribute('src');
+    expect(src).toBeTruthy();
+    expect(createdUrls).toContain(src);
+    expect(revokedUrls).not.toContain(src);
+    // Whatever the simulated unmount revoked was one of ours, never the live one.
+    expect(revokedUrls.every((url) => createdUrls.includes(url))).toBe(true);
   });
 
   it('renders the real composer as an inert, non-sendable shell', () => {

--- a/e2e/tests/projects/create-preparation-deadline.test.ts
+++ b/e2e/tests/projects/create-preparation-deadline.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment node
+
+// OPEND-2617: the Web enters the project frame the moment Send is pressed, so
+// POST /api/projects needs a hard ceiling. When preparation cannot finish in
+// time the daemon must answer a typed, retryable 504 through the real HTTP
+// boundary (web proxy included) and leave no project row behind, so the
+// client can roll back to the composer instead of waiting indefinitely.
+
+import { randomUUID } from 'node:crypto';
+
+import { describe, expect, test } from 'vitest';
+
+import { requestJson } from '@/vitest/http';
+import { createSmokeSuite } from '@/vitest/suite';
+
+type ProjectListResponse = { projects: Array<{ id: string }> };
+
+describe('project create preparation deadline', () => {
+  test('a stalled create answers 504 PROJECT_CREATE_PREPARATION_TIMEOUT and persists nothing', async () => {
+    const suite = await createSmokeSuite('project-create-preparation-deadline');
+
+    await suite.with.toolsDev(async ({ webUrl }) => {
+      const base = webUrl.replace(/\/$/, '');
+      const projectId = randomUUID();
+      const response = await fetch(`${base}/api/projects`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          id: projectId,
+          name: 'Deadline project',
+          designSystemId: null,
+          skillId: null,
+          metadata: { kind: 'prototype' },
+          pendingPrompt: 'Make a landing page for a coffee shop',
+        }),
+      });
+      const body = await response.json() as {
+        error?: { code?: string; retryable?: boolean; message?: string };
+      };
+      expect(response.status).toBe(504);
+      expect(body.error?.code).toBe('PROJECT_CREATE_PREPARATION_TIMEOUT');
+      expect(body.error?.retryable).toBe(true);
+
+      const list = await requestJson<ProjectListResponse>(webUrl, '/api/projects');
+      expect(list.projects.some((project) => project.id === projectId)).toBe(false);
+    }, {
+      // A 1ms ceiling makes every real preparation read overrun it; the
+      // route's own accumulated-time check turns that into the 504.
+      env: { OD_PROJECT_CREATE_PREPARATION_TIMEOUT_MS: '1' },
+    });
+  }, 180_000);
+});

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -164,6 +164,15 @@ export const API_ERROR_CODES = [
   // so a client can attach to it instead of starting another. Not retryable
   // while that run is active; ordinary chat turns are never gated by this.
   'DESIGN_SYSTEM_ENRICHMENT_IN_PROGRESS',
+  // POST /api/projects bounds every read-only preparation step that runs
+  // before the project/conversation transaction (design-system and skill
+  // validation, plugin and location lookups, plugin registry loads, template
+  // seeding) with one request-wide deadline. When the deadline passes the
+  // daemon answers HTTP 504 with this code and commits nothing, so a client
+  // that already entered an optimistic project surface can roll back to its
+  // composer instead of waiting on a stalled create. Retryable: the same
+  // client-minted project id may be resubmitted.
+  'PROJECT_CREATE_PREPARATION_TIMEOUT',
   'INTERNAL_ERROR',
 ] as const;
 


### PR DESCRIPTION
<!-- No GitHub issue: tracked in Plane OPEND-2617 (OPEND-2553 首页链路 Demo 复刻, PR-F6). -->

## Why

**Use case.** Phase-one acceptance of the Home entry refresh (Plane OPEND-2553). QA (黄玉婷) filed OPEND-2617: after pressing Send on Home nothing visibly happens until the daemon answers `POST /api/projects` — on a warm local daemon that is a few hundred milliseconds, with many plugins, a slow disk or template seeding it stretches to seconds, and the composer gives no feedback because PR-B removed the button's `is-sending` state to match the Demo. Product chose option B: enter the project optimistically and show the sent message, rather than restoring a spinner on the button.

**Pain.** Three things were missing on `feat/home-entry-refresh`:

1. The optimistic surface (`ProjectCreationPendingView`, from #6741) was only rendered when `activeProject` resolved from the project list, so it depended on the optimistic row surviving list refreshes, and it showed neither the staged attachments nor a composer — the frame visibly jumped when `ProjectView` took over.
2. If the user backed out or the create failed, the staged `File` objects were lost with the unmounted Home (the prompt draft survives through localStorage; the files never did).
3. The daemon had no ceiling on create preparation. A stalled catalogue read left the optimistic frame open indefinitely, and the Web had no typed error to roll back on. Demo #7635 added a 15 s request-wide deadline; this PR ports that increment with a dedicated error code instead of the Demo's `INTERNAL_ERROR`.

## What users will see

- Pressing Send (or Enter) on Home switches to the project frame on the same tick the create request leaves: title, the sent prompt bubble, the attachment chips in send order, the agent's "Preparing…" line, and an inert copy of the chat composer at the bottom. When the daemon confirms the project, `ProjectView` takes over in place — same header, same bubble, same composer position — with no second jump.
- If the daemon cannot finish preparing the project within 15 s (or the create fails for any other reason), the app returns to Home with the prompt **and** the staged attachments still in the composer, and shows a retryable error toast: "Project setup timed out before it could start. Try sending again." (localized in all 19 locales).
- `od project create --json` now prints a structured `{ "error": { "code", "message", "data": { "status", "retryable" } } }` envelope on any daemon error (including `PROJECT_CREATE_PREPARATION_TIMEOUT`) instead of a free-form log line; the non-JSON form is unchanged.
- No pending orb or row is added to the left rail or the tab switcher: before the daemon confirms the project nothing new appears there, afterwards the normal run-status flow applies.

## Surface area

- [x] **UI** — pending project frame in `apps/web` (attachment chips, inert composer, creation-record-driven render); failure toast copy
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — `od project create --json` structured error envelope; `OD_PROJECT_CREATE_PREPARATION_TIMEOUT_MS` (test seam for the daemon deadline, unset in production)
- [x] **API / contract** — `POST /api/projects` answers `504 PROJECT_CREATE_PREPARATION_TIMEOUT` (`retryable: true`, `details.stage`) when preparation overruns 15 s; new code in `packages/contracts/src/errors.ts`
- [ ] **Extension point**
- [x] **i18n keys** — `home.createTimedOut` in all 19 locales
- [ ] **New top-level dependency**
- [x] **Default behavior change** — create preparation is now bounded (15 s, request-wide) and template files are seeded before the SQLite transaction instead of after it (with compensation on failure), per the Demo increment
- [ ] **None**

## Screenshots

Entry point is the Home composer's Send button. Captured on `tools-dev` with the `mocks/` replay CLI (`claude`, trace `04097377`), Playwright at 1440×900, dev build.

**Send → pending frame → ProjectView hand-off** (attachment `brief.txt` staged; the label in the corner is time since the click):

![send to pending](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f6/f6-send-to-pending.gif)

| Before (feature branch) | After |
| --- | --- |
| ![baseline pending](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f6/baseline-pending-no-composer.png) | ![pending with attachment and composer](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f6/after-pending-with-attachment.png) |

**Timeout rollback** (POST /api/projects answered with the new 504 through the proxy; prompt, attachment chip and the localized toast are all back on Home):

![timeout rollback](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f6/f6-timeout-rollback.gif)

![home after rollback](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f6/after-timeout-rollback-home.png)

Measured click → pending frame (capture-phase click listener vs. MutationObserver, warm dev build, `mocks/` CLI): 253 ms / 391 ms / 410 ms across three runs, with no network request in that window; `POST /api/projects` itself took 360 ms–1.6 s locally and the frame covers it. The first run after a daemon restart measured 1.37 s because Next compiled the new modules on demand; excluded.

## Bug fix verification

- `apps/web/tests/components/App.project-create-race.test.tsx` — new cases: the pending frame is present synchronously after the click and shows the staged attachment plus an inert composer; a `PROJECT_CREATE_PREPARATION_TIMEOUT` rejection returns to Home with the localized toast and hands the attachments back. Red on `feat/home-entry-refresh` (no chips, no composer, English daemon message, files lost), green here. The existing "enters the project preparing surface before Home project creation settles" and "rolls a failed optimistic Home creation back" cases keep covering the hand-off and the plain rollback.
- `apps/web/tests/components/ProjectCreationPendingView.test.tsx` — creation-record-only render, chips in send order, `inert` attribute set on the DOM node (React 18 drops the boolean prop), no `/api/projects/*` read while unconfirmed.
- `apps/web/tests/components/HomeView.attachment-stash.test.tsx` — the remounted Home takes the stashed files (page variant only; one-shot).
- `apps/daemon/tests/routes/project-create-preparation-deadline.test.ts` — a stalled read answers 504 with the code and `insertProject` / `insertConversation` are never called; the deadline is shared across stages rather than restarted per read; a fast create still succeeds. Red on the base (400 `BAD_REQUEST`, never times out), green here.
- `e2e/tests/projects/create-preparation-deadline.test.ts` — real daemon + web proxy with `OD_PROJECT_CREATE_PREPARATION_TIMEOUT_MS=1`: 504 `PROJECT_CREATE_PREPARATION_TIMEOUT`, `retryable: true`, and the project id is absent from `GET /api/projects` afterwards.

## Validation

- `pnpm guard` ✅, `pnpm typecheck` ✅, `pnpm i18n:check` ✅, `pnpm --filter @open-design/e2e typecheck` ✅
- `pnpm --filter @open-design/web test` ✅ 694 files, 7354 passed (1 expected fail, 11 skipped)
- `pnpm --filter @open-design/daemon test` — 740 files / 9864 passed locally; 7 failures are the known machine-local ones (`chat-route` ×1 and `connection-test` ×4 need the local Claude CLI auth) plus two 3s-timeout flakes under full-suite load (`runtime-version-provenance`, `registry-and-args`) that pass 37/37 when run alone. CI's four daemon shards are green.
- `pnpm --filter @open-design/contracts test` ✅ (523)
- `e2e/tests/projects/create-preparation-deadline.test.ts` ✅ (15 s, isolated tools-dev runtime)
- Red-spec check: with `App.tsx`, `ProjectCreationPendingView.tsx`, `HomeView.tsx` and `routes/project/index.ts` swapped back to `feat/home-entry-refresh`, all 7 new web cases and both daemon deadline cases fail; green on this branch.
- Review follow-ups (0c93b6a615): attachments are handed back through `HOME_COMPOSER_ATTACHMENTS_EVENT` as well as the mount slot, so Back-mid-create no longer loses them (`App.project-create-race` + `HomeView.attachment-stash` cases); pending image previews create/revoke inside one effect and a `<StrictMode>` case asserts the `<img src>` stays live. Re-verified on the Strict Mode tools-dev build with a PNG staged.
- Review round 2 (915ce41832): the attachment stash is a snapshot (`peek` + explicit `clear`) so StrictMode's double-invoked initializer cannot drop the files (new `<StrictMode>` HomeView case); the example-card lookup and manifest digest in `POST /api/projects` are now inside the preparation deadline (new daemon case with a hanging `getLocalPluginBySource`).
- Second commit: `run-failure-telemetry-smoke.test.ts` stubbed every `setTimeout(…, 15_000)` to 0 ms for the Langfuse fallback and thereby fired the new create deadline instantly (CI daemon shard 4/4 saw 504). The stub is now installed after the project is created; CI is green on the rerun.
- Manual: `pnpm tools-dev run web --namespace f6-pending --daemon-port 17812 --web-port 17912` with `mocks/` replay CLI; Playwright probes for the success path, the attachment path, and a proxied 504 (assets above). `od project create --json` against that daemon: `PLUGIN_NOT_FOUND` comes back as the structured envelope with exit 1; success output unchanged.

## Differences from Demo #7635

- Error code: Demo answered the deadline with `504 INTERNAL_ERROR`; this PR adds `PROJECT_CREATE_PREPARATION_TIMEOUT` to `packages/contracts` so the Web and CLI can branch on it.
- Demo did not change the Web rollback; here the failure path also hands staged attachments back to Home and localizes the timeout toast.
- Pending header keeps the back arrow + title (as in Demo); ProjectView's collapse toggle and project dropdown are F5 territory and are not mirrored here, so the header still changes once at hand-off.
- The AMR pre-run balance gate still runs on Home before the optimistic switch (product invariant: hard blocks show their dialog on Home and keep the draft). With a warm wallet cache that is one local read; a cold cache adds its round trip before the frame appears.

## Adjacent issues

- `apps/web/src/utils/notifications.ts` `getCtx()` constructs an `AudioContext` inside the Send click (audio unlock) and showed ~100 ms of self time in a CPU profile of the click → pending window. Not touched here.
- The Web has no client-side abort for `POST /api/projects`; it relies on the daemon deadline. A proxy that never answers still leaves the pending frame open.
- The top chrome above the pending frame is still the entry chrome (search / rail icons) until ProjectView mounts; F5 owns `WorkspaceTabsBar` and the collapse control.
