### PR TITLE
fix(web): link composer comboboxes to active popups

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -2913,19 +2913,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
         // Drive a single index over the visible section union. MentionPopover
         // renders the same files-first section order and highlights the
         // matching row from activeIndex.
-        const showFiles = mentionTab === 'all' || mentionTab === 'files';
-        const showTabs = mentionTab === 'all' || mentionTab === 'tabs';
-        const showPlugins = mentionTab === 'all' || mentionTab === 'plugins';
-        const showSkills = mentionTab === 'all' || mentionTab === 'skills';
-        const showMcp = mentionTab === 'all' || mentionTab === 'mcp';
-        const showConnectors = mentionTab === 'all' || mentionTab === 'connectors';
-        const total =
-          (showFiles ? filteredFiles.length : 0) +
-          (showTabs ? filteredWorkspaceContexts.length : 0) +
-          (showPlugins ? filteredPlugins.length : 0) +
-          (showSkills ? filteredSkills.length : 0) +
-          (showMcp ? filteredMcpServers.length : 0) +
-          (showConnectors ? filteredConnectors.length : 0);
+        const total = visibleMentionOptionCount;
         if (total > 0) {
           if (key === 'ArrowDown') {
             setMentionIndex((i) => (i + 1) % total);
@@ -3223,6 +3211,13 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
         .filter((s) => skillMatchesQuery(s, mentionQuery))
         .sort((a, b) => skillMentionRank(a, mentionQuery) - skillMentionRank(b, mentionQuery));
     }, [mention, mentionQuery, skills, stagedSkills]);
+    const visibleMentionOptionCount =
+      (mentionTab === 'all' || mentionTab === 'files' ? filteredFiles.length : 0) +
+      (mentionTab === 'all' || mentionTab === 'tabs' ? filteredWorkspaceContexts.length : 0) +
+      (mentionTab === 'all' || mentionTab === 'plugins' ? filteredPlugins.length : 0) +
+      (mentionTab === 'all' || mentionTab === 'skills' ? filteredSkills.length : 0) +
+      (mentionTab === 'all' || mentionTab === 'mcp' ? filteredMcpServers.length : 0) +
+      (mentionTab === 'all' || mentionTab === 'connectors' ? filteredConnectors.length : 0);
     const liveCommentAttachments = currentCommentAttachments();
     const placeholderCarouselActive =
       !streaming
