### PR TITLE
fix(chat): keep Retry alive when no host can take the Cloud handoff

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -2382,7 +2382,30 @@ export function ChatPane({
   const showByokRecoveryCta =
     showByokRecoveryAction && Boolean(onSwitchToLocalCli) && !runFailureHasAction;
   const showErrorActions = showByokRecoveryCta || runFailureHasAction;
-  const showCloudSwitchCta = Boolean(cloudSwitchTracking);
+  /**
+   * 这颗〔切换到 Cloud〕的**接手方在不在**。
+   *
+   * 和 `balanceCardCannotTakeTheHandoff` / `reconnectRowCannotTakeTheHandoff`
+   * 同一个形状,同一条不变量:**让位只在接手方真的在场时成立**。
+   *
+   * 这颗 CTA 自己不做事,它把这一轮交给宿主 —— `onSwitchToAmrAndRetry`
+   * (`ProjectView.handleSwitchToAmrAndRetry`:先武装一次性自动重试,再先切 mode
+   * 后切 agent),接不住时回落 `onOpenAmrSettings`。两个都没接的宿主,这颗按钮
+   * 的 onClick 走完两个分支什么都不会发生。
+   *
+   * 三个宿主里正好有这一种:`workspace/SideChatTab` 接了 `onRetry`,两个 AMR
+   * 口子一个都没接(`DesignSystemFlow` 三个都没接)。在那儿画出来的是一颗
+   * **点了没反应**的主按钮,而且它一出场,`errorActionVariant` 就把真能用的
+   * 〔重试〕挤到次级、`contactSupportIsPrimary` 也跟着不再升格 —— 第 4 档那种
+   * 本来就没有恢复动作的卡会连一颗主按钮都不剩。用户在一轮失败之后,屏幕上唯一
+   * 显眼的那颗按钮是假的。
+   *
+   * ⚠️ 这不是在 OPEND-2772「铺到所有报错」上开例外:铺不铺由
+   * `runFailureUi.cloudSwitchCta` 说了算,这里只回答**这个宿主接不接得住**。
+   */
+  const cloudSwitchCtaCannotTakeTheHandoff = !onSwitchToAmrAndRetry && !onOpenAmrSettings;
+  const showCloudSwitchCta =
+    Boolean(cloudSwitchTracking) && !cloudSwitchCtaCannotTakeTheHandoff;
   /**
    * 一张卡只有一颗主按钮。
    *

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -3480,7 +3480,7 @@ export const ar: Dict = {
   'assistant.unfinishedMore': '+{n} أكثر',
   'assistant.continueRemaining': 'متابعة المهام المتبقية',
   'chat.resumeRunCta': 'متابعة التشغيل',
-  'chat.runError.contactSupportCta': "التواصل مع الدعم",
+  'chat.runError.contactSupportCta': "التواصل معنا",
   'chat.runError.exportLogsCta': "تصدير السجلات",
   'chat.runError.switchModelCta': "تغيير النموذج",
   'chat.runError.openSettingsCta': 'فتح الإعدادات',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -3480,7 +3480,7 @@ export const de: Dict = {
   'assistant.unfinishedMore': '+{n} weitere',
   'assistant.continueRemaining': 'Offene Aufgaben fortsetzen',
   'chat.resumeRunCta': 'Lauf fortsetzen',
-  'chat.runError.contactSupportCta': "Support kontaktieren",
+  'chat.runError.contactSupportCta': "Kontakt aufnehmen",
   'chat.runError.exportLogsCta': "Protokolle exportieren",
   'chat.runError.switchModelCta': "Modell wechseln",
   'chat.runError.openSettingsCta': 'Einstellungen öffnen',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -3494,7 +3494,7 @@ export const en: Dict = {
   'assistant.unfinishedMore': '+{n} more',
   'assistant.continueRemaining': 'Continue remaining tasks',
   'chat.resumeRunCta': 'Continue the run',
-  'chat.runError.contactSupportCta': "Contact support",
+  'chat.runError.contactSupportCta': "Contact us",
   'chat.runError.exportLogsCta': "Export logs",
   'chat.runError.switchModelCta': "Switch model",
   'chat.runError.openSettingsCta': 'Open settings',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -3480,7 +3480,7 @@ export const esES: Dict = {
   'assistant.unfinishedMore': '+{n} más',
   'assistant.continueRemaining': 'Continuar tareas pendientes',
   'chat.resumeRunCta': 'Continuar la ejecución',
-  'chat.runError.contactSupportCta': "Contactar con soporte",
+  'chat.runError.contactSupportCta': "Contactar con nosotros",
   'chat.runError.exportLogsCta': "Exportar registros",
   'chat.runError.switchModelCta': "Cambiar de modelo",
   'chat.runError.openSettingsCta': 'Abrir ajustes',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -3480,7 +3480,7 @@ export const fa: Dict = {
   'assistant.unfinishedMore': '+{n} بیشتر',
   'assistant.continueRemaining': 'ادامه وظایف باقی مانده',
   'chat.resumeRunCta': 'ادامهٔ اجرا',
-  'chat.runError.contactSupportCta': "تماس با پشتیبانی",
+  'chat.runError.contactSupportCta': "تماس با ما",
   'chat.runError.exportLogsCta': "خروجی گرفتن گزارش‌ها",
   'chat.runError.switchModelCta': "تغییر مدل",
   'chat.runError.openSettingsCta': 'باز کردن تنظیمات',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -3480,7 +3480,7 @@ export const fr: Dict = {
   'assistant.unfinishedMore': '+{n} de plus',
   'assistant.continueRemaining': 'Continuer les tâches restantes',
   'chat.resumeRunCta': 'Reprendre l’exécution',
-  'chat.runError.contactSupportCta': "Contacter le support",
+  'chat.runError.contactSupportCta': "Nous contacter",
   'chat.runError.exportLogsCta': "Exporter les journaux",
   'chat.runError.switchModelCta': "Changer de modèle",
   'chat.runError.openSettingsCta': 'Ouvrir les paramètres',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -3480,7 +3480,7 @@ export const hu: Dict = {
   'assistant.unfinishedMore': '+{n} további',
   'assistant.continueRemaining': 'Hátralévő feladatok folytatása',
   'chat.resumeRunCta': 'Futás folytatása',
-  'chat.runError.contactSupportCta': "Kapcsolatfelvétel a támogatással",
+  'chat.runError.contactSupportCta': "Kapcsolatfelvétel",
   'chat.runError.exportLogsCta': "Naplók exportálása",
   'chat.runError.switchModelCta': "Modellváltás",
   'chat.runError.openSettingsCta': 'Beállítások megnyitása',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -3480,7 +3480,7 @@ export const id: Dict = {
   'assistant.unfinishedMore': '+{n} lagi',
   'assistant.continueRemaining': 'Lanjutkan',
   'chat.resumeRunCta': 'Lanjutkan proses',
-  'chat.runError.contactSupportCta': "Hubungi dukungan",
+  'chat.runError.contactSupportCta': "Hubungi kami",
   'chat.runError.exportLogsCta': "Ekspor log",
   'chat.runError.switchModelCta': "Ganti model",
   'chat.runError.openSettingsCta': 'Buka pengaturan',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -3480,7 +3480,7 @@ export const it: Dict = {
   'assistant.unfinishedMore': '+{n} in più',
   'assistant.continueRemaining': 'Continua le attività rimanenti',
   'chat.resumeRunCta': 'Riprendi l’esecuzione',
-  'chat.runError.contactSupportCta': "Contatta il supporto",
+  'chat.runError.contactSupportCta': "Contattaci",
   'chat.runError.exportLogsCta': "Esporta i log",
   'chat.runError.switchModelCta': "Cambia modello",
   'chat.runError.openSettingsCta': 'Apri impostazioni',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -3480,7 +3480,7 @@ export const ja: Dict = {
   'assistant.unfinishedMore': '+{n} 件',
   'assistant.continueRemaining': '残りのタスクを続ける',
   'chat.resumeRunCta': '実行を続ける',
-  'chat.runError.contactSupportCta': "サポートに問い合わせる",
+  'chat.runError.contactSupportCta': "お問い合わせ",
   'chat.runError.exportLogsCta': "ログを書き出す",
   'chat.runError.switchModelCta': "モデルを変更",
   'chat.runError.openSettingsCta': '設定を開く',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -3480,7 +3480,7 @@ export const ko: Dict = {
   'assistant.unfinishedMore': '+{n}개 추가',
   'assistant.continueRemaining': '남은 작업 계속하기',
   'chat.resumeRunCta': '실행 계속하기',
-  'chat.runError.contactSupportCta': "지원팀에 문의",
+  'chat.runError.contactSupportCta': "문의하기",
   'chat.runError.exportLogsCta': "로그 내보내기",
   'chat.runError.switchModelCta': "모델 변경",
   'chat.runError.openSettingsCta': '설정 열기',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -3480,7 +3480,7 @@ export const pl: Dict = {
   'assistant.unfinishedMore': '+{n} więcej',
   'assistant.continueRemaining': 'Kontynuuj pozostałe zadania',
   'chat.resumeRunCta': 'Wznów działanie',
-  'chat.runError.contactSupportCta': "Skontaktuj się z pomocą",
+  'chat.runError.contactSupportCta': "Skontaktuj się z nami",
   'chat.runError.exportLogsCta': "Eksportuj logi",
   'chat.runError.switchModelCta': "Zmień model",
   'chat.runError.openSettingsCta': 'Otwórz ustawienia',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -3480,7 +3480,7 @@ export const ptBR: Dict = {
   'assistant.unfinishedMore': '+{n} mais',
   'assistant.continueRemaining': 'Continuar tarefas restantes',
   'chat.resumeRunCta': 'Continuar a execução',
-  'chat.runError.contactSupportCta': "Falar com o suporte",
+  'chat.runError.contactSupportCta': "Fale conosco",
   'chat.runError.exportLogsCta': "Exportar registros",
   'chat.runError.switchModelCta': "Trocar de modelo",
   'chat.runError.openSettingsCta': 'Abrir configurações',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -3480,7 +3480,7 @@ export const ru: Dict = {
   'assistant.unfinishedMore': '+{n} еще',
   'assistant.continueRemaining': 'Продолжить оставшиеся задачи',
   'chat.resumeRunCta': 'Продолжить выполнение',
-  'chat.runError.contactSupportCta': "Связаться с поддержкой",
+  'chat.runError.contactSupportCta': "Связаться с нами",
   'chat.runError.exportLogsCta': "Экспорт логов",
   'chat.runError.switchModelCta': "Сменить модель",
   'chat.runError.openSettingsCta': 'Открыть настройки',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -3480,7 +3480,7 @@ export const th: Dict = {
   'assistant.unfinishedMore': 'ทิ้งเพิ่มมาอีก +{n}',
   'assistant.continueRemaining': 'สานต่อภาระหน้าที่หลงเหลือที',
   'chat.resumeRunCta': 'ดำเนินการต่อ',
-  'chat.runError.contactSupportCta': "ติดต่อฝ่ายสนับสนุน",
+  'chat.runError.contactSupportCta': "ติดต่อเรา",
   'chat.runError.exportLogsCta': "ส่งออกบันทึก",
   'chat.runError.switchModelCta': "เปลี่ยนโมเดล",
   'chat.runError.openSettingsCta': 'เปิดการตั้งค่า',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -3480,7 +3480,7 @@ export const tr: Dict = {
   'assistant.unfinishedMore': '+{n} daha',
   'assistant.continueRemaining': 'Kalan görevleri sürdür',
   'chat.resumeRunCta': 'Çalıştırmayı sürdür',
-  'chat.runError.contactSupportCta': "Destekle iletişime geç",
+  'chat.runError.contactSupportCta': "Bize ulaşın",
   'chat.runError.exportLogsCta': "Günlükleri dışa aktar",
   'chat.runError.switchModelCta': "Model değiştir",
   'chat.runError.openSettingsCta': 'Ayarları aç',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -3480,7 +3480,7 @@ export const uk: Dict = {
   'assistant.unfinishedMore': '+ще {n}',
   'assistant.continueRemaining': 'Продовжити залишкові завдання',
   'chat.resumeRunCta': 'Продовжити виконання',
-  'chat.runError.contactSupportCta': "Звернутися до підтримки",
+  'chat.runError.contactSupportCta': "Зв’язатися з нами",
   'chat.runError.exportLogsCta': "Експортувати логи",
   'chat.runError.switchModelCta': "Змінити модель",
   'chat.runError.openSettingsCta': 'Відкрити налаштування',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -3675,7 +3675,7 @@ export const zhCN: Dict = {
   "assistant.unfinishedMore": "还有 {n} 个",
   "assistant.continueRemaining": "继续剩余任务",
   "chat.resumeRunCta": "继续运行",
-  "chat.runError.contactSupportCta": "联系支持",
+  "chat.runError.contactSupportCta": "联系我们",
   "chat.runError.exportLogsCta": "导出日志",
   "chat.runError.switchModelCta": "换个模型",
   "chat.runError.openSettingsCta": "去设置",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -3685,7 +3685,7 @@ export const zhTW: Dict = {
   "assistant.unfinishedMore": "還有 {n} 個",
   "assistant.continueRemaining": "繼續剩餘任務",
   "chat.resumeRunCta": "繼續執行",
-  "chat.runError.contactSupportCta": "聯絡支援",
+  "chat.runError.contactSupportCta": "聯絡我們",
   "chat.runError.exportLogsCta": "匯出日誌",
   "chat.runError.switchModelCta": "換個模型",
   "chat.runError.openSettingsCta": "開啟設定",

--- a/apps/web/tests/components/ChatPane.error-card-ladder.test.tsx
+++ b/apps/web/tests/components/ChatPane.error-card-ladder.test.tsx
@@ -103,6 +103,14 @@ function renderChat(
       onSend={vi.fn()}
       onStop={vi.fn()}
       onRetry={vi.fn()}
+      /*
+       * 这份文件里凡是提到〔切换到 Cloud〕的判据,说的都是 `ProjectView` 那个宿主 ——
+       * 也只有它接了这颗 CTA 的动作。夹具原来一个都没接,于是它模拟的其实是
+       * `workspace/SideChatTab`(两个 AMR 口子都不接),而那儿这颗按钮点了没反应,
+       * 现在也不再画。补上这一条,夹具才和它想照的那个宿主对得上;
+       * 全文件 11 条断言的期望值一条都没动。
+       */
+      onSwitchToAmrAndRetry={vi.fn()}
       conversations={[
         { projectId: 'project-1', id: 'conv-1', title: 'Current', createdAt: 1, updatedAt: 1 },
       ]}

--- a/apps/web/tests/components/chat/cloud-cta-handoff-presence.test.tsx
+++ b/apps/web/tests/components/chat/cloud-cta-handoff-presence.test.tsx
@@ -1,0 +1,298 @@
+// @vitest-environment jsdom
+/**
+ * 报错卡上那颗〔切换到 Cloud〕**只在接手方在场时**才画。
+ *
+ * 这颗 CTA 自己不做事,它把这一轮交给宿主:`onSwitchToAmrAndRetry`,接不住时
+ * 回落 `onOpenAmrSettings`。两个都没接的宿主,onClick 走完两个分支什么都不会
+ * 发生 —— 而 `ChatPane` 里凡是读 `showCloudSwitchCta` 的地方都当它已经把主位
+ * 接走了:`errorActionVariant` 把真能用的〔重试〕挤到次级,
+ * `contactSupportIsPrimary` 也不再升格。
+ *
+ * 三个宿主正好有这一种:
+ *   · `ProjectView`              —— `onSwitchToAmrAndRetry` + `onOpenAmrSettings` 都接
+ *   · `workspace/SideChatTab`    —— 只接 `onRetry`,两个 AMR 口子一个都没接
+ *   · `DesignSystemFlow`         —— 三个都没接
+ *
+ * 所以侧边聊天里,一轮失败之后屏幕上唯一显眼的那颗按钮是**假的**,同时真能用的
+ * 那颗被降级;第 4 档(没有任何恢复动作)的卡更是连一颗主按钮都不剩。
+ *
+ * 不变量和 `balanceCardCannotTakeTheHandoff` / `reconnectRowCannotTakeTheHandoff`
+ * 是同一条:**让位只在接手方真的在场时成立**。
+ *
+ * ⚠️ 这里**不**碰「卡上该有几颗按钮」。铺不铺这颗 CTA 由
+ * `runFailureUi.cloudSwitchCta`(OPEND-2772「铺到所有报错」)说了算;这份文件只问
+ * 「这个宿主接不接得住」。反向锚点那一条钉的就是:接得住的宿主,一格都不许变。
+ *
+ * 判据一律走渲染文本 / `data-testid` / 点击行为,不碰 CSS 类名
+ * (`apps/web/src/components/chat/AGENTS.md` §5)。
+ */
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { forwardRef } from 'react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../src/analytics/events', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/analytics/events')>();
+  return {
+    ...actual,
+    trackChatPanelClick: vi.fn(),
+    trackRunFailedToastSurfaceView: vi.fn(),
+    trackRunFailedToastGoAmrClick: vi.fn(),
+    trackRunRecoveryActionClick: vi.fn(),
+    trackRunRecoveryActionSurfaceView: vi.fn(),
+  };
+});
+
+import { ChatPane } from '../../../src/components/ChatPane';
+import type { AppConfig, ChatMessage } from '../../../src/types';
+
+/** 真字典 —— 判据钉在用户看到的那行字上,不钉键名 */
+vi.mock('../../../src/i18n', async () => {
+  const { zhCN } = await import('../../../src/i18n/locales/zh-CN');
+  const dict = zhCN as unknown as Record<string, string>;
+  const t = (key: string, vars?: Record<string, string | number>): string => {
+    const raw = dict[key] ?? key;
+    if (!vars) return raw;
+    return raw.replace(/\{(\w+)\}/g, (_, name: string) => {
+      const v = vars[name];
+      return v == null ? `{${name}}` : String(v);
+    });
+  };
+  return {
+    useI18n: () => ({ locale: 'zh-CN', setLocale: () => undefined, t }),
+    useT: () => t,
+  };
+});
+
+vi.mock('../../../src/components/AssistantMessage', () => ({
+  AssistantMessage: ({ message }: { message: ChatMessage }) => (
+    <div data-testid={`assistant-${message.id}`}>{message.content}</div>
+  ),
+}));
+
+vi.mock('../../../src/components/ChatComposer', () => ({
+  ChatComposer: forwardRef((_props, _ref) => <div data-testid="composer" />),
+}));
+
+beforeAll(() => {
+  const store = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      clear: () => store.clear(),
+      getItem: (key: string) => store.get(key) ?? null,
+      removeItem: (key: string) => store.delete(key),
+      setItem: (key: string, value: string) => store.set(key, value),
+    },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function failedMessage(code: string, detail?: string): ChatMessage {
+  return {
+    id: 'msg-failed',
+    role: 'assistant',
+    content: 'Partial work before the failure.',
+    createdAt: 1,
+    runId: 'run-failed',
+    runStatus: 'failed',
+    agentId: 'claude',
+    events: [
+      {
+        kind: 'status',
+        label: 'error',
+        detail: detail ?? 'raw upstream sentence',
+        code,
+      },
+    ],
+  } as ChatMessage;
+}
+
+interface HostWiring {
+  onSwitchToAmrAndRetry?: (message: ChatMessage) => void;
+  onOpenAmrSettings?: () => void;
+}
+
+function renderFailure(opts: { code: string; detail?: string; host: HostWiring }) {
+  const onRetry = vi.fn();
+  const rendered = render(
+    <ChatPane
+      messages={[failedMessage(opts.code, opts.detail)]}
+      streaming={false}
+      error={null}
+      projectId="project-1"
+      projectFiles={[]}
+      onEnsureProject={async () => 'project-1'}
+      onSend={vi.fn()}
+      onStop={vi.fn()}
+      onRetry={onRetry}
+      amrBalanceCardUsd={null}
+      onOpenSettings={vi.fn() as never}
+      conversations={[
+        { projectId: 'project-1', id: 'conv-1', title: 'Current', createdAt: 1, updatedAt: 1 },
+      ]}
+      activeConversationId="conv-1"
+      onSelectConversation={vi.fn()}
+      onDeleteConversation={vi.fn()}
+      config={{ agentId: 'claude', agentCliEnv: {} } as unknown as AppConfig}
+      {...opts.host}
+    />,
+  );
+  return { ...rendered, onRetry };
+}
+
+/** 卡上那一排里的主按钮(`RunErrorCardAction` 给每颗都盖了 `data-run-error-action`) */
+function primaryActions(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>('[data-run-error-action="primary"]'),
+  );
+}
+
+/** `workspace/SideChatTab` 的接线:能重试,但两个 AMR 口子都没接 */
+const SIDE_CHAT_TAB: HostWiring = {};
+
+/** `ProjectView` 的接线:两个都接 */
+function projectViewWiring(): Required<HostWiring> & { onSwitchToAmrAndRetry: ReturnType<typeof vi.fn> } {
+  return {
+    onSwitchToAmrAndRetry: vi.fn(),
+    onOpenAmrSettings: vi.fn(),
+  } as never;
+}
+
+describe('接手方不在场时,报错卡不许让位', () => {
+  /*
+   * S19 进程崩了(每月 20,868 次,第二大桶):阶梯第 2 档,答案是〔重试〕。
+   * 侧边聊天接了 `onRetry`,所以这颗按钮是**真的能用**的。
+   */
+  it('侧边聊天:不画那颗点了没反应的 Cloud 按钮', () => {
+    const { container } = renderFailure({
+      code: 'AGENT_EXECUTION_FAILED',
+      detail: 'process_crashed',
+      host: SIDE_CHAT_TAB,
+    });
+
+    expect(screen.queryByTestId('chat-error-switch-to-cloud')).toBeNull();
+    expect(
+      Array.from(container.querySelectorAll('button')).filter((b) =>
+        (b.textContent ?? '').includes('切换到 Cloud'),
+      ),
+    ).toHaveLength(0);
+  });
+
+  it('侧边聊天:〔重试〕还在,而且拿回主位', () => {
+    const { container } = renderFailure({
+      code: 'AGENT_EXECUTION_FAILED',
+      detail: 'process_crashed',
+      host: SIDE_CHAT_TAB,
+    });
+
+    const retry = screen.getByTestId('chat-error-retry');
+    expect(retry.getAttribute('data-run-error-action')).toBe('primary');
+    const primaries = primaryActions(container);
+    expect(primaries).toHaveLength(1);
+    expect(primaries[0]).toBe(retry);
+  });
+
+  it('侧边聊天:那颗〔重试〕点下去真的走宿主的重试', () => {
+    const { onRetry } = renderFailure({
+      code: 'AGENT_EXECUTION_FAILED',
+      detail: 'process_crashed',
+      host: SIDE_CHAT_TAB,
+    });
+
+    fireEvent.click(screen.getByTestId('chat-error-retry'));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry.mock.calls[0]![0]).toMatchObject({ id: 'msg-failed' });
+  });
+
+  /*
+   * 阶梯第 4 档(`AGENT_RUNTIME_DEF_INVALID`):卡上本来就没有恢复动作,唯一的
+   * 主按钮来自「常驻次级〔联系支持〕升格」。那颗假 CTA 一出场,升格被压掉 ——
+   * 于是整张卡真的一颗主按钮都不剩,正是第 4 档存在的理由要防的那件事。
+   */
+  it('侧边聊天 · 第 4 档:卡不许变成「零个主按钮 + 一颗假按钮」', () => {
+    const { container } = renderFailure({
+      code: 'AGENT_RUNTIME_DEF_INVALID',
+      host: SIDE_CHAT_TAB,
+    });
+
+    expect(screen.queryByTestId('chat-error-switch-to-cloud')).toBeNull();
+    const primaries = primaryActions(container);
+    expect(primaries).toHaveLength(1);
+    expect(primaries[0]!.getAttribute('data-testid')).toBe('chat-error-contact-support');
+  });
+
+  it('两个口子只要接了一个(回落到打开 Cloud 设置),CTA 照旧在', () => {
+    const onOpenAmrSettings = vi.fn();
+    renderFailure({
+      code: 'AGENT_EXECUTION_FAILED',
+      detail: 'process_crashed',
+      host: { onOpenAmrSettings },
+    });
+
+    fireEvent.click(screen.getByTestId('chat-error-switch-to-cloud'));
+
+    expect(onOpenAmrSettings).toHaveBeenCalledTimes(1);
+  });
+});
+
+/*
+ * 反向锚点。`ProjectView` 那种两个 handler 都接的宿主,这次改动**一格都不许变** ——
+ * OPEND-2772 的主位归属、〔重试〕让位到次级,全部照旧。
+ */
+describe('反向锚点 · 接手方在场的宿主行为不变', () => {
+  it('ProjectView:主位仍是那颗〔切换到 Cloud〕', () => {
+    const { container } = renderFailure({
+      code: 'AGENT_EXECUTION_FAILED',
+      detail: 'process_crashed',
+      host: projectViewWiring(),
+    });
+
+    const cta = screen.getByTestId('chat-error-switch-to-cloud');
+    const primaries = primaryActions(container);
+    expect(primaries).toHaveLength(1);
+    expect(primaries[0]).toBe(cta);
+  });
+
+  it('ProjectView:〔重试〕仍在,仍是次级', () => {
+    renderFailure({
+      code: 'AGENT_EXECUTION_FAILED',
+      detail: 'process_crashed',
+      host: projectViewWiring(),
+    });
+
+    expect(screen.getByTestId('chat-error-retry').getAttribute('data-run-error-action')).toBe(
+      'secondary',
+    );
+  });
+
+  it('ProjectView:点它走的仍是 onSwitchToAmrAndRetry', () => {
+    const host = projectViewWiring();
+    renderFailure({
+      code: 'AGENT_EXECUTION_FAILED',
+      detail: 'process_crashed',
+      host,
+    });
+
+    fireEvent.click(screen.getByTestId('chat-error-switch-to-cloud'));
+
+    expect(host.onSwitchToAmrAndRetry).toHaveBeenCalledTimes(1);
+    expect(host.onOpenAmrSettings).not.toHaveBeenCalled();
+  });
+
+  it('ProjectView · 第 4 档:主位仍是那颗 CTA,〔联系支持〕不升格', () => {
+    const { container } = renderFailure({
+      code: 'AGENT_RUNTIME_DEF_INVALID',
+      host: projectViewWiring(),
+    });
+
+    const primaries = primaryActions(container);
+    expect(primaries).toHaveLength(1);
+    expect(primaries[0]!.getAttribute('data-testid')).toBe('chat-error-switch-to-cloud');
+  });
+});

