### PR TITLE
chore(bot): configure grouped dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(bot):"
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    cooldown:
+      default-days: 2
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore(bot):"
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+    groups:
+      node:
+        patterns: ["*"]
+
+  - package-ecosystem: "docker"
+    directories:
+      - "/deploy"
+      - "/tools/pack"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore(bot):"
+    groups:
+      docker:
+        patterns: ["*"]


### PR DESCRIPTION
## Summary
- add grouped weekly GitHub Actions and monthly npm updates
- keep Node type definitions on their current major and apply a two-day cooldown
- group Docker updates across deploy and tools/pack manifests

## Validation
- Dependabot YAML, grouping semantics, and manifest-directory validation
- git diff --cached --check