@@ -3586,8 +3581,15 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
               popoverOpen={Boolean(mention) || Boolean(slash && filteredSlash.length > 0)}
               onPopoverKey={handlePopoverKey}
               comboboxAria={{
-                expanded: Boolean(mention),
-                activeId: mention ? `mention-opt-${mentionIndex}` : null,
+                expanded: Boolean(mention) || Boolean(slash && filteredSlash.length > 0),
+                controlsId:
+                  slash && filteredSlash.length > 0 ? 'slash-listbox' : 'mention-listbox',
+                activeId:
+                  slash && filteredSlash.length > 0
+                    ? `slash-opt-${Math.min(slashIndex, filteredSlash.length - 1)}`
+                    : mention && visibleMentionOptionCount > 0
+                      ? `mention-opt-${Math.min(mentionIndex, visibleMentionOptionCount - 1)}`
+                      : null,
               }}
             />
             {placeholderScenarios.length > 0 ? (
@@ -6454,6 +6456,7 @@ function SlashPopover({
       <div
         className="slash-popover-list"
         role="listbox"
+        id="slash-listbox"
         aria-label={t('pet.slashPopoverAria')}
       >
         {commands.map((cmd, idx) => {

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -1662,7 +1662,11 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
               onPopoverKey={handlePopoverKey}
               comboboxAria={{
                 expanded: pickerOpen,
-                activeId: pickerOpen ? `home-hero-option-${selectedIndex}` : null,
+                controlsId: 'home-hero-context-picker',
+                activeId:
+                  pickerOpen && visiblePickerOptions.length > 0
+                    ? `home-hero-option-${selectedIndex}`
+                    : null,
               }}
             />
             <PlaceholderCarousel

--- a/apps/web/src/components/composer/LexicalComposerInput.tsx
+++ b/apps/web/src/components/composer/LexicalComposerInput.tsx
@@ -164,8 +164,12 @@ export interface LexicalComposerInputProps {
     key: 'ArrowDown' | 'ArrowUp' | 'Tab' | 'Enter' | 'Escape',
   ): boolean;
   // Optional combobox a11y. When set, the ContentEditable announces the active
-  // mention row (id lives in the portaled listbox) without moving DOM focus.
-  comboboxAria?: { activeId: string | null; expanded: boolean };
+  // popup option (id lives in the portaled listbox) without moving DOM focus.
+  comboboxAria?: {
+    activeId: string | null;
+    controlsId: string;
+    expanded: boolean;
+  };
   // Read-only mode (team-shared project viewer). Makes the Lexical editor
   // non-editable so the caret/typing is blocked, applies a muted read-only
   // visual state, and hard-stops Enter from firing a send (belt-and-suspenders
@@ -819,7 +823,7 @@ export const LexicalComposerInput = forwardRef<
               title={title ?? placeholder}
               role="combobox"
               aria-expanded={comboboxAria?.expanded ? 'true' : 'false'}
-              aria-controls="mention-listbox"
+              aria-controls={comboboxAria?.controlsId}
               {...(comboboxAria?.activeId
                 ? { 'aria-activedescendant': comboboxAria.activeId }
                 : {})}

--- a/apps/web/src/components/composer/LexicalComposerInput.tsx
+++ b/apps/web/src/components/composer/LexicalComposerInput.tsx
@@ -823,7 +823,7 @@ export const LexicalComposerInput = forwardRef<
               title={title ?? placeholder}
               role="combobox"
               aria-expanded={comboboxAria?.expanded ? 'true' : 'false'}
-              aria-controls={comboboxAria?.controlsId}
+              aria-controls={comboboxAria?.expanded ? comboboxAria.controlsId : undefined}
               {...(comboboxAria?.activeId
                 ? { 'aria-activedescendant': comboboxAria.activeId }
                 : {})}

--- a/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
+++ b/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
@@ -378,6 +378,10 @@ describe('ChatComposer context pickers', () => {
     expect(screen.getByRole('tab', { name: 'Design files' })).toBeTruthy();
     expect(screen.getByRole('tab', { name: 'Tabs' })).toBeTruthy();
     expect(screen.getByText('Search Design Files, tabs, plugins, skills, MCP servers, and connectors.')).toBeTruthy();
+    const editor = screen.getByTestId('chat-composer-input');
+    expect(editor.getAttribute('aria-expanded')).toBe('true');
+    expect(editor.getAttribute('aria-controls')).toBe('mention-listbox');
+    expect(editor.getAttribute('aria-activedescendant')).toBeNull();
   });
 
   it('localizes @ panel tabs and empty states in Chinese mode', async () => {
@@ -420,6 +424,12 @@ describe('ChatComposer context pickers', () => {
     await typeAndSettle('/');
 
     const popover = await screen.findByTestId('slash-popover');
+    const editor = screen.getByTestId('chat-composer-input');
+    expect(editor.getAttribute('aria-expanded')).toBe('true');
+    expect(editor.getAttribute('aria-controls')).toBe('slash-listbox');
+    const activeOptionId = editor.getAttribute('aria-activedescendant');
+    expect(activeOptionId).toBe('slash-opt-0');
+    expect(document.getElementById(activeOptionId!)).toBeTruthy();
     const settingsRow = within(popover).getByText('/mcp').closest('button');
     const mcpRow = within(popover).getByText('/mcp slack').closest('button');
     expect(settingsRow).toBeTruthy();

--- a/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
+++ b/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
@@ -359,6 +359,10 @@ describe('ChatComposer context pickers', () => {
     renderComposer();
     await flushMounts();
 
+    const editor = screen.getByTestId('chat-composer-input');
+    expect(editor.getAttribute('aria-expanded')).toBe('false');
+    expect(editor.getAttribute('aria-controls')).toBeNull();
+
     await typeAndSettle('@');
 
     await waitFor(() => expect(screen.getByTestId('mention-popover')).toBeTruthy());
@@ -378,7 +382,6 @@ describe('ChatComposer context pickers', () => {
     expect(screen.getByRole('tab', { name: 'Design files' })).toBeTruthy();
     expect(screen.getByRole('tab', { name: 'Tabs' })).toBeTruthy();
     expect(screen.getByText('Search Design Files, tabs, plugins, skills, MCP servers, and connectors.')).toBeTruthy();
-    const editor = screen.getByTestId('chat-composer-input');
     expect(editor.getAttribute('aria-expanded')).toBe('true');
     expect(editor.getAttribute('aria-controls')).toBe('mention-listbox');
     expect(editor.getAttribute('aria-activedescendant')).toBeNull();

--- a/apps/web/tests/components/HomeHero.plugin-picker.test.tsx
+++ b/apps/web/tests/components/HomeHero.plugin-picker.test.tsx
@@ -134,6 +134,10 @@ describe('HomeHero plugin picker', () => {
       />,
     );
 
+    const editor = screen.getByTestId('home-hero-input');
+    expect(editor.getAttribute('aria-expanded')).toBe('false');
+    expect(editor.getAttribute('aria-controls')).toBeNull();
+
     setHomeHeroPrompt('@');
     await settle();
     expect(screen.getByTestId('home-hero-plugin-picker')).toBeTruthy();

--- a/apps/web/tests/components/HomeHero.plugin-picker.test.tsx
+++ b/apps/web/tests/components/HomeHero.plugin-picker.test.tsx
@@ -452,6 +452,10 @@ describe('HomeHero plugin picker', () => {
     expect(screen.getByRole('tab', { name: /mcp/i })).toBeTruthy();
     expect(screen.getByRole('tab', { name: /connectors/i })).toBeTruthy();
     expect(screen.getByText('Search files, plugins, skills, MCP servers, and connectors.')).toBeTruthy();
+    const editor = screen.getByTestId('home-hero-input');
+    expect(editor.getAttribute('aria-expanded')).toBe('true');
+    expect(editor.getAttribute('aria-controls')).toBe('home-hero-context-picker');
+    expect(editor.getAttribute('aria-activedescendant')).toBeNull();
   });
 
   it('can mention staged files from the home @ picker and keeps removal in sync', async () => {


### PR DESCRIPTION
## Why

The shared Lexical composer hardcoded `aria-controls="mention-listbox"`, even when the active popup was the Home context picker or slash-command list. As a result, assistive technology could be directed to the wrong element. Slash suggestions were also exposed as collapsed, and an empty mention picker exposed an `aria-activedescendant` whose option did not exist.

## What users will see

There is no visual change. Screen readers now receive the correct expanded state, controlled listbox, and active option for Home context, project mention, and slash-command popups.

## Surface area

- [x] **UI** — accessibility semantics for composer suggestion popups in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is a semantic accessibility fix with no visual changes.

## Bug fix verification

- Test paths:
  - `apps/web/tests/components/ChatComposer.context-pickers.test.tsx`
  - `apps/web/tests/components/HomeHero.plugin-picker.test.tsx`
- The three new regression assertions fail against `main` and pass on this branch.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts --maxWorkers=2 tests/components/ChatComposer.context-pickers.test.tsx tests/components/HomeHero.plugin-picker.test.tsx` — 48 passed
