### PR TITLE
fix(web): keep a failed question-form turn in the transcript

### DIFF
--- a/apps/web/src/artifacts/question-form.ts
+++ b/apps/web/src/artifacts/question-form.ts
@@ -1138,6 +1138,43 @@ export function formatFormAnswers(
   return lines.join('\n');
 }
 
+/**
+ * `[form answers — <id>]` —— {@link formatFormAnswers} 顶上那一行**机器载荷**。
+ *
+ * 它是写给 agent 的路由头,不是写给人的。id 后面允许任意文字是因为
+ * `QuestionForm.parseSubmittedAnswers` 也只认「以 `[form answers` 开头」,
+ * agent 复述时可以改写这一行。
+ */
+const FORM_ANSWERS_HEADER_LINE = /^\[form answers\b[^\n]*\n?/i;
+
+/**
+ * 这条用户消息是不是一份表单答案。
+ *
+ * 判据和 `QuestionForm.parseSubmittedAnswers` 同源:只认 `[form answers` 开头,
+ * 用户随口说的话不会被误判。
+ */
+export function isFormAnswersMessage(content: string): boolean {
+  return /^\[form answers\b/i.test(content.trim());
+}
+
+/**
+ * 一份表单答案里**给人看的**那一半。
+ *
+ * 交付成功的答案根本不画用户气泡(#5496:摘要已经长在上一条助手消息上)。
+ * 但发送失败的那一条必须留在流水里 —— 它是「这一轮为什么没了」的唯一凭据,
+ * 也挂着唯一的复原入口(那颗「重试」)。放它出来的同时不能把
+ * `[form answers — <id>]` 这行机器载荷摆到用户脸上,所以这里只去掉头一行,
+ * 底下那几条 `- 问题: 回答` 本来就是人话。
+ *
+ * 去掉之后什么都不剩(agent 只复述了个头)时原样返回,宁可露出机器载荷也
+ * 不给一个空气泡 —— 空气泡等于这一轮又消失了一次。
+ */
+export function formAnswersDisplayBody(content: string): string {
+  if (!isFormAnswersMessage(content)) return content;
+  const body = content.trim().replace(FORM_ANSWERS_HEADER_LINE, '').trim();
+  return body.length > 0 ? body : content;
+}
+
 function formOptionDisplayForValue(
   question: Pick<FormQuestion, 'options' | 'type'>,
   value: string,

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -87,7 +87,11 @@ import { fetchProjectMediaTasks, projectRawUrl } from '../providers/registry';
 import { appendResourceQuery } from '../collab/workspace-identity';
 import { useProjectCollabContext } from '../collab/collab-context';
 import { takeComposerSeedFor } from '../state/libraryHandoff';
-import { splitOnQuestionForms } from '../artifacts/question-form';
+import {
+  formAnswersDisplayBody,
+  isFormAnswersMessage,
+  splitOnQuestionForms,
+} from '../artifacts/question-form';
 import { stripArtifact } from '../artifacts/strip';
 import type { TodoItem } from '../runtime/todos';
 import type {
@@ -5669,12 +5673,31 @@ function VirtualChatRow({
  * 意图澄清表单的答案(`^[form answers`)。答案已经以摘要形式长在上一条助手消息
  * 上;再画一个用户气泡等于把同一个决定说两遍,还会把 `[form answers — <id>]`
  * 这种机器载荷摆到用户脸上(#5496)。这是产品取向,不是权宜之计。
+ *
+ * ## 【不变量】没送出去的那一份答案**不在**被收走的范围里
+ *
+ * 收走的前提是「答案已经以摘要形式长在上一条助手消息上」—— 那句话只有在这一轮
+ * **真的开出去了**的时候才成立。`POST /api/runs` 还没给回 runId 就失败时,
+ * `ProjectView` 的 `onError` 会按设计删掉那条乐观的 assistant 行(从没有过 agent
+ * 进程,留着它等于伪造一轮),只把用户那一行盖成 `sendFailed`,而且显式
+ * `setError(null)` 不出全局横幅。于是这一行就是「这一轮为什么没了」的**唯一凭据**,
+ * 它上面那颗常驻的「重试」是**唯一的复原入口**。
+ *
+ * 老写法把它也一起收走,结果就是 QA 报的那个形状:答完表单屏幕上确实新开了一轮,
+ * 过一会儿整轮凭空消失 —— 没有报错、没有卡片、没有重试,而表单自己已经落成
+ * 「已作答」锁死了(`handleSend` 在建流那一刻就返回 `true`)。
+ *
+ * 机器载荷那一半由 `formAnswersDisplayBody` 在气泡里摘掉,#5496 那条取向照旧成立。
  */
 function buildChatRenderItems(messages: ChatMessage[]): ChatRenderItem[] {
   const items: ChatRenderItem[] = [];
   for (let i = 0; i < messages.length; i += 1) {
     const message = messages[i]!;
-    if (message.role === 'user' && /^\[form answers\b/i.test(message.content.trim())) {
+    if (
+      message.role === 'user'
+      && message.sendFailed !== true
+      && isFormAnswersMessage(message.content)
+    ) {
       continue;
     }
     items.push({
@@ -6721,9 +6744,13 @@ const UserMessage = memo(UserMessageImpl);
 
      `displayContent` 仍留着:它是「复制」按钮真正会写进剪贴板的那一段,
      用户复制到的应该是卡面上看得见的标题,不是内部 prompt。 */
+  /* 表单答案只有在**没送出去**的时候才走到这里(`buildChatRenderItems` 收走的是
+     交付成功的那些)。这一条要留给用户看的是他自己填的答案,不是顶上那行
+     `[form answers — <id>]` 路由头 —— #5496 说的就是别把机器载荷摆到用户脸上。
+     重发走的是 `message.content`(`handleResendUserMessage`),头一行原样保留。 */
   const displayContent = isDesignSystemWorkspaceRequest
     ? t('chat.designSystemStatus.title')
-    : message.content;
+    : formAnswersDisplayBody(message.content);
 
   useEffect(() => {
     return () => {

--- a/apps/web/tests/components/ChatPane.question-form-send-failed.test.tsx
+++ b/apps/web/tests/components/ChatPane.question-form-send-failed.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+
+/*
+ * 【不变量】填完 question-form 开出去的那一轮,**发送失败也必须留在流水里**。
+ *
+ * QA(AMR)报的形状:答完表单 → 屏幕上确实新开了一轮 → 过一会儿那一轮整个
+ * 没了,既没有报错也没有可以重来的入口。
+ *
+ * 因果链(三段都在代码里对得上):
+ *
+ *   1. `ProjectView.handleSend` 先把 `user + assistant(running)` 画上屏,再去
+ *      `POST /api/runs`。用户看见的「新开的那一轮」就是这一对乐观行。
+ *   2. `POST /api/runs` 没能给回 runId 时,流的 `onError` 走
+ *      `config.mode === 'daemon' && !currentRunId` 那一支:**删掉 assistant 那一行**
+ *      (从没有过 agent 进程,留着它等于伪造一轮),把用户那一行盖成
+ *      `sendFailed: true`,并且显式 `setError(null)` —— 不出全局横幅。
+ *      于是「这一轮为什么没了」的**唯一凭据**就只剩那条用户消息,以及它上面
+ *      常驻的那颗「重试」。
+ *   3. `buildChatRenderItems` 无条件跳过所有 `^[form answers` 开头的用户消息
+ *      (#5496:答案已经以摘要形式长在上一条助手消息上,再画一遍是把机器载荷
+ *      摆到用户脸上)。这条规则把第 2 步留下的**那唯一一份凭据也一起收走了**。
+ *
+ * 净效果:普通输入框发失败 → 气泡还在、重试还在;表单答案发失败 → 屏幕上
+ * 一个字都不剩,而表单自己已经落成「已作答」并锁死(`handleSend` 在建流那一刻
+ * 就返回了 `true`,`FormBlock` 据此 `acceptSubmission()`)。用户既看不到原因,
+ * 也回不去重来。
+ *
+ * 这里钉的是「失败的那一轮必须留下」,不是钉现状。反向锚点(第 3、4 条)钉的是
+ * **该收走的仍然要收走**:成功交付的表单答案照旧不画用户气泡,并且被放出来的
+ * 那一条也不许把 `[form answers — <id>]` 这种机器载荷摆到用户脸上。
+ */
+
+// Polyfill scrollTo for jsdom (not available in jsdom's HTMLElement).
+if (typeof HTMLElement.prototype.scrollTo !== 'function') {
+  HTMLElement.prototype.scrollTo = function (
+    options?: ScrollToOptions | number,
+    _y?: number,
+  ) {
+    if (typeof options === 'object' && options !== null) {
+      if (options.top !== undefined) this.scrollTop = options.top;
+      if (options.left !== undefined) this.scrollLeft = options.left;
+    }
+  };
+}
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ChatPane } from '../../src/components/ChatPane';
+import type { ChatMessage } from '../../src/types';
+
+const FORM_ID = 'discovery';
+const ANSWER_BODY = '- What are we building? A pricing page';
+const ANSWER_CONTENT = `[form answers — ${FORM_ID}]\n${ANSWER_BODY}`;
+
+function questionFormAssistant(): ChatMessage {
+  const formContent = [
+    `<question-form id="${FORM_ID}" title="Quick check">`,
+    JSON.stringify({
+      questions: [{ id: 'a', label: 'What are we building?', type: 'text' }],
+    }),
+    '</question-form>',
+  ].join('\n');
+  return {
+    id: 'assistant-1',
+    role: 'assistant',
+    content: formContent,
+    createdAt: 1_700_000_000_000,
+    startedAt: 1_700_000_000_000,
+    endedAt: 1_700_000_003_000,
+    runStatus: 'succeeded',
+  };
+}
+
+function formAnswerUser(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'user-form-answer',
+    role: 'user',
+    content: ANSWER_CONTENT,
+    createdAt: 1_700_000_004_000,
+    ...overrides,
+  };
+}
+
+function chatPaneEl(messages: ChatMessage[]) {
+  return (
+    <ChatPane
+      messages={messages}
+      streaming={false}
+      error={null}
+      projectId="project-1"
+      projectFiles={[]}
+      onEnsureProject={async () => 'project-1'}
+      onSend={() => {}}
+      onStop={() => {}}
+      conversations={[]}
+      activeConversationId={null}
+      onSelectConversation={() => {}}
+      onDeleteConversation={() => {}}
+      onResendUserMessage={() => {}}
+    />
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('a question-form answer whose send died before a run existed', () => {
+  /*
+   * 判据自检:同一套夹具、同一颗按钮,换成普通用户消息**今天就是绿的**。
+   * 没有这一条,下面那条红说明不了是「表单答案被藏了」还是「这个测试压根
+   * 量不到重试按钮」。
+   */
+  it('control — an ordinary failed send keeps its bubble and its Retry', () => {
+    render(
+      chatPaneEl([
+        questionFormAssistant(),
+        formAnswerUser({
+          id: 'user-plain',
+          content: 'Make the hero bigger',
+          sendFailed: true,
+        }),
+      ]),
+    );
+
+    expect(screen.getByText('Make the hero bigger')).toBeTruthy();
+    expect(screen.getByTestId('user-send-failed')).toBeTruthy();
+  });
+
+  it('keeps the failed turn on screen with a way to send it again', () => {
+    render(chatPaneEl([questionFormAssistant(), formAnswerUser({ sendFailed: true })]));
+
+    // 这一轮必须还在:用户看得见自己答了什么。
+    expect(screen.getByText(new RegExp(ANSWER_BODY.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))).toBeTruthy();
+    // 并且回得去:失败那一行上常驻的「重试」是唯一的复原入口。
+    expect(screen.getByTestId('user-send-failed')).toBeTruthy();
+  });
+
+  it('does not put the machine payload header in front of the user', () => {
+    render(chatPaneEl([questionFormAssistant(), formAnswerUser({ sendFailed: true })]));
+
+    expect(screen.queryByText(new RegExp(`\\[form answers — ${FORM_ID}\\]`))).toBeNull();
+  });
+
+  /*
+   * 反向锚点:**该收走的仍然要收走**。答案送到了的那一轮,用户气泡照旧不画
+   * (#5496 —— 摘要已经长在上一条助手消息上)。修复不许退化成「什么都不藏了」。
+   */
+  it('reverse anchor — a delivered answer still draws no user bubble', () => {
+    render(chatPaneEl([questionFormAssistant(), formAnswerUser()]));
+
+    expect(screen.queryByTestId('user-send-failed')).toBeNull();
+    expect(screen.queryByText(new RegExp(ANSWER_BODY.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))).toBeNull();
+    expect(screen.queryByText(new RegExp(`\\[form answers — ${FORM_ID}\\]`))).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why

**Use case.** Following up a QA report against an AMR run: *"用 AMR 跑的时候,填写了 question-form 之后,会自动新开一轮运行,但一会儿之后那一轮就消失了。"* — answer the inline question form, watch a new turn start, and a moment later that turn is gone.

**The pain.** The turn does not just stop — it leaves *nothing*. No error banner, no failure card, no Retry, and the form above it stays locked as "answered". The user cannot see why the round went away and cannot get it back without reloading and re-answering, which the form's persisted occurrence lock also resists.

**Causal chain** (all three beats are in the code):

1. `ProjectView.handleSend` paints `user + assistant(running)` on screen *before* `POST /api/runs` returns. That optimistic pair is the round the user watches start.
2. When the create never yields a runId, the stream's `onError` takes its `config.mode === 'daemon' && !currentRunId` branch: it **deletes the optimistic assistant row** (deliberate — no agent process ever existed, and keeping it would fabricate a run and route the user to the wrong recovery action), stamps the user row `sendFailed: true`, and explicitly calls `setError(null)` so no global banner appears. That user row and its always-on Retry are now the **only** evidence the round ever existed.
3. `ChatPane.buildChatRenderItems` skips **every** user message starting with `[form answers` — because a delivered answer is already summarized on the assistant message above it (#5496, a product ruling, not a shortcut). That rule swallowed the row step 2 just left behind.

Net effect: an ordinary typed message that fails to send keeps its bubble and its Retry; a **question-form answer** that fails to send leaves an empty transcript. `handleSend` returns `true` the moment it wires the stream, so `FormBlock` has already run `acceptSubmission()` and the occurrence is locked before the failure is known.

**Classification.** This is *"the run was never created"*, not *"the run is still running but stopped rendering"* and not *"the run was cancelled"*. The optimistic row is reclaimed on purpose; the defect is that the failure evidence for a form answer is invisible.

**Is it AMR-specific?** The mechanism is agent-agnostic — nothing in `buildChatRenderItems` or the `!currentRunId` branch looks at the agent. What is AMR-specific is how *reachable* it is: AMR is the only agent whose send crosses extra pre-run authority/billing round trips (`checkAmrBalanceGate` in `ProjectView`, `WORKSPACE_AUTHORITY_UNAVAILABLE` retries in `providers/daemon.ts`, workspace-scoped run creation), so its `POST /api/runs` has materially more ways to die before yielding a runId, and takes materially longer doing so — which is also where QA's *"一会儿之后"* comes from. On claude/codex/opencode the same code path exists but is rarely entered.

## What users will see

Answering an intent-clarification form and having that send fail now leaves the turn on screen: the user sees the answers they submitted, plus the standing **Retry** button that resends them. Previously the whole round disappeared silently.

The visible row shows the answers themselves — the `[form answers - <id>]` routing header is stripped from the bubble, so the machine payload still never reaches the user (#5496). Resending replays the untouched original content.

**Unchanged:** a form answer that *did* reach a turn still draws no user bubble at all. This fix does not make the transcript stop hiding things; it narrows the hiding rule to the case its own rationale covers.

## Surface area

- [x] **UI** — a question-form answer that failed to send now renders in the chat transcript (`apps/web` chat pane)
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — none added; the surfaced row reuses the existing `chat.sendFailedRetryAria` / `chat.record.retry` strings
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Not attached — reproducing the entry point needs a `POST /api/runs` that fails after the optimistic paint, which is exactly what the red spec drives deterministically. The rendered result is the existing failed-send user row (`data-testid="user-send-failed"`), unchanged in appearance from the ordinary failed-send case it already ships for typed messages.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ChatPane.question-form-send-failed.test.tsx`
- Did the test go red on `main` and green on this branch? **yes** — the branch is cut from `origin/main` (`fc959c7a5a`) and the spec was written and run before any source edit: `1 failed | 3 passed`, failing on *"keeps the failed turn on screen with a way to send it again"*.
- The spec carries its own instrument check. A **control** case asserts that an ordinary (non-form) failed send renders its bubble and its Retry — that case is green on `main`, so the red is "form answers are hidden", not "this test cannot see the Retry button".
- **Implementation pulled back out, twice, to confirm each half is load-bearing:**
  - removing `message.sendFailed !== true` from `buildChatRenderItems` → red again on *"keeps the failed turn on screen…"*
  - removing `formAnswersDisplayBody(...)` from the bubble's `displayContent` → red on *"does not put the machine payload header in front of the user"*
- **Reverse anchor** (a separate case, so the fix cannot degrade into "stop hiding everything"): a *delivered* form answer must still draw no user bubble and must not leak the header. Green before and after.

## Validation

- `pnpm typecheck` → exit **0**
- `pnpm guard` → exit **0**
- `pnpm --filter @open-design/web build` → exit **0**
- Red spec: `apps/web/tests/components/ChatPane.question-form-send-failed.test.tsx` → 4 passed
- Neighbouring question-form / chat-pane suites: `ChatPane.jump-button-question-form`, `ChatPane.streaming`, `ChatPane.strategy-blocked-refresh-race`, `ChatPane.send-failed`, `ProjectView.questionFormKey`, `QuestionForm`, `AssistantMessage.question-form-answered-status`, `AssistantMessage.question-form-resubmit`, `qf-next-gate` → 119 passed
- Wider batch (`tests/components/chat/**`, `chat-anchor-to-top`, `ProjectView.fork-folded-turn`, `ProjectView.run-isolation`, `AssistantMessage`, `runtime/chat/fork-boundary`) → 1916 passed, 1 unrelated load-induced timeout (`chat/audio-wave-pulse.test.tsx`) that passes on its own re-run

## Adjacent issues (not fixed here — deliberately out of scope)

Found while tracing, each deserving its own red spec and PR:

1. **`retractPaintedTurn` on `gate.kind === 'unavailable'` is silent (AMR-only).** `ProjectView`'s AMR balance gate paints the turn, awaits two HTTP round trips (one forcing an authoritative upstream Vela read), and on an *unreadable* wallet calls `parkBlockedSend()` — which retracts the painted turn, re-queues the send, and adds the conversation to `amrGatePausedQueueConversationsRef` so the auto-drain effect refuses to drain it. Unlike the `hard` branches there is no dialog and no balance card. Visible symptom is similar to this bug, but distinguishable: the send survives as a queued row, so it is not the silent-total-loss shape QA described. `Home` retries `unavailable` via `retryUnavailableAmrBalanceGate`; the project chat does not.
2. **A `sendFailed` form answer leaves the form locked.** `FormBlock` calls `acceptSubmission()` as soon as `handleSend` returns `true`, which happens when the stream is wired, not when it succeeds. After this PR the failed row's Retry is the recovery path, but the form itself still reads "answered". Whether it should unlock is a product call.
3. **AMR opencode-SSE EOF is classified as a resume failure even after visible output.** `isAmrOpencodeEventStreamResumeFailure` matches `"opencode SSE ended before prompt completion"`, which can arrive *after* the model already streamed a complete `<question-form>`; the auto-reseed at `server.ts` then restarts the same run, and the restart's `start` event runs `retireSupersededAttemptProse` → `dropTrailingMessageAgentDeltas`, erasing that trailing prose from `events_json` and `content`. That path is not gated by `decideSafeRunRetry`, so its `userVisibleOutputSeen` suppression does not apply. A different failure mode from this PR (content erased in place rather than the round vanishing), but worth its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQSowXMsTxbEoZyGYfxgyb
