### PR TITLE
fix(web): quiet the template preview eye, colour the lead type chips, name awaiting replies, drop the community dock (OPEND-2553 F4)

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -843,6 +843,19 @@ function AssistantMessageImpl({
         (!nextUserContent || !parseSubmittedAnswers(seg.form, nextUserContent)),
     );
   }, [message.content, nextUserContent, suppressDirectionForms]);
+  // The run title while that handshake is open (OPEND-2744): a turn that ended
+  // on a form the user has not answered is not "Done" from their side, it is
+  // waiting on them. Only the LAST assistant turn can be waiting — an older
+  // form renders locked (see FormBlock's `interactive`), and the reply that
+  // superseded it is what settled it. Failures and cancellations keep their
+  // own wording; the moment the immediate user reply submits or skips the
+  // form, `hasPendingQuestionForm` drops and the title reads Done again.
+  const awaitingReply =
+    !!isLast &&
+    !streaming &&
+    hasPendingQuestionForm &&
+    message.runStatus !== "canceled" &&
+    message.runStatus !== "failed";
   // "Next step" is a delivery affordance, not a generic terminal-state card.
   // Keep it out of pure Q&A, failures/cancellations and incomplete Todo turns;
   // only a successful turn that actually produced something may surface it.
@@ -917,6 +930,7 @@ function AssistantMessageImpl({
                 message.runStatus === "canceled" ||
                 hasResultDeliveryFailure)
             }
+            awaitingReply={awaitingReply}
             startedAt={message.startedAt}
             endedAt={message.endedAt}
             durationMs={usage?.durationMs}
