### PR TITLE
fix(daemon): carry a plugin's declared MCP servers onto its run

### DIFF
--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -174,6 +174,7 @@ import { classifyRunFailure } from '../run-failure-classification.js';
 import { deriveRunErrorCode, runResultFromStatus } from '../run-result.js';
 import type { RunStatusForAnalytics } from '../run-result.js';
 import {
+  mergeSnapshotMcpServersIntoToolBundle,
   parseRunToolBundleForRequest,
   validateRunToolBundleForAgent,
 } from '../run-tool-bundle.js';
@@ -2127,6 +2128,13 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         ).trim();
         if (renderedQuery.length > 0) meta.message = renderedQuery;
       }
+      // The plugin's own MCP servers are a default, not an override: fold
+      // them in under whatever the caller already put in toolBundle so an
+      // explicit run-scoped entry always wins on a name collision.
+      meta.toolBundle = mergeSnapshotMcpServersIntoToolBundle(
+        toolBundle.bundle,
+        resolvedSnapshot.snapshot.mcpServers,
+      );
     }
     if (clarificationContinuation) {
       applyClarificationContinuationMeta(meta, clarificationContinuation);

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -178,6 +178,7 @@ import {
   parseRunToolBundleForRequest,
   validateRunToolBundleForAgent,
 } from '../run-tool-bundle.js';
+import type { RunToolBundle } from '../run-tool-bundle.js';
 import type { DetectedAgent, RuntimeAgentDef } from '../runtimes/types.js';
 import {
   buildOpenCodeByokProviderConfig,
@@ -2105,10 +2106,16 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         resolvedSnapshot = resolved;
       }
     }
+    // Tracks the tool bundle actually attached to this run: the request's
+    // bundle, or that bundle merged with an applied plugin snapshot's MCP
+    // servers below. Kept as its own typed binding (rather than reading back
+    // through `meta.toolBundle`, which widens to `unknown`) so validation can
+    // be run against whichever one this run ends up with.
+    let effectiveToolBundle: RunToolBundle = toolBundle.bundle;
     const meta: RunCreateMeta = {
       ...withoutSensitiveRunInput(requestBody),
       mediaExecution: mediaExecution.policy,
-      toolBundle: toolBundle.bundle,
+      toolBundle: effectiveToolBundle,
       ...(effectiveAgentId ? { agentId: effectiveAgentId } : {}),
       // Always replace any untrusted request field, including with null for an
       // unbound project.
@@ -2131,10 +2138,11 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       // The plugin's own MCP servers are a default, not an override: fold
       // them in under whatever the caller already put in toolBundle so an
       // explicit run-scoped entry always wins on a name collision.
-      meta.toolBundle = mergeSnapshotMcpServersIntoToolBundle(
+      effectiveToolBundle = mergeSnapshotMcpServersIntoToolBundle(
         toolBundle.bundle,
         resolvedSnapshot.snapshot.mcpServers,
       );
+      meta.toolBundle = effectiveToolBundle;
     }
     if (clarificationContinuation) {
       applyClarificationContinuationMeta(meta, clarificationContinuation);
@@ -2195,7 +2203,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       );
     }
     const toolBundleSupport = validateRunToolBundleForAgent(
-      toolBundle.bundle,
+      effectiveToolBundle,
       typeof meta.agentId === 'string' ? getAgentDef(meta.agentId) : null,
       {
         deliveryTarget: runToolBundleDeliveryTargetForProject(

--- a/apps/daemon/src/run-tool-bundle.ts
+++ b/apps/daemon/src/run-tool-bundle.ts
@@ -1,3 +1,4 @@
+import type { McpServerSpec } from '@open-design/contracts';
 import type { McpAuthMode, McpServerConfig, McpTransport } from './mcp-config.js';
 import type { RuntimeAgentDef } from './runtimes/types.js';
 import { sanitizeMcpConfig, sanitizeMcpServer } from './mcp-config.js';
@@ -182,4 +183,48 @@ export function resolveExternalMcpServersForRun({
     enabledServers: Array.from(byId.values()).filter((server) => server.enabled),
     persistedTokenServerIds,
   };
+}
+
+/**
+ * Adapts a plugin manifest's declared MCP server (`od.context.mcp[]`, frozen
+ * onto the snapshot as `McpServerSpec` — `name`/`command`/`args`/`env`/`url`)
+ * into the run-scoped `McpServerConfig` shape (`id`/`transport`/`enabled`)
+ * the tool bundle understands. Runs through the same `sanitizeMcpServer()`
+ * guard every other run-scoped or persisted MCP entry goes through, so a
+ * malformed manifest entry is dropped rather than corrupting the bundle.
+ * Trust is not re-checked here: `resolvePluginSnapshot()` already required
+ * the scoped `mcp:<name>` capability before this snapshot could be created
+ * (see `plugins/resolve-snapshot.ts` and `plugins/trust.ts`).
+ */
+function mcpServerConfigFromPluginSpec(spec: McpServerSpec): McpServerConfig | null {
+  return sanitizeMcpServer({
+    id: spec.name,
+    transport: spec.command ? 'stdio' : 'http',
+    command: spec.command,
+    args: spec.args,
+    env: spec.env,
+    url: spec.url,
+  });
+}
+
+/**
+ * Folds an applied plugin snapshot's declared MCP servers into a run's tool
+ * bundle. The snapshot's servers are the default; a caller-supplied entry
+ * with the same id wins on collision, since it names an explicit choice for
+ * *this* run rather than the plugin's baseline. Mirrors the precedence
+ * `resolveExternalMcpServersForRun` already uses for persisted vs. run-scoped
+ * servers (run-scoped applied last into the same id-keyed map).
+ */
+export function mergeSnapshotMcpServersIntoToolBundle(
+  bundle: RunToolBundle,
+  snapshotMcpServers: McpServerSpec[],
+): RunToolBundle {
+  if (snapshotMcpServers.length === 0) return bundle;
+  const byId = new Map<string, McpServerConfig>();
+  for (const spec of snapshotMcpServers) {
+    const server = mcpServerConfigFromPluginSpec(spec);
+    if (server) byId.set(server.id, server);
+  }
+  for (const server of bundle.mcpServers) byId.set(server.id, server);
+  return { mcpServers: Array.from(byId.values()) };
 }

--- a/apps/daemon/tests/run-plugin-snapshot-mcp-bundle.test.ts
+++ b/apps/daemon/tests/run-plugin-snapshot-mcp-bundle.test.ts
@@ -33,6 +33,7 @@ import type { McpServerSpec } from '@open-design/contracts';
 
 let server: http.Server | null = null;
 let tempDir: string | null = null;
+let externalProjectDir: string | null = null;
 let lastCreatedRun: any = null;
 
 afterEach(async () => {
@@ -44,10 +45,16 @@ afterEach(async () => {
   closeDatabase();
   if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
   tempDir = null;
+  if (externalProjectDir) fs.rmSync(externalProjectDir, { recursive: true, force: true });
+  externalProjectDir = null;
   lastCreatedRun = null;
 });
 
 const PROJECT_ID = 'p-mcp-join';
+// A folder-imported project: `metadata.baseDir` points outside PROJECTS_DIR,
+// so `runToolBundleDeliveryTargetForProject` resolves it to 'external-project'
+// rather than 'managed-project' — the same shape `/api/import/folder` produces.
+const EXTERNAL_PROJECT_ID = 'p-mcp-join-external';
 
 function sendApiError(
   res: any,
@@ -59,10 +66,10 @@ function sendApiError(
   return res.status(status).json({ error: { code, message, ...details } });
 }
 
-function seedPluginSnapshot(mcpServers: McpServerSpec[]) {
+function seedPluginSnapshot(mcpServers: McpServerSpec[], projectId: string = PROJECT_ID) {
   const db = openDatabase(tempDir!);
   const snapshot = createSnapshot(db, {
-    projectId: PROJECT_ID,
+    projectId,
     conversationId: null,
     runId: null,
     pluginId: 'mcp-join-plugin',
@@ -85,7 +92,7 @@ function seedPluginSnapshot(mcpServers: McpServerSpec[]) {
     mcpServers,
     query: 'Use the fixture MCP server',
   });
-  linkSnapshotToProject(db, snapshot.snapshotId, PROJECT_ID);
+  linkSnapshotToProject(db, snapshot.snapshotId, projectId);
   return snapshot;
 }
 
@@ -142,9 +149,17 @@ function createRunsServiceStub() {
 
 async function startTestServer(): Promise<string> {
   tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-run-mcp-join-'));
+  externalProjectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-run-mcp-join-external-'));
   const db = openDatabase(tempDir);
   const now = Date.now();
   insertProject(db, { id: PROJECT_ID, name: PROJECT_ID, createdAt: now, updatedAt: now });
+  insertProject(db, {
+    id: EXTERNAL_PROJECT_ID,
+    name: EXTERNAL_PROJECT_ID,
+    metadata: { baseDir: externalProjectDir },
+    createdAt: now,
+    updatedAt: now,
+  });
   // Deliberately no workspace_projects row: this project is unbound, the
   // same "headerless local run" case `run-create-workspace-gate.test.ts`
   // asserts stays open, so POST /api/runs needs no x-od-workspace-* headers.
@@ -165,13 +180,25 @@ async function startTestServer(): Promise<string> {
     paths: { PROJECTS_DIR: tempDir, RUNTIME_DATA_DIR: tempDir },
     agents: {
       detectAgents: async () => [],
-      // 'acp-merge' accepts any stdio-transport run-scoped MCP server
-      // regardless of delivery target, so the stub doesn't need to model a
-      // daemon-managed project just to clear `validateRunToolBundleForAgent`.
-      getAgentDef: (agentId: string) =>
-        agentId === 'claude'
-          ? { id: 'claude', name: 'Claude Code', externalMcpInjection: 'acp-merge' }
-          : null,
+      getAgentDef: (agentId: string) => {
+        // 'acp-merge' accepts any stdio-transport run-scoped MCP server
+        // regardless of delivery target, so the stub doesn't need to model a
+        // daemon-managed project just to clear `validateRunToolBundleForAgent`.
+        if (agentId === 'claude') {
+          return { id: 'claude', name: 'Claude Code', externalMcpInjection: 'acp-merge' };
+        }
+        // 'claude-mcp-json' only receives run-scoped servers via project
+        // .mcp.json, which `validateRunToolBundleForAgent` gates on the run's
+        // delivery target being a daemon-managed project.
+        if (agentId === 'claude-mcp-json') {
+          return {
+            id: 'claude-mcp-json',
+            name: 'Claude Code (mcp.json)',
+            externalMcpInjection: 'claude-mcp-json',
+          };
+        }
+        return null;
+      },
     },
     chat: { startChatRun: async () => undefined },
     byokCredentials: { has: async () => false },
@@ -351,5 +378,44 @@ describe('POST /api/runs — applied plugin snapshot MCP servers', () => {
         args: ['override.js'],
       }),
     ]);
+  });
+});
+
+describe('POST /api/runs — snapshot-merged tool bundle is validated, not the pre-merge request bundle', () => {
+  // A run started with no explicit `toolBundle` has an empty PRE-merge bundle
+  // (zero enabled servers), which `validateRunToolBundleForAgent` always
+  // waves through regardless of agent or delivery target. If the route
+  // validated that pre-merge bundle instead of the one actually attached to
+  // the run, a plugin snapshot's MCP server would ride along unvalidated —
+  // for `claude-mcp-json`, silently reproducing the exact bug this whole
+  // snapshot-merge feature exists to fix, but only for imported-folder
+  // projects: the daemon has no way to deliver that server (no managed-project
+  // `.mcp.json` to write it into), so Claude Code simply never gets it, with
+  // no error surfaced anywhere.
+  it('rejects a snapshot MCP server for claude-mcp-json on an imported-folder project, even with no request-supplied toolBundle', async () => {
+    const baseUrl = await startTestServer();
+    const snapshot = seedPluginSnapshot(
+      [{ name: 'bookboost-twig', command: 'node', args: ['/srv/twig-mcp/server.js'] }],
+      EXTERNAL_PROJECT_ID,
+    );
+
+    const response = await fetch(`${baseUrl}/api/runs`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        projectId: EXTERNAL_PROJECT_ID,
+        agentId: 'claude-mcp-json',
+        appliedPluginSnapshotId: snapshot.snapshotId,
+        message: 'apply the plugin on an imported folder',
+        // No toolBundle at all: the pre-merge request bundle is empty.
+      }),
+    });
+
+    const responseText = await response.text();
+    expect(response.status, responseText).toBe(400);
+    const body = JSON.parse(responseText) as { error?: { message?: string } };
+    expect(body.error?.message).toContain('requires a daemon-managed project');
+    // The rejection must happen before a run is ever created.
+    expect(lastCreatedRun).toBeNull();
   });
 });

--- a/apps/daemon/tests/run-plugin-snapshot-mcp-bundle.test.ts
+++ b/apps/daemon/tests/run-plugin-snapshot-mcp-bundle.test.ts
@@ -1,0 +1,355 @@
+// Join test for the applied-plugin-snapshot -> run tool-bundle gap.
+//
+// `od.context.mcp[]` on a plugin manifest is persisted correctly onto the
+// applied snapshot (`plugins/apply.ts` -> `plugins/snapshots.ts`, covered by
+// `plugins-snapshots.test.ts`), but nothing carried those servers onto a
+// run's tool bundle: `POST /api/runs` built `toolBundle` solely from the
+// request body, so applying a plugin never actually attached its MCP
+// server to a run. This file exercises the join at the route layer
+// (`routes/runs.ts`) directly, the same way `run-create-workspace-gate.test.ts`
+// does for its own POST /api/runs scenarios, rather than re-proving the
+// plugin apply/persist half (already covered elsewhere).
+
+import express from 'express';
+import http from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  closeDatabase,
+  getWorkspaceProject,
+  getWorkspaceProjectByProjectId,
+  insertProject,
+  openDatabase,
+} from '../src/db.js';
+import { createSnapshot, linkSnapshotToProject } from '../src/plugins/snapshots.js';
+import { createAuthorizeProjectRequest } from '../src/collab/project-request-authority.js';
+import { createEnforceWorkspaceProjectMutation } from '../src/routes/project/index.js';
+import { registerRunRoutes } from '../src/routes/runs.js';
+import { connectorService } from '../src/connectors/service.js';
+import type { McpServerSpec } from '@open-design/contracts';
+
+let server: http.Server | null = null;
+let tempDir: string | null = null;
+let lastCreatedRun: any = null;
+
+afterEach(async () => {
+  if (server) {
+    const toClose = server;
+    server = null;
+    await new Promise<void>((resolve) => toClose.close(() => resolve()));
+  }
+  closeDatabase();
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  tempDir = null;
+  lastCreatedRun = null;
+});
+
+const PROJECT_ID = 'p-mcp-join';
+
+function sendApiError(
+  res: any,
+  status: number,
+  code: string,
+  message: string,
+  details: Record<string, unknown> = {},
+) {
+  return res.status(status).json({ error: { code, message, ...details } });
+}
+
+function seedPluginSnapshot(mcpServers: McpServerSpec[]) {
+  const db = openDatabase(tempDir!);
+  const snapshot = createSnapshot(db, {
+    projectId: PROJECT_ID,
+    conversationId: null,
+    runId: null,
+    pluginId: 'mcp-join-plugin',
+    pluginVersion: '1.0.0',
+    pluginTitle: 'MCP Join Fixture',
+    pluginDescription: 'Fixture plugin declaring an MCP server for the run join test.',
+    manifestSourceDigest: 'mcp-join-digest',
+    sourceMarketplaceId: null,
+    pinnedRef: null,
+    taskKind: 'new-generation',
+    inputs: {},
+    resolvedContext: { items: [] },
+    pipeline: undefined,
+    genuiSurfaces: [],
+    capabilitiesGranted: ['prompt:inject', 'mcp:*'],
+    capabilitiesRequired: ['prompt:inject'],
+    assetsStaged: [],
+    connectorsRequired: [],
+    connectorsResolved: [],
+    mcpServers,
+    query: 'Use the fixture MCP server',
+  });
+  linkSnapshotToProject(db, snapshot.snapshotId, PROJECT_ID);
+  return snapshot;
+}
+
+// A minimal in-memory ChatRunService stub, modeled on the one in
+// `run-create-workspace-gate.test.ts`. It deliberately never spawns a
+// process — this test only asserts on what `registerRunRoutes` hands to
+// `design.runs.create(meta)`, specifically `meta.toolBundle`.
+function createRunsServiceStub() {
+  const runs = new Map<string, unknown>();
+  let seq = 0;
+  return {
+    create(meta: any) {
+      const run = {
+        id: `run-${++seq}`,
+        projectId: typeof meta.projectId === 'string' ? meta.projectId : null,
+        conversationId: null,
+        assistantMessageId:
+          typeof meta.assistantMessageId === 'string' ? meta.assistantMessageId : null,
+        agentId: typeof meta.agentId === 'string' ? meta.agentId : null,
+        message: meta.message,
+        currentPrompt: meta.currentPrompt,
+        appliedPluginSnapshotId: meta.appliedPluginSnapshotId,
+        clientRequestId: meta.clientRequestId,
+        requestFingerprint: meta.requestFingerprint,
+        workspaceScope: meta.workspaceScope,
+        toolBundle: meta.toolBundle,
+        status: 'queued',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        events: [],
+        clients: new Set(),
+      };
+      runs.set(run.id, run);
+      lastCreatedRun = run;
+      return run;
+    },
+    createOrReuse(meta: any) {
+      return { kind: 'created' as const, run: this.create(meta) };
+    },
+    get: (id: string) => runs.get(id) ?? null,
+    list: () => Array.from(runs.values()),
+    statusBody: (run: any) => ({ ...run }),
+    stream: (run: any, req: any, res: any) => {
+      res.status(req.method === 'GET' ? 200 : 202).json({ runId: run.id });
+    },
+    start: (run: any) => run,
+    fail: () => {},
+    wait: async () => ({ status: 'succeeded' }),
+    cancel: async (run: any) => run,
+    isTerminal: (status: string) =>
+      status === 'succeeded' || status === 'failed' || status === 'canceled',
+  };
+}
+
+async function startTestServer(): Promise<string> {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-run-mcp-join-'));
+  const db = openDatabase(tempDir);
+  const now = Date.now();
+  insertProject(db, { id: PROJECT_ID, name: PROJECT_ID, createdAt: now, updatedAt: now });
+  // Deliberately no workspace_projects row: this project is unbound, the
+  // same "headerless local run" case `run-create-workspace-gate.test.ts`
+  // asserts stays open, so POST /api/runs needs no x-od-workspace-* headers.
+
+  const app = express();
+  app.use(express.json());
+  registerRunRoutes(app, {
+    db,
+    design: {
+      runs: createRunsServiceStub(),
+      analytics: { capture: () => {} },
+      getAppVersion: () => 'test',
+    },
+    http: {
+      createSseResponse: () => ({ send() {}, end() {}, cleanup() {} }),
+      sendApiError,
+    },
+    paths: { PROJECTS_DIR: tempDir, RUNTIME_DATA_DIR: tempDir },
+    agents: {
+      detectAgents: async () => [],
+      // 'acp-merge' accepts any stdio-transport run-scoped MCP server
+      // regardless of delivery target, so the stub doesn't need to model a
+      // daemon-managed project just to clear `validateRunToolBundleForAgent`.
+      getAgentDef: (agentId: string) =>
+        agentId === 'claude'
+          ? { id: 'claude', name: 'Claude Code', externalMcpInjection: 'acp-merge' }
+          : null,
+    },
+    chat: { startChatRun: async () => undefined },
+    byokCredentials: { has: async () => false },
+    lifecycle: { isDaemonShuttingDown: () => false },
+    plugins: {
+      connectorService,
+      detectSkillPluginCandidateOnRunSuccess: () => {},
+      firePipelineForRun: () => {},
+      loadPluginRegistryView: async () => ({}) as never,
+      renderPluginBriefTemplate: (template: string) => template,
+    },
+    telemetry: {
+      reportRunCompletionTelemetryFallback: () => {},
+      resolveRunProjectKindForAnalytics: () => null,
+      runArtifactBaselines: { take: () => undefined },
+      runRetryEventsForAnalytics: () => [],
+    },
+    messages: {
+      pinAssistantMessageOnRunCreate: (_db: any, _run: any, options?: any) => {
+        options?.beforeClaimCommit?.();
+        return { ok: true };
+      },
+      reconcileAssistantMessageOnRunEnd: () => {},
+    },
+    enforceWorkspaceProjectMutation: createEnforceWorkspaceProjectMutation(),
+    amrWorkspaceScope: { isSignedIn: () => false },
+    authorizeProjectRequest: createAuthorizeProjectRequest({
+      db,
+      getWorkspaceProject: (dbArg: unknown, workspaceId: string, projectId: string) =>
+        getWorkspaceProject(dbArg as ReturnType<typeof openDatabase>, workspaceId, projectId),
+      getWorkspaceProjectByProjectId: (dbArg: unknown, projectId: string) =>
+        getWorkspaceProjectByProjectId(dbArg as ReturnType<typeof openDatabase>, projectId),
+      sendApiError,
+    }),
+    projectStore: {
+      getWorkspaceProject,
+      getWorkspaceProjectByProjectId,
+      ensureWorkspaceProject: () => {},
+    },
+  } as any);
+
+  const created = http.createServer(app);
+  server = created;
+  await new Promise<void>((resolve) => created.listen(0, resolve));
+  const address = created.address();
+  const port = typeof address === 'object' && address ? address.port : 0;
+  return `http://127.0.0.1:${port}`;
+}
+
+describe('POST /api/runs — applied plugin snapshot MCP servers', () => {
+  it('folds a snapshot-declared MCP server into a run started with no explicit toolBundle', async () => {
+    const baseUrl = await startTestServer();
+    const snapshot = seedPluginSnapshot([
+      { name: 'bookboost-twig', command: 'node', args: ['/srv/twig-mcp/server.js'] },
+    ]);
+
+    const response = await fetch(`${baseUrl}/api/runs`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        projectId: PROJECT_ID,
+        agentId: 'claude',
+        appliedPluginSnapshotId: snapshot.snapshotId,
+        message: 'apply the plugin',
+      }),
+    });
+
+    const responseText = await response.text();
+    expect(response.status, responseText).toBe(202);
+    expect(lastCreatedRun.toolBundle?.mcpServers).toEqual([
+      expect.objectContaining({
+        id: 'bookboost-twig',
+        transport: 'stdio',
+        command: 'node',
+        args: ['/srv/twig-mcp/server.js'],
+      }),
+    ]);
+  });
+
+  it('leaves the run tool bundle empty when no appliedPluginSnapshotId is supplied', async () => {
+    const baseUrl = await startTestServer();
+
+    const response = await fetch(`${baseUrl}/api/runs`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        projectId: PROJECT_ID,
+        agentId: 'claude',
+        message: 'no plugin involved',
+      }),
+    });
+
+    const responseText = await response.text();
+    expect(response.status, responseText).toBe(202);
+    expect(lastCreatedRun.toolBundle?.mcpServers).toEqual([]);
+  });
+
+  it('leaves an explicit toolBundle untouched when no appliedPluginSnapshotId is supplied', async () => {
+    const baseUrl = await startTestServer();
+
+    const response = await fetch(`${baseUrl}/api/runs`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        projectId: PROJECT_ID,
+        agentId: 'claude',
+        message: 'caller brought its own server',
+        toolBundle: {
+          mcpServers: [{ id: 'caller-tools', transport: 'stdio', command: 'node' }],
+        },
+      }),
+    });
+
+    const responseText = await response.text();
+    expect(response.status, responseText).toBe(202);
+    expect(lastCreatedRun.toolBundle?.mcpServers).toEqual([
+      expect.objectContaining({ id: 'caller-tools', transport: 'stdio', command: 'node' }),
+    ]);
+  });
+
+  it('merges a snapshot server alongside a differently-named explicit server', async () => {
+    const baseUrl = await startTestServer();
+    const snapshot = seedPluginSnapshot([
+      { name: 'bookboost-twig', command: 'node', args: ['server.js'] },
+    ]);
+
+    const response = await fetch(`${baseUrl}/api/runs`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        projectId: PROJECT_ID,
+        agentId: 'claude',
+        appliedPluginSnapshotId: snapshot.snapshotId,
+        message: 'both a plugin default and a caller-supplied server',
+        toolBundle: {
+          mcpServers: [{ id: 'caller-tools', transport: 'stdio', command: 'python' }],
+        },
+      }),
+    });
+
+    const responseText = await response.text();
+    expect(response.status, responseText).toBe(202);
+    const ids = (lastCreatedRun.toolBundle?.mcpServers as Array<{ id: string }>)
+      .map((server) => server.id)
+      .sort();
+    expect(ids).toEqual(['bookboost-twig', 'caller-tools']);
+  });
+
+  it('lets an explicit request-scoped server win a name collision with the snapshot default', async () => {
+    const baseUrl = await startTestServer();
+    const snapshot = seedPluginSnapshot([
+      { name: 'bookboost-twig', command: 'node', args: ['plugin-default.js'] },
+    ]);
+
+    const response = await fetch(`${baseUrl}/api/runs`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        projectId: PROJECT_ID,
+        agentId: 'claude',
+        appliedPluginSnapshotId: snapshot.snapshotId,
+        message: 'this run pins its own instance of the same server id',
+        toolBundle: {
+          mcpServers: [
+            { id: 'bookboost-twig', transport: 'stdio', command: 'node', args: ['override.js'] },
+          ],
+        },
+      }),
+    });
+
+    const responseText = await response.text();
+    expect(response.status, responseText).toBe(202);
+    expect(lastCreatedRun.toolBundle?.mcpServers).toEqual([
+      expect.objectContaining({
+        id: 'bookboost-twig',
+        command: 'node',
+        args: ['override.js'],
+      }),
+    ]);
+  });
+});

--- a/apps/daemon/tests/run-tool-bundle.test.ts
+++ b/apps/daemon/tests/run-tool-bundle.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  mergeSnapshotMcpServersIntoToolBundle,
   normalizeRunToolBundleForRun,
   parseRunToolBundleForRequest,
   resolveExternalMcpServersForRun,
@@ -226,6 +227,87 @@ describe('run-scoped tool bundles', () => {
       message:
         'Claude Code (claude) receives run-scoped MCP tool bundles through project .mcp.json, ' +
         'so toolBundle requires a daemon-managed project',
+    });
+  });
+
+  describe('mergeSnapshotMcpServersIntoToolBundle', () => {
+    it('returns the bundle unchanged when the snapshot declares no MCP servers', () => {
+      const bundle = normalizeRunToolBundleForRun({
+        mcpServers: [{ id: 'caller-tools', transport: 'stdio', command: 'node' }],
+      });
+
+      expect(mergeSnapshotMcpServersIntoToolBundle(bundle, [])).toBe(bundle);
+    });
+
+    it('adopts a plugin-declared MCP server onto an empty tool bundle', () => {
+      const bundle = normalizeRunToolBundleForRun({ mcpServers: [] });
+
+      const merged = mergeSnapshotMcpServersIntoToolBundle(bundle, [
+        { name: 'bookboost-twig', command: 'node', args: ['server.js'] },
+      ]);
+
+      expect(merged.mcpServers).toEqual([
+        expect.objectContaining({
+          id: 'bookboost-twig',
+          transport: 'stdio',
+          command: 'node',
+          args: ['server.js'],
+          enabled: true,
+        }),
+      ]);
+    });
+
+    it('keeps a differently-named caller-supplied server alongside the snapshot default', () => {
+      const bundle = normalizeRunToolBundleForRun({
+        mcpServers: [{ id: 'caller-tools', transport: 'stdio', command: 'python' }],
+      });
+
+      const merged = mergeSnapshotMcpServersIntoToolBundle(bundle, [
+        { name: 'bookboost-twig', command: 'node' },
+      ]);
+
+      expect(merged.mcpServers.map((server) => server.id).sort()).toEqual([
+        'bookboost-twig',
+        'caller-tools',
+      ]);
+    });
+
+    it('lets a caller-supplied server win a name collision with the snapshot default', () => {
+      const bundle = normalizeRunToolBundleForRun({
+        mcpServers: [
+          { id: 'bookboost-twig', transport: 'stdio', command: 'node', args: ['override.js'] },
+        ],
+      });
+
+      const merged = mergeSnapshotMcpServersIntoToolBundle(bundle, [
+        { name: 'bookboost-twig', command: 'node', args: ['plugin-default.js'] },
+      ]);
+
+      expect(merged.mcpServers).toEqual([
+        expect.objectContaining({ id: 'bookboost-twig', args: ['override.js'] }),
+      ]);
+    });
+
+    it('drops a snapshot MCP server whose name is not a valid server id', () => {
+      const bundle = normalizeRunToolBundleForRun({ mcpServers: [] });
+
+      const merged = mergeSnapshotMcpServersIntoToolBundle(bundle, [
+        { name: 'not a valid id!', command: 'node' },
+      ]);
+
+      expect(merged.mcpServers).toEqual([]);
+    });
+
+    it('adapts a url-based snapshot MCP server to the http transport', () => {
+      const bundle = normalizeRunToolBundleForRun({ mcpServers: [] });
+
+      const merged = mergeSnapshotMcpServersIntoToolBundle(bundle, [
+        { name: 'remote-tools', url: 'https://example.test/mcp' },
+      ]);
+
+      expect(merged.mcpServers).toEqual([
+        expect.objectContaining({ id: 'remote-tools', transport: 'http' }),
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Why

A plugin can declare MCP servers under `od.context.mcp[]`. Applying the plugin persists them correctly — `plugins/apply.ts` puts them on the applied snapshot and `plugins/snapshots.ts` writes them to `applied_plugin_snapshots.mcp_servers_json` — but nothing carries them into a run. A run's tool bundle is built solely from `parseRunToolBundleForRequest(requestBody.toolBundle)`, and neither the web client nor `od run start` supplies the snapshot's servers.

The effect is that applying an MCP-backed plugin appears to succeed and then silently does nothing: the agent never receives the server, so its tools never appear, and there is no error anywhere to explain it. `initial-prompt-bundle-service.ts`'s `runScopedMcpServers(toolBundle)` — the consumer that reads them at run time — sees an empty list.

We hit this building a plugin that fronts an internal API. The plugin installed, the snapshot carried the server, and the agent had no tools.

## What users will see

Applying a plugin that declares `od.context.mcp[]` now actually attaches its MCP server to runs started against that snapshot. Previously it silently did not.

No change for plugins that declare no MCP servers, or for runs started without an `appliedPluginSnapshotId`.

## Surface area

- `apps/daemon/src/run-tool-bundle.ts` — new `mergeSnapshotMcpServersIntoToolBundle`, reusing the existing `sanitizeMcpServer` so a malformed manifest entry is dropped by the same guard as before.
- `apps/daemon/src/routes/runs.ts` — merge at run start; validate the merged bundle rather than the request-only one.
- `apps/daemon/tests/` — two new test files.

No API shape change, no migration, no config.

## Bug fix verification

**Commit 1 — the servers never reach the run.**
`apps/daemon/tests/run-plugin-snapshot-mcp-bundle.test.ts` stands up a real Express app via `registerRunRoutes`, seeds a real snapshot with `createSnapshot`/`linkSnapshotToProject`, POSTs `/api/runs`, and asserts on the `meta.toolBundle` actually handed to `runs.create` — the route layer, not the helper. Reverting only the two source files while keeping the tests makes exactly 2 of 5 fail; the other 3 are regression fences that pass on `main`.

**Commit 2 — the merged bundle was not validated.**
The first commit introduced a path where `validateRunToolBundleForAgent` still received the pre-merge, request-only bundle. Since it returns `{ok: true}` immediately when no servers are enabled, an empty request bundle skipped every capability gate and the plugin's server was merged in afterwards, unvalidated. Concretely, a `claude-mcp-json` agent on an imported-folder project would previously have been rejected with *"requires a daemon-managed project"* — instead the run was created and Claude Code silently never received the server, reinstating the original bug for imported projects.

Verified red-then-green: pre-fix that request returns **202** with the server merged in unvalidated; post-fix it returns **400** and no run is created.

Note the two `validateRunToolBundleForAgent` call sites differ deliberately. The runs route validates the merged bundle; the chat route still validates `toolBundle.bundle`, because it never merges snapshot servers, so the two are identical there.

## Validation

- `pnpm --filter @open-design/daemon test` — 38/38 green, including the adjacent `run-tool-bundle`, `mcp-spawn` and `server-startup-smoke` suites.
- `pnpm --filter @open-design/daemon typecheck`, repo-root `pnpm typecheck`, and `pnpm guard` all exit 0.
- No existing test changed outcome: every pre-existing case uses an `acp-merge` agent with stdio servers, which passes validation both before and after.

## Adjacent issues, not fixed here

`mcpServerConfigFromPluginSpec` drops a malformed spec silently, so a plugin author who names a server with a space gets no signal — the same silent-failure class as the bug above. Left alone to keep this PR to one concern; happy to follow up.