--- a/apps/web/tests/components/chat/w124-chat-tooltips-and-panel-head.test.tsx
+++ b/apps/web/tests/components/chat/w124-chat-tooltips-and-panel-head.test.tsx
@@ -215,7 +215,11 @@ describe('① 报错卡 —— 稿子 body-scene.html:302 的 data-tip="联系�
     const support = screen.getByTestId('chat-error-contact-support');
 
     expect(classList(support)).toContain('od-tooltip');
-    expect(attr(support, 'data-tooltip')).toBe('联系支持');
+    /* ⚠️ 稿子 body-scene.html:302 的 `data-tip` 写的是「联系支持」,
+       OPEND-2807 把这颗按钮的文案改成「联系我们」(19 语齐),工单是较新的权威。
+       要守的是「挂了可见提示、且和按钮文字同源」,不是那四个字本身。 */
+    expect(attr(support, 'data-tooltip')).toBe('联系我们');
+    expect(support.textContent).toContain('联系我们');
   });
 });
 
@@ -325,9 +329,11 @@ describe('i18n —— 19 语一个都不能少', () => {
     expect(zhCN['chat.conversationsAria']).toBe('历史会话');
     expect(zhCN['chat.newSession']).toBe('新会话');
     expect(zhCN['chat.record.viewLarge']).toBe('查看大图');
-    /* 这两条今天就成立,留着当护栏:稿子 body-components.html:324 / body-scene.html:302 */
+    /* 稿子 body-components.html:324 */
     expect(zhCN['chat.edge.reconnectDetail']).toBe('查看详情');
-    expect(zhCN['chat.runError.contactSupportCta']).toBe('联系支持');
+    /* ⚠️ 稿子 body-scene.html:302 写的是「联系支持」,但 OPEND-2807 的工单
+       逐字给的是「联系我们」——工单较新,以它为准。 */
+    expect(zhCN['chat.runError.contactSupportCta']).toBe('联系我们');
   });
 
   it('zh-TW 跟着 zh-CN 走同一套词序', () => {

--- a/apps/web/tests/i18n/opend-2807-contact-us-cta.test.ts
+++ b/apps/web/tests/i18n/opend-2807-contact-us-cta.test.ts
@@ -1,0 +1,117 @@
+/**
+ * OPEND-2807 · 报错卡上那颗常驻按钮从〔联系支持〕改成〔联系我们〕,19 语齐。
+ *
+ * 工单逐字给的是「联系我们」。这条改的**只有值**,`chat.runError.contactSupportCta`
+ * 这个键本身早就在 `i18n/types.ts` 里,按钮位置、行为、testid 都不动。
+ *
+ * ⚠️ 稿子 `body-scene.html:302` 的 `data-tip` 写的还是「联系支持」——**工单较新,
+ * 以工单为准**(同一条裁决也写在 `w124-chat-tooltips-and-panel-head.test.tsx` 里)。
+ *
+ * 这条扫**全部 19 个 locale**,不是只测 en:文案回归最常见的形状就是「英文改了、
+ * 其余 18 个语言还留着旧词」。反向对照钉住旧值 —— 光断言新值,一个把整本词典
+ * 塞成英文占位的回归也能过。
+ */
+import { describe, expect, it } from 'vitest';
+
+import { LOCALES, type Dict, type Locale } from '../../src/i18n/types';
+
+async function loadDict(locale: Locale): Promise<Dict> {
+  const module = await import(`../../src/i18n/locales/${locale}.ts`);
+  const dict = Object.values(module).find((value): value is Dict => {
+    return Boolean(value) && typeof value === 'object';
+  });
+  if (!dict) throw new Error(`No dictionary export found for locale ${locale}`);
+  return dict;
+}
+
+/**
+ * 工单要求的最终值,逐字。**不是重译** —— 19 语的译文由 OPEND-2807 那次评审
+ * 定稿,这里只是把定稿抄成判据。
+ */
+const CONTACT_US: Record<Locale, string> = {
+  ar: 'التواصل معنا',
+  de: 'Kontakt aufnehmen',
+  en: 'Contact us',
+  'es-ES': 'Contactar con nosotros',
+  fa: 'تماس با ما',
+  fr: 'Nous contacter',
+  hu: 'Kapcsolatfelvétel',
+  id: 'Hubungi kami',
+  it: 'Contattaci',
+  ja: 'お問い合わせ',
+  ko: '문의하기',
+  pl: 'Skontaktuj się z nami',
+  'pt-BR': 'Fale conosco',
+  ru: 'Связаться с нами',
+  th: 'ติดต่อเรา',
+  tr: 'Bize ulaşın',
+  uk: 'Зв’язатися з нами',
+  'zh-CN': '联系我们',
+  'zh-TW': '聯絡我們',
+};
+
+/** 改之前那一版「联系支持」。命中说明这个语言被漏掉了。 */
+const OLD_CONTACT_SUPPORT: Record<Locale, string> = {
+  ar: 'التواصل مع الدعم',
+  de: 'Support kontaktieren',
+  en: 'Contact support',
+  'es-ES': 'Contactar con soporte',
+  fa: 'تماس با پشتیبانی',
+  fr: 'Contacter le support',
+  hu: 'Kapcsolatfelvétel a támogatással',
+  id: 'Hubungi dukungan',
+  it: 'Contatta il supporto',
+  ja: 'サポートに問い合わせる',
+  ko: '지원팀에 문의',
+  pl: 'Skontaktuj się z pomocą',
+  'pt-BR': 'Falar com o suporte',
+  ru: 'Связаться с поддержкой',
+  th: 'ติดต่อฝ่ายสนับสนุน',
+  tr: 'Destekle iletişime geç',
+  uk: 'Звернутися до підтримки',
+  'zh-CN': '联系支持',
+  'zh-TW': '聯絡支援',
+};
+
+describe('OPEND-2807 · 〔联系我们〕19 语齐', () => {
+  it('清点:确实是 19 本词典', () => {
+    expect(LOCALES.length).toBe(19);
+    expect(Object.keys(CONTACT_US).length).toBe(19);
+    expect(Object.keys(OLD_CONTACT_SUPPORT).length).toBe(19);
+  });
+
+  it.each(LOCALES)('%s 的值就是工单定稿那一句', async (locale) => {
+    const dict = await loadDict(locale);
+    expect(dict['chat.runError.contactSupportCta']).toBe(CONTACT_US[locale]);
+  });
+
+  it.each(LOCALES)('%s 不许留着旧的〔联系支持〕', async (locale) => {
+    const dict = await loadDict(locale);
+    expect(dict['chat.runError.contactSupportCta']).not.toBe(
+      OLD_CONTACT_SUPPORT[locale],
+    );
+  });
+
+  /*
+   * 真空探针:上面那条 `not.toBe` 只有在「旧值确实是这些字」时才有意义。
+   * 这里证明这张旧值表不是空话 —— 它和新值一一不同。
+   */
+  it('新旧两张表逐语言都不一样 —— 反向对照不是摆设', () => {
+    LOCALES.forEach((locale) => {
+      expect(CONTACT_US[locale], `${locale} 新旧值写成了同一句`).not.toBe(
+        OLD_CONTACT_SUPPORT[locale],
+      );
+    });
+  });
+
+  /*
+   * 回归的另一种形状:整本词典被英文占位盖掉。RTL 两语(ar / fa)单独点名 ——
+   * 它们最容易在批量改文案时被当成「反正看不懂」直接抄英文。
+   */
+  it.each(['ar', 'fa'] as const)('%s 是真译文,不是英文回落', async (locale) => {
+    const dict = await loadDict(locale);
+    const value = dict['chat.runError.contactSupportCta'];
+    expect(value).not.toMatch(/[A-Za-z]/);
+    expect(value).not.toMatch(/TODO/i);
+  });
+});


### PR DESCRIPTION
Split out of #7882. That PR bundles three things with very different value and
risk; this one carries the two that stand on their own, so they can land now.
#7882 stays open with the part that still needs a product ruling.

## Why

**Use case.** Reviewing #7882 (OPEND-2807, "collapse the run error card to three
buttons") turned up a defect that has nothing to do with the button redesign, plus
a copy change the ticket asks for verbatim. Both were riding along inside a change
that also removes 〔Continue〕 (`onResumeRun`) and the antigravity terminal
authorization entry (`onLaunchAntigravityOauth`) — a functional regression that
needs product sign-off. Holding a real bug fix hostage to that decision is the
wrong trade, so the independent parts come out here.

**The pain.**

1. 〔Switch to Cloud〕 does nothing on its own. It hands the failed turn to the
   host — `onSwitchToAmrAndRetry`, falling back to `onOpenAmrSettings`. Two of the
   three `ChatPane` hosts wire neither: `workspace/SideChatTab` wires only
   `onRetry`, `DesignSystemFlow` wires nothing. In the side chat the button's
   `onClick` walks both branches and nothing happens.

   The inert button is not the whole cost. Everything downstream of
   `showCloudSwitchCta` assumes the primary slot has been taken:
   `errorActionVariant` demotes the ladder's *working* Retry to secondary, and
   `contactSupportIsPrimary` stops promoting. On a rung-4 card — the failures with
   no recovery action at all — that leaves **zero primary buttons and one dead
   one**. After a failed run, the only prominent button on screen is fake.

   The invariant is one the card already uses twice
   (`balanceCardCannotTakeTheHandoff`, `reconnectRowCannotTakeTheHandoff`): a
   handoff only holds while the target is actually present.

2. OPEND-2807 gives `chat.runError.contactSupportCta` verbatim as 「联系我们」;
   the product still reads 「联系支持」 in all 19 locales.

## What users will see

- **Side chat (workspace) run failures:** the 〔切换到 Cloud〕 button is gone —
  it never did anything there — and 〔重试〕 goes back to being the prominent
  button. Failures that have no recovery action at all get their 〔联系我们〕
  promoted again, so the card is never a dead end.
- **Everywhere else (project chat):** unchanged. Same buttons, same order, same
  primary — `ProjectView` wires the handoff, so nothing about it moves.
- **All run error cards, 19 languages:** the standing button reads 「联系我们」
  instead of 「联系支持」 (en: "Contact us" instead of "Contact support").

Net effect on the card: the **number and kind of buttons is identical to main**.
Only (a) the side chat stops drawing a dead button and hiding a working one, and
(b) one label changes.

## Surface area

- [x] **UI** — run error card in `apps/web` (button presence in the side chat; one label)
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [x] **i18n keys** — no new keys; `chat.runError.contactSupportCta` changes value in all 19 locales
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

No CLI counterpart applies: this is presentational state of a chat surface, with
no `/api/*` capability behind it. The recovery actions it gates
(`POST /api/chat` retry, AMR mode switch) are already reachable from `od`.

## Screenshots

Not attached — the visible change is inside `workspace/SideChatTab`'s error card,
which needs a real failed run in a team workspace to stage. The behavior is
covered by rendering-level specs instead
(`apps/web/tests/components/chat/cloud-cta-handoff-presence.test.tsx`), which
assert on rendered text, `data-testid` and click behavior, and go red without the
fix. Happy to stage a manual comparison if a reviewer wants one before merge.

## Bug fix verification

- Test path that reproduces the bug:
  `apps/web/tests/components/chat/cloud-cta-handoff-presence.test.tsx`
- Did the test go red on `main` and green on this branch? **yes.** With the guard
  removed (`showCloudSwitchCta = Boolean(cloudSwitchTracking) && true`), 3 of 9
  fail:
  - `侧边聊天:不画那颗点了没反应的 Cloud 按钮` — the button renders
  - `侧边聊天:〔重试〕还在,而且拿回主位` — `expected 'secondary' to be 'primary'`
  - `侧边聊天 · 第 4 档:卡不许变成「零个主按钮 + 一颗假按钮」` — the button renders
- The copy spec `apps/web/tests/i18n/opend-2807-contact-us-cta.test.ts` was
  likewise verified by reverting all 19 locale values to `origin/main` and
  re-running: 40 failed / 16 passed across it and
  `w124-chat-tooltips-and-panel-head.test.tsx`.
- **Reverse anchor:** four specs pin that `ProjectView`'s wiring (both handlers)
  behaves exactly as on main — Cloud CTA still primary, Retry still present and
  secondary, click still routes to `onSwitchToAmrAndRetry`, rung-4 contact-support
  still not promoted. Those stay green in both directions.

## Validation

- `pnpm --filter @open-design/web typecheck` → exit `0`
- `pnpm guard` → exit `0`
- `apps/web` — `vitest run tests/components tests/i18n tests/runtime`:
  **8653 passed / 834 files**, 1 expected-fail, 11 skipped. One unrelated
  load-sensitive flake under full parallelism
  (`tests/components/chat/plan-step-weight.test.tsx > 接缝真的把 500 传下来了`,
  6.5s); it passes on its own (5/5) and touches no error-card code.
- New/changed specs on their own: `cloud-cta-handoff-presence` 9 passed,
  `opend-2807-contact-us-cta` 42 passed, `w124-chat-tooltips-and-panel-head` and
  `ChatPane.error-card-ladder` green.

## Relationship to #7882 — and what is deliberately *not* here

#7882 (`fix/error-card-single-cta`) is untouched and stays open. Not carried over:

- removal of `RunErrorCardActionGroup`
- removal of `AmrLoginPill` from the card
- any removal of `onResumeRun` / `onLaunchAntigravityOauth` /
  `RESUME_CONTINUE_PROMPT` / `contactSupportIsPrimary` / `showErrorActions`
- the `showRetryCta = !showCloudSwitchCta` mutual exclusion
- any "exactly three buttons" assertion
- `specs/current/chat-panel-decisions-sheet.md`

Those delete 〔继续运行〕 and the only UI entry to
`/api/agents/antigravity/oauth-launch`, which is a functional regression and needs
a product ruling. `git diff origin/main HEAD` shows 0 removed lines for every one
of the symbols above, and every one keeps its exact occurrence count from `main`
in `ChatPane.tsx`.

The guard here is **not** #7882's two lines pasted over. `main` and that branch
have diverged (it removes the ladder and rewrites `showRetryCta`), so the same
invariant is expressed against main's current structure: one named predicate,
`cloudSwitchCtaCannotTakeTheHandoff`, folded into `showCloudSwitchCta` so every
existing consumer (`errorActionVariant`, `contactSupportIsPrimary`,
`visibleRecoveryActionTypes`, the render site) inherits it without its own `if`.

### ⚠️ One copy key deliberately left out — needs your call

The split was scoped as two label changes. Only one is applied.
`chat.amrCard.switchCta` is **not** touched, because `main` has moved since #7882
branched:

| | value |
|---|---|
| #7882's base (pre-split) | 「切换到 OpenDesign Cloud 并重试」 |
| **`main` today** (#7871, `819c10d49f`) | **「切换到 Cloud」** |
| #7882's branch | 「切换到 OpenDesign Cloud」 |

#7871 is already merged and is the *newer* product ruling — `ChatPane.tsx` on main
records it as 「产品原话『切换到 cloud 就行了』」, and the merged spec
`opend-2772-one-card-one-cta.test.tsx` pins the rendered string to 「切换到 Cloud」
verbatim. The ticket's goal for this key (drop the 「并重试」 tail) is therefore
already satisfied on main; applying #7882's value would re-add "OpenDesign" and
revert a landed, product-ruled string. That is not a call to make silently, so it
is left for @lefarcen to decide — say the word and it is a one-line follow-up.

`chat.runError.contactSupportCta` has no such conflict (unchanged on main since
#7518) and is applied in full, 19 locales, copied byte-for-byte from
`origin/fix/error-card-single-cta` — including `tr`'s reviewed vowel-harmony
suffix — with no re-translation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQSowXMsTxbEoZyGYfxgyb
