### PR TITLE
feat(whats-new): announce OpenDesign Arena for 0.22.0

### DIFF
--- a/docs/whats-new.json
+++ b/docs/whats-new.json
@@ -1,13 +1,13 @@
 {
   "id": "0.22.0",
   "title": "Introducing OpenDesign Arena",
-  "body": "Over a dozen models tested: Compare design quality and cost across models evaluated with the OpenDesign Harness.\n85% of the score. 2% of the cost: DeepSeek V4 Flash achieved 85% of top-ranked GPT-6 Astra's average score at just 2% of its average cost.\nFind the right model for you: Explore the benchmarks to choose a model for your design needs and budget.",
+  "body": "Over a dozen models tested: Compare design quality and cost across models evaluated with the OpenDesign Harness.\nDeepSeek V4.1 Flash Leads in Scores: DeepSeek V4.1 Flash achieved 98% of top-ranked GPT-6 Astra’s average score at just 1% of its average cost.\nFind the right model for you: Explore the benchmarks to choose a model for your design needs and budget.",
   "imageUrl": "https://whatsnew.open-design.ai/0.18.0.webp",
   "linkUrl": "https://open-design.ai/llm-arena-for-design/",
   "locales": {
     "zh-CN": {
       "title": "OpenDesign Arena 正式上线",
-      "body": "十多款模型实测：使用 OpenDesign Harness，对比模型的设计表现与成本。\n85% 均分，2% 成本：DeepSeek V4 Flash 的均分达到榜首 GPT-6 Astra 的 85%，平均成本仅为其 2%。\n找到适合你的模型：前往 Arena，根据创作需求与预算选择模型。",
+      "body": "十多款模型实测：使用 OpenDesign Harness，对比模型的设计表现与成本。\nDeepSeek V4.1 Flash 评分领先：DeepSeek V4.1 Flash 的均分达到榜首 GPT-6 Astra 的 98%，平均成本仅为其 1%。\n找到适合你的模型：前往 Arena，根据创作需求与预算选择模型。",
       "linkUrl": "https://open-design.ai/zh/llm-arena-for-design/"
     }
   }

--- a/docs/whats-new.json
+++ b/docs/whats-new.json
@@ -1,13 +1,14 @@
 {
-  "id": "0.21.0",
-  "title": "Reliable, Start to Finish",
-  "body": "HTML previews stay visible as you switch projects, files, or between Code and Preview.\nAgent connections are more reliable, with improved support for current DeepSeek Harness and Kimi releases.\nRelaunching Open Design now recovers more reliably after an unexpected shutdown.",
+  "id": "0.22.0",
+  "title": "Introducing OpenDesign Arena",
+  "body": "Over a dozen models tested: Compare design quality and cost across models evaluated with the OpenDesign Harness.\n85% of the score. 2% of the cost: DeepSeek V4 Flash achieved 85% of top-ranked GPT-6 Astra's average score at just 2% of its average cost.\nFind the right model for you: Explore the benchmarks to choose a model for your design needs and budget.",
   "imageUrl": "https://whatsnew.open-design.ai/0.18.0.webp",
-  "linkUrl": "https://github.com/nexu-io/open-design/releases/tag/open-design-v0.21.0",
+  "linkUrl": "https://open-design.ai/llm-arena-for-design/",
   "locales": {
     "zh-CN": {
-      "title": "从启动到预览，始终可靠",
-      "body": "切换项目、文件，或在「代码」与「预览」之间切换时，HTML 预览保持正常显示。\n提升 Agent 连接稳定性，并完善对新版 DeepSeek Harness 与 Kimi 的兼容。\n意外退出后重新启动时，Open Design 能够更可靠地恢复运行。"
+      "title": "OpenDesign Arena 正式上线",
+      "body": "十多款模型实测：使用 OpenDesign Harness，对比模型的设计表现与成本。\n85% 均分，2% 成本：DeepSeek V4 Flash 的均分达到榜首 GPT-6 Astra 的 85%，平均成本仅为其 2%。\n找到适合你的模型：前往 Arena，根据创作需求与预算选择模型。",
+      "linkUrl": "https://open-design.ai/zh/llm-arena-for-design/"
     }
   }
 }


### PR DESCRIPTION
## Why

0.22.0 shipped, and the post-update card still shows 0.21.0 copy. Product supplied the Arena announcement; this lands it through the publish pipeline that #7892 just added, so no one needs Cloudflare credentials to change the card any more.

This is also the **first real use** of that pipeline — merging it exercises guard → environment → upload → read-back end to end.

## What users will see

Everyone who updates to 0.22.0 (and everyone already on it who dismissed the 0.21.0 card) gets the card once more, announcing OpenDesign Arena, with a button that opens the benchmark site. The button label itself already ships in 0.22.0 (`Explore Arena` / `查看评测站`).

Bumping `id` from `0.21.0` to `0.22.0` is what re-opens it — the client remembers the last `id` it showed.

## One correction to the supplied copy

Product's zh-CN CTA was `https://open-design.ai/zh/llm-arena/llm-arena-for-design/`. That path **404s** — it carries one `llm-arena` segment too many. The live Chinese page is `https://open-design.ai/zh/llm-arena-for-design/`.

Verified immediately before commit:

| | |
|---|---|
| `https://open-design.ai/llm-arena-for-design/` | **200** — used for `linkUrl` |
| `https://open-design.ai/zh/llm-arena-for-design/` | **200** — used for the zh-CN override |
| `https://open-design.ai/zh/llm-arena/llm-arena-for-design/` | 404 — as supplied, not used |

Worth confirming with product that the shorter path is the intended one and the extra segment was a typo.

## Notes

- `imageUrl` still points at `0.18.0.webp`. Product has not supplied 0.22.0 cover art; per the release skill, reusing the previous image is the norm rather than shipping a broken one. Swap it when new art arrives.
- English copy is verbatim from product. zh-CN copy is verbatim except the corrected URL.

## Surface area

- [x] `docs/whats-new.json` — the published card document
- [ ] No code, workflow, or contract changes

## Validation

- `python3 -m json.tool` — parses
- `pnpm guard` — passes, including `check-whats-new-document.ts` (the guard #7892 added, which validates this file against the daemon's own `parseWhatsNewDocument`)