@@ -1111,6 +1125,7 @@ function AssistantMessageImpl({
                   forking,
                   forceVisible: true,
                   isLast: !!isLast,
+                  awaitingReply,
                   hideRunStatus:
                     taskActivity !== null ||
                     hasTodoSnapshot ||
@@ -1129,6 +1144,7 @@ function AssistantMessageImpl({
                 onFork={canFork ? onForkFromMessage : undefined}
                 forking={forking}
                 isLast={!!isLast}
+                awaitingReply={awaitingReply}
                 hideRunStatus={
                   taskActivity !== null ||
                   hasTodoSnapshot ||
@@ -1633,6 +1649,8 @@ interface AssistantFooterProps {
   // When the turn has an execution disclosure, its run state lives at the top
   // of the answer. The footer keeps only actions so run state is not repeated.
   hideRunStatus?: boolean;
+  /** The turn ended on a question form the user has not answered yet. */
+  awaitingReply?: boolean;
 }
 
 function AssistantFooter({
@@ -1649,6 +1667,7 @@ function AssistantFooter({
   forceVisible = false,
   isLast = false,
   hideRunStatus = false,
+  awaitingReply = false,
 }: AssistantFooterProps) {
   const t = useT();
   if (
@@ -1684,6 +1703,8 @@ function AssistantFooter({
               ? t("assistant.canceledLabel")
               : hasUnfinishedTodos
               ? t("assistant.unfinishedLabel")
+              : awaitingReply
+              ? t("assistant.awaitingReplyLabel")
               : t("assistant.doneLabel")}
           </span>
         </>
@@ -3860,6 +3881,7 @@ function TaskActivityCard({
   terminalRunSucceeded,
   runCanceled,
   runFailed,
+  awaitingReply = false,
   startedAt,
   endedAt,
   durationMs,
@@ -3875,6 +3897,8 @@ function TaskActivityCard({
   terminalRunSucceeded: boolean;
   runCanceled: boolean;
   runFailed: boolean;
+  /** The turn ended on a question form the user has not answered yet. */
+  awaitingReply?: boolean;
   startedAt: number | undefined;
   endedAt: number | undefined;
   durationMs: number | undefined;
@@ -3912,7 +3936,9 @@ function TaskActivityCard({
       ? t("assistant.canceledLabel")
       : hasError
         ? t("critiqueTheater.failedHeading")
-        : t("assistant.doneLabel");
+        : awaitingReply
+          ? t("assistant.awaitingReplyLabel")
+          : t("assistant.doneLabel");
   const runState = running
     ? "running"
     : runCanceled

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -834,26 +834,35 @@ function AssistantMessageImpl({
   // path), the turn is mid-handshake, not settled. Suppressed direction forms
   // render as a locked pill the user cannot answer, so they don't hold the
   // card back.
-  const hasPendingQuestionForm = useMemo(() => {
-    if (hasUnterminatedQuestionForm(message.content)) return true;
-    return splitOnQuestionForms(message.content).some(
-      (seg) =>
-        seg.kind === "form" &&
-        !(suppressDirectionForms && isDirectionForm(seg.form)) &&
-        (!nextUserContent || !parseSubmittedAnswers(seg.form, nextUserContent)),
-    );
-  }, [message.content, nextUserContent, suppressDirectionForms]);
+  // A parsed, answerable form the immediate reply has not settled. This is
+  // the half the user can act on; an unterminated form (below) is not.
+  const hasUnansweredQuestionForm = useMemo(
+    () =>
+      splitOnQuestionForms(message.content).some(
+        (seg) =>
+          seg.kind === "form" &&
+          !(suppressDirectionForms && isDirectionForm(seg.form)) &&
+          (!nextUserContent || !parseSubmittedAnswers(seg.form, nextUserContent)),
+      ),
+    [message.content, nextUserContent, suppressDirectionForms],
+  );
+  const hasPendingQuestionForm =
+    hasUnterminatedQuestionForm(message.content) || hasUnansweredQuestionForm;
   // The run title while that handshake is open (OPEND-2744): a turn that ended
   // on a form the user has not answered is not "Done" from their side, it is
   // waiting on them. Only the LAST assistant turn can be waiting — an older
   // form renders locked (see FormBlock's `interactive`), and the reply that
   // superseded it is what settled it. Failures and cancellations keep their
   // own wording; the moment the immediate user reply submits or skips the
-  // form, `hasPendingQuestionForm` drops and the title reads Done again.
+  // form, `hasUnansweredQuestionForm` drops and the title reads Done again.
+  // Deliberately NOT `hasPendingQuestionForm`: a form the run never closed
+  // (output limit hit mid-form) renders no form and no skip once the run is
+  // terminal, so there is nothing for the user to reply to and the label
+  // would be stuck forever.
   const awaitingReply =
     !!isLast &&
     !streaming &&
-    hasPendingQuestionForm &&
+    hasUnansweredQuestionForm &&
     message.runStatus !== "canceled" &&
     message.runStatus !== "failed";
   // "Next step" is a delivery affordance, not a generic terminal-state card.

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -1211,13 +1211,6 @@ export function EntryShell({
   const [homePromptHandoff, setHomePromptHandoff] = useState<HomePromptHandoff | null>(
     () => takeHomePromptHandoff(),
   );
-  // The same one-shot binding, addressed at the community view's docked
-  // composer instead. Kept separate rather than shared: `promptHandoff` is
-  // consumed by id, so one piece of state fed to both instances would have
-  // whichever consumed it first mark it spent for the other.
-  const [dockPromptHandoff, setDockPromptHandoff] = useState<HomePromptHandoff | null>(
-    null,
-  );
   const entryMainScrollRef = useRef<HTMLElement | null>(null);
   // Entry views share this element, so route changes must not inherit the previous view's offset.
   useLayoutEffect(() => {
@@ -1822,8 +1815,11 @@ export function EntryShell({
                 onDeleteProject={onDeleteProject}
                 onDuplicateProject={onDuplicateProject}
                 onRenameProject={onRenameProject}
-                /* Home alone consumes the page handoff. A docked instance
-                   (community) has its own — see `dockPromptHandoff`. */
+                /* Home is the one composer in the shell and consumes the page
+                   handoff. The community view used to dock a second HomeView
+                   (`variant="dock"`) with a handoff of its own; that mount
+                   was taken out (OPEND-2793) until phase three gives it a
+                   template-bound shape. */
                 promptHandoff={homePromptHandoff}
                 executionSwitcher={view === 'home' ? homeExecutionSwitcher : undefined}
               />
@@ -1984,19 +1980,20 @@ export function EntryShell({
                   })();
                 }}
                 onUsePrompt={(target) => {
-                  // Stays put (per product): the prompt lands in the docked
-                  // composer at the foot of THIS page and unfolds it, instead
-                  // of throwing the user back to 首页 and making them find
-                  // their place in the gallery again. Same seed + binding pair
-                  // Home used, only addressed at the dock.
-                  // (App.tsx's standalone /community route has no dock and
-                  // still hands off to Home — see the branch there.)
-                  seedHomeComposerPrompt(target.prompt, 'dock');
-                  setDockPromptHandoff(createPluginUseHandoff(Date.now(), target.templateId, {
+                  // Hands off to Home (OPEND-2793, product decision B): the
+                  // community view no longer docks a composer at its foot —
+                  // that bar had no relation to the gallery, the filters or
+                  // the card under it, and phase three will bring it back in
+                  // a template-bound shape. Same seed + binding pair the
+                  // standalone /community route in App.tsx uses, so Use
+                  // lands the prompt AND the plugin driver in Home's composer.
+                  seedHomeComposerPrompt(target.prompt);
+                  setHomePromptHandoff(createPluginUseHandoff(Date.now(), target.templateId, {
                     action: 'use',
                     chipId: target.chipId,
                     projectKind: target.projectKind,
                   }));
+                  changeView('home');
                 }}
                 // The gallery card's full details modal routes Use through the
                 // same Home hand-off the plugin library uses, so the plugin
@@ -2009,31 +2006,6 @@ export function EntryShell({
                   });
                 }}
               />
-            ) : null}
-            {/* Home's composer, docked to the bottom of the community view: you
-                can browse templates and still start from your own sentence
-                without going back to 首页. Collapsed it is the input line and
-                the send button; typing unfolds the rest (HomeHero's `dock`
-                variant owns both states). Mounted only while the view is up so
-                it does not hold a second composer's worth of pickers alive
-                behind every other destination. */}
-            {view === 'community' ? (
-              <div
-                className="community-composer-dock"
-                data-testid="community-composer-dock"
-              >
-                <HomeView
-                  {...homeViewProps}
-                  variant="dock"
-                  isActive
-                  /* The agent/model chip too, so the docked row is the same
-                     control set as Home's. Only ever one of the two instances
-                     renders it — each is gated on a different view — so the
-                     switcher is never mounted twice. */
-                  executionSwitcher={homeExecutionSwitcher}
-                  promptHandoff={dockPromptHandoff}
-                />
-              </div>
             ) : null}
             {/* Team destinations — the entry shell owns the nav frame only; each
                 view is provided by another lane (B = members/board, D = team

--- a/apps/web/src/components/home-hero/TemplatePicker.tsx
+++ b/apps/web/src/components/home-hero/TemplatePicker.tsx
@@ -55,6 +55,8 @@ export function TemplatePicker({
     <div
       className="home-hero__footer-option home-hero__footer-option--select home-hero__template-option has-selection"
       data-field-name="template"
+      // The stylesheet keys the lead types' hue (原型 / 幻灯片 / 文档) on this.
+      data-chip={active.id}
       data-testid="home-hero-template-picker"
     >
       {/* Not a button any more — there is nothing to open; the clear inside it

--- a/apps/web/src/components/home-hero/TypePillRow.tsx
+++ b/apps/web/src/components/home-hero/TypePillRow.tsx
@@ -118,6 +118,8 @@ export function TypePillRow({ chips, activeChipId, disabled, labelFor, onPick }:
         className={`home-hero__type-pill${isActive ? ' is-active' : ''}`}
         disabled={disabled}
         data-testid={`home-hero-type-pill-${chip.id}${inPopover ? '-more' : ''}`}
+        // The stylesheet keys the lead chips' hue (原型 / 幻灯片 / 文档) on this.
+        data-chip={chip.id}
         onClick={() => {
           setMoreOpen(false);
           if (chip.id !== activeChipId) onPick(chip);
@@ -172,7 +174,7 @@ export function TypePillRow({ chips, activeChipId, disabled, labelFor, onPick }:
           measure pill widths — never interactive, never painted. */}
       <div className="home-hero__type-pills-probe" ref={probeRef} aria-hidden>
         {flowing.map((chip) => (
-          <span key={chip.id} className="home-hero__type-pill">
+          <span key={chip.id} className="home-hero__type-pill" data-chip={chip.id}>
             <Icon name={chip.icon} size={14} />
             <span>{labelFor(chip.id)}</span>
           </span>

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -3415,6 +3415,7 @@ export const ar: Dict = {
   'assistant.role': 'المساعد',
   'assistant.workingLabel': 'جاري العمل',
   'assistant.doneLabel': 'تم',
+  'assistant.awaitingReplyLabel': 'في انتظار ردك',
   'assistant.canceledLabel': 'ملغى',
   'assistant.copyMarkdown': 'نسخ Markdown الرد',
   'assistant.forkConversation': 'تفرع من هنا',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -3415,6 +3415,7 @@ export const de: Dict = {
   'assistant.role': 'Assistent',
   'assistant.workingLabel': 'Arbeitet',
   'assistant.doneLabel': 'Fertig',
+  'assistant.awaitingReplyLabel': 'Wartet auf Antwort',
   'assistant.canceledLabel': 'Abgebrochen',
   'assistant.copyMarkdown': 'Antwort-Markdown kopieren',
   'assistant.forkConversation': 'Ab hier forken',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -3429,6 +3429,7 @@ export const en: Dict = {
   'assistant.role': 'Assistant',
   'assistant.workingLabel': 'Working',
   'assistant.doneLabel': 'Done',
+  'assistant.awaitingReplyLabel': 'Awaiting your reply',
   'assistant.canceledLabel': 'Canceled',
   'assistant.copyMarkdown': 'Copy response markdown',
   'assistant.forkConversation': 'Fork from here',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -3415,6 +3415,7 @@ export const esES: Dict = {
   'assistant.role': 'Asistente',
   'assistant.workingLabel': 'Trabajando',
   'assistant.doneLabel': 'Listo',
+  'assistant.awaitingReplyLabel': 'Esperando respuesta',
   'assistant.canceledLabel': 'Cancelado',
   'assistant.copyMarkdown': 'Copiar Markdown de la respuesta',
   'assistant.forkConversation': 'Bifurcar desde aquí',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -3415,6 +3415,7 @@ export const fa: Dict = {
   'assistant.role': 'دستیار',
   'assistant.workingLabel': 'در حال کار',
   'assistant.doneLabel': 'انجام شد',
+  'assistant.awaitingReplyLabel': 'در انتظار پاسخ',
   'assistant.canceledLabel': 'لغو شد',
   'assistant.copyMarkdown': 'کپی Markdown پاسخ',
   'assistant.forkConversation': 'فورک از اینجا',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -3415,6 +3415,7 @@ export const fr: Dict = {
   'assistant.role': 'Assistant',
   'assistant.workingLabel': 'En cours',
   'assistant.doneLabel': 'Terminé',
+  'assistant.awaitingReplyLabel': 'En attente de réponse',
   'assistant.canceledLabel': 'Annulé',
   'assistant.copyMarkdown': 'Copier le Markdown de la réponse',
   'assistant.forkConversation': 'Créer un fork à partir d’ici',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -3415,6 +3415,7 @@ export const hu: Dict = {
   'assistant.role': 'Asszisztens',
   'assistant.workingLabel': 'Dolgozik',
   'assistant.doneLabel': 'Kész',
+  'assistant.awaitingReplyLabel': 'Válaszra vár',
   'assistant.canceledLabel': 'Megszakítva',
   'assistant.copyMarkdown': 'Válasz Markdown másolása',
   'assistant.forkConversation': 'Fork innen',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -3415,6 +3415,7 @@ export const id: Dict = {
   'assistant.role': 'Asisten',
   'assistant.workingLabel': 'Sedang bekerja',
   'assistant.doneLabel': 'Selesai',
+  'assistant.awaitingReplyLabel': 'Menunggu balasan',
   'assistant.canceledLabel': 'Dibatalkan',
   'assistant.copyMarkdown': 'Salin Markdown respons',
   'assistant.forkConversation': 'Fork dari sini',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -3415,6 +3415,7 @@ export const it: Dict = {
   'assistant.role': 'Assistente',
   'assistant.workingLabel': 'In corso',
   'assistant.doneLabel': 'Completato',
+  'assistant.awaitingReplyLabel': 'In attesa di risposta',
   'assistant.canceledLabel': 'Annullato',
   'assistant.copyMarkdown': 'Copia il Markdown della risposta',
   'assistant.forkConversation': 'Fork da qui',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -3415,6 +3415,7 @@ export const ja: Dict = {
   'assistant.role': 'アシスタント',
   'assistant.workingLabel': '作業中',
   'assistant.doneLabel': '完了',
+  'assistant.awaitingReplyLabel': '返信待ち',
   'assistant.canceledLabel': 'キャンセル済み',
   'assistant.copyMarkdown': '応答のMarkdownをコピー',
   'assistant.forkConversation': 'ここからフォーク',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -3415,6 +3415,7 @@ export const ko: Dict = {
   'assistant.role': '어시스턴트 (Assistant)',
   'assistant.workingLabel': '작업 중',
   'assistant.doneLabel': '완료됨',
+  'assistant.awaitingReplyLabel': '답변 대기 중',
   'assistant.canceledLabel': '취소됨',
   'assistant.copyMarkdown': '응답 Markdown 복사',
   'assistant.forkConversation': '여기서 포크',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -3415,6 +3415,7 @@ export const pl: Dict = {
   'assistant.role': 'Asystent',
   'assistant.workingLabel': 'Pracuję',
   'assistant.doneLabel': 'Gotowe',
+  'assistant.awaitingReplyLabel': 'Czeka na odpowiedź',
   'assistant.canceledLabel': 'Anulowano',
   'assistant.copyMarkdown': 'Kopiuj Markdown odpowiedzi',
   'assistant.forkConversation': 'Fork od tego miejsca',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -3415,6 +3415,7 @@ export const ptBR: Dict = {
   'assistant.role': 'Assistente',
   'assistant.workingLabel': 'Trabalhando',
   'assistant.doneLabel': 'Concluído',
+  'assistant.awaitingReplyLabel': 'Aguardando resposta',
   'assistant.canceledLabel': 'Cancelado',
   'assistant.copyMarkdown': 'Copiar Markdown da resposta',
   'assistant.forkConversation': 'Bifurcar daqui',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -3415,6 +3415,7 @@ export const ru: Dict = {
   'assistant.role': 'Ассистент',
   'assistant.workingLabel': 'Работает',
   'assistant.doneLabel': 'Готово',
+  'assistant.awaitingReplyLabel': 'Ожидает ответа',
   'assistant.canceledLabel': 'Отменено',
   'assistant.copyMarkdown': 'Скопировать Markdown ответа',
   'assistant.forkConversation': 'Создать форк отсюда',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -3415,6 +3415,7 @@ export const th: Dict = {
   'assistant.role': 'หน่วยผู้ช่วยเหลือส่วนตัว',
   'assistant.workingLabel': 'ดำเนินระบบรับทำงานอยู่',
   'assistant.doneLabel': 'บรรลุสู่ระดับพร้อมแล้ว',
+  'assistant.awaitingReplyLabel': 'รอการตอบกลับ',
   'assistant.canceledLabel': 'ยกเลิกแล้ว',
   'assistant.copyMarkdown': 'คัดลอก Markdown ของคำตอบ',
   'assistant.forkConversation': 'Fork จากตรงนี้',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -3415,6 +3415,7 @@ export const tr: Dict = {
   'assistant.role': 'Asistan',
   'assistant.workingLabel': 'Çalışıyor',
   'assistant.doneLabel': 'Bitti',
+  'assistant.awaitingReplyLabel': 'Yanıt bekleniyor',
   'assistant.canceledLabel': 'İptal edildi',
   'assistant.copyMarkdown': 'Yanıt Markdown\'unu kopyala',
   'assistant.forkConversation': 'Buradan fork et',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -3415,6 +3415,7 @@ export const uk: Dict = {
   'assistant.role': 'Асистент',
   'assistant.workingLabel': 'Роботи',
   'assistant.doneLabel': 'Готово',
+  'assistant.awaitingReplyLabel': 'Очікує відповіді',
   'assistant.canceledLabel': 'Скасовано',
   'assistant.copyMarkdown': 'Скопіювати Markdown відповіді',
   'assistant.forkConversation': 'Створити форк звідси',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -3609,6 +3609,7 @@ export const zhCN: Dict = {
   "assistant.role": "助手",
   "assistant.workingLabel": "执行中",
   "assistant.doneLabel": "已完成",
+  "assistant.awaitingReplyLabel": "等待回复",
   "assistant.canceledLabel": "已取消",
   "assistant.copyMarkdown": "复制回复 Markdown",
   "assistant.forkConversation": "从这里分叉",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -3619,6 +3619,7 @@ export const zhTW: Dict = {
   "assistant.role": "助手",
   "assistant.workingLabel": "執行中",
   "assistant.doneLabel": "已完成",
+  "assistant.awaitingReplyLabel": "等待回覆",
   "assistant.canceledLabel": "已取消",
   "assistant.copyMarkdown": "複製回覆 Markdown",
   "assistant.forkConversation": "從這裡分叉",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -4283,6 +4283,8 @@ export interface Dict {
   'assistant.role': string;
   'assistant.workingLabel': string;
   'assistant.doneLabel': string;
+  /** Run title while the last turn's question form is still unanswered (OPEND-2744). */
+  'assistant.awaitingReplyLabel': string;
   'assistant.canceledLabel': string;
   'assistant.copyMarkdown': string;
   'assistant.forkConversation': string;

--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -361,11 +361,13 @@
   gap: 6px;
   min-height: 32px;
   padding: 5px 12px;
-  /* Outline only (per product): a #EDEDED hairline and NO fill, so the pill
-     is a ring on the page ground rather than a chip sitting on it. Written as
-     `--bg-subtle`, the token that holds #EDEDED, so dark mode follows the
-     neutral ladder instead of pinning a light gray onto a dark ground. */
-  border: 1px solid var(--bg-subtle);
+  /* Outline only (per product): a hairline and NO fill, so the pill is a
+     ring on the page ground rather than a chip sitting on it. The ring is
+     mixed from the text ink at 20% (OPEND-2684): the #EDEDED it used to be
+     sat too close to a white page to read as an edge, and on the dark panel
+     it vanished altogether. Through --text rather than a literal, so the same
+     20% is a visible outline on either theme's ground. */
+  border: 1px solid color-mix(in srgb, var(--text) 20%, transparent);
   border-radius: var(--radius-pill);
   background: transparent;
   /* Label + icon rest at the hover ink (#202020) — the old --text-soft rest
@@ -385,10 +387,31 @@
 .home-hero__type-pill:hover:not(:disabled) {
   color: var(--text-strong);
   /* Hover darkens the RING, not the inside: the pill has no fill at rest, so
-     growing one on hover would make it change category rather than state. */
-  border-color: color-mix(in srgb, var(--bg-subtle) 82%, var(--text));
+     growing one on hover would make it change category rather than state.
+     One step up the same ink ladder the rest ring is mixed from. */
+  border-color: color-mix(in srgb, var(--text) 40%, transparent);
   background: transparent;
   transform: translateY(-0.5px);
+}
+/* The three lead types each carry a hue (OPEND-2684): 原型 blue, 幻灯片
+   orange, 文档 green, so the three entries read as three things and not one
+   grey row. The hue lives on the ICON only — the label stays ink, so the row
+   keeps one text colour and stays readable — and is keyed on the chip id the
+   component stamps, so 更多 and every other type stay neutral. Set as a custom
+   property on the chip so the icon rule below reads it. (There is no lit pill
+   in this row: picking a type retires the row, and the composer's template
+   pill — see the picker section — carries the selected tint.) */
+.home-hero__type-pill[data-chip='prototype'] {
+  --type-pill-hue: var(--type-prototype);
+}
+.home-hero__type-pill[data-chip='deck'] {
+  --type-pill-hue: var(--type-deck);
+}
+.home-hero__type-pill[data-chip='document'] {
+  --type-pill-hue: var(--type-document);
+}
+.home-hero__type-pill > .od-icon {
+  color: var(--type-pill-hue, currentColor);
 }
 /* Selected pill mirrors the composer's selected template chip exactly (the
    `.has-selection` pair above: 极浅品牌背景 --brand-surface, brand green
@@ -3281,50 +3304,59 @@
     visibility 0s linear 120ms;
 }
 /* Preview control, sitting ON the poster at its top-right corner (per
-   product) and revealed with the row. A dark scrim disc rather than a bare
-   glyph: it lands on whatever the poster happens to show there, which is as
-   often white paper as it is ink. Hidden with opacity + visibility, never
-   `display` — the poster must not reflow under the pointer — and
-   `pointer-events` come back only once it is visible, so an invisible control
-   can never swallow a click meant for the row. */
+   product) and revealed with the row. A SECONDARY affordance (OPEND-2697):
+   the row's main path is pick → fill the composer → send, and the eye must
+   not compete with it. So: hidden at rest, faded in with the row's hover or
+   keyboard focus, one size step down (16px, was 20), and on a translucent
+   LIGHT ground with dark ink instead of the dark scrim disc it used to wear —
+   the disc read as the row's focal point. The hairline under it is what keeps
+   the ground legible on a white poster (a paper document, a resume).
+   Hidden with opacity + visibility, never `display` — the poster must not
+   reflow under the pointer — and `pointer-events` stay off so an invisible
+   control can never swallow a click meant for the row. Enter ~200ms, exit
+   ~140ms on the shared ease-out curve: the rest state carries the exit
+   timing, the reveal rule below carries the enter timing. */
 .home-hero__plugin-preset-row-preview {
   position: absolute;
   /* Never a click target of its own: the poster behind it takes the click, so
-     the badge must not swallow one that lands on its 20px disc. */
+     the badge must not swallow one that lands on its disc. */
   pointer-events: none;
   top: 4px;
   right: 4px;
-  width: 20px;
-  height: 20px;
+  width: 16px;
+  height: 16px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   border-radius: var(--radius-pill);
-  background: color-mix(in srgb, #000 55%, transparent);
-  color: #fff;
-  cursor: pointer;
+  background: color-mix(in srgb, #fff 82%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, #000 10%, transparent);
+  color: #202020;
   opacity: 0;
   visibility: hidden;
-  pointer-events: none;
   transition:
-    opacity 120ms var(--ease-out),
-    visibility 0s linear 120ms;
+    opacity 140ms cubic-bezier(0.23, 1, 0.32, 1),
+    visibility 0s linear 140ms;
 }
 .home-hero__plugin-preset-row-preview svg {
-  width: 13px;
-  height: 13px;
-  flex: 0 0 13px;
+  width: 11px;
+  height: 11px;
+  flex: 0 0 11px;
 }
 .home-hero__plugin-preset-row:not(:disabled):hover .home-hero__plugin-preset-row-preview,
 .home-hero__plugin-preset-row:not(:disabled):focus-visible .home-hero__plugin-preset-row-preview {
   opacity: 1;
   visibility: visible;
-  transition-delay: 0s;
+  transition:
+    opacity 200ms cubic-bezier(0.23, 1, 0.32, 1),
+    visibility 0s;
 }
-/* Deepens with the POSTER's hover, not its own — the badge takes no pointer
-   events, so `:hover` on it would never fire. */
+/* Firms up with the POSTER's hover, not its own — the badge takes no pointer
+   events, so `:hover` on it would never fire. Still a light ground: only the
+   translucency closes, so the eye reads "this is the click" without turning
+   back into a dark disc. */
 .home-hero__plugin-preset-row-thumb:hover .home-hero__plugin-preset-row-preview {
-  background: color-mix(in srgb, #000 72%, transparent);
+  background: color-mix(in srgb, #fff 96%, transparent);
 }
 /* The prompt underneath, one step back so the name leads the row. */
 .home-hero__plugin-preset-row-text {
@@ -4042,6 +4074,43 @@
   /* Strokeless through open/focus too — the generic template hover rule above
      would otherwise swap in shadow-xs. */
   box-shadow: none;
+}
+/* Picked LEAD type (OPEND-2684): the pill that names 原型 / 幻灯片 / 文档
+   wears that type's own hue instead of the brand-green pair — a 10% tint of
+   the hue as its ground, a 36% ring of it, the hue on the icon, and the
+   label in the strong ink so the row keeps one text colour. Keyed on the
+   chip id `TemplatePicker` stamps, so every other type keeps the pair above.
+   The type row under the composer retires the moment a type is picked, so
+   THIS pill is the selected state — there is no lit pill in that row. Same
+   specificity as the hover / open / focus restatements above and later in
+   the sheet, so it holds through all three; the hue is set once as a custom
+   property so the icon rule below reads the same value. */
+.home-hero__footer-option--select.home-hero__template-option.has-selection[data-field-name='template'][data-chip='prototype'] {
+  --type-pill-hue: var(--type-prototype);
+}
+.home-hero__footer-option--select.home-hero__template-option.has-selection[data-field-name='template'][data-chip='deck'] {
+  --type-pill-hue: var(--type-deck);
+}
+.home-hero__footer-option--select.home-hero__template-option.has-selection[data-field-name='template'][data-chip='document'] {
+  --type-pill-hue: var(--type-document);
+}
+.home-hero__footer-option--select.home-hero__template-option.has-selection[data-field-name='template'][data-chip='prototype'],
+.home-hero__footer-option--select.home-hero__template-option.has-selection[data-field-name='template'][data-chip='deck'],
+.home-hero__footer-option--select.home-hero__template-option.has-selection[data-field-name='template'][data-chip='document'] {
+  border-color: transparent;
+  background-color: color-mix(in srgb, var(--type-pill-hue) 10%, transparent);
+  color: var(--text-strong);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--type-pill-hue) 36%, transparent);
+}
+.home-hero__template-option.has-selection[data-chip='prototype'] .home-hero__footer-option-icon,
+.home-hero__template-option.has-selection[data-chip='deck'] .home-hero__footer-option-icon,
+.home-hero__template-option.has-selection[data-chip='document'] .home-hero__footer-option-icon {
+  color: var(--type-pill-hue);
+}
+.home-hero__template-option.has-selection[data-chip='prototype'] .home-hero__footer-select-label,
+.home-hero__template-option.has-selection[data-chip='deck'] .home-hero__footer-select-label,
+.home-hero__template-option.has-selection[data-chip='document'] .home-hero__footer-select-label {
+  color: var(--text-strong);
 }
 .home-hero__footer-option.home-hero__template-option:hover,
 .home-hero__footer-option.home-hero__template-option.is-open,

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -88,6 +88,15 @@
   --amber: #FF7528;
   --amber-bg: color-mix(in srgb, #FFBA12 18%, #fafafa);
 
+  /* Home type chips (OPEND-2684): one hue per lead entry — 原型 blue, 幻灯片
+     orange, 文档 green — carried by the chip's icon and, at 10%, by its
+     selected ground. Their own names rather than the --blue/--amber/--green
+     they alias here, so a status pill and a type chip can drift apart later
+     without one silently recolouring the other. */
+  --type-prototype: var(--blue);
+  --type-deck: var(--amber);
+  --type-document: var(--green);
+
   /* Project-kind tag hues (see `.design-card-tag.tag-*`). Each kind carries an
      ink; the three whose tint is a lighter sibling of that ink also carry a
      `-tint` the pill's fill/border are mixed from. `tag-brand` /
@@ -224,6 +233,12 @@
   --amber: #FFC740;
   --amber-bg: color-mix(in srgb, #FFBA12 22%, #202020);
 
+  /* Dark keeps the deck chip ORANGE: --amber turns yellow on this theme (a
+     status hue), and the chip's identity is the orange. */
+  --type-prototype: var(--blue);
+  --type-deck: #ff9a5c;
+  --type-document: var(--green);
+
   --shadow-xs: 0 1px 0 rgba(0, 0, 0, 0.2);
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.2);
   --shadow-md: 0 6px 24px rgba(0, 0, 0, 0.4), 0 2px 6px rgba(0, 0, 0, 0.25);
@@ -286,6 +301,9 @@
     --red-border: color-mix(in srgb, #FF5E5E 34%, #5c5c5c);
     --amber: #FFC740;
     --amber-bg: color-mix(in srgb, #FFBA12 22%, #202020);
+    --type-prototype: var(--blue);
+    --type-deck: #ff9a5c;
+    --type-document: var(--green);
 
     --shadow-xs: 0 1px 0 rgba(0, 0, 0, 0.2);
     --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.2);

--- a/apps/web/tests/components/EntryShell.blank-project-naming.test.tsx
+++ b/apps/web/tests/components/EntryShell.blank-project-naming.test.tsx
@@ -249,11 +249,16 @@ describe('EntryShell signed-out recent projects', () => {
     expect(window.location.pathname).toBe('/projects');
   });
 
-  it('keeps the Community dock to the composer with local projects present', async () => {
+  // OPEND-2793 (product decision B): the community gallery browses without a
+  // docked composer until phase three gives it a template-bound shape. The
+  // `dock` variant of HomeView stays in the codebase; Community just no longer
+  // mounts it, so the grid can use the full page height.
+  it('renders the Community gallery without a docked composer', async () => {
     renderAt('/community', { projects: [localProject] });
-    const dock = await screen.findByTestId('community-composer-dock');
-    expect(within(dock).getByTestId('home-hero-composer-card')).toBeTruthy();
-    expect(dock.querySelector('.recent-projects')).toBeNull();
+    await screen.findByTestId('entry-view-home');
+    expect(screen.queryByTestId('community-composer-dock')).toBeNull();
+    // Home's own composer is still the single composer in the shell.
+    expect(screen.getAllByTestId('home-hero-composer-card')).toHaveLength(1);
   });
 });
 

--- a/apps/web/tests/components/assistant-message-awaiting-reply.test.tsx
+++ b/apps/web/tests/components/assistant-message-awaiting-reply.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+
+/**
+ * OPEND-2744 — a run that ended on an unanswered `<question-form>` is not
+ * "Done" from the user's side: the turn is waiting on them. The run title
+ * (footer label, or the task activity card's state when one is shown) reads
+ * "Awaiting your reply" until the immediate user reply submits or skips that
+ * form, then falls back to the normal terminal wording.
+ */
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { AssistantMessage } from '../../src/components/AssistantMessage';
+import { formatFormAnswers, splitOnQuestionForms } from '../../src/artifacts/question-form';
+import type { AgentEvent, ChatMessage } from '../../src/types';
+
+const FORM = [
+  'Two quick questions first.',
+  '<question-form id="brief" title="Quick brief">',
+  JSON.stringify({
+    questions: [{ id: 'audience', label: 'Audience', type: 'text' }],
+  }),
+  '</question-form>',
+].join('\n');
+
+const PARSED_FORM = (() => {
+  const seg = splitOnQuestionForms(FORM).find((item) => item.kind === 'form');
+  if (!seg || seg.kind !== 'form') throw new Error('fixture form did not parse');
+  return seg.form;
+})();
+
+function formMessage(extraEvents: AgentEvent[] = []): ChatMessage {
+  return {
+    id: 'assistant-form',
+    role: 'assistant',
+    content: FORM,
+    runStatus: 'succeeded',
+    startedAt: 1_000,
+    endedAt: 3_000,
+    events: [...extraEvents, { kind: 'text', text: FORM }],
+  } as ChatMessage;
+}
+
+const TOOL_EVENT: AgentEvent = {
+  kind: 'tool_use',
+  id: 'tool-1',
+  name: 'Bash',
+  input: { command: 'pnpm guard', description: 'Run guard' },
+} as AgentEvent;
+
+function footerLabel(container: HTMLElement): string {
+  return container.querySelector('.assistant-footer .assistant-label')?.textContent ?? '';
+}
+
+describe('AssistantMessage run title while a question form waits (OPEND-2744)', () => {
+  afterEach(() => cleanup());
+
+  it('reads "Awaiting your reply" instead of Done on the last turn with an unanswered form', () => {
+    const { container } = render(
+      <AssistantMessage
+        message={formMessage()}
+        streaming={false}
+        projectId="project-1"
+        conversationId="conv-1"
+        isLast
+        onSubmitQuestionForm={() => undefined}
+      />,
+    );
+    expect(footerLabel(container)).toBe('Awaiting your reply');
+    expect(screen.queryByText('Done')).toBeNull();
+  });
+
+  it('returns to Done once the immediate user reply submits the form', () => {
+    const { container } = render(
+      <AssistantMessage
+        message={formMessage()}
+        streaming={false}
+        projectId="project-1"
+        conversationId="conv-1"
+        isLast
+        nextUserContent={formatFormAnswers(PARSED_FORM, { audience: 'Founders' })}
+      />,
+    );
+    expect(footerLabel(container)).toBe('Done');
+  });
+
+  it('returns to Done once the form is skipped (skip submits through the same path)', () => {
+    const { container } = render(
+      <AssistantMessage
+        message={formMessage()}
+        streaming={false}
+        projectId="project-1"
+        conversationId="conv-1"
+        isLast
+        nextUserContent={formatFormAnswers(PARSED_FORM, {})}
+      />,
+    );
+    expect(footerLabel(container)).toBe('Done');
+  });
+
+  it('does not hold an older turn open: a non-last form is locked, not awaiting', () => {
+    const { container } = render(
+      <AssistantMessage
+        message={formMessage()}
+        streaming={false}
+        projectId="project-1"
+        conversationId="conv-1"
+        isLast={false}
+      />,
+    );
+    expect(footerLabel(container)).toBe('Done');
+  });
+
+  it('carries the same wording on the task activity card when tools ran before the form', () => {
+    render(
+      <AssistantMessage
+        message={formMessage([TOOL_EVENT])}
+        streaming={false}
+        projectId="project-1"
+        conversationId="conv-1"
+        isLast
+        onSubmitQuestionForm={() => undefined}
+      />,
+    );
+    const activity = screen.getByTestId('task-activity-toggle');
+    expect(activity.textContent).toContain('Awaiting your reply');
+    expect(activity.textContent).not.toContain('Done');
+    expect(activity.getAttribute('data-run-state')).toBe('completed');
+  });
+});

--- a/apps/web/tests/components/assistant-message-awaiting-reply.test.tsx
+++ b/apps/web/tests/components/assistant-message-awaiting-reply.test.tsx
@@ -112,6 +112,26 @@ describe('AssistantMessage run title while a question form waits (OPEND-2744)', 
     expect(footerLabel(container)).toBe('Done');
   });
 
+  it('does not wait on a form the run never closed (output limit hit mid-form)', () => {
+    // An unterminated <question-form> renders neither a form nor a skip once
+    // the run is terminal, so "Awaiting your reply" would point at nothing
+    // and never clear. The label falls back to Done.
+    const truncated = FORM.slice(0, FORM.indexOf('</question-form>') - 20);
+    const message = { ...formMessage(), content: truncated, events: [{ kind: 'text', text: truncated }] } as ChatMessage;
+    const { container } = render(
+      <AssistantMessage
+        message={message}
+        streaming={false}
+        projectId="project-1"
+        conversationId="conv-1"
+        isLast
+        onSubmitQuestionForm={() => undefined}
+      />,
+    );
+    expect(footerLabel(container)).toBe('Done');
+    expect(screen.queryByText('Awaiting your reply')).toBeNull();
+  });
+
   it('carries the same wording on the task activity card when tools ran before the form', () => {
     render(
       <AssistantMessage

--- a/apps/web/tests/styles/home-hero-preset-rows.test.ts
+++ b/apps/web/tests/styles/home-hero-preset-rows.test.ts
@@ -73,3 +73,53 @@ describe('home hero — placeholder caret', () => {
     expect(caret).not.toMatch(/border-radius/);
   });
 });
+
+describe('home hero — template row preview badge (OPEND-2697)', () => {
+  // Product: the eye is a secondary affordance. It must not compete with the
+  // row's "pick → fill the composer → send" main path, so it stays hidden at
+  // rest, fades in with the row's hover (or keyboard focus), sits on a
+  // translucent LIGHT ground rather than a dark scrim disc, and is one size
+  // step smaller than before (20 → 16).
+  const badge = declarations('.home-hero__plugin-preset-row-preview');
+  const reveal = declarations(
+    '.home-hero__plugin-preset-row:not(:disabled):hover .home-hero__plugin-preset-row-preview',
+  );
+
+  it('is hidden at rest and never a click target of its own', () => {
+    expect(badge).toMatch(/opacity:\s*0;/);
+    expect(badge).toMatch(/visibility:\s*hidden;/);
+    expect(badge).toMatch(/pointer-events:\s*none;/);
+  });
+
+  it('is one size step smaller, on a translucent light ground with dark ink', () => {
+    expect(badge).toMatch(/width:\s*16px;/);
+    expect(badge).toMatch(/height:\s*16px;/);
+    expect(declarations('.home-hero__plugin-preset-row-preview svg')).toMatch(/width:\s*11px;/);
+    expect(badge).toMatch(/background:\s*color-mix\(in srgb, #fff 82%, transparent\);/);
+    expect(badge).toMatch(/color:\s*#202020;/);
+    // No dark scrim disc anywhere on the badge, at rest or under the poster's
+    // own hover.
+    expect(badge).not.toMatch(/#000 55%/);
+    expect(declarations('.home-hero__plugin-preset-row-thumb:hover .home-hero__plugin-preset-row-preview'))
+      .not.toMatch(/#000/);
+  });
+
+  it('fades in over ~200ms and out over ~140ms on the shared ease-out curve', () => {
+    const curve = 'cubic-bezier\\(0\\.23, 1, 0\\.32, 1\\)';
+    // Rest state carries the EXIT timing (the transition that runs when hover
+    // leaves), hover carries the ENTER timing.
+    expect(badge).toMatch(new RegExp(`opacity 140ms ${curve}`));
+    expect(badge).toMatch(/visibility 0s linear 140ms/);
+    expect(reveal).toMatch(/opacity:\s*1;/);
+    expect(reveal).toMatch(/visibility:\s*visible;/);
+    expect(reveal).toMatch(new RegExp(`opacity 200ms ${curve}`));
+  });
+
+  it('shows for keyboard focus on the row as well as pointer hover', () => {
+    expect(
+      declarations(
+        '.home-hero__plugin-preset-row:not(:disabled):focus-visible .home-hero__plugin-preset-row-preview',
+      ),
+    ).toMatch(/opacity:\s*1;/);
+  });
+});

--- a/apps/web/tests/styles/home-hero-type-pills.test.ts
+++ b/apps/web/tests/styles/home-hero-type-pills.test.ts
@@ -1,0 +1,116 @@
+// Measurement spec for the type chips under the Home composer (原型 / 幻灯片 /
+// 文档) — OPEND-2684. The three lead chips carry a visible 1px ring and each
+// its own icon hue; the selected state is a light tint of that hue. Every
+// other chip (更多, the rest of the row) stays neutral.
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const homeHeroCss = readFileSync(
+  new URL('../../src/styles/home/home-hero.css', import.meta.url),
+  'utf8',
+);
+const tokensCss = readFileSync(
+  new URL('../../src/styles/tokens.css', import.meta.url),
+  'utf8',
+);
+
+function rules(css: string): Array<{ selectors: string[]; body: string }> {
+  const withoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  const out: Array<{ selectors: string[]; body: string }> = [];
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(withoutComments)) !== null) {
+    out.push({
+      selectors: (match[1] ?? '').split(',').map((item) => item.trim()),
+      body: match[2] ?? '',
+    });
+  }
+  return out;
+}
+
+function declarations(css: string, selector: string): string {
+  return rules(css)
+    .filter((rule) => rule.selectors.includes(selector))
+    .map((rule) => rule.body)
+    .join('\n');
+}
+
+const HUES = [
+  ['prototype', '--type-prototype'],
+  ['deck', '--type-deck'],
+  ['document', '--type-document'],
+] as const;
+
+describe('home hero — type chips (OPEND-2684)', () => {
+  it('every chip wears a clearly visible 1px ring on both themes', () => {
+    const pill = declarations(homeHeroCss, '.home-hero__type-pill');
+    // Mixed from the text ink, not a fixed light gray: 20% of --text is a
+    // visible outline on a white page AND on the dark panel, where #EDEDED
+    // used to vanish into the ground.
+    expect(pill).toMatch(
+      /border:\s*1px solid color-mix\(in srgb, var\(--text\) 20%, transparent\);/,
+    );
+  });
+
+  it('the three lead chips each carry their own icon hue; the label stays ink', () => {
+    for (const [chipId, token] of HUES) {
+      const chip = declarations(homeHeroCss, `.home-hero__type-pill[data-chip='${chipId}']`);
+      expect(chip, chipId).toMatch(new RegExp(`--type-pill-hue:\\s*var\\(${token}\\);`));
+    }
+    const icon = declarations(homeHeroCss, '.home-hero__type-pill > .od-icon');
+    expect(icon).toMatch(/color:\s*var\(--type-pill-hue, currentColor\);/);
+    // The label keeps the strong ink at rest — colour lives on the icon only.
+    expect(declarations(homeHeroCss, '.home-hero__type-pill')).toMatch(
+      /color:\s*var\(--text-strong\);/,
+    );
+  });
+
+  it('the composer pill naming a picked lead type is a light tint of that hue, not the brand green', () => {
+    // Picking a type retires the type row, so the selected state lives on the
+    // composer's template pill (`TemplatePicker` stamps `data-chip`).
+    const pill = (chipId: string) =>
+      `.home-hero__footer-option--select.home-hero__template-option.has-selection[data-field-name='template'][data-chip='${chipId}']`;
+    for (const [chipId, token] of HUES) {
+      expect(declarations(homeHeroCss, pill(chipId)), chipId).toMatch(
+        new RegExp(`--type-pill-hue:\\s*var\\(${token}\\);`),
+      );
+    }
+    const active = declarations(homeHeroCss, pill('prototype'));
+    expect(active).toMatch(
+      /background-color:\s*color-mix\(in srgb, var\(--type-pill-hue\) 10%, transparent\);/,
+    );
+    expect(active).toMatch(
+      /box-shadow:\s*inset 0 0 0 1px color-mix\(in srgb, var\(--type-pill-hue\) 36%, transparent\);/,
+    );
+    expect(active).toMatch(/color:\s*var\(--text-strong\);/);
+    // One rule covers all three lead types; the icon takes the hue and the
+    // label stays ink.
+    const rule = rules(homeHeroCss).find(
+      (item) => item.selectors.includes(pill('prototype')) && /background-color/.test(item.body),
+    );
+    expect(rule?.selectors).toEqual(expect.arrayContaining([pill('deck'), pill('document')]));
+    expect(
+      declarations(
+        homeHeroCss,
+        ".home-hero__template-option.has-selection[data-chip='prototype'] .home-hero__footer-option-icon",
+      ),
+    ).toMatch(/color:\s*var\(--type-pill-hue\);/);
+    expect(
+      declarations(
+        homeHeroCss,
+        ".home-hero__template-option.has-selection[data-chip='prototype'] .home-hero__footer-select-label",
+      ),
+    ).toMatch(/color:\s*var\(--text-strong\);/);
+  });
+
+  it('the hues are tokens with a value on the light root and on both dark entry points', () => {
+    const light = declarations(tokensCss, ':root');
+    const darkExplicit = declarations(tokensCss, '[data-theme="dark"]');
+    const darkSystem = declarations(tokensCss, '@media (prefers-color-scheme: dark)');
+    for (const [, token] of HUES) {
+      expect(light, `${token} light`).toMatch(new RegExp(`${token}:\\s*[^;]+;`));
+      expect(darkExplicit, `${token} dark`).toMatch(new RegExp(`${token}:\\s*[^;]+;`));
+      expect(darkSystem, `${token} dark system`).toMatch(new RegExp(`${token}:\\s*[^;]+;`));
+    }
+  });
+});


### PR DESCRIPTION
## Why

OPEND-2553 首页链路一期第三批（PR-F4）。第二轮验收在首页与项目页上留下四条视觉 / 文案问题，产品已逐条拍板方案；本 PR 把它们一次收口，base 是一期长期分支 `feat/home-entry-refresh`，与并行的 F5（左栏折叠按钮移顶栏）、F6（发送后乐观进入 pending 页）不共享文件（本 PR 对 `EntryShell.tsx` 只改社区 dock 那一处挂载）。

- **OPEND-2697**（孙庆雨）模板行缩略图上的眼睛预览按钮是深色圆底、视觉权重压过了「选 Prompt → 填入输入框 → 发送」这条主流程。
- **OPEND-2684**（孙庆雨）「原型 / 幻灯片 / 文档」三个 Chip 外框弱到看不见，配色单一，入口辨识度不足。
- **OPEND-2744** 项目页里 run 已 succeeded、但会话中还有未回答的 `<question-form>` 时，运行标题写「已完成」，与左栏 awaiting 状态球冲突，容易误判项目已结束（产品选 A：改文案）。
- **OPEND-2793** 社区页底部常驻与首页相同的对话输入框，但与当前作品、分类、搜索没有任何上下文关系，还遮挡底部卡片（产品选 B：先摘掉，阶段三按带作品上下文的形态做回来）。

## What users will see

- **模板行**：默认不再看到眼睛按钮；鼠标移到某一行（或键盘 Tab 到该行）时，缩略图右上角淡入一枚 16px 的浅色半透明眼睛（约 200ms 进、140ms 出，同一 ease-out 曲线）；移到缩略图上时浅底更实一点。整块缩略图仍是预览的点击目标，行本身仍是选择。
- **类型 Chip**：三个 Chip（以及「更多」）都有一圈清晰可见的 1px 外框，hover 时加深；「原型」蓝、「幻灯片」橙、「文档」绿各自的图标带色，文字保持深色。选中某个类型后，输入框里命名该类型的胶囊改为对应色的 10% 浅底 + 同色描边，图标同色、文字深色；其它类型（图片 / 视频 / 音频 / …）与「更多」保持原来的中性 / 品牌绿。深色主题下三色有各自的深色取值（幻灯片保持橙而不是 `--amber` 的黄）。
- **项目页运行标题**：最后一轮 run 已完成但表单还没答时，助手消息顶部的任务卡片状态与底部页脚都显示「等待回复」（en: Awaiting your reply）；用户提交或点「跳过」后立刻回到「已完成」。更早的、已锁定的表单，以及失败 / 取消的 run 不受影响。
- **社区页**：底部不再有对话输入框，作品卡片可以用满页面高度。卡片上的「使用」会把提示词和模板一起交给首页输入框并跳到首页（与独立 `/community` 路由已有的行为一致）。

## Surface area

- [x] **UI** — 首页模板行、类型 Chip 与已选类型胶囊、项目页运行标题、社区页底部
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — `assistant.awaitingReplyLabel`（19 个 locale）
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [x] **Default behavior change** — 社区页不再渲染底部输入框（产品决定，阶段三再设计）；社区卡片「使用」改为跳回首页
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

改前为 `feat/home-entry-refresh` 头 549b2703ec，改后为本分支；两套 `tools-dev` 运行时并排，同一 Playwright 脚本、同一造数（daemon HTTP API 写入一条 run 已 succeeded 且带未答 `<question-form>` 的助手消息）。

**OPEND-2697 模板行眼睛按钮**（默认 / hover 行 / hover 缩略图 / 键盘 focus）

![rows](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f4/f4-rows.png)

**OPEND-2684 类型 Chip 默认与 hover（浅 / 深）**

![chips](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f4/f4-chips-default.png)

**OPEND-2684 选中态：输入框里的已选类型胶囊（浅 / 深 × 原型 / 幻灯片 / 文档）**

![chips selected](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f4/f4-chips-selected.png)

**OPEND-2744 运行标题**（改前 / 改后 / 写入答复后重载）

![awaiting](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f4/f4-awaiting-title.png)

![awaiting page](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f4/f4-awaiting-page.png)

**OPEND-2793 社区页底部**

![community](https://raw.githubusercontent.com/Siri-Ray/open-design/assets/opend-2553-f4/f4-community.png)

### 最终取值

| 项 | 取值 |
|---|---|
| 眼睛按钮尺寸 | 16px 圆（原 20px），图标 11px（原 13px），`top/right: 4px` 不变 |
| 眼睛按钮底色 | `color-mix(in srgb, #fff 82%, transparent)`，缩略图 hover 时 96%；1px 描边 `color-mix(in srgb, #000 10%, transparent)`；图标 `#202020`（原 55% / 72% 黑底白图标） |
| 眼睛按钮动效 | 进 `opacity 200ms cubic-bezier(0.23, 1, 0.32, 1)`，出 140ms 同曲线，`visibility` 随之延时；`pointer-events: none` 不变 |
| Chip 外框 | `1px solid color-mix(in srgb, var(--text) 20%, transparent)`（原 `var(--bg-subtle)` = #EDEDED）；hover 40%（原 `--bg-subtle` 82% 混 `--text`） |
| 三色 token | 浅色 `--type-prototype: var(--blue)` #1A74FF、`--type-deck: var(--amber)` #FF7528、`--type-document: var(--green)` #00AA54；深色 #3AA5F0 / #FF9A5C / #3BBF7D |
| 选中胶囊 | 底 `color-mix(in srgb, var(--type-pill-hue) 10%, transparent)`，内描边 1px 36%，图标取 hue，文字 `--text-strong` |
| 运行标题 | `assistant.awaitingReplyLabel`：zh-CN「等待回复」/ en「Awaiting your reply」 |

### 与 Demo #7635 的差异

三方 diff（`78baa5228..upstream/pr-7635-new` vs 本分支）确认 Demo 在眼睛按钮、类型 Chip、运行标题、社区 dock 四处都没有相关改动：眼睛按钮与 Chip 外框 / 配色是产品在验收后新给的方向，Demo 仍是 20px 深色圆底与 #EDEDED 外框；「等待回复」文案与社区 dock 摘除是产品在 2744 / 2793 上的决定，Demo 的社区页带 dock。因此这四处都是相对 Demo 的**有意偏离**。

### 实现说明

- 类型行在选中后整体退场（`HomeHero` 里 `activeChipId ? null : <TypePillRow>`），所以「选中态」落在输入框里命名该类型的胶囊（`TemplatePicker`）上，通过 `data-chip` 键控；`TypePillRow` 同样打上 `data-chip` 供图标着色。
- 「未回答」复用 `AssistantMessage` 既有的 `hasPendingQuestionForm`（`parseSubmittedAnswers` 判定下一条用户消息是否回答了该表单，跳过走同一路径），只加了一个 `awaitingReply` 派生值传给页脚与任务卡片，没有另写检测。
- 社区 dock：只摘掉 `EntryShell` 里的挂载，`HomeView` / `HomeHero` 的 `dock` variant 与 `home-intent.ts` 的 dock 槽位保留；`dockPromptHandoff` 状态随之删除，`onUsePrompt` 改走 `setHomePromptHandoff + changeView('home')`。`.community-composer-dock` 的样式块保留待阶段三复用。

## Bug fix verification

- OPEND-2697：`apps/web/tests/styles/home-hero-preset-rows.test.ts`（新增 describe「template row preview badge」，4 例）
- OPEND-2684：`apps/web/tests/styles/home-hero-type-pills.test.ts`（新增，4 例，含三色 token 在 `:root` / `[data-theme="dark"]` / `prefers-color-scheme` 三处都有值）
- OPEND-2744：`apps/web/tests/components/assistant-message-awaiting-reply.test.tsx`（新增，5 例：等待 / 提交后 / 跳过后 / 非最后一轮 / 任务卡片）
- OPEND-2793：`apps/web/tests/components/EntryShell.blank-project-naming.test.tsx`（原「社区 dock 存在」用例改为断言不存在且 shell 里只有一个 composer）
- 四个文件在改源码前跑过一次：9 例红（其余为既有行为的护栏，本来就绿），改后全绿。

## Validation

- `pnpm guard` ✅
- `pnpm typecheck` ✅
- `pnpm --filter @open-design/web test`：694 文件、7358 通过、1 expected fail、11 skipped ✅
- `pnpm i18n:check` ✅
- `pnpm --filter @open-design/e2e typecheck` ✅（e2e 里没有依赖社区 dock 的用例；`community-template-modal-mapping` 走的是 `onUsePlugin` → 首页，不受影响）
- 本地 `pnpm tools-dev run web --namespace f4-polish --daemon-port 17810 --web-port 17910` 与基线 `f4-base`（17820/17920）并排截图，见上；运行标题用 daemon HTTP API 写入答复后重载核过回到「已完成」。

## Adjacent issues

- 深色主题目前被 `appearance.ts` 的 `FORCED_APP_THEME` 钉在 light；上面的深色截图是加载后手动切 `data-theme=dark` 取的 token 值，正式深色回归时再复核。
- 「跳过」在本地环境无法直接落库验证（daemon 无可用 agent 时 `POST /api/chat` 被拒），文案切换靠单测与 API 写入答复的方式核过。
