### PR TITLE
fix(observability): 滚动探针上报之后不该把自己关掉

### DIFF
--- a/apps/web/src/observability/chat-scroll-freeze-blockers.ts
+++ b/apps/web/src/observability/chat-scroll-freeze-blockers.ts
@@ -165,7 +165,12 @@ export function evaluateReportBlockers(input: ReportBlockerInput): ReportBlocker
     ok: !surface.reported && !state.reported,
     actual: surface.reported || state.reported ? 'already reported' : 'not yet',
     needed: 'not yet',
-    note: 'One report per chat log element. This is a success, not a failure.',
+    note:
+      'One TELEMETRY event per chat log element. This is a success, not a '
+      + 'failure — and it gates the event only. The detector, the shortfall '
+      + 'ledger, the activity ring, the write trace and the snap-back route '
+      + 'all keep running on a surface that has already reported, so a '
+      + 'reproduction driven after the first event is still captured.',
   });
 
   out.push({
@@ -260,7 +265,13 @@ export interface SnapBackRoute {
    * just watched a chat refuse to scroll.
    */
   layoutStable: boolean;
-  /** A downward notch landing at or below this reports on the spot. */
+  /**
+   * A downward notch landing at or below this is called frozen on the spot.
+   *
+   * "Called frozen", not "reported": on a surface that has already sent its
+   * one event the verdict still happens — it is what keeps the ledger and the
+   * streak honest — and only the emit is skipped.
+   */
   reportsAtOrBelowPx: number | null;
   note: string;
 }
@@ -270,15 +281,20 @@ export function describeSnapBackRoute(
   geometry: ScrollGeometry,
 ): SnapBackRoute {
   const previousTop = state.lastScrollTop;
-  if (previousTop == null || state.reported) {
+  // `state.reported` is deliberately NOT consulted. It was, and it made this
+  // route describe itself as disarmed on every surface that had already sent
+  // an event — which is the one population where the route matters most,
+  // because those are the surfaces a stale compositor ceiling has already
+  // been proven on. The route is armed or not by the geometry in front of it;
+  // whether the resulting verdict would also be TELEMETERED is the
+  // `surface_unreported` blocker's question, and it is answered there.
+  if (previousTop == null) {
     return {
       armed: false,
       lastScrollTop: previousTop,
       layoutStable: false,
       reportsAtOrBelowPx: null,
-      note: state.reported
-        ? 'already reported on this surface'
-        : 'no frame sampled yet, so there is nothing to snap back FROM',
+      note: 'no frame sampled yet, so there is nothing to snap back FROM',
     };
   }
   const landing = previousTop - SNAP_BACK_MIN_PX;
@@ -294,8 +310,9 @@ export function describeSnapBackRoute(
     layoutStable: stable,
     reportsAtOrBelowPx: landing,
     note: stable
-      ? `A downward notch landing at or below ${px(landing)} reports at once, `
-        + `provided at least ${MIN_UNREACHABLE_PX}px is still unreachable there.`
+      ? `A downward notch landing at or below ${px(landing)} is called frozen `
+        + `at once, provided at least ${MIN_UNREACHABLE_PX}px is still `
+        + 'unreachable there.'
       : 'The content or viewport height has moved since the last reading, so a '
         + 'backwards step here could be the browser\'s own scroll anchoring. '
         + 'This route stays shut until one frame is sampled against a settled '

--- a/apps/web/src/observability/chat-scroll-freeze-detector.ts
+++ b/apps/web/src/observability/chat-scroll-freeze-detector.ts
@@ -109,7 +109,19 @@ export interface ScrollFreezeState {
   readonly stallAt: number | null;
   readonly stallWheelCount: number;
   readonly stallRequestedPx: number;
-  /** Once true the detector is silent for the rest of this surface. */
+  /**
+   * A freeze has been called on this surface.
+   *
+   * A RECORD, not a latch. Nothing in this module short-circuits on it, and
+   * nothing that does may be added back — see `observeWheelBatch`, where such
+   * a short-circuit used to sit.
+   *
+   * It reads as "the detector has already had its say", which is the honest
+   * thing for an audit to print beside a surface. It is NOT the thing that
+   * stops a second `client_chat_scroll_frozen`; de-duplicating the telemetry
+   * event is the emit site's job, and the emit site alone
+   * (`freezeTelemetryAlreadySent` in `chat-scroll-freeze.ts`).
+   */
   readonly reported: boolean;
 }
 
@@ -339,8 +351,21 @@ export function observeWheelBatch(
   state: ScrollFreezeState,
   input: { geometry: ScrollGeometry; requestedPx: number; wheelCount: number },
 ): { state: ScrollFreezeState; verdict: ScrollFreezeVerdict } {
-  if (state.reported) return { state, verdict: { kind: 'ignored' } };
-
+  // There is deliberately NO `if (state.reported) return` here.
+  //
+  // One used to be the first line of this function, and it did not throttle
+  // an event — it stopped the detector. The baseline stopped advancing, the
+  // stall streak stopped counting, and `describeSnapBackRoute` had nothing
+  // current to describe, so the one-notch route that exists FOR the stale
+  // compositor ceiling went permanently dark on exactly the surface that had
+  // just proved it was stale. A real machine shows the price: three
+  // diagnostic bundles exported 5.4 minutes apart carried a byte-identical
+  // ledger and the same `stallWheelCount` of 83, and a deterministic
+  // reproduction run in between was structurally incapable of being seen.
+  //
+  // A report is one thing switching off — the emit. Everything upstream of it
+  // keeps running for the life of the surface, because the moments worth
+  // capturing are the ones after the symptom, not before it.
   const { geometry, requestedPx, wheelCount } = input;
   const top = geometry.scrollTop;
   const maxScrollTopSeen = Math.max(state.maxScrollTopSeen, top);

--- a/apps/web/src/observability/chat-scroll-freeze.ts
+++ b/apps/web/src/observability/chat-scroll-freeze.ts
@@ -317,12 +317,22 @@ interface Surface {
   idleHandle: number | null;
   reported: boolean;
   /**
-   * Frozen verdicts the inner-scroller gate threw away.
+   * Frozen verdicts the inner-scroller gate threw away INSTEAD of reporting.
    *
    * Incremented only inside that gate's own branch, which has just walked an
    * ancestor chain reading layout — so this costs nothing measurable and it
    * is the ONLY record that the probe saw a freeze and chose silence. Without
    * it, suppression and "no defect ever happened" are the same observation.
+   *
+   * "Instead of reporting" is the whole meaning, so the counter stops once
+   * this surface has reported — a verdict discarded after the event was
+   * already sent was never going to be sent again anyway, and counting it
+   * would make the audit's `inner_scroller_free` line ("the probe SAW the
+   * freeze and chose not to report it") read as an explanation for a silence
+   * that did not happen. The gate's RETRACTION is unconditional; only this
+   * bookkeeping about it is not. Do not restore the symmetry by moving the
+   * gate instead: the retraction is what keeps an absorbed wheel out of the
+   * stall streak.
    */
   innerScrollerSuppressions: number;
   resizeObserver: ResizeObserver | null;
@@ -1273,34 +1283,40 @@ function runFrame(active: Surface): void {
   active.state = result.state;
   if (result.verdict.kind !== 'frozen') return;
 
-  // The de-duplication gate, and the ONLY thing a previous report switches
-  // off. Above this line the surface is fully instrumented for as long as it
-  // lives; below it, nothing happens twice.
-  //
-  // It sits BEFORE the inner-scroller walk on purpose. That walk reads layout
-  // up an ancestor chain, and a frozen surface produces a frozen verdict on
-  // every subsequent batch — paying for the walk each time would make a
-  // reported surface more expensive to keep watching than an unreported one,
-  // which is how the sampling got switched off in the first place. Keeping it
-  // below also preserves what `innerScrollerSuppressions` means: verdicts
-  // discarded INSTEAD of being reported, not verdicts that were never going
-  // to be sent anyway.
-  if (freezeTelemetryAlreadySent(active)) return;
-
   // Last gate before reporting, and the expensive one — so it runs only
   // here. If a scrollable box between the wheel target and the chat log
   // still had travel in the requested direction, the chat log was never
   // asked to move and this is not our defect. Every code block and
   // tool-output box in a transcript is such a box.
+  //
+  // It runs UNCONDITIONALLY, before any de-duplication. This is attribution,
+  // not reporting: its job is to decide whose scroller the notch was aimed
+  // at, and that question has the same answer whether or not an event has
+  // already been sent. Putting a `reported` check above it — which this
+  // branch briefly did — leaves the streak reset below unreachable on a
+  // surface that has reported, so wheels the transcript's own code blocks
+  // absorbed keep climbing `stallWheelCount` for a chat scroller nobody was
+  // scrolling. A later snapshot then shows ordinary nested scrolling as a
+  // stall streak, which is the exact evidence this probe exists to produce.
+  // An instrument that is slightly more expensive is survivable; one that
+  // manufactures its own findings is not.
   const innerScrollerCount = countAbsorbingScrollers(active.element, wheelTarget);
   if (innerScrollerCount > 0) {
     // The only trace this decision leaves. A suppressed freeze and a chat
     // that never froze are otherwise indistinguishable from outside, which is
     // how a real 1493px failure produced no event and no explanation.
-    active.innerScrollerSuppressions += 1;
+    //
+    // Counted only while the surface can still report, because that is what
+    // the field means — see its docblock on `Surface`. The retraction below
+    // is what must be unconditional; the bookkeeping about why a report did
+    // not happen is meaningless once one has.
+    if (!freezeTelemetryAlreadySent(active)) active.innerScrollerSuppressions += 1;
     // Clear the streak as well as the verdict. Leaving it at the threshold
     // would re-run this ancestor walk — which does read layout — on every
     // single frame for as long as the user keeps scrolling that inner box.
+    // It is also the only thing keeping an absorbed wheel out of the streak:
+    // the notch has already been folded in by `observeWheelBatch` above, and
+    // this is where it is taken back out.
     active.state = {
       ...active.state,
       reported: false,
@@ -1619,9 +1635,17 @@ function scanAncestorLayerTriggers(root: HTMLElement): Set<ScrollLayerTrigger> {
  * Has this surface already sent its one `client_chat_scroll_frozen`?
  *
  * The invariant this name exists to hold: **a report suppresses the EVENT and
- * nothing else.** `Surface.reported` may be read here, and by the audit in
- * `evaluateReportBlockers` which prints it, and nowhere else in this module —
- * not by a listener, not by an observer callback, not by the detector.
+ * nothing else.** Not a listener, not an observer callback, not the detector,
+ * and — the case that had to be learned twice — not an attribution gate. Every
+ * remaining reader is inside the reporting path itself: `report()` below, and
+ * the suppression counter, which is bookkeeping ABOUT reporting. The audit in
+ * `evaluateReportBlockers` prints the flag without acting on it.
+ *
+ * "Suppresses the event" is deliberately narrow. Deciding whether a wheel was
+ * even aimed at this scroller is not suppression, it is measurement, and it
+ * has to keep happening — a gate that skips it lets an absorbed wheel's notch
+ * stay in the stall streak, which turns scrolling a code block into evidence
+ * of a frozen chat log.
  *
  * It used to be read by nine other places, and the nine turned "we have told
  * PostHog about this surface" into "stop watching this surface". A real

--- a/apps/web/src/observability/chat-scroll-freeze.ts
+++ b/apps/web/src/observability/chat-scroll-freeze.ts
@@ -1256,6 +1256,25 @@ function runFrame(active: Surface): void {
     return;
   }
 
+  // Whose scroller was this batch aimed at?
+  //
+  // Asked ONCE per wheel-bearing frame, here, and the single answer is used by
+  // both the shortfall ledger below and the freeze verdict further down. It
+  // used to be asked only at report time, on the grounds that it is the
+  // expensive check — but "expensive" does not survive reading it: the walk is
+  // the ancestor chain from the wheel target up to the chat log, which is
+  // nesting depth and never transcript length, it returns immediately when the
+  // wheel was aimed at the log itself, and `absorbsWheelInDirection` rejects on
+  // geometry before it will pay for a `getComputedStyle`. Layout is already
+  // clean here, because the frame callback above has just read `scrollHeight`.
+  //
+  // Asking early is what makes the answer usable. A wheel a code block or a
+  // tool-output box absorbed is a wheel the chat log was never asked to move,
+  // so it is not evidence about the chat log — and everything below this line
+  // records evidence about the chat log.
+  const innerScrollerCount = countAbsorbingScrollers(active.element, wheelTarget);
+  const absorbedByInnerScroller = innerScrollerCount > 0;
+
   // One round of "the wheel asked to go further; this is where it stopped".
   // Read BEFORE `observeWheelBatch`, which replaces the baseline this is
   // judged against.
@@ -1266,7 +1285,15 @@ function runFrame(active: Surface): void {
   // below a baseline it never actually failed to pass, and banking that as a
   // shortfall permanently claims `ledger.first` — the field the report exists
   // for — with a number the wheel had nothing to do with.
-  if (wheelPx > 0 && ceilingProbeAttributable(active.state, geometry)) {
+  //
+  // An absorbed wheel is the same mistake by a different route, and a worse
+  // one, because it is indistinguishable from a real round by arithmetic
+  // alone: the chat log genuinely did not move, and it genuinely has travel
+  // left, because the user was scrolling something else entirely. `first` is
+  // never evicted, so one such round owns "where the drift began" for the life
+  // of the surface. It is excluded here rather than retracted later for that
+  // exact reason — there is no taking `first` back.
+  if (!absorbedByInnerScroller && wheelPx > 0 && ceilingProbeAttributable(active.state, geometry)) {
     recordCeilingProbe(active.ledger, {
       at,
       reachedPx: geometry.scrollTop,
@@ -1283,25 +1310,22 @@ function runFrame(active: Surface): void {
   active.state = result.state;
   if (result.verdict.kind !== 'frozen') return;
 
-  // Last gate before reporting, and the expensive one — so it runs only
-  // here. If a scrollable box between the wheel target and the chat log
-  // still had travel in the requested direction, the chat log was never
-  // asked to move and this is not our defect. Every code block and
-  // tool-output box in a transcript is such a box.
+  // The attribution answered at the top of this frame, applied to the verdict.
+  // If a scrollable box between the wheel target and the chat log still had
+  // travel in the requested direction, the chat log was never asked to move
+  // and this is not our defect. Every code block and tool-output box in a
+  // transcript is such a box.
   //
-  // It runs UNCONDITIONALLY, before any de-duplication. This is attribution,
-  // not reporting: its job is to decide whose scroller the notch was aimed
-  // at, and that question has the same answer whether or not an event has
-  // already been sent. Putting a `reported` check above it — which this
-  // branch briefly did — leaves the streak reset below unreachable on a
-  // surface that has reported, so wheels the transcript's own code blocks
-  // absorbed keep climbing `stallWheelCount` for a chat scroller nobody was
-  // scrolling. A later snapshot then shows ordinary nested scrolling as a
-  // stall streak, which is the exact evidence this probe exists to produce.
-  // An instrument that is slightly more expensive is survivable; one that
+  // Nothing may put a de-duplication check above this branch. That is not a
+  // style preference: `observeWheelBatch` has ALREADY folded the notch into
+  // the stall streak by the time we get here, and the retraction below is the
+  // only thing that takes it back out. Gating the branch on `reported` — which
+  // this PR briefly did, to save the walk — left ordinary code-block scrolling
+  // climbing `stallWheelCount` for a chat scroller nobody was scrolling, and a
+  // later snapshot then presents that as exactly the signal this probe exists
+  // to produce. An instrument that costs a little more is survivable; one that
   // manufactures its own findings is not.
-  const innerScrollerCount = countAbsorbingScrollers(active.element, wheelTarget);
-  if (innerScrollerCount > 0) {
+  if (absorbedByInnerScroller) {
     // The only trace this decision leaves. A suppressed freeze and a chat
     // that never froze are otherwise indistinguishable from outside, which is
     // how a real 1493px failure produced no event and no explanation.
@@ -1311,12 +1335,12 @@ function runFrame(active: Surface): void {
     // is what must be unconditional; the bookkeeping about why a report did
     // not happen is meaningless once one has.
     if (!freezeTelemetryAlreadySent(active)) active.innerScrollerSuppressions += 1;
-    // Clear the streak as well as the verdict. Leaving it at the threshold
-    // would re-run this ancestor walk — which does read layout — on every
-    // single frame for as long as the user keeps scrolling that inner box.
-    // It is also the only thing keeping an absorbed wheel out of the streak:
-    // the notch has already been folded in by `observeWheelBatch` above, and
-    // this is where it is taken back out.
+    // Clear the streak as well as the verdict. This is the retraction: the
+    // notch has already been folded in by `observeWheelBatch` above, and this
+    // is where it is taken back out, so an absorbed wheel can never leave a
+    // stall standing in a snapshot. Leaving the streak parked at the threshold
+    // would also mean re-deciding a freeze on every single frame for as long
+    // as the user keeps scrolling that inner box.
     active.state = {
       ...active.state,
       reported: false,

--- a/apps/web/src/observability/chat-scroll-freeze.ts
+++ b/apps/web/src/observability/chat-scroll-freeze.ts
@@ -208,10 +208,26 @@ const SCROLL_SAMPLE_MIN_INTERVAL_MS = 250;
 // froze and a session that never froze again look exactly alike. Silence
 // reading as "no defect" is the one failure mode this module exists to avoid.
 //
-// What remains is `Surface.reported`: one report per chat log element. That is
+// What remains is `Surface.reported`: one EVENT per chat log element. That is
 // de-duplication, not rate limiting — a frozen surface has one story, and
 // repeating it says nothing new — and it is per element, so it can never take
 // the probe off a surface it has not yet described.
+//
+// It took a second pass to make that true. The same flag was also being read
+// by every listener and observer callback in this file, which meant sending
+// the event ALSO stopped the scroll sampler, the wheel path, the activity
+// trail and the shortfall ledger — the session cap's failure mode again, one
+// surface at a time and with the collectors that would have explained the
+// freeze. The flag is now read at exactly one place,
+// `freezeTelemetryAlreadySent`, whose docblock carries the rule.
+//
+// Keeping everything running costs nothing unbounded: every collector on this
+// surface is a fixed-size ring that was already sized for a whole session —
+// `activity` at ACTIVITY_CAPACITY, `ledger.steps`/`ledger.probes` at
+// LEDGER_CAPACITY each, `transitions` at MAX_TRANSITIONS, the write trace at
+// its own capacity — with running totals kept as counters so a trimmed ring
+// cannot read as complete. Nothing here grows with time or with transcript
+// length, and `childHeights` is a WeakMap so it cannot outlive its nodes.
 
 /** Element budget for the compositing-layer census. */
 const MAX_LAYER_SCAN = 600;
@@ -525,7 +541,6 @@ function onScrollCapture(event: Event): void {
       discover(target);
       return;
     }
-    if (active.reported) return;
     active.scrollSamplePending = true;
     const at = now();
     if (at - active.lastScrollSampleAt < SCROLL_SAMPLE_MIN_INTERVAL_MS) return;
@@ -568,7 +583,7 @@ function onWheelDiscover(event: WheelEvent): void {
  */
 function onSurfaceWheel(event: WheelEvent): void {
   const active = surface;
-  if (active === null || active.reported) return;
+  if (active === null) return;
   // `detach()` removes this listener, so a superseded element should never
   // reach here — but if it ever did, its wheels would be attributed to the
   // wrong surface, which is worse than missing them.
@@ -663,7 +678,7 @@ function attach(element: HTMLElement): Surface {
   if (typeof ResizeObserver !== 'undefined') {
     try {
       const observer = new ResizeObserver(() => {
-        if (surface !== active || active.reported) return;
+        if (surface !== active) return;
         // The entry's own `contentRect` would be free, but the ring buffer
         // wants a moment, not a measurement — and the frame below reads the
         // real geometry a beat later anyway.
@@ -976,7 +991,7 @@ function isJumpActive(el: Element): boolean {
  */
 function onStructureMutations(records: MutationRecord[]): void {
   const active = surface;
-  if (active === null || active.reported) return;
+  if (active === null) return;
   const at = now();
   let partsDirty = false;
 
@@ -1053,7 +1068,7 @@ function onStructureMutations(records: MutationRecord[]): void {
  */
 function onStreamMutations(records: MutationRecord[]): void {
   const active = surface;
-  if (active === null || active.reported) return;
+  if (active === null) return;
   const at = now();
   for (const record of records) {
     const target = record.target;
@@ -1081,7 +1096,7 @@ function onStreamMutations(records: MutationRecord[]): void {
  */
 function onSurfaceMotion(event: Event): void {
   const active = surface;
-  if (active === null || active.reported) return;
+  if (active === null) return;
   if (event.currentTarget !== active.shell) return;
   const kind = MOTION_KIND[event.type];
   if (kind === undefined) return;
@@ -1090,7 +1105,7 @@ function onSurfaceMotion(event: Event): void {
 
 function onVisibilityChange(): void {
   const active = surface;
-  if (active === null || active.reported) return;
+  if (active === null) return;
   const hidden = typeof document !== 'undefined' && document.visibilityState === 'hidden';
   pushActivity(active.activity, hidden ? 'doc_hidden' : 'doc_visible', 'other', now());
 }
@@ -1115,7 +1130,7 @@ function observeHostBox(active: Surface): void {
   const target = host;
   try {
     const observer = new ResizeObserver(() => {
-      if (surface !== active || active.reported) return;
+      if (surface !== active) return;
       // Record only. Unlike the chat log's own observer this does NOT
       // schedule a geometry frame: the host's height is not one of the three
       // numbers the verdict is made from.
@@ -1257,6 +1272,20 @@ function runFrame(active: Surface): void {
   });
   active.state = result.state;
   if (result.verdict.kind !== 'frozen') return;
+
+  // The de-duplication gate, and the ONLY thing a previous report switches
+  // off. Above this line the surface is fully instrumented for as long as it
+  // lives; below it, nothing happens twice.
+  //
+  // It sits BEFORE the inner-scroller walk on purpose. That walk reads layout
+  // up an ancestor chain, and a frozen surface produces a frozen verdict on
+  // every subsequent batch — paying for the walk each time would make a
+  // reported surface more expensive to keep watching than an unreported one,
+  // which is how the sampling got switched off in the first place. Keeping it
+  // below also preserves what `innerScrollerSuppressions` means: verdicts
+  // discarded INSTEAD of being reported, not verdicts that were never going
+  // to be sent anyway.
+  if (freezeTelemetryAlreadySent(active)) return;
 
   // Last gate before reporting, and the expensive one — so it runs only
   // here. If a scrollable box between the wheel target and the chat log
@@ -1586,6 +1615,31 @@ function scanAncestorLayerTriggers(root: HTMLElement): Set<ScrollLayerTrigger> {
 // Report
 // ---------------------------------------------------------------------------
 
+/**
+ * Has this surface already sent its one `client_chat_scroll_frozen`?
+ *
+ * The invariant this name exists to hold: **a report suppresses the EVENT and
+ * nothing else.** `Surface.reported` may be read here, and by the audit in
+ * `evaluateReportBlockers` which prints it, and nowhere else in this module —
+ * not by a listener, not by an observer callback, not by the detector.
+ *
+ * It used to be read by nine other places, and the nine turned "we have told
+ * PostHog about this surface" into "stop watching this surface". A real
+ * machine measured the cost: the operator clicked to the bottom, the scroller
+ * landed at 718.5, and 3.8 seconds later the compositor clamped it back to
+ * its own stale ceiling of 245.5 with no JS write in between — the exact
+ * symptom this probe is for, on a surface whose `snapBack` route read
+ * `armed: false, note: "already reported on this surface"` and whose ledger
+ * had not moved in five and a half minutes. A deterministic reproduction was
+ * driven through an instrument that had been structurally switched off by its
+ * own success.
+ *
+ * De-duplication is a property of the sink, so it lives at the sink.
+ */
+function freezeTelemetryAlreadySent(active: Surface): boolean {
+  return active.reported;
+}
+
 function report(
   active: Surface,
   geometry: ScrollGeometry,
@@ -1593,7 +1647,7 @@ function report(
   innerScrollerCount: number,
   at: number,
 ): void {
-  if (active.reported) return;
+  if (freezeTelemetryAlreadySent(active)) return;
   active.reported = true;
   reportedThisSession += 1;
 

--- a/apps/web/src/observability/chat-scroll-freeze.ts
+++ b/apps/web/src/observability/chat-scroll-freeze.ts
@@ -1334,7 +1334,8 @@ function runFrame(active: Surface): void {
     // the field means — see its docblock on `Surface`. The retraction below
     // is what must be unconditional; the bookkeeping about why a report did
     // not happen is meaningless once one has.
-    if (!freezeTelemetryAlreadySent(active)) active.innerScrollerSuppressions += 1;
+    const alreadySent = freezeTelemetryAlreadySent(active);
+    if (!alreadySent) active.innerScrollerSuppressions += 1;
     // Clear the streak as well as the verdict. This is the retraction: the
     // notch has already been folded in by `observeWheelBatch` above, and this
     // is where it is taken back out, so an absorbed wheel can never leave a
@@ -1343,7 +1344,19 @@ function runFrame(active: Surface): void {
     // as the user keeps scrolling that inner box.
     active.state = {
       ...active.state,
-      reported: false,
+      // Retract the VERDICT, not the history.
+      //
+      // Before this surface has reported there is no history: the verdict was
+      // discarded, no event went out, and the surface must still be able to
+      // report a real freeze later — so this goes back to false.
+      //
+      // After it has reported, an event DID go out, and `ScrollFreezeState`'s
+      // `reported` is documented as the permanent record of that. Writing
+      // false here unconditionally — which this branch did until review caught
+      // it, back when it was unreachable post-report — would leave a snapshot
+      // saying `surface.reported: true` beside `detector.reported: false` and
+      // contradict that contract to the one person who reads both.
+      reported: alreadySent,
       stallAt: null,
       stallWheelCount: 0,
       stallRequestedPx: 0,

--- a/apps/web/tests/observability/chat-scroll-freeze-handle.test.ts
+++ b/apps/web/tests/observability/chat-scroll-freeze-handle.test.ts
@@ -767,51 +767,94 @@ describe('observability/chat-scroll-freeze — runtime handle', () => {
     expect(route?.note).not.toContain('already reported');
   });
 
-  it('stops at the sink, before the gate that would rewrite what it found', () => {
-    // The de-duplication gate sits ABOVE the inner-scroller gate, and that
-    // order is load-bearing twice over.
-    //
-    // `innerScrollerSuppressions` means "the probe saw a freeze and chose
-    // silence" — it is the only trace that decision leaves. Letting it run on
-    // a surface whose event has already gone would fill it with verdicts that
-    // were never going to be sent, and each pass also CLEARS the stall streak,
-    // so the forensic counter this fix exists to keep alive would be reset by
-    // any wheel that happened to land on a code block. The walk itself reads
-    // layout up an ancestor chain, on every batch, for as long as the user
-    // keeps scrolling a surface that is already known to be broken.
-    const log = buildChatLog();
-    stubGeometry(log, { scrollTop: 91, scrollHeight: 2347, clientHeight: 583 });
-    // `.markdown-rendered pre { overflow: auto }` — stated as the longhand
-    // because jsdom does not expand the shorthand for `getComputedStyle`.
+  /**
+   * `.markdown-rendered pre { overflow: auto }` — the box every transcript is
+   * full of. Stated as the longhand because jsdom does not expand the
+   * `overflow` shorthand for `getComputedStyle`, and the longhand is what the
+   * gate reads.
+   */
+  function appendAbsorbingBox(log: HTMLElement): HTMLElement {
     const inner = document.createElement('pre');
     inner.style.overflowY = 'auto';
     log.appendChild(inner);
     stubGeometry(inner, { scrollTop: 0, scrollHeight: 900, clientHeight: 200 });
+    return inner;
+  }
+
+  it('keeps an absorbed wheel out of the stall streak after the surface reports', () => {
+    // A wheel a code block ate is not a wheel the chat log refused. The gate
+    // that tells those apart is ATTRIBUTION, so it runs on every frozen
+    // verdict, before any de-duplication — and its streak retraction is the
+    // only thing that takes the absorbed notch back out of `stallWheelCount`,
+    // which `observeWheelBatch` has already folded it into.
+    //
+    // Skipping that on a reported surface — which an earlier revision of this
+    // branch did, to save the ancestor walk — lets ordinary nested scrolling
+    // pile up a streak on a scroller nobody was scrolling. The snapshot then
+    // presents it as exactly the signal this probe exists to produce: "the
+    // chat log would not move, N notches running". A slower instrument is
+    // survivable; one that manufactures its own findings is not.
+    const log = buildChatLog();
+    stubGeometry(log, { scrollTop: 91, scrollHeight: 2347, clientHeight: 583 });
+    const inner = appendAbsorbingBox(log);
 
     installChatScrollFreezeObserver();
     scrolled(log);
-    // Wheels on the log itself, so nothing absorbs them and the surface
-    // reports.
+    // Wheels on the log itself: nothing absorbs them, so the surface reports.
     for (let i = 0; i < 12; i += 1) {
       advanceClock(16);
       wheel(log, 120);
     }
     expect(eventsNamed('client_chat_scroll_frozen')).toHaveLength(1);
     const atReport = handle().snapshot().surface;
+    const streakAtReport = atReport?.detector.stallWheelCount ?? 0;
+    expect(streakAtReport).toBeGreaterThanOrEqual(FREEZE_WHEEL_COUNT);
     expect(atReport?.innerScrollerSuppressions).toBe(0);
 
-    // Now the user scrolls a code block inside the transcript.
+    // Now the user scrolls a code block inside the transcript. Six notches,
+    // none of them aimed at the chat scroller.
     for (let i = 0; i < 6; i += 1) {
       advanceClock(16);
       wheel(inner, 120);
     }
 
     const after = handle().snapshot().surface;
+    // The false streak this spec exists to forbid.
+    expect(after?.detector.stallWheelCount).not.toBe(streakAtReport + 6);
+    // Retracted every time it reaches the bar, so a reader of the snapshot
+    // never sees absorbed notches standing as a stall.
+    expect(after?.detector.stallWheelCount).toBeLessThan(FREEZE_WHEEL_COUNT);
+    // The counter keeps its meaning — "seen and NOT reported" — so it does not
+    // collect verdicts on a surface whose event has already gone.
     expect(after?.innerScrollerSuppressions).toBe(0);
-    expect(after?.detector.stallWheelCount).toBe(
-      (atReport?.detector.stallWheelCount ?? 0) + 6,
-    );
+    // And moving the gate did not cost the de-duplication: `report()` owns it.
     expect(eventsNamed('client_chat_scroll_frozen')).toHaveLength(1);
+  });
+
+  it('counts a suppression while the surface can still report, and not after', () => {
+    // The control for the spec above. Before any event has gone out, an
+    // absorbed wheel is a decision the probe has to account for: it saw a
+    // frozen verdict and chose silence, and `innerScrollerSuppressions` is the
+    // only trace that decision leaves. The audit prints it as the reason a
+    // report did not happen, which is why it must not keep accruing on a
+    // surface where one did.
+    const log = buildChatLog();
+    stubGeometry(log, { scrollTop: 91, scrollHeight: 2347, clientHeight: 583 });
+    const inner = appendAbsorbingBox(log);
+
+    installChatScrollFreezeObserver();
+    scrolled(log);
+    for (let i = 0; i < 6; i += 1) {
+      advanceClock(16);
+      wheel(inner, 120);
+    }
+
+    const surface = handle().snapshot().surface;
+    expect(eventsNamed('client_chat_scroll_frozen')).toHaveLength(0);
+    expect(surface?.innerScrollerSuppressions).toBeGreaterThan(0);
+    // Same retraction, same bound, on a surface that has never reported: the
+    // gate's behaviour is not a function of whether an event went out.
+    expect(surface?.detector.stallWheelCount).toBeLessThan(FREEZE_WHEEL_COUNT);
   });
 
   it('sends exactly one event per surface however long the freeze goes on', () => {

--- a/apps/web/tests/observability/chat-scroll-freeze-handle.test.ts
+++ b/apps/web/tests/observability/chat-scroll-freeze-handle.test.ts
@@ -831,6 +831,12 @@ describe('observability/chat-scroll-freeze — runtime handle', () => {
     // The counter keeps its meaning — "seen and NOT reported" — so it does not
     // collect verdicts on a surface whose event has already gone.
     expect(after?.innerScrollerSuppressions).toBe(0);
+    // The retraction takes back the verdict, not the history. An event went
+    // out on this surface, and `detector.reported` is the record of it, so a
+    // snapshot can never show it disagreeing with `surface.reported`.
+    expect(after?.detector.reported).toBe(true);
+    expect(handle().snapshot().blockers.find((b) => b.id === 'surface_unreported')?.ok)
+      .toBe(false);
     // And moving the gate did not cost the de-duplication: `report()` owns it.
     expect(eventsNamed('client_chat_scroll_frozen')).toHaveLength(1);
   });
@@ -867,6 +873,12 @@ describe('observability/chat-scroll-freeze — runtime handle', () => {
     // user was simply scrolling something else.
     expect(surface?.ledger.probeCount).toBe(0);
     expect(surface?.ledger.first).toBeNull();
+    // The other side of the retraction: no event went out, so there is no
+    // history to keep and this surface must still be able to report a real
+    // freeze later.
+    expect(surface?.detector.reported).toBe(false);
+    expect(handle().snapshot().blockers.find((b) => b.id === 'surface_unreported')?.ok)
+      .toBe(true);
   });
 
   it('sends exactly one event per surface however long the freeze goes on', () => {

--- a/apps/web/tests/observability/chat-scroll-freeze-handle.test.ts
+++ b/apps/web/tests/observability/chat-scroll-freeze-handle.test.ts
@@ -824,6 +824,10 @@ describe('observability/chat-scroll-freeze — runtime handle', () => {
     // Retracted every time it reaches the bar, so a reader of the snapshot
     // never sees absorbed notches standing as a stall.
     expect(after?.detector.stallWheelCount).toBeLessThan(FREEZE_WHEEL_COUNT);
+    // Nor in the ledger. Six notches aimed at a code block add no rounds of
+    // "the chat log would not go further" to the shortfall record.
+    expect(after?.ledger.probeCount).toBe(atReport?.ledger.probeCount);
+    expect(after?.ledger.probes).toBe(atReport?.ledger.probes);
     // The counter keeps its meaning — "seen and NOT reported" — so it does not
     // collect verdicts on a surface whose event has already gone.
     expect(after?.innerScrollerSuppressions).toBe(0);
@@ -855,6 +859,14 @@ describe('observability/chat-scroll-freeze — runtime handle', () => {
     // Same retraction, same bound, on a surface that has never reported: the
     // gate's behaviour is not a function of whether an event went out.
     expect(surface?.detector.stallWheelCount).toBeLessThan(FREEZE_WHEEL_COUNT);
+    // And the ledger stayed empty. This is the half that cannot be undone
+    // later: `ledger.first` is never evicted, so a single absorbed round would
+    // own `shortfall_first_*` — the field the whole report is read for — for
+    // the life of the surface, while looking arithmetically identical to a
+    // real one. The chat log did not move and it does have travel left; the
+    // user was simply scrolling something else.
+    expect(surface?.ledger.probeCount).toBe(0);
+    expect(surface?.ledger.first).toBeNull();
   });
 
   it('sends exactly one event per surface however long the freeze goes on', () => {

--- a/apps/web/tests/observability/chat-scroll-freeze-handle.test.ts
+++ b/apps/web/tests/observability/chat-scroll-freeze-handle.test.ts
@@ -7,9 +7,12 @@ import {
   setExceptionTrackingContext,
 } from '../../src/analytics/error-tracking';
 import {
+  ACTIVITY_CAPACITY,
   FREEZE_REQUESTED_PX,
   FREEZE_WHEEL_COUNT,
+  LEDGER_CAPACITY,
   MIN_UNREACHABLE_PX,
+  SNAP_BACK_MIN_PX,
   createScrollFreezeState,
   observeScroll,
   observeWheelBatch,
@@ -668,6 +671,184 @@ describe('observability/chat-scroll-freeze — runtime handle', () => {
     expect(snapshot.reportedThisSession).toBe(1);
     expect(snapshot.blockers.find((b) => b.id === 'surface_unreported')?.ok).toBe(false);
     expect(snapshot.verdict).toContain('surface_unreported');
+  });
+
+  /**
+   * What a report is allowed to switch off, and what it is not.
+   *
+   * These three specs exist because of a live capture. The operator clicked
+   * jump-to-bottom on a frozen chat, the scroller landed at 718.5 — the real
+   * layout bottom — and 3.8 seconds later it was back at 245.5, the ceiling
+   * the compositor still believed in, with zero JS writes in the interval and
+   * the write trace armed over all four scroll APIs the whole time. That is
+   * the cleanest evidence this probe has ever had, and it produced nothing,
+   * because the surface had already reported and the same flag that gated the
+   * event had also switched off the sampler:
+   *
+   *   verdict:  "blocked_by=surface_unreported"
+   *   snapBack: { armed: false, lastScrollTop: 245.5, layoutStable: false,
+   *               reportsAtOrBelowPx: null,
+   *               note: "already reported on this surface" }
+   *
+   * Three bundles pulled 5.4 minutes apart off that machine carried the same
+   * `stallWheelCount` of 83 and a byte-identical `steps` string.
+   */
+  it('keeps recording after the report, so a repro driven afterwards is captured', () => {
+    const log = buildChatLog();
+    const geometry = stubGeometry(log, {
+      scrollTop: 91,
+      scrollHeight: 2347,
+      clientHeight: 583,
+    });
+    installChatScrollFreezeObserver();
+    scrolled(log);
+    for (let i = 0; i < 12; i += 1) {
+      advanceClock(16);
+      wheel(log, 120);
+    }
+    expect(eventsNamed('client_chat_scroll_frozen')).toHaveLength(1);
+    const atReport = handle().snapshot().surface;
+    expect(atReport?.detector.reported).toBe(true);
+
+    // The reproduction a tester actually runs: the turn keeps streaming, the
+    // user keeps wheeling, and the ceiling keeps refusing.
+    for (let i = 0; i < 12; i += 1) {
+      advanceClock(16);
+      geometry.setContent(2347 + (i + 1) * 40);
+      wheel(log, 120);
+    }
+
+    const after = handle().snapshot().surface;
+    // The streak the real machine had stuck at 83.
+    expect(after?.detector.stallWheelCount).toBeGreaterThan(
+      atReport?.detector.stallWheelCount ?? 0,
+    );
+    // The ledger the real machine exported byte-identical three times.
+    expect(after?.ledger.stepCount).toBeGreaterThan(atReport?.ledger.stepCount ?? 0);
+    expect(after?.ledger.probeCount).toBeGreaterThan(atReport?.ledger.probeCount ?? 0);
+    expect(after?.ledger.steps).not.toBe(atReport?.ledger.steps);
+    // Bounded, not merely alive: the rings are the ones this surface was
+    // always sized for, so "keep sampling" cannot become "keep growing".
+    expect((after?.ledger.steps ?? '').split(',').length).toBeLessThanOrEqual(
+      LEDGER_CAPACITY,
+    );
+    expect(after?.activity.size).toBeLessThanOrEqual(ACTIVITY_CAPACITY);
+    // And still exactly one event.
+    expect(eventsNamed('client_chat_scroll_frozen')).toHaveLength(1);
+  });
+
+  it('leaves the one-notch snap-back route armed on a surface that has reported', () => {
+    const log = buildChatLog();
+    const geometry = stubGeometry(log, {
+      scrollTop: 91,
+      scrollHeight: 2347,
+      clientHeight: 583,
+    });
+    installChatScrollFreezeObserver();
+    scrolled(log);
+    for (let i = 0; i < 12; i += 1) {
+      advanceClock(16);
+      wheel(log, 120);
+    }
+    expect(eventsNamed('client_chat_scroll_frozen')).toHaveLength(1);
+
+    // Jump-to-bottom. The write lands where layout says the bottom is, which
+    // is the setup for the snap-back the operator then watched happen.
+    geometry.setTop(1700);
+    advanceClock(400);
+    scrolled(log);
+
+    const route = handle().snapshot().snapBack;
+    // Not the stale ceiling the sampler used to be frozen at.
+    expect(route?.lastScrollTop).toBe(1700);
+    expect(route?.layoutStable).toBe(true);
+    expect(route?.armed).toBe(true);
+    expect(route?.reportsAtOrBelowPx).toBe(1700 - SNAP_BACK_MIN_PX);
+    expect(route?.note).not.toContain('already reported');
+  });
+
+  it('stops at the sink, before the gate that would rewrite what it found', () => {
+    // The de-duplication gate sits ABOVE the inner-scroller gate, and that
+    // order is load-bearing twice over.
+    //
+    // `innerScrollerSuppressions` means "the probe saw a freeze and chose
+    // silence" — it is the only trace that decision leaves. Letting it run on
+    // a surface whose event has already gone would fill it with verdicts that
+    // were never going to be sent, and each pass also CLEARS the stall streak,
+    // so the forensic counter this fix exists to keep alive would be reset by
+    // any wheel that happened to land on a code block. The walk itself reads
+    // layout up an ancestor chain, on every batch, for as long as the user
+    // keeps scrolling a surface that is already known to be broken.
+    const log = buildChatLog();
+    stubGeometry(log, { scrollTop: 91, scrollHeight: 2347, clientHeight: 583 });
+    // `.markdown-rendered pre { overflow: auto }` — stated as the longhand
+    // because jsdom does not expand the shorthand for `getComputedStyle`.
+    const inner = document.createElement('pre');
+    inner.style.overflowY = 'auto';
+    log.appendChild(inner);
+    stubGeometry(inner, { scrollTop: 0, scrollHeight: 900, clientHeight: 200 });
+
+    installChatScrollFreezeObserver();
+    scrolled(log);
+    // Wheels on the log itself, so nothing absorbs them and the surface
+    // reports.
+    for (let i = 0; i < 12; i += 1) {
+      advanceClock(16);
+      wheel(log, 120);
+    }
+    expect(eventsNamed('client_chat_scroll_frozen')).toHaveLength(1);
+    const atReport = handle().snapshot().surface;
+    expect(atReport?.innerScrollerSuppressions).toBe(0);
+
+    // Now the user scrolls a code block inside the transcript.
+    for (let i = 0; i < 6; i += 1) {
+      advanceClock(16);
+      wheel(inner, 120);
+    }
+
+    const after = handle().snapshot().surface;
+    expect(after?.innerScrollerSuppressions).toBe(0);
+    expect(after?.detector.stallWheelCount).toBe(
+      (atReport?.detector.stallWheelCount ?? 0) + 6,
+    );
+    expect(eventsNamed('client_chat_scroll_frozen')).toHaveLength(1);
+  });
+
+  it('sends exactly one event per surface however long the freeze goes on', () => {
+    // The reverse anchor. Keeping the instrument sampling after a report must
+    // not turn one finding into a stream of duplicates: the detector now calls
+    // `frozen` on every batch that still qualifies, and every one of those
+    // after the first has to die at the sink.
+    const log = buildChatLog();
+    const geometry = stubGeometry(log, {
+      scrollTop: 91,
+      scrollHeight: 2347,
+      clientHeight: 583,
+    });
+    installChatScrollFreezeObserver();
+    scrolled(log);
+    for (let i = 0; i < 12; i += 1) {
+      advanceClock(16);
+      wheel(log, 120);
+    }
+    expect(eventsNamed('client_chat_scroll_frozen')).toHaveLength(1);
+
+    // Sixty more notches of the four-notch route…
+    for (let i = 0; i < 60; i += 1) {
+      advanceClock(16);
+      wheel(log, 120);
+    }
+    // …and then a fresh snap-back, which needs only one notch and is the
+    // easiest way there is to a second event.
+    geometry.setTop(1700);
+    advanceClock(400);
+    scrolled(log);
+    geometry.setTop(91);
+    advanceClock(16);
+    wheel(log, 120);
+
+    expect(eventsNamed('client_chat_scroll_frozen')).toHaveLength(1);
+    expect(handle().snapshot().reportedThisSession).toBe(1);
   });
 
   it('is still attached and still ready after more reports than the old cap allowed', () => {

--- a/apps/web/tests/observability/chat-scroll-freeze.test.ts
+++ b/apps/web/tests/observability/chat-scroll-freeze.test.ts
@@ -496,19 +496,44 @@ describe('chat-scroll-freeze-detector — freeze decision', () => {
     expect(verdict.verdict.evidence.trigger).toBe('wheel_stall');
   });
 
-  it('goes quiet for good once it has reported', () => {
+  it('keeps its baseline and its streak current after calling a freeze', () => {
+    // The one-event-per-surface promise is real, and it is kept at the SINK —
+    // `freezeTelemetryAlreadySent` in `chat-scroll-freeze.ts`. It used to be
+    // kept here instead, by a `if (state.reported) return` on the first line
+    // of `observeWheelBatch`, and that did not throttle an event: it stopped
+    // the detector. The baseline froze at the reported position, the streak
+    // stopped counting, and `describeSnapBackRoute` — the one-notch route
+    // that exists FOR a stale compositor ceiling — had nothing current to
+    // describe on the very surface that had just proved the ceiling stale.
+    //
+    // A real machine measured what that costs: three diagnostic bundles
+    // exported 5.4 minutes apart carried the same `stallWheelCount` of 83 and
+    // a byte-identical ledger, while a tester drove a deterministic
+    // reproduction through the gap.
     let state = createScrollFreezeState();
-    let frozen = 0;
-    for (let i = 0; i < 40; i += 1) {
+    let firstFrozenRound: number | null = null;
+    for (let round = 0; round < 40; round += 1) {
       const result = observeWheelBatch(state, {
         geometry: FROZEN,
         requestedPx: 120,
         wheelCount: 1,
       });
       state = result.state;
-      if (result.verdict.kind === 'frozen') frozen += 1;
+      if (result.verdict.kind === 'frozen' && firstFrozenRound == null) {
+        firstFrozenRound = round;
+      }
     }
-    expect(frozen).toBe(1);
+    // Still calls it at the same round it always did — the thresholds are
+    // untouched.
+    expect(firstFrozenRound).toBe(FREEZE_WHEEL_COUNT - 1);
+    // …and thirty-six rounds later it is still counting, which is the whole
+    // point. A latch here would leave this at four.
+    expect(state.stallWheelCount).toBe(40);
+    expect(state.stallRequestedPx).toBe(40 * 120);
+    expect(state.lastScrollTop).toBe(FROZEN.scrollTop);
+    expect(state.lastScrollHeight).toBe(FROZEN.scrollHeight);
+    // The flag survives as a RECORD of what happened, for the audit to print.
+    expect(state.reported).toBe(true);
   });
 
   it('ignores upward wheels — they are not the symptom', () => {

--- a/apps/web/tests/runtime/chat-scroll-takeover.test.ts
+++ b/apps/web/tests/runtime/chat-scroll-takeover.test.ts
@@ -350,12 +350,28 @@ describe('chat scroll takeover — once the probe has called it frozen', () => {
     wheelEvent(log, 40);
     wheelEvent(log, 40);
     expect(geometry.writes).toEqual([]);
+    const framesForThreeNotches = callbacks.length;
 
-    // Exactly one frame was asked for, and it carries all three notches.
-    const takeoverFrames = callbacks.length;
-    expect(takeoverFrames).toBe(1);
+    // One frame carries all three notches.
     callbacks.forEach((cb) => cb(clock));
     expect(geometry.writes).toEqual([FROZEN.scrollTop + 120]);
+
+    // Twice the notches, the same number of frames, and still one write.
+    //
+    // The count is compared against itself rather than pinned at the literal
+    // 1, because the takeover is not the only thing on this element asking
+    // for frames: the freeze probe keeps sampling a surface it has already
+    // reported, which is deliberate — it is what makes a second symptom on an
+    // already-reported surface catchable at all. Both coalesce per frame, so
+    // what this spec is about, and all it should be able to see, is that
+    // neither of them scales with the number of EVENTS.
+    callbacks.length = 0;
+    geometry.writes.length = 0;
+    geometry.setTop(FROZEN.scrollTop);
+    for (let i = 0; i < 6; i += 1) wheelEvent(log, 40);
+    expect(callbacks.length).toBe(framesForThreeNotches);
+    callbacks.forEach((cb) => cb(clock));
+    expect(geometry.writes).toEqual([FROZEN.scrollTop + 240]);
   });
 
   it('normalises line and page wheels the way the detector does', () => {


### PR DESCRIPTION
## Why

This is an **instrumentation defect found while investigating a live one**, not a product change. I hit it myself chasing the chat-scroll lock-up report ("scroll jumps away as soon as I nudge the wheel after jump-to-bottom"), and it is currently blocking that investigation.

The root cause of the user-facing bug is already pinned down: the browser holds two copies of the scroll ceiling and they disagree — layout says 718px, the compositor is still on 245.5px. The wheel obeys the compositor, JS obeys layout. So the app writes the position to 718.5 (the real bottom), the user touches the wheel, and the compositor clamps the out-of-range position back to its own stale 245.5.

The probe that exists precisely to capture this could not. On a real machine, after the surface had already sent its one event, the snapshot read:

```
verdict:  "blocked_by=surface_unreported"
blockers: { id: "surface_unreported", ok: false,
            actual: "already reported", needed: "not yet",
            note: "One report per chat log element. This is a success, not a failure." }
snapBack: { armed: false, lastScrollTop: 245.5, layoutStable: false,
            reportsAtOrBelowPx: null, note: "already reported on this surface" }
```

Three consequences, all from one flag:

1. **The `snapBack` route was switched off.** It is the route written for exactly this symptom — a downward notch landing *above* where the scroller started, which only a stale compositor ceiling produces, and which needs just one notch. `describeSnapBackRoute()` opened with `if (previousTop == null || state.reported) return`, so it reported `armed: false` on the entire population of surfaces that had already proved their ceiling stale.
2. **The ledger was frozen by the same latch.** Three diagnostic bundles exported 5.4 minutes apart off one machine carried `stallWheelCount: 83` and a byte-identical `steps` string. Nothing was recorded after the report.
3. **A completely standard deterministic reproduction was therefore structurally impossible to capture.** The clearest evidence this probe has ever had — the click landing at 718.5, the position back at 245.5 3.8 seconds later, **zero JS writes in between** while the write interceptor was armed over all four APIs (`scrollTop` / `scrollTo` / `scrollBy` / `scrollIntoView`) with zero drops — produced nothing.

`Surface.reported` was carrying two jobs at once: "PostHog has been told about this surface" and "stop watching this surface". It was read by nine places. This PR separates them.

This is the same failure mode the module already fought once and documented at length: a session-level cap of three that did not throttle events but switched the observer off. That one is gone. This one is the same thing, one surface at a time, and with the collectors that would have explained the freeze.

## What users will see

Nothing. This is instrumentation only — no product behavior, no scroll behavior, no new or changed telemetry event, no threshold moved. Users who were already sending `client_chat_scroll_frozen` keep sending exactly one per chat log element, as before.

For anyone running a forensic build (`window.__chatScrollFreeze.snapshot()`), a surface that has already reported now keeps a live ledger, a current baseline, and an armable `snapBack` route, instead of going permanently silent.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — internal instrumentation fix plus tests.

Explicitly **not** an API/contract change: the `client_chat_scroll_frozen` event, its properties, and its one-per-surface cardinality are untouched. `ChatScrollFreezeSnapshot` keeps its shape; only the values inside it stop being frozen.

> **Telemetry value change, flagged for a maintainer call.** `47e63194ab` stops a wheel that an inner scroller absorbed from entering the shortfall ledger. That gate applies to un-reported surfaces too, which is `main`'s behaviour today, so `shortfall_first_px` / `_reached_px` / `_layout_max_px` / `_content_px` will carry **different values** than they would on `main` — more accurate ones, with manufactured rounds removed, but different. It was added at review request ([thread](https://github.com/nexu-io/open-design/pull/7896#discussion_r3957439151)) because `ledger.first` is never evicted, so one absorbed round permanently owns the field the whole report is read for. Event name, property names, types and cardinality are all unchanged. Happy to split this half into its own PR if you would rather land it separately.

## Screenshots

n/a — no UI surface.

## Bug fix verification

Red specs, each pinning an **invariant** rather than the status quo, and each verified red by removing the corresponding piece of implementation and re-running.

| Spec | File |
| --- | --- |
| `keeps its baseline and its streak current after calling a freeze` | `apps/web/tests/observability/chat-scroll-freeze.test.ts` |
| `keeps recording after the report, so a repro driven afterwards is captured` | `apps/web/tests/observability/chat-scroll-freeze-handle.test.ts` |
| `leaves the one-notch snap-back route armed on a surface that has reported` | `apps/web/tests/observability/chat-scroll-freeze-handle.test.ts` |
| `keeps an absorbed wheel out of the stall streak after the surface reports` | `apps/web/tests/observability/chat-scroll-freeze-handle.test.ts` |
| `counts a suppression while the surface can still report, and not after` | `apps/web/tests/observability/chat-scroll-freeze-handle.test.ts` |
| `sends exactly one event per surface however long the freeze goes on` (**reverse anchor**) | `apps/web/tests/observability/chat-scroll-freeze-handle.test.ts` |

Rather than diffing against `main` as a whole, each of the four implementation pieces was reverted **individually** on this branch and the suites re-run, so every piece is attributable to a spec that fails without it:

```
GREEN baseline                    105 passed
un-fix detector short-circuit       3 failed | 102 passed
un-fix snapBack early-return        1 failed | 104 passed
un-fix listener latches             3 failed | 102 passed
un-fix attribution-gate order       1 failed | 104 passed
un-fix suppression-counter guard    1 failed | 104 passed
un-fix ledger attribution           2 failed | 103 passed
un-fix retraction record            1 failed | 104 passed
un-fix report() latch              16 failed |  89 passed
```

The last row is the answer to "does moving the dedupe gate cost de-duplication": removing the single latch line in `report()` turns 16 specs red, including the repo's **pre-existing** `still refuses to report the same surface twice`. `report()` has owned the cardinality all along.

The reverse anchor is the one that matters most here: keeping the instrument sampling means the detector now calls `frozen` on every batch that still qualifies, so the spec drives 72 further notches **plus a fresh snap-back** (the cheapest possible route to a second event — it needs one notch) and asserts the event count is still exactly `1` and `reportedThisSession` is still `1`.

## Validation

```
pnpm --filter @open-design/web typecheck   → 0
pnpm guard                                 → 0
```

```
apps/web ./node_modules/.bin/vitest run \
  tests/observability/chat-scroll-freeze.test.ts \
  tests/observability/chat-scroll-freeze-handle.test.ts \
  tests/observability/chat-scroll-forensics.test.ts \
  tests/runtime/chat-scroll-takeover.test.ts
  → 154 passed (4 files), exit 0
```

Wider sweep over every suite that could see the probe or its consumers:

```
apps/web ./node_modules/.bin/vitest run tests/observability/ tests/runtime/
  → 2101 passed (146 files)
```

### How it is decoupled

`Surface.reported` is now read at exactly one place in the module, behind a named predicate whose docblock carries the rule:

```ts
/**
 * Has this surface already sent its one `client_chat_scroll_frozen`?
 *
 * The invariant this name exists to hold: a report suppresses the EVENT and
 * nothing else. ...
 */
function freezeTelemetryAlreadySent(active: Surface): boolean
```

- The nine reads became one. The eight listener/observer latches (`onScrollCapture`, `onSurfaceWheel`, the log and host `ResizeObserver`s, `onStructureMutations`, `onStreamMutations`, `onSurfaceMotion`, `onVisibilityChange`) are gone, so the sampler, the wheel path, the activity trail and the ledger keep running for the life of the surface.
- `observeWheelBatch`'s opening `if (state.reported) return` is gone; a comment in its place says why nothing may put it back. `ScrollFreezeState.reported` survives as a **record** for the audit to print, not a latch.
- `describeSnapBackRoute()` no longer consults `state.reported`. Whether a verdict would also be *telemetered* is the `surface_unreported` blocker's question, and it is still answered there — that blocker stays, with its note corrected to say it gates the event only.
- The inner-scroller gate in `runFrame` runs **unconditionally, before any de-duplication**. It is attribution, not reporting: "whose scroller was this notch aimed at" has the same answer whether or not an event has gone out. An earlier revision of this branch put the dedupe check above it to save the ancestor walk; [review caught it](https://github.com/nexu-io/open-design/pull/7896#discussion_r3957393601), and correctly — that gate's streak retraction is the **only** thing that takes an absorbed notch back out of `stallWheelCount`, since `observeWheelBatch` has already folded it in, so skipping it let ordinary code-block scrolling accumulate a stall streak on a scroller nobody was scrolling. Fixed in `f2e25493da`, with its own spec.
- `innerScrollerSuppressions` is protected by its own counting condition rather than by gate order: the field means "seen and NOT reported", so it stops counting once the surface has reported, while the retraction stays unconditional. The rule lives in the field's docblock.

### Memory

Continuing to record does not become unbounded growth. Every collector on the surface is a fixed-size ring already sized for a whole session — `activity` at `ACTIVITY_CAPACITY` (64), `ledger.steps` and `ledger.probes` at `LEDGER_CAPACITY` (32) each evicting from the front, `transitions` at `MAX_TRANSITIONS` (20), the write trace at its own capacity (200) — with running totals kept as separate counters so a trimmed ring cannot read as complete. `childHeights` is a `WeakMap`. Nothing added here grows with time or with transcript length, and the specs assert the ring bounds directly rather than trusting the reading.

On cost: the ancestor walk is `target === root ? 0 : the chain from the wheel target up to the log`, geometry-first with early rejection, so it is O(1) for a wheel aimed at the log itself and bounded by nesting depth otherwise — never by transcript length. It already ran on every frozen verdict before this PR, and the restored retraction is what stops it recurring, because the streak can no longer sit parked at the threshold. No performance argument is being used to justify anything here.

### Adjacent issues, deliberately not in this PR

- The **product** defect (stale compositor ceiling vs. layout) is untouched. This PR only makes it catchable.
- `chat-scroll-takeover.ts` stays off by default; whether to turn it on is a separate call.
- `stick-to-bottom.ts` has its own separate defect and its own owner.
(Nothing else outstanding — the `recordCeilingProbe` item that sat here was folded in instead, see the telemetry note below.)
- One assertion in `tests/runtime/chat-scroll-takeover.test.ts` had to change: it counted **all** `requestAnimationFrame` calls during a burst and pinned the total at `1`, which silently depended on the probe being switched off after a report. It now compares the frame count against itself across a 3-notch and a 6-notch burst, which is what "once per frame, not once per event" actually means and which still fails on a per-event frame storm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQSowXMsTxbEoZyGYfxgyb



