### PR TITLE
fix(web): stop a compositor scroll clamp from silently killing auto-follow

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -1560,15 +1560,28 @@ export function ChatPane({
     clientHeight: 0,
   });
   /**
-   * 上一次 scroll 事件之后收到的滚轮格数,按方向分开数。
+   * 「就在这个位置上,用户的滚轮在朝下要」——一张**只解释一次位移**的证词。
    *
    * 唯一的用途是给 `nextFollowIntent` 一个否决权:朝下的滚轮配上朝上的位移不是
    * 用户上滑(见 `stick-to-bottom.ts` 的 `isCompositorSnapBack`)。
    *
-   * ⚠️ 它是**一次性**的,而且只由输入清空 —— 见 `resetWheelWitness` 的调用点。
-   * 这个见证留得越久,越可能替一次真正的用户上滑背书。
+   * ## ⚠️ 生命周期是这张条子的安全性所在
+   *
+   * 一张能解释任意后续位移的条子会把跟随焊死 —— 那比它要修的 bug 更糟。三条边界
+   * 各自堵一个别的堵不住的洞,缺一不可:
+   *
+   *  1. **用掉就清**(`onScroll`)—— 一次位移一张条子,不许连用。
+   *  2. **上下文换了就清**(切会话、日志节点换掉、面板卸载,以及滚轮之外的输入)
+   *     —— 结构性的那一半;`atScrollTop` 在判据里再兜一层。
+   *  3. **过一帧就过期**(`armWheelWitnessExpiry`)—— 唯一能堵住「一格朝下的滚轮
+   *     落在已经到底的日志上,位置不动、连 scroll 事件都不发」的洞:那张条子
+   *     没人来用掉,得自己死。
+   *
+   * `null` = 没有见证 = 判据退回「方向 + 几何」,也就是这套东西出现之前的行为。
    */
-  const wheelWitnessRef = useRef<WheelWitness>({ downwardEvents: 0, upwardEvents: 0 });
+  const wheelWitnessRef = useRef<WheelWitness | null>(null);
+  /** (3) 的那一帧。挂着的时候说明有一张条子在等着过期。 */
+  const wheelWitnessFrameRef = useRef<number | null>(null);
   const scrolledToFormRef = useRef<Set<string>>(new Set());
   const refreshInlineAmrLoginStatus = useCallback(async (options: { refresh?: boolean } = {}) => {
     const next = await fetchVelaLoginStatus(options).catch(() => null);
@@ -2629,6 +2642,25 @@ export function ChatPane({
      */
     armFollow();
     lastScrollSampleRef.current = { scrollTop: 0, scrollHeight: 0, clientHeight: 0 };
+    /*
+     * 滚轮见证是**这条会话这个位置**上的证词,跟着基线和跟随意图一起归位。
+     *
+     * 漏掉它会漏出一条完整的路(nettee 在 #7898 上点名的):用户已经在底部,
+     * 再往下拨一格 —— 位置不动,不发 scroll 事件,条子没人用掉;从历史记录切换
+     * 会话的那次点击发生在**日志元素之外**,一个 pointerdown 都收不到;新会话
+     * 定位好之后一次页内查找跳到前面,就撞上那张旧条子,被判成夹取,跟随不释放。
+     *
+     * ⚠️ 【实测交待】这一行**单独撤掉,现有测试不会变红**,原因清楚:换会话必然
+     * 会排一帧(初次定位那条 effect 会 `armFollow()` 并贴底),那一帧一跑,过期
+     * 边界就已经把条子杀了;就算帧没跑,基线也就没被刷新,判据里的 `atScrollTop`
+     * 同样对不上。也就是说评审点的这个洞今天是被那两条堵住的。
+     *
+     * 留着它不是保险起见,是**作用域声明**:见证属于「这条会话的这个位置」,
+     * 上下文边界该由上下文自己划。那两条一条是时间的、一条是判据时刻的,谁先
+     * 松一点(比如哪天给 `atScrollTop` 加个亚像素容差 —— 这个仓库到处是 8px 容差)
+     * 这一行就是唯一还站着的。
+     */
+    resetWheelWitness();
   }, [activeConversationId]);
 
   // ChatComposer's internal `seededRef` latches after the first
@@ -3035,8 +3067,7 @@ export function ChatPane({
        * 位置被甩到 91」(`observability/chat-scroll-freeze-detector.ts` 的抬头)。
        * 记漏了,随之而来的那次「位置变小」就还是会被读成用户上滑。
        */
-      if (event.deltaY > 0) wheelWitnessRef.current.downwardEvents += 1;
-      else if (event.deltaY < 0) wheelWitnessRef.current.upwardEvents += 1;
+      recordWheelWitness(target, event.deltaY);
       if (event.deltaY >= 0) return;
       /*
        * 判据是**这一格有没有可能真的离开底部**,不是「有没有发生一次滚轮手势」。
@@ -3105,6 +3136,17 @@ export function ChatPane({
       el.removeEventListener('touchmove', onTouchMove);
       el.removeEventListener('pointerdown', onOtherInput);
       el.removeEventListener('keydown', onOtherInput);
+      /*
+       * 这个节点不再是我们监听的那个了(面板卸载、日志被换掉)。挂在它身上的
+       * 证词跟着走,连同那一帧过期。
+       *
+       * ⚠️ 【实测交待】这一行单独撤掉现有测试也不会红:`setTab` 今天没有任何调用点,
+       * 所以这条 effect 的清理只在卸载时跑,跑完 ref 也跟着组件一起没了。
+       * 它防的是重挂之后的一个真实死法 —— `armWheelWitnessExpiry` 见到
+       * `wheelWitnessFrameRef` 非空就不再排帧,于是一个既没跑也没被取消的旧帧号
+       * 会让过期这条边界**永久失效**。这一天在 `tab` 真的会变的时候就会到。
+       */
+      resetWheelWitness();
     };
   }, [tab]);
 
@@ -3368,17 +3410,78 @@ export function ChatPane({
   }
 
   /**
-   * 把滚轮见证清空。
+   * 把滚轮见证撕掉,连同它那一帧过期定时。
    *
-   * 清空点只有两个,而且都是**输入**:scroll 事件把它用掉,别的输入通道
-   * (拖滚动条 / 键盘)一动就把它作废。见证越短命越安全。
+   * 每一个调用点都是一条**边界**,不是保险起见:用掉了(`onScroll`)、滚轮之外的
+   * 输入来了(`onOtherInput`)、上下文换了(切会话、面板卸载)。
    *
    * 特意**不**挂在 `rememberScrollSample` 上:我们自己写 `scrollTop` 在流式期间
    * 随时可能插进「用户滚轮」和「随之而来的 scroll 事件」中间,把见证擦掉,
-   * 那一格夹取就又变回一次「用户上滑」。基线归位和见证归位是两件事。
+   * 那一格夹取就又变回一次「用户上滑」。基线挪走这件事由判据里的 `atScrollTop`
+   * 处理 —— 它作废的是「对不上号的条子」,不是「所有条子」。
    */
   function resetWheelWitness() {
-    wheelWitnessRef.current = { downwardEvents: 0, upwardEvents: 0 };
+    wheelWitnessRef.current = null;
+    const frame = wheelWitnessFrameRef.current;
+    wheelWitnessFrameRef.current = null;
+    if (frame === null) return;
+    if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(frame);
+  }
+
+  /**
+   * 让这张条子最多活到下一帧。
+   *
+   * ## 为什么必须有这一条
+   *
+   * 用户已经在底部,再往下拨一格 —— 位置一个像素都不动,**连 scroll 事件都不发**。
+   * 那张条子于是没人来用掉。它要是能一直留着,后面任何一次**非滚轮**的位置变化
+   * (页内查找、焦点驱动的滚动)都会撞上它,被判成夹取 —— 跟随焊死。
+   *
+   * ## 为什么界限是「一帧」而不是一个毫秒数
+   *
+   * 夹取是**紧跟着**那一格滚轮的:合成器接管输入、把越界位置夹回、在同一次渲染
+   * 更新里把 scroll 事件发出来。按 HTML 规范的 update-the-rendering,scroll 事件
+   * 排在这一帧的 animation frame 回调**之前**,所以「这一格滚轮引起的 scroll」
+   * 一定在下一个 rAF 回调跑到之前就已经到了。一帧因此不是调出来的数,是那条因果
+   * 链本身的长度。
+   *
+   * ⚠️ 别把这个数和诊断包里的 3.8 秒搞混:那 3.8 秒是**点击写入**和夹取之间的
+   * 间隔(期间零条 JS 写入),不是滚轮和夹取之间的间隔。
+   *
+   * 后台标签页不发 rAF,所以这一条**不能**独自承担全部生命周期 —— 切会话那条
+   * 结构性的清理必须自己存在,不能指望这一帧替它兜底。
+   */
+  /**
+   * 把这一格滚轮记进见证。
+   *
+   * 条子是**按位置**攒的:位置一变就是新的一张。滚轮把日志真滚动了,那次位移
+   * 自己会带一个 scroll 事件来把旧条子用掉;而合成器卡住的那一档里位置纹丝不动,
+   * 同一张条子于是能把一次轻扫里的十几格(包括中途掉头的那几格)攒全。
+   *
+   * 没有 rAF 就**不记**:那样过期这条边界不存在,而一张不会过期的条子迟早会替
+   * 一次真正的用户上滑背书。没有见证只是回到这套东西出现之前的行为,是安全的那边。
+   */
+  function recordWheelWitness(el: HTMLDivElement, deltaY: number) {
+    if (deltaY === 0) return;
+    if (typeof requestAnimationFrame !== 'function') return;
+    const atScrollTop = el.scrollTop;
+    const current = wheelWitnessRef.current;
+    const witness =
+      current !== null && current.atScrollTop === atScrollTop
+        ? current
+        : { downwardEvents: 0, upwardEvents: 0, atScrollTop };
+    if (deltaY > 0) witness.downwardEvents += 1;
+    else witness.upwardEvents += 1;
+    wheelWitnessRef.current = witness;
+    armWheelWitnessExpiry();
+  }
+
+  function armWheelWitnessExpiry() {
+    if (wheelWitnessFrameRef.current !== null) return;
+    wheelWitnessFrameRef.current = requestAnimationFrame(() => {
+      wheelWitnessFrameRef.current = null;
+      wheelWitnessRef.current = null;
+    });
   }
 
   /** 唯一的 `scrollTop` 写入口:写完就记基线。 */

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -8,6 +8,7 @@ import {
   upwardGestureCanEscapeBottom,
   type FollowIntent,
   type ScrollSample,
+  type WheelWitness,
 } from '../runtime/chat/stick-to-bottom';
 import {
   ANCHOR_TOP_PADDING,
@@ -1558,6 +1559,16 @@ export function ChatPane({
     scrollHeight: 0,
     clientHeight: 0,
   });
+  /**
+   * 上一次 scroll 事件之后收到的滚轮格数,按方向分开数。
+   *
+   * 唯一的用途是给 `nextFollowIntent` 一个否决权:朝下的滚轮配上朝上的位移不是
+   * 用户上滑(见 `stick-to-bottom.ts` 的 `isCompositorSnapBack`)。
+   *
+   * ⚠️ 它是**一次性**的,而且只由输入清空 —— 见 `resetWheelWitness` 的调用点。
+   * 这个见证留得越久,越可能替一次真正的用户上滑背书。
+   */
+  const wheelWitnessRef = useRef<WheelWitness>({ downwardEvents: 0, upwardEvents: 0 });
   const scrolledToFormRef = useRef<Set<string>>(new Set());
   const refreshInlineAmrLoginStatus = useCallback(async (options: { refresh?: boolean } = {}) => {
     const next = await fetchVelaLoginStatus(options).catch(() => null);
@@ -2975,8 +2986,12 @@ export function ChatPane({
         followIntentRef.current,
         lastScrollSampleRef.current,
         sample,
+        wheelWitnessRef.current,
       );
       lastScrollSampleRef.current = sample;
+      // 见证是一次性的:它只为**这一段**位移作数。留到下一段就可能替一次真正的
+      // 用户上滑背书 —— 那是把跟随焊死,比它要修的 bug 更糟。
+      resetWheelWitness();
       snapshot(target);
       // `syncFollowState` 里的函数式更新在值没变时原地返回,所以流式期间那一串
       // scroll 事件不会每一跳都排一次重渲,也就不会撞上 React 的
@@ -3014,6 +3029,14 @@ export function ChatPane({
     function onWheel(event: WheelEvent) {
       const target = logRef.current;
       if (!target) return;
+      /*
+       * 先记方向,再走下面的早退 —— 朝下的滚轮在这一条里什么都不做,可它正是
+       * 合成器夹取的**触发者**:真机实测「`scrollTop = 800`,一格朝下的滚轮,
+       * 位置被甩到 91」(`observability/chat-scroll-freeze-detector.ts` 的抬头)。
+       * 记漏了,随之而来的那次「位置变小」就还是会被读成用户上滑。
+       */
+      if (event.deltaY > 0) wheelWitnessRef.current.downwardEvents += 1;
+      else if (event.deltaY < 0) wheelWitnessRef.current.upwardEvents += 1;
       if (event.deltaY >= 0) return;
       /*
        * 判据是**这一格有没有可能真的离开底部**,不是「有没有发生一次滚轮手势」。
@@ -3051,11 +3074,26 @@ export function ChatPane({
       }
     }
 
+    /*
+     * 滚轮之外的每条输入通道,一动就把滚轮见证作废。
+     *
+     * 见证平时由 scroll 事件用掉。但滚轮**打不动**这个框的时候(合成器卡住的
+     * 那一档,真机实测「12 格朝下的滚轮要 1440px,停在 91 一动不动」)一个
+     * scroll 事件都不会发,见证就留在那儿。这时用户改用滚动条或键盘往上走,
+     * 那次位移会撞上一个陈旧的「滚轮在朝下要」见证 —— 一次真正的用户上滑被吞掉。
+     * 这两条监听把那个窗口关掉。
+     */
+    function onOtherInput() {
+      resetWheelWitness();
+    }
+
     rememberScrollSample(el);
     el.addEventListener('scroll', onScroll);
     el.addEventListener('wheel', onWheel, { passive: true });
     el.addEventListener('touchstart', onTouchStart, { passive: true });
     el.addEventListener('touchmove', onTouchMove, { passive: true });
+    el.addEventListener('pointerdown', onOtherInput, { passive: true });
+    el.addEventListener('keydown', onOtherInput, { passive: true });
     return () => {
       // Capture final scroll state before unmount; the ref normally
       // tracks via onScroll, but programmatic scrolls or layout shifts
@@ -3065,6 +3103,8 @@ export function ChatPane({
       el.removeEventListener('wheel', onWheel);
       el.removeEventListener('touchstart', onTouchStart);
       el.removeEventListener('touchmove', onTouchMove);
+      el.removeEventListener('pointerdown', onOtherInput);
+      el.removeEventListener('keydown', onOtherInput);
     };
   }, [tab]);
 
@@ -3325,6 +3365,20 @@ export function ChatPane({
    */
   function rememberScrollSample(el: HTMLDivElement) {
     lastScrollSampleRef.current = readViewportSample(el);
+  }
+
+  /**
+   * 把滚轮见证清空。
+   *
+   * 清空点只有两个,而且都是**输入**:scroll 事件把它用掉,别的输入通道
+   * (拖滚动条 / 键盘)一动就把它作废。见证越短命越安全。
+   *
+   * 特意**不**挂在 `rememberScrollSample` 上:我们自己写 `scrollTop` 在流式期间
+   * 随时可能插进「用户滚轮」和「随之而来的 scroll 事件」中间,把见证擦掉,
+   * 那一格夹取就又变回一次「用户上滑」。基线归位和见证归位是两件事。
+   */
+  function resetWheelWitness() {
+    wheelWitnessRef.current = { downwardEvents: 0, upwardEvents: 0 };
   }
 
   /** 唯一的 `scrollTop` 写入口:写完就记基线。 */

--- a/apps/web/src/runtime/chat/stick-to-bottom.ts
+++ b/apps/web/src/runtime/chat/stick-to-bottom.ts
@@ -175,6 +175,80 @@ export function upwardGestureCanEscapeBottom(sample: ScrollSample): boolean {
 }
 
 /**
+ * 这一段位移发生时,**滚轮**在朝哪个方向要。
+ *
+ * 计数而不是存最后一格的方向:一次触控板轻扫在两个 scroll 事件之间能吐十几格,
+ * 中途还可能掉头。只记最后一格会把「净上滚的一串里最后碰巧朝下的那一格」
+ * 读成朝下。
+ */
+export interface WheelWitness {
+  /** 朝底部(`deltaY > 0`)的格数。 */
+  downwardEvents: number;
+  /** 朝上(`deltaY < 0`)的格数。 */
+  upwardEvents: number;
+}
+
+/**
+ * 这一次「位置变小」是**合成器把越界位置夹回它自己的陈旧上限**,不是用户上滑。
+ *
+ * ## 为什么 `nextFollowIntent` 原来那条判据分不出来
+ *
+ * 原来的注释写着「内容变化引起的位移必然伴随 `scrollHeight` 变化」。这句话对
+ * **内容驱动**的位移成立(scroll anchoring、回流),但对下面这种位移不成立:
+ * Chromium 为了让滚轮不等主线程,自己另存一份「这个框能滚多远」,而这份拷贝
+ * 会卡在旧值上不再跟着布局走。真机(Electron 41 / Chromium 146)诊断包:
+ *
+ *   scrollTop 245.5   layoutMax 718   scrollHeight 1307   unreachablePx 472.5
+ *
+ * 点【滚动到最新】→ `scrollTo({top:1307})` → 位置落在 718.5(布局的真底部);
+ * 用户碰一下滚轮,合成器把它甩回自己那份陈旧上限 245.5。这中间 `scrollHeight`
+ * 一个像素没变(内容是静态的)—— 于是「位置变小 + `scrollHeight` 没变」两条
+ * 同时成立,每一次夹取都被读成一次用户上滑,跟随被静默关掉。
+ *
+ * 同一现象在 `observability/chat-scroll-freeze-detector.ts` 里被独立量到过,
+ * 那份实测记的是:`scrollTop = 800`,**一格朝下**的滚轮,位置被甩到 91。
+ *
+ * ## 判据:朝下的滚轮 + 位置反而往上跑
+ *
+ * 用户上滑要么带**朝上**的滚轮,要么根本没有滚轮(拖滚动条 / 键盘 / 触摸)。
+ * 所以「这段窗口里的滚轮**只**朝下」这一条,用户上滑永远不成立 —— 它是在说
+ * 「用户此刻要的是往底部去」。位置却反着跑,那就不是他的手。
+ *
+ * 另外三条候选都不够:
+ *
+ *  · **落点等于已知的陈旧上限** —— 那个上限只能靠 freeze detector 的连续
+ *    stall / snap-back 状态机推出来,而 `runtime/chat-scroll-takeover.ts` 写明
+ *    那个检测器的误报率**至今未知**(`client_chat_scroll_frozen` 线上零事件,
+ *    而那个零后来查出是上报缺陷)。何况用户完全可以正好停在那个数上。
+ *  · **和 `layoutMax` 的差** —— 用户上滑可以停在 `[0, layoutMax]` 里任何位置,
+ *    这一条不携带任何区分信息。
+ *  · **紧邻一次 JS 写入** —— 被诊断包本身证伪:夹取发生在写入之后 **3.8 秒**,
+ *    期间零条 JS 写入记录。能盖住 3.8 秒的时间窗会连正常上滑一起吞掉。
+ *
+ * ⚠️ 这里只回答「**不是**用户上滑」,不回答「合成器一定坏了」。判据宁可漏
+ * (没有滚轮见证的夹取照旧被当成上滑)也不许多:多判一次就是把跟随焊死,
+ * 那比现在这个 bug 更糟。
+ *
+ * 位移门槛复用 `AT_BOTTOM_TOLERANCE_PX`(8px)—— 高 DPI / 分数缩放下贴底位置
+ * 本来就有亚像素抖动,和这套状态机其余部分同一把尺子。freeze detector 的
+ * `SNAP_BACK_MIN_PX` 从同一批实测里独立得到的也是 8。
+ */
+export function isCompositorSnapBack(
+  previous: ScrollSample,
+  next: ScrollSample,
+  wheel: WheelWitness | null | undefined,
+): boolean {
+  if (wheel == null) return false;
+  // 一格朝上就作废:那一格本身就是用户在要求上滑。
+  if (wheel.upwardEvents > 0) return false;
+  if (wheel.downwardEvents <= 0) return false;
+  // 内容动过就不是这个现象 —— 那种位移由 `layoutStable` 那条负责。
+  if (next.scrollHeight !== previous.scrollHeight) return false;
+  if (next.clientHeight !== previous.clientHeight) return false;
+  return previous.scrollTop - next.scrollTop > AT_BOTTOM_TOLERANCE_PX;
+}
+
+/**
  * 一次滚动之后,跟随意图该变成什么。
  *
  * **只有这里(以及几处显式动作:点「回到最新」、发消息、切会话)能改意图。**
@@ -193,11 +267,18 @@ export function upwardGestureCanEscapeBottom(sample: ScrollSample): boolean {
  * 更麻烦的是流式:浏览器的落点在调用那一刻算死,内容还在长,于是动画落在一个
  * 早就不是底部的位置上,连「最后一帧贴底顺手救回来」都没有。
  * (`ChatPane` 的 question-form 定位在这上面栽过一次,两份拷贝只修了一份。)
+ *
+ * ## `wheel`:这段位移发生时滚轮朝哪儿要
+ *
+ * 可选。给了就多一条否决:朝下的滚轮配上朝上的位移不是用户上滑,是合成器夹取
+ * (见 `isCompositorSnapBack`)。不给等于没有见证,判据退回「方向 + 几何」——
+ * 也就是这个参数出现之前的行为,一格不差。
  */
 export function nextFollowIntent(
   current: FollowIntent,
   previous: ScrollSample,
   next: ScrollSample,
+  wheel?: WheelWitness | null,
 ): FollowIntent {
   // 位置变小**且内容总高没变** = 用户的手。内容变化引起的位移(浏览器夹取、
   // scroll anchoring 修正)必然伴随 `scrollHeight` 变化,在这里就被排掉了。
@@ -226,7 +307,9 @@ export function nextFollowIntent(
 
   let { following, escaped } = current;
   // 还贴在底上的一两个像素抖动不算挣脱 —— 高 DPI 屏上这种抖动是常态。
-  if (scrolledUp && !isAtBottom(next)) {
+  // 合成器把越界位置夹回陈旧上限也长这个样子(位置变小 + `scrollHeight` 没变),
+  // 但那一刻用户的滚轮要的是**往底部去** —— 那不是挣脱,见 `isCompositorSnapBack`。
+  if (scrolledUp && !isAtBottom(next) && !isCompositorSnapBack(previous, next, wheel)) {
     escaped = true;
     following = false;
   }

--- a/apps/web/src/runtime/chat/stick-to-bottom.ts
+++ b/apps/web/src/runtime/chat/stick-to-bottom.ts
@@ -180,12 +180,29 @@ export function upwardGestureCanEscapeBottom(sample: ScrollSample): boolean {
  * 计数而不是存最后一格的方向:一次触控板轻扫在两个 scroll 事件之间能吐十几格,
  * 中途还可能掉头。只记最后一格会把「净上滚的一串里最后碰巧朝下的那一格」
  * 读成朝下。
+ *
+ * ## 一张条子只解释一次位移
+ *
+ * 见证是**证词**,不是状态:它说的是「就在这个位置上,用户的滚轮在朝下要」。
+ * 一张能解释任意后续位移的条子会把跟随焊死,而那比它要修的 bug 更糟。
+ * 所以它带着 `atScrollTop` —— 位移的起点必须就是记录它时的那个位置。
+ *
+ * 这一条是**结构性**的,不是时间窗:会话切换、我们自己写 `scrollTop`、日志节点
+ * 被换掉,都会把基线挪走,于是旧条子对不上号,自动作废。调用方还要另外管两件
+ * 时间上的事(用掉就清、过一帧就过期),见 `ChatPane` 的 `resetWheelWitness`。
  */
 export interface WheelWitness {
   /** 朝底部(`deltaY > 0`)的格数。 */
   downwardEvents: number;
   /** 朝上(`deltaY < 0`)的格数。 */
   upwardEvents: number;
+  /**
+   * 记录这张条子时滚动条所在的位置。
+   *
+   * 位移的起点(`previous.scrollTop`)必须**正好**是它。差一点都作废 —— 对不上
+   * 就说明中间还有别的东西动过这个滚动条,那这张条子解释的已经不是眼前这一段。
+   */
+  atScrollTop: number;
 }
 
 /**
@@ -225,6 +242,17 @@ export interface WheelWitness {
  *  · **紧邻一次 JS 写入** —— 被诊断包本身证伪:夹取发生在写入之后 **3.8 秒**,
  *    期间零条 JS 写入记录。能盖住 3.8 秒的时间窗会连正常上滑一起吞掉。
  *
+ * ## 见证必须**紧贴**它解释的那一段位移
+ *
+ * 一格朝下的滚轮如果落在**已经到底**的日志上,位置一个像素都不动,于是连 scroll
+ * 事件都不发 —— 那张条子就没人来用掉。它要是还留着,后面任何一次**非滚轮**的
+ * 位置变化(页内查找、焦点驱动的滚动、换会话之后的重新定位)都会撞上它,被判成
+ * 夹取,跟随不释放。那正是「把跟随焊死」,方向和这个 bug 反过来,但更糟
+ * (nettee 在 #7898 上点名的就是这条)。
+ *
+ * `atScrollTop` 挡住其中**结构性**的那一半:基线因为别的原因挪过,条子就对不上。
+ * 剩下「基线没挪、但那一格滚轮已经是很久以前的事」由调用方的过期负责。
+ *
  * ⚠️ 这里只回答「**不是**用户上滑」,不回答「合成器一定坏了」。判据宁可漏
  * (没有滚轮见证的夹取照旧被当成上滑)也不许多:多判一次就是把跟随焊死,
  * 那比现在这个 bug 更糟。
@@ -242,6 +270,8 @@ export function isCompositorSnapBack(
   // 一格朝上就作废:那一格本身就是用户在要求上滑。
   if (wheel.upwardEvents > 0) return false;
   if (wheel.downwardEvents <= 0) return false;
+  // 这张条子记的不是眼前这一段位移的起点 —— 中间有别的东西动过滚动条,作废。
+  if (wheel.atScrollTop !== previous.scrollTop) return false;
   // 内容动过就不是这个现象 —— 那种位移由 `layoutStable` 那条负责。
   if (next.scrollHeight !== previous.scrollHeight) return false;
   if (next.clientHeight !== previous.clientHeight) return false;

--- a/apps/web/tests/components/chat-scroll-following.test.tsx
+++ b/apps/web/tests/components/chat-scroll-following.test.tsx
@@ -14,6 +14,7 @@ if (typeof HTMLElement.prototype.scrollTo !== 'function') {
 }
 
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ReactElement } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ChatPane } from '../../src/components/ChatPane';
 import { flushMounts, pressEnter, typeInComposer } from '../helpers/lexical-composer';
@@ -1299,5 +1300,159 @@ describe('尾部预留空白不能把「用户滑走了」这件事吃掉(用户
     await userScrollTo(900);
     expect(geom.contentHeight - geom.scrollTop - geom.clientHeight).toBe(360);
     expect(jumpBtnShown()).toBe(true);
+  });
+});
+
+/*
+ * ── 合成器把位置甩回陈旧上限,不算用户上滑 ────────────────────────────
+ *
+ * 真机诊断包(Electron 41 / Chromium 146,用户客户端):布局层和合成器层各持一份
+ * 「这个框能滚多远」,合成器那份卡在旧值上 ——
+ *
+ *   scrollTop 245.5   layoutMax 718   scrollHeight 1307   unreachablePx 472.5
+ *
+ * 点【滚动到最新】→ `scrollTo({top:1307})` → 位置落在 718.5;用户碰一下滚轮,
+ * 合成器把越界位置甩回自己那份陈旧上限 245.5。写入拦截(`scrollTop`/`scrollTo`/
+ * `scrollBy`/`scrollIntoView` 四个 API)全程武装、零丢弃,这 3.8 秒里**零条 JS
+ * 写入记录** —— 没有任何 JS 移过它。
+ *
+ * 那一段位移「位置变小 + `scrollHeight` 没变」,正好命中判据里「用户上滑」的
+ * 定义,于是每一次夹取都把自动跟随静默关掉。
+ *
+ * 判据只由「这段窗口里的滚轮**只**朝下」授权 —— 用户此刻要的是往底部去,位置却
+ * 反着跑,那就不是他的手。下面两条反向用例比正向那条更重要:多判一次就是把跟随
+ * 焊死,比这个 bug 更糟。
+ */
+describe('合成器夹取不许关掉自动跟随', () => {
+  /** 不经过 `scrollTop` setter 的位移 —— 合成器干的,不是 JS 写的。 */
+  async function compositorClampTo(top: number) {
+    await act(async () => {
+      geom.scrollTop = top;
+      fireEvent.scroll(chatLog());
+      await Promise.resolve();
+    });
+  }
+
+  async function wheel(deltaY: number) {
+    await act(async () => {
+      fireEvent.wheel(chatLog(), { deltaY });
+      await Promise.resolve();
+    });
+  }
+
+  async function streamOneChunk(
+    rerender: (ui: ReactElement) => void,
+    text: string,
+    px = 120,
+  ): Promise<void> {
+    geom.contentHeight += px;
+    await act(async () => {
+      rerender(chatPaneEl(longConversation(text), { streaming: true }));
+    });
+    await triggerResize();
+    await flushFrames();
+  }
+
+  it('朝下的滚轮把位置甩到上面去之后,流式输出仍然自动吸底', async () => {
+    geom = { contentHeight: 5000, clientHeight: 400, scrollTop: 0 };
+    const { rerender } = render(chatPaneEl(longConversation('chunk'), { streaming: true }));
+    await flushFrames();
+    expect(geom.scrollTop).toBe(4600);
+
+    // 用户想往底部去。合成器把他甩回自己那份陈旧上限。
+    await wheel(40);
+    await compositorClampTo(1200);
+
+    await streamOneChunk(rerender, 'chunk more');
+    expect(geom.scrollTop).toBe(maxScrollTop());
+  });
+
+  it('【反向】滚轮朝上带来的同一段位移,跟随必须照旧松开', async () => {
+    geom = { contentHeight: 5000, clientHeight: 400, scrollTop: 0 };
+    const { rerender } = render(chatPaneEl(longConversation('chunk'), { streaming: true }));
+    await flushFrames();
+
+    await wheel(-40);
+    await compositorClampTo(1200);
+
+    await streamOneChunk(rerender, 'chunk more');
+    expect(geom.scrollTop).toBe(1200);
+  });
+
+  it('【反向】滚轮打不动这个框时改用滚动条上滑,那一次上滑不许被吞掉', async () => {
+    /*
+     * 合成器卡住的那一档里,朝下的滚轮一个 scroll 事件都不发(真机实测「12 格朝下
+     * 的滚轮要 1440px,停在 91 一动不动」)。见证于是留在那儿没人用掉 —— 这时用户
+     * 改用滚动条往上走,那一次**真正的**用户上滑会撞上一个陈旧的「滚轮在朝下要」。
+     *
+     * 所以滚轮之外的每条输入通道一动就把见证作废。这一条钉的就是那个作废。
+     */
+    geom = { contentHeight: 5000, clientHeight: 400, scrollTop: 0 };
+    const { rerender } = render(chatPaneEl(longConversation('chunk'), { streaming: true }));
+    await flushFrames();
+
+    // 朝下拨了几格,框一动不动 —— 没有任何 scroll 事件来用掉这个见证。
+    await wheel(40);
+    await wheel(40);
+
+    // 改用滚动条:按下去,然后真的滑上去。
+    await act(async () => {
+      fireEvent.pointerDown(chatLog());
+      await Promise.resolve();
+    });
+    await userScrollTo(1200);
+
+    await streamOneChunk(rerender, 'chunk more');
+    expect(geom.scrollTop).toBe(1200);
+  });
+  it('【反向】见证只为这一段位移作数 —— 下一段没有新滚轮就不许再拿它当挡箭牌', async () => {
+    /*
+     * 夹取那一段用掉见证之后,紧接着的下一段位移是**另一件事**。这时如果见证还留着,
+     * 一次没有滚轮的用户上滑(拖滚动条、find-in-page、焦点跳转)就会被那张旧条子
+     * 挡掉 —— 跟随焊死。这一条钉的是「见证是一次性的」。
+     */
+    geom = { contentHeight: 5000, clientHeight: 400, scrollTop: 0 };
+    const { rerender } = render(chatPaneEl(longConversation('chunk'), { streaming: true }));
+    await flushFrames();
+
+    // 第一段:朝下的滚轮 + 夹取 —— 跟随保住(正向那条已经钉过)。
+    await wheel(40);
+    await compositorClampTo(1200);
+    await streamOneChunk(rerender, 'chunk more');
+    expect(geom.scrollTop).toBe(maxScrollTop());
+
+    // 第二段:没有任何新滚轮,用户自己往上走。必须松手。
+    await userScrollTo(900);
+    await streamOneChunk(rerender, 'chunk more more');
+    expect(geom.scrollTop).toBe(900);
+  });
+
+  it('【反向】这段窗口里出现过朝上的滚轮 —— 哪怕后面又朝下拨,也归用户', async () => {
+    /*
+     * 用户 2026-09-07 那一档的形状:会话短到滚不动,往上拨几格屏幕纹丝不动
+     * (`upwardGestureCanEscapeBottom` 在那儿挡住了松手,是对的);内容长起来之后
+     * 他又往下拨了一格。见证必须**如实**记下那几格朝上的 —— 记漏了,随后的位移
+     * 就会被当成夹取,一次真正的上滑被吞掉。
+     *
+     * 这条同时说明了见证的偏置:拿不准就松手,不拿不准就焊死。
+     */
+    geom = { contentHeight: 200, clientHeight: 400, scrollTop: 0 };
+    const { rerender } = render(chatPaneEl(longConversation('chunk'), { streaming: true }));
+    await flushFrames();
+    expect(maxScrollTop()).toBe(0);
+
+    // 一屏装得下,往上拨一格 —— 位置一个像素都没动,也没有 scroll 事件。
+    await wheel(-40);
+    expect(geom.scrollTop).toBe(0);
+
+    // 内容长过视口,跟随把他带到底部。
+    await streamOneChunk(rerender, 'chunk 2', 4800);
+    expect(geom.scrollTop).toBe(maxScrollTop());
+
+    // 再往下拨一格,然后位置反而往上跑。见证里有朝上的那一格,不算夹取。
+    await wheel(40);
+    await compositorClampTo(1200);
+    await streamOneChunk(rerender, 'chunk 3');
+    expect(geom.scrollTop).toBe(1200);
   });
 });

--- a/apps/web/tests/components/chat-scroll-following.test.tsx
+++ b/apps/web/tests/components/chat-scroll-following.test.tsx
@@ -328,6 +328,7 @@ function chatPaneEl(
     streaming?: boolean;
     queuedItems?: Array<{ id: string; prompt: string }>;
     onUpdateQueuedSend?: Parameters<typeof ChatPane>[0]['onUpdateQueuedSend'];
+    activeConversationId?: string;
   } = {},
 ) {
   return (
@@ -343,7 +344,7 @@ function chatPaneEl(
       onSend={() => {}}
       onStop={() => {}}
       conversations={[]}
-      activeConversationId="conv-1"
+      activeConversationId={overrides.activeConversationId ?? 'conv-1'}
       onSelectConversation={() => {}}
       onDeleteConversation={() => {}}
     />
@@ -1427,32 +1428,202 @@ describe('合成器夹取不许关掉自动跟随', () => {
     expect(geom.scrollTop).toBe(900);
   });
 
-  it('【反向】这段窗口里出现过朝上的滚轮 —— 哪怕后面又朝下拨,也归用户', async () => {
+});
+
+/*
+ * ── 见证的生命周期(nettee 在 #7898 上点名的过度抑制) ────────────────
+ *
+ * 上一版的见证**没有生命周期边界**。评审给的那条路是完整的:
+ *
+ *   1. 用户已经在底部,再往下拨一格 —— 位置一个像素都不动,**不发 scroll 事件**,
+ *      那张「滚轮在朝下要」的条子没人来用掉;
+ *   2. 从历史记录切换会话 —— 那次点击发生在**日志元素之外**,连 pointerdown 都
+ *      收不到;重置基线和跟随意图的那个 effect 当时不碰这个 ref;
+ *   3. 之后一次**非滚轮**的位置变化(页内查找、焦点驱动的滚动)撞上那张旧条子
+ *      → 被判成夹取 → **跟随不释放**。
+ *
+ * 方向和原 bug 反过来,而且更糟:原 bug 只在合成器真卡住时发作,这个在完全正常
+ * 的使用里就会发作。三条边界各堵一个洞,下面逐条钉死;每一条都配着本文件里
+ * 「真夹取仍然不释放跟随」那一条一起读 —— 收窄抑制最容易弄坏的就是那一半。
+ */
+describe('滚轮见证的生命周期', () => {
+  async function wheel(deltaY: number) {
+    await act(async () => {
+      fireEvent.wheel(chatLog(), { deltaY });
+      await Promise.resolve();
+    });
+  }
+
+  /** 不经过 `scrollTop` setter 的位移 —— 合成器干的,不是 JS 写的。 */
+  async function compositorClampTo(top: number) {
+    await act(async () => {
+      geom.scrollTop = top;
+      fireEvent.scroll(chatLog());
+      await Promise.resolve();
+    });
+  }
+
+  /**
+   * 模型又吐了一块。
+   *
+   * ⚠️ `conversationId` 必须原样带着:漏了它,这次 rerender 就是一次**会话切换**,
+   * `armFollow()` 会把刚刚判出来的挣脱又抹掉,用例于是量的是自己的夹具。
+   */
+  async function streamOneChunk(
+    rerender: (ui: ReactElement) => void,
+    text: string,
+    conversationId = 'conv-1',
+  ) {
+    geom.contentHeight += 120;
+    await act(async () => {
+      rerender(
+        chatPaneEl(longConversation(text), {
+          streaming: true,
+          activeConversationId: conversationId,
+        }),
+      );
+    });
+    await triggerResize();
+    await flushFrames();
+  }
+
+  it('① 到底之后再往下拨一格(不发 scroll 事件),那张条子活不过这一帧', async () => {
     /*
-     * 用户 2026-09-07 那一档的形状:会话短到滚不动,往上拨几格屏幕纹丝不动
-     * (`upwardGestureCanEscapeBottom` 在那儿挡住了松手,是对的);内容长起来之后
-     * 他又往下拨了一格。见证必须**如实**记下那几格朝上的 —— 记漏了,随后的位移
-     * 就会被当成夹取,一次真正的上滑被吞掉。
+     * 评审场景的第一段。位置纹丝不动 = 没有 scroll 事件来消费见证,所以它必须
+     * 自己过期 —— 否则后面第一次非滚轮的位置变化就会被它解释掉。
      *
-     * 这条同时说明了见证的偏置:拿不准就松手,不拿不准就焊死。
+     * 界限取「一帧」不是调出来的:夹取是紧跟着那一格滚轮的,scroll 事件按规范
+     * 排在同一帧的 rAF 回调**之前**。所以一帧之后还没来的位移,不是那一格的事。
      */
-    geom = { contentHeight: 200, clientHeight: 400, scrollTop: 0 };
+    geom = { contentHeight: 5000, clientHeight: 400, scrollTop: 0 };
     const { rerender } = render(chatPaneEl(longConversation('chunk'), { streaming: true }));
     await flushFrames();
-    expect(maxScrollTop()).toBe(0);
+    expect(geom.scrollTop).toBe(4600);
 
-    // 一屏装得下,往上拨一格 —— 位置一个像素都没动,也没有 scroll 事件。
-    await wheel(-40);
-    expect(geom.scrollTop).toBe(0);
+    // 已经在底部,再往下拨一格 —— 一个像素都不动,一个 scroll 事件都没有。
+    await wheel(40);
+    expect(geom.scrollTop).toBe(4600);
 
-    // 内容长过视口,跟随把他带到底部。
-    await streamOneChunk(rerender, 'chunk 2', 4800);
+    // 一帧过去(rAF 跑了)。
+    await flushFrames();
+
+    // 页内查找跳到前面的内容:没有滚轮,没有 pointerdown,只有一次位置变化。
+    await userScrollTo(1200);
+
+    await streamOneChunk(rerender, 'chunk more');
+    expect(geom.scrollTop).toBe(1200);
+  });
+
+  it('② 切换会话之后,上一条会话攒下的条子不再作数', async () => {
+    /*
+     * 评审场景的第二段,而且**不能**指望那一帧过期兜底:后台标签页压根不发 rAF。
+     * 用户拨完滚轮切出去、切回来、换个会话,条子原样还在。所以这里刻意不跑帧,
+     * 只让上下文变化本身来划这条边界。
+     *
+     * 两条会话的几何一样(`atScrollTop` 因此对得上),把「位置对不上号」那层兜底
+     * 也让开 —— 剩下的只有 effect 里那一次显式清理。
+     */
+    geom = { contentHeight: 5000, clientHeight: 400, scrollTop: 0 };
+    const { rerender } = render(chatPaneEl(longConversation('chunk'), { streaming: true }));
+    await flushFrames();
+    expect(geom.scrollTop).toBe(4600);
+
+    // 到底了还往下拨 —— 条子留下,没有 scroll 事件来用掉它。
+    await wheel(40);
+
+    /*
+     * 从历史记录换一条会话。那次点击在日志元素之外,收不到任何输入事件。
+     * 新会话内容更长,所以 `syncFollowState` 会**同步**把日志写到新的底部 ——
+     * 基线就是在这一步被刷成真实几何的,一帧都不用跑。评审描述的正是这个时序。
+     */
+    geom.contentHeight = 6000;
+    await act(async () => {
+      rerender(
+        chatPaneEl(longConversation('other'), {
+          streaming: true,
+          activeConversationId: 'conv-2',
+        }),
+      );
+    });
+    /*
+     * 换会话本来就会排一帧(初次定位那条 effect 会 `armFollow()` 并贴底),用户
+     * 在那一帧落地之前根本插不进手。所以这里必须把它跑完 —— 不跑完量到的是一个
+     * 真实浏览器里不存在的时序。
+     */
+    await flushFrames();
     expect(geom.scrollTop).toBe(maxScrollTop());
 
-    // 再往下拨一格,然后位置反而往上跑。见证里有朝上的那一格,不算夹取。
+    // 新会话里一次非滚轮的位置变化。必须归用户。
+    await userScrollTo(1200);
+
+    await streamOneChunk(rerender, 'other more', 'conv-2');
+    expect(geom.scrollTop).toBe(1200);
+  });
+
+  it('③ 一张条子只解释一次位移,不许解释第二次', async () => {
+    /*
+     * 第一次位移(真夹取)用掉见证;紧接着的第二次位移是另一件事,这时**没有**
+     * 新的滚轮,必须归用户。
+     */
+    geom = { contentHeight: 5000, clientHeight: 400, scrollTop: 0 };
+    const { rerender } = render(chatPaneEl(longConversation('chunk'), { streaming: true }));
+    await flushFrames();
+
     await wheel(40);
     await compositorClampTo(1200);
-    await streamOneChunk(rerender, 'chunk 3');
+    // 第一段:跟随保住(正向那一条钉的就是它)。
+    await streamOneChunk(rerender, 'chunk more');
+    expect(geom.scrollTop).toBe(maxScrollTop());
+
+    // 第二段:没有新滚轮。必须松手。
+    await userScrollTo(900);
+    await streamOneChunk(rerender, 'chunk more more');
+    expect(geom.scrollTop).toBe(900);
+  });
+
+  it('③b 位移为 0 的那次 scroll 事件也算用掉 —— 条子不许跨过它', async () => {
+    /*
+     * 「用掉就清」和「位置对不上就作废」是**两条**边界,这一条把它们分开量。
+     *
+     * 一次一个像素都没挪的 scroll 事件(滚动被夹住、动画落定)照样是一次
+     * 「这张条子已经交待过了」。它之后位置**从同一个起点**再往上跑,那就是新的
+     * 一段,没有新滚轮就归用户 —— 位置检查在这儿帮不上忙,因为起点一模一样。
+     */
+    geom = { contentHeight: 5000, clientHeight: 400, scrollTop: 0 };
+    const { rerender } = render(chatPaneEl(longConversation('chunk'), { streaming: true }));
+    await flushFrames();
+    expect(geom.scrollTop).toBe(4600);
+
+    await wheel(40);
+    // 位置纹丝不动的一次 scroll 事件。
+    await act(async () => {
+      fireEvent.scroll(chatLog());
+      await Promise.resolve();
+    });
+
+    // 同一个起点,这次真的往上跑了。没有新滚轮 —— 归用户。
+    await compositorClampTo(1200);
+    await streamOneChunk(rerender, 'chunk more');
     expect(geom.scrollTop).toBe(1200);
+  });
+
+  it('【正向仍要成立】真夹取:滚轮那一格紧跟着的位移,跟随照旧不许关', async () => {
+    /*
+     * 这一条是上面三条的**代价检查**,单独钉死。收窄抑制最容易弄坏的就是这一半:
+     * 边界收得太紧,真夹取也被放行,原 bug 原样回来。
+     *
+     * 真机形状:滚轮那一格和夹取之间**没有插进任何一帧** —— 合成器在同一次渲染
+     * 更新里就把 scroll 事件发出来了。
+     */
+    geom = { contentHeight: 5000, clientHeight: 400, scrollTop: 0 };
+    const { rerender } = render(chatPaneEl(longConversation('chunk'), { streaming: true }));
+    await flushFrames();
+    expect(geom.scrollTop).toBe(4600);
+
+    await wheel(40);
+    await compositorClampTo(1200);
+
+    await streamOneChunk(rerender, 'chunk more');
+    expect(geom.scrollTop).toBe(maxScrollTop());
   });
 });

--- a/apps/web/tests/runtime/chat/stick-to-bottom.test.ts
+++ b/apps/web/tests/runtime/chat/stick-to-bottom.test.ts
@@ -237,6 +237,7 @@ describe('合成器夹取 vs 用户上滑', () => {
       nextFollowIntent(following, atLayoutBottom, clampedToStaleCeiling, {
         downwardEvents: 1,
         upwardEvents: 0,
+        atScrollTop: 718.5,
       }),
     ).toEqual(following);
   });
@@ -250,6 +251,7 @@ describe('合成器夹取 vs 用户上滑', () => {
       nextFollowIntent(following, atLayoutBottom, clampedToStaleCeiling, {
         downwardEvents: 0,
         upwardEvents: 1,
+        atScrollTop: 718.5,
       }),
     ).toEqual(escaped);
   });
@@ -259,6 +261,7 @@ describe('合成器夹取 vs 用户上滑', () => {
       nextFollowIntent(following, atLayoutBottom, clampedToStaleCeiling, {
         downwardEvents: 0,
         upwardEvents: 0,
+        atScrollTop: 718.5,
       }),
     ).toEqual(escaped);
     // 调用方压根不传见证时,行为和这个参数出现之前一模一样。
@@ -277,6 +280,7 @@ describe('合成器夹取 vs 用户上滑', () => {
       nextFollowIntent(following, atLayoutBottom, clampedToStaleCeiling, {
         downwardEvents: 9,
         upwardEvents: 1,
+        atScrollTop: 718.5,
       }),
     ).toEqual(escaped);
   });
@@ -284,7 +288,11 @@ describe('合成器夹取 vs 用户上滑', () => {
   it('【反向】朝下的滚轮把位置往下带 —— 恢复跟随这条路一格都没挡', () => {
     const away = { scrollTop: 200, scrollHeight: 1307, clientHeight: 589 };
     expect(
-      nextFollowIntent(escaped, away, atLayoutBottom, { downwardEvents: 3, upwardEvents: 0 }),
+      nextFollowIntent(escaped, away, atLayoutBottom, {
+        downwardEvents: 3,
+        upwardEvents: 0,
+        atScrollTop: 200,
+      }),
     ).toEqual(following);
   });
 });
@@ -292,7 +300,7 @@ describe('合成器夹取 vs 用户上滑', () => {
 describe('isCompositorSnapBack', () => {
   const previous = { scrollTop: 718.5, scrollHeight: 1307, clientHeight: 589 };
   const clamped = { scrollTop: 245.5, scrollHeight: 1307, clientHeight: 589 };
-  const downOnly = { downwardEvents: 1, upwardEvents: 0 };
+  const downOnly = { downwardEvents: 1, upwardEvents: 0, atScrollTop: 718.5 };
 
   it('朝下的滚轮 + 位置反而往上跑 + 布局没动 = 夹取', () => {
     expect(isCompositorSnapBack(previous, clamped, downOnly)).toBe(true);
@@ -301,12 +309,20 @@ describe('isCompositorSnapBack', () => {
   it('没有见证 / 见证里有朝上的一格 / 一格朝下的都没有 —— 都不是', () => {
     expect(isCompositorSnapBack(previous, clamped, null)).toBe(false);
     expect(isCompositorSnapBack(previous, clamped, undefined)).toBe(false);
-    expect(isCompositorSnapBack(previous, clamped, { downwardEvents: 1, upwardEvents: 1 })).toBe(
-      false,
-    );
-    expect(isCompositorSnapBack(previous, clamped, { downwardEvents: 0, upwardEvents: 0 })).toBe(
-      false,
-    );
+    expect(
+      isCompositorSnapBack(previous, clamped, {
+        downwardEvents: 1,
+        upwardEvents: 1,
+        atScrollTop: 718.5,
+      }),
+    ).toBe(false);
+    expect(
+      isCompositorSnapBack(previous, clamped, {
+        downwardEvents: 0,
+        upwardEvents: 0,
+        atScrollTop: 718.5,
+      }),
+    ).toBe(false);
   });
 
   it('内容动过就不是这个现象 —— 那种位移归 layoutStable 管', () => {
@@ -319,7 +335,11 @@ describe('isCompositorSnapBack', () => {
   });
 
   it('位移方向朝下、或小到落在贴底容差里 —— 都不是', () => {
-    expect(isCompositorSnapBack(clamped, previous, downOnly)).toBe(false);
+    // 起点换成 245.5,条子也跟着换 —— 否则这一条会因为「位置对不上」而通过,
+    // 量到的就不是方向那一条判据了。
+    expect(
+      isCompositorSnapBack(clamped, previous, { ...downOnly, atScrollTop: 245.5 }),
+    ).toBe(false);
     // 8px 是容差本身,要**超过**才算。高 DPI / 分数缩放下的亚像素抖动全在这以内。
     expect(
       isCompositorSnapBack(previous, { ...previous, scrollTop: 710.5 }, downOnly),
@@ -327,5 +347,25 @@ describe('isCompositorSnapBack', () => {
     expect(
       isCompositorSnapBack(previous, { ...previous, scrollTop: 710.4 }, downOnly),
     ).toBe(true);
+  });
+  /*
+   * ── 条子只解释它记下的那一段 ──────────────────────────────────────
+   *
+   * nettee 在 #7898 上点名的过度抑制,结构性的那一半就堵在这里:一格朝下的滚轮
+   * 落在已经到底的日志上,位置不动、不发 scroll 事件,条子没人用掉;等基线被别的
+   * 东西挪走之后(切会话、我们自己写 `scrollTop`),它还留着,就会去解释一段和它
+   * 毫无关系的位移 —— 一次真实的用户位置变化被判成夹取,跟随焊死。
+   */
+  it('条子记的位置不是这一段位移的起点 —— 一律不算夹取', () => {
+    // 差 0.5px 都不行:对不上就说明中间有别的东西动过这个滚动条。
+    for (const atScrollTop of [718, 719, 0, 245.5, 1307]) {
+      expect(
+        isCompositorSnapBack(previous, clamped, { ...downOnly, atScrollTop }),
+      ).toBe(false);
+    }
+    // 对得上才算 —— 正向那一半不许被这条顺手废掉。
+    expect(isCompositorSnapBack(previous, clamped, { ...downOnly, atScrollTop: 718.5 })).toBe(
+      true,
+    );
   });
 });

--- a/apps/web/tests/runtime/chat/stick-to-bottom.test.ts
+++ b/apps/web/tests/runtime/chat/stick-to-bottom.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  isCompositorSnapBack,
   nextFollowIntent,
   upwardGestureCanEscapeBottom,
 } from '../../../src/runtime/chat/stick-to-bottom';
@@ -200,6 +201,131 @@ describe('往上的手势有没有可能挣脱', () => {
     // 正在跟随的长会话贴在底上 —— 快速流式时的逃逸路径,一格都不许挡。
     expect(
       upwardGestureCanEscapeBottom({ scrollTop: 1600, scrollHeight: 2000, clientHeight: 400 }),
+    ).toBe(true);
+  });
+});
+
+/*
+ * ── 合成器夹取不是用户上滑 ────────────────────────────────────────────
+ *
+ * 真机诊断包(Electron 41 / Chromium 146,用户客户端):
+ *
+ *   scrollTop 245.5   layoutMax 718   scrollHeight 1307   unreachablePx 472.5
+ *
+ * 点【滚动到最新】→ `scrollTo({top:1307})` → 位置落在 718.5(布局的真底部);
+ * 用户碰一下滚轮,合成器把它甩回自己那份陈旧上限 245.5。`__chatScrollFreeze`
+ * 的写入拦截全程武装、零丢弃、覆盖 `scrollTop`/`scrollTo`/`scrollBy`/
+ * `scrollIntoView` 四个 API,而这 3.8 秒里**零条 JS 写入记录** —— 没有任何 JS
+ * 移过它,是合成器干的。
+ *
+ * 这一段位移「位置变小 + `scrollHeight` 没变」两条同时成立,正好命中判据里
+ * 「用户上滑」的定义,于是每一次夹取都把自动跟随静默关掉。
+ *
+ * ⚠️ 下面**反向那几条比正向这条更重要**:修法只要多判一次,就是把跟随焊死。
+ * 判据只由「这段窗口里的滚轮只朝下」授权,别的一律照旧当成用户上滑。
+ */
+describe('合成器夹取 vs 用户上滑', () => {
+  const following = { following: true, escaped: false } as const;
+  const escaped = { following: false, escaped: true };
+
+  // 真机那一组数:clientHeight = 1307 − 718 = 589,布局能滚到 718。
+  const atLayoutBottom = { scrollTop: 718.5, scrollHeight: 1307, clientHeight: 589 };
+  const clampedToStaleCeiling = { scrollTop: 245.5, scrollHeight: 1307, clientHeight: 589 };
+
+  it('朝下的滚轮把位置甩到上面去 —— 跟随不许关', () => {
+    expect(
+      nextFollowIntent(following, atLayoutBottom, clampedToStaleCeiling, {
+        downwardEvents: 1,
+        upwardEvents: 0,
+      }),
+    ).toEqual(following);
+  });
+
+  /*
+   * ── 反向锚点 ───────────────────────────────────────────────────────
+   * 一模一样的两份几何,只换滚轮方向。用户上滑必须照旧松手。
+   */
+  it('【反向】同样的位移,滚轮朝上 —— 必须松手', () => {
+    expect(
+      nextFollowIntent(following, atLayoutBottom, clampedToStaleCeiling, {
+        downwardEvents: 0,
+        upwardEvents: 1,
+      }),
+    ).toEqual(escaped);
+  });
+
+  it('【反向】根本没有滚轮(拖滚动条 / 键盘 / 触摸)—— 必须松手', () => {
+    expect(
+      nextFollowIntent(following, atLayoutBottom, clampedToStaleCeiling, {
+        downwardEvents: 0,
+        upwardEvents: 0,
+      }),
+    ).toEqual(escaped);
+    // 调用方压根不传见证时,行为和这个参数出现之前一模一样。
+    expect(nextFollowIntent(following, atLayoutBottom, clampedToStaleCeiling)).toEqual(escaped);
+    expect(nextFollowIntent(following, atLayoutBottom, clampedToStaleCeiling, null)).toEqual(
+      escaped,
+    );
+  });
+
+  it('【反向】一次轻扫里掉过头:有一格朝上就作废 —— 必须松手', () => {
+    /*
+     * 触控板一次轻扫在两个 scroll 事件之间能吐十几格,中途完全可能上下都有。
+     * 净方向朝下也不行:只要用户要过一次上滑,这一段就归他。
+     */
+    expect(
+      nextFollowIntent(following, atLayoutBottom, clampedToStaleCeiling, {
+        downwardEvents: 9,
+        upwardEvents: 1,
+      }),
+    ).toEqual(escaped);
+  });
+
+  it('【反向】朝下的滚轮把位置往下带 —— 恢复跟随这条路一格都没挡', () => {
+    const away = { scrollTop: 200, scrollHeight: 1307, clientHeight: 589 };
+    expect(
+      nextFollowIntent(escaped, away, atLayoutBottom, { downwardEvents: 3, upwardEvents: 0 }),
+    ).toEqual(following);
+  });
+});
+
+describe('isCompositorSnapBack', () => {
+  const previous = { scrollTop: 718.5, scrollHeight: 1307, clientHeight: 589 };
+  const clamped = { scrollTop: 245.5, scrollHeight: 1307, clientHeight: 589 };
+  const downOnly = { downwardEvents: 1, upwardEvents: 0 };
+
+  it('朝下的滚轮 + 位置反而往上跑 + 布局没动 = 夹取', () => {
+    expect(isCompositorSnapBack(previous, clamped, downOnly)).toBe(true);
+  });
+
+  it('没有见证 / 见证里有朝上的一格 / 一格朝下的都没有 —— 都不是', () => {
+    expect(isCompositorSnapBack(previous, clamped, null)).toBe(false);
+    expect(isCompositorSnapBack(previous, clamped, undefined)).toBe(false);
+    expect(isCompositorSnapBack(previous, clamped, { downwardEvents: 1, upwardEvents: 1 })).toBe(
+      false,
+    );
+    expect(isCompositorSnapBack(previous, clamped, { downwardEvents: 0, upwardEvents: 0 })).toBe(
+      false,
+    );
+  });
+
+  it('内容动过就不是这个现象 —— 那种位移归 layoutStable 管', () => {
+    expect(
+      isCompositorSnapBack(previous, { ...clamped, scrollHeight: 1400 }, downOnly),
+    ).toBe(false);
+    expect(isCompositorSnapBack(previous, { ...clamped, clientHeight: 600 }, downOnly)).toBe(
+      false,
+    );
+  });
+
+  it('位移方向朝下、或小到落在贴底容差里 —— 都不是', () => {
+    expect(isCompositorSnapBack(clamped, previous, downOnly)).toBe(false);
+    // 8px 是容差本身,要**超过**才算。高 DPI / 分数缩放下的亚像素抖动全在这以内。
+    expect(
+      isCompositorSnapBack(previous, { ...previous, scrollTop: 710.5 }, downOnly),
+    ).toBe(false);
+    expect(
+      isCompositorSnapBack(previous, { ...previous, scrollTop: 710.4 }, downOnly),
     ).toBe(true);
   });
 });


### PR DESCRIPTION
## Why

**Use case.** Triaging a real user's diagnostic bundle from the packaged client (Electron 41 / Chromium 146). The reported symptom was that auto-follow keeps switching itself off mid-run — the user presses **Scroll to latest**, the view lands at the bottom, and a few seconds later streaming output is running off-screen again with no visible cause.

**The pain.** The chat log decides "did the user scroll away" from exactly one criterion, in `apps/web/src/runtime/chat/stick-to-bottom.ts`:

> position got smaller **and** `scrollHeight` did not change → user scrolled up → `escaped = true, following = false`

The file's own comment justifies that with *"content-driven displacement always comes with a `scrollHeight` change."* That premise holds for content-driven displacement. It does **not** hold for a compositor clamp.

Chromium keeps its own copy of how far a scroller travels, so a wheel does not have to wait on the main thread. On the chat log that copy can go stale while layout moves on. From the bundle:

```
scrollTop      245.5     ← pinned here
layoutMax      718       ← layout says it can go this far
scrollHeight   1307      ← content height, static
unreachablePx  472.5
```

Jump-to-latest issues `scrollTo({top: 1307})`; the position lands at **718.5** (the real layout bottom); **3.8 s later** it is back at **245.5**. Over that interval `__chatScrollFreeze.writes.list()` holds **zero JS write records**, while the write interceptor was armed the whole time, dropped nothing, and covered all four APIs (`scrollTop`, `scrollTo`, `scrollBy`, `scrollIntoView`). No JavaScript moved it — the compositor did, clamping the out-of-range position back onto its own stale ceiling.

That displacement is "position got smaller" + "`scrollHeight` unchanged" (the content really is static) — both halves of the criterion. So every clamp reads as one more user scroll-up, and auto-follow is switched off without a word.

**What this PR is not.** It does not try to fix the stale ceiling. That is not a front-end fix, and `runtime/chat-scroll-takeover.ts` already exists for it (still switched off, pending a product call). This PR fixes the downstream consequence only: a clamp must not also cost the user auto-follow.

## What users will see

During a run, if the compositor throws the chat log backwards onto a stale ceiling, the view keeps following the newest output instead of silently stopping. Nothing changes for anyone not hitting the freeze; scrolling up by any means still pins the view exactly where it does today.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — behavior-preserving bug fix inside the existing chat scroll state machine; no new surface, no new setting, no new dependency.

Not dual-track (UI/CLI): this is scroll-position bookkeeping inside the web chat pane, with no capability to expose. The `od` CLI has no chat viewport.

## How a clamp is told apart from a user scroll-up

Two scroll samples alone **cannot** separate them — the numbers are identical. The fix therefore brings in one more observable: which direction the wheel was asking, over the window since the previous sample.

**Chosen criterion.** *The only wheel input in this window pointed downward, the layout held still, and the position moved up by more than the at-bottom tolerance.* A user scrolling up either carries an **upward** wheel — which `ChatPane`'s existing `onWheel` already releases follow on, ahead of the scroll event — or carries **no wheel at all** (scrollbar drag, keyboard, touch). So "wheel asked only downward" is never true of a user scroll-up. It says the user asked to move *toward* the bottom; a position that moves *away* from it under that input is not their hand.

The same shape was measured independently for the freeze detector and is quoted at the top of `observability/chat-scroll-freeze-detector.ts`: `scrollTop = 800`, **one downward notch**, thrown back to 91.

**Why the other candidates are not enough:**

| Candidate | Why it fails |
|---|---|
| Landing on a known stale ceiling | Needs the ceiling, which only the freeze detector's stall/snap-back state machine can infer — and `chat-scroll-takeover.ts` records that detector's false-positive rate as **unknown** (`client_chat_scroll_frozen` had zero production events, and that zero turned out to be a reporting bug). A user can also legitimately stop exactly on that value. |
| Gap between landing position and `layoutMax` | A user scroll-up can land anywhere in `[0, layoutMax]`. Carries no discriminating information at all. |
| Adjacency to a JS write | Falsified by the bundle itself: the clamp landed **3.8 s** after the write, with zero JS write records in between. Any time window wide enough to cover that swallows ordinary user scrolls. |
| Presence of input events | The clamp is *caused by* a wheel, so presence cannot separate. **Direction** can — that is the criterion above. |

**Bias.** The criterion is deliberately built to under-fire. A clamp with no wheel witness is still treated as a user scroll-up, exactly as today. Welding follow on would be worse than the bug being fixed, so every ambiguous case releases.

## Bug fix verification

Red spec first, and verified red in **both** directions — a fix that only stopped clamps from releasing follow, but also stopped genuine scroll-ups from releasing it, would pass a one-sided test.

- Tests that reproduce the bug:
  - `apps/web/tests/runtime/chat/stick-to-bottom.test.ts` — the pure criterion, driven with the real-machine geometry (`245.5 / 718 / 1307`).
  - `apps/web/tests/components/chat-scroll-following.test.tsx` — the same thing end-to-end through `ChatPane` (wheel → clamp → next streamed chunk), plus four reverse anchors.
- Did they go red before the source change and green after? **Yes**, and every added line was individually mutation-checked:

| Mutation | Result |
|---|---|
| A — criterion removed entirely (pre-fix behavior) | **red** (3 tests) |
| B — criterion always true (follow welded on) | **red** (25 tests, incl. 20 pre-existing ones) |
| C — other-input channels stop invalidating the witness | **red** (1) |
| D — `ChatPane` stops passing the witness | **red** (2) |
| E — `onScroll` stops consuming the witness | **red** (1) |
| F — `onWheel` stops recording upward wheels | **red** (1) |

Mutation B is the important column: over-suppression is caught by 20 tests that were already in the suite before this PR, so the "welded follow" failure mode cannot land quietly.

Two further reset calls I had initially written (on conversation switch, and at listener setup) survived mutation — `setTab` is never called, so that effect runs once per mount, and the conversation-switch reset sits behind a `{0,0,0}` baseline that makes the escape branch unreachable. Both were **deleted** rather than left in as untestable code.

**Not verified on a real frozen machine.** The compositor freeze cannot be reproduced on demand; the geometry in the specs is replayed from the user's bundle. What is verified is the decision the criterion makes when handed that geometry.

## Adjacent issues (deliberately out of scope)

- The stale compositor ceiling itself. `runtime/chat-scroll-takeover.ts` exists for it and is switched off pending a product decision; untouched here.
- `useThinkingFollow` and `TerminalOutput` share `nextFollowIntent` and pass no witness, so they keep today's behavior exactly. There is no evidence of the freeze on those inner scrollers, and wiring a witness into each would need its own plumbing.

## Validation

- `pnpm --filter @open-design/web typecheck` → exit 0
- `pnpm guard` → exit 0
- `apps/web` scroll suites → **111 passed / 7 files**, exit 0
  (`stick-to-bottom`, `chat-scroll-following`, `chat-programmatic-scroll`, `chat-scroll-zero-displacement`, `chat-anchor-to-top`, `chat/thinking-follow`, `chat/terminal-follow`)
- Wider sweep `tests/runtime/chat/` + `tests/observability/` → **893 passed / 67 files**, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQSowXMsTxbEoZyGYfxgyb


---

## Review follow-up — witness lifetime (`e6440b29ee`)

nettee found the over-suppression this criterion exists to avoid: the witness had **no lifetime boundary**, so a downward wheel at the bottom (which moves nothing and therefore fires no `scroll` event) left a note that a later **non-wheel** move could collide with — welding auto-follow ON. That is worse than the original bug, and unlike it, it needs no compositor freeze to happen.

The witness now has three independent bounds, each covering a hole the other two cannot:

1. **Consumed on use** — any `scroll` event spends it, including one that moves nothing. One witness, one displacement.
2. **Scoped to the scroll context** — `WheelWitness.atScrollTop` records where the scroller was; the displacement's origin must be exactly that, so a baseline moved by anything else voids the note *structurally* rather than on a timer. Conversation switch, log-node swap and unmount clear it alongside baseline and follow intent.
3. **Expires after a frame** — the only bound that can kill a witness no `scroll` event will ever consume. Not a tuned constant: the clamp is dispatched in the same rendering update as the notch, and per the HTML update-the-rendering steps scroll events run *before* that frame's animation callbacks. (Distinct from the 3.8 s in the bundle, which is the write→clamp gap, not the wheel→clamp gap.) Recording is skipped when `requestAnimationFrame` is unavailable — no witness means today's behavior, which is the safe side.

### Mutation matrix (second round)

| Mutation | Result |
|---|---|
| criterion removed entirely | **red** (5) |
| criterion always true (follow welded on) | **red** (29 — 20 pre-existing) |
| `atScrollTop` check removed | **red** (1) |
| frame expiry removed | **red** (1) |
| `onScroll` consume removed | **red** (1) |
| pointerdown/keydown clear removed | **red** (1) |
| conversation-switch clear removed | green — see disclosure |
| unmount clear removed | green — see disclosure |

**Disclosures, in place of a coverage claim I can't back.** The conversation-switch and unmount clears cannot be turned red today, and the code says so at each site: a conversation switch always schedules a frame (the initial-pin effect), so expiry has already fired; and if no frame ran, the baseline was not refreshed either, so `atScrollTop` does not match. `setTab` has no call site, so the teardown only runs at unmount. Both are kept as scope statements — the lines still standing if either other bound is relaxed. Separately, the upward-wheel counter is pinned at the predicate level only, because `onWheel` releases follow on an upward notch before any scroll event; it stays because a witness that under-reports upward notches is a lying witness, and the safety argument rests on it being truthful.

### Validation (second round)

- `pnpm --filter @open-design/web typecheck` → exit 0
- `pnpm guard` → exit 0
- `tests/runtime/chat/` + `tests/observability/` + all chat-scroll component suites → **987 passed / 73 files**, exit 0
