### PR TITLE
fix(web): open the model picker on the model in effect

### DIFF
--- a/apps/web/src/components/InlineModelSwitcher.tsx
+++ b/apps/web/src/components/InlineModelSwitcher.tsx
@@ -80,6 +80,7 @@ import {
   notifyAmrLoginStatusChanged,
 } from './amrLoginPolling';
 import { orderAgentsWithOpenDesignFirst } from './agentOrdering';
+import { anchorSelectionInView } from './pickerSelectionAnchor';
 import {
   agentModelIsSelectable,
   defaultAgentModelId,
@@ -204,6 +205,8 @@ export function InlineModelSwitcher({
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
+  const compactModelListRef = useRef<HTMLDivElement | null>(null);
+  const compactSelectionAnchoredRef = useRef(false);
   const campaignBenefitTrackedForOpenRef = useRef(false);
   // Viewport clamp for the popover (issue #99): the anchor chip can sit
   // anywhere on screen (home hero mid-page, chat composer at the bottom), so
@@ -783,6 +786,23 @@ export function InlineModelSwitcher({
       })),
     [currentAgent, inlineAgentModelOptions],
   );
+
+  // The compact list caps at six visible rows and scrolls, so a longer catalog
+  // used to open on row one with the model actually in effect below the fold —
+  // the hunting OPEND-2812 reports. Anchor the list on the row it already marks
+  // `aria-checked`; nothing new is remembered here, the selection is read back
+  // out of the rendered list. Once per open, so a later re-render (the catalog
+  // arriving, the popover re-measuring) cannot yank the list back under a user
+  // who has started browsing it.
+  useLayoutEffect(() => {
+    if (!open) {
+      compactSelectionAnchoredRef.current = false;
+      return;
+    }
+    if (compactSelectionAnchoredRef.current || !compactModelListRef.current) return;
+    compactSelectionAnchoredRef.current = true;
+    anchorSelectionInView(compactModelListRef.current, '[aria-checked="true"]');
+  }, [compactModelRows, open]);
 
   useEffect(() => {
     if (!open) {
@@ -1382,7 +1402,11 @@ export function InlineModelSwitcher({
             // the execution settings entry below.
             <div className="inline-switcher__row">
               {currentAgent && compactModelRows.length > 0 ? (
-                <div className="inline-switcher__agent-grid" role="radiogroup">
+                <div
+                  className="inline-switcher__agent-grid"
+                  role="radiogroup"
+                  ref={compactModelListRef}
+                >
                   {compactModelRows.map(({ model: m, selectable }) => {
                     const active = currentModelId === m.id;
                     // A model above the caller's plan is shown, but honestly:

--- a/apps/web/src/components/modelOptions.tsx
+++ b/apps/web/src/components/modelOptions.tsx
@@ -4,6 +4,7 @@ import type { AgentModelOption } from '../types';
 import { useT } from '../i18n';
 import { Icon } from './Icon';
 import { modelProviderIconSrc } from './modelProviderIcon';
+import { anchorSelectionInView } from './pickerSelectionAnchor';
 import {
   getModelCostTier,
   getModelCapabilityTag,
@@ -430,6 +431,22 @@ export const SearchableModelSelect = forwardRef<
     }
   }, [open]);
 
+  // Land the opened list on the model in effect (OPEND-2812) instead of on the
+  // top of the catalog. Once per open: the popover re-measures on scroll and
+  // resize, and re-anchoring there would yank the list back out from under a
+  // user who is browsing it. `popoverStyle` is a dependency because the popover
+  // does not mount until the first measurement lands.
+  const selectionAnchoredRef = useRef(false);
+  useLayoutEffect(() => {
+    if (!open) {
+      selectionAnchoredRef.current = false;
+      return;
+    }
+    if (selectionAnchoredRef.current || !popoverRef.current) return;
+    selectionAnchoredRef.current = true;
+    anchorSelectionInView(popoverRef.current, '[data-selected="true"]');
+  }, [open, popoverStyle]);
+
   /** One option row — shared by the flat list and the two-level browse's
    *  models pane, so cost-tier / capability-tag / upgrade-lock affordances
    *  render identically in either layout. `index` only needs to be unique
@@ -653,6 +670,10 @@ export const SearchableModelSelect = forwardRef<
                               type="button"
                               className={`model-select-searchable__company${isActive ? ' is-active' : ''}${hasSelected ? ' has-selected' : ''}`}
                               data-testid={`model-company-${group.key}`}
+                              /* The company rail scrolls too — mark the one
+                                 holding the selection so opening anchors both
+                                 panes on it, not just the models pane. */
+                              data-selected={hasSelected ? 'true' : undefined}
                               onMouseEnter={() => setHoverCompany(group.key)}
                               onFocus={() => setHoverCompany(group.key)}
                               onClick={() => setHoverCompany(group.key)}

--- a/apps/web/src/components/pickerSelectionAnchor.ts
+++ b/apps/web/src/components/pickerSelectionAnchor.ts
@@ -1,0 +1,33 @@
+/**
+ * Opening a picker must land on the choice already in effect.
+ *
+ * Every model list in the app caps its height and scrolls — the compact home
+ * list at six rows, the searchable popover at 280px — so a catalog longer than
+ * the cap opens on its first row with the model actually running below the
+ * fold. The user then hunts for a selection the list has already made
+ * (OPEND-2812). `anchorSelectionInView` puts the rows the list itself marks as
+ * selected back inside their scroller the moment the list appears.
+ *
+ * It reads the selection off the rendered DOM instead of taking an element:
+ * "which row is selected" is decided exactly once, by the same attribute the
+ * accessibility tree exposes (`aria-checked` / `aria-selected` / a mirroring
+ * `data-selected`), so there is no second copy of that state to drift out of
+ * sync. Nothing marked selected means nothing moves — a list with no choice in
+ * effect must not be scrolled anywhere.
+ *
+ * `block: 'nearest'` keeps the movement minimal: a row already visible stays
+ * put, and no scroller beyond the list's own is disturbed. `scrollIntoView` is
+ * called optionally because layout-free environments (jsdom) do not implement
+ * it.
+ */
+export function anchorSelectionInView(
+  container: HTMLElement | null | undefined,
+  selectedSelector: string,
+): void {
+  if (!container) return;
+  for (const row of Array.from(
+    container.querySelectorAll<HTMLElement>(selectedSelector),
+  )) {
+    row.scrollIntoView?.({ block: 'nearest' });
+  }
+}

--- a/apps/web/tests/components/ModelPickerSelectionAnchor.test.tsx
+++ b/apps/web/tests/components/ModelPickerSelectionAnchor.test.tsx
@@ -1,0 +1,312 @@
+// @vitest-environment jsdom
+//
+// OPEND-2812 — "模型选择器打开时定位到上次选中的模型".
+//
+// Reported pain: "用户频繁切换模型时,每次都要重新查找上次选中的模型,选择效率低."
+// Expected: "打开选择器时高亮当前／上次选择的模型,并滚动定位到对应位置."
+//
+// Both model lists cap their height and scroll — the compact home list at six
+// rows (`.inline-switcher--compact .inline-switcher__agent-grid`, max-height
+// 226px) and the searchable popover at 280px. A catalog longer than the cap
+// therefore opens on its FIRST row, with the model actually in effect below the
+// fold, which is exactly the hunting the ticket describes.
+//
+// "Current" and "last" are the same thing here: the model in effect is what the
+// chip already shows and what the list already marks selected. So these specs
+// pin the two halves of the requirement against that existing selection — no
+// second "last picked" state is invented:
+//   1. the model in effect is marked selected (aria-checked / aria-selected),
+//   2. and it is put inside its scroller's visible area when the list opens.
+//
+// Judged on observable behavior only: ARIA state plus the scroll-positioning
+// call recorded off the elements themselves. No CSS class assertions
+// (apps/web/src/components/chat/AGENTS.md §5).
+
+import { useRef, useState } from 'react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { InlineModelSwitcher } from '../../src/components/InlineModelSwitcher';
+import { SearchableModelSelect } from '../../src/components/modelOptions';
+import type { AgentInfo, AgentModelOption, AppConfig } from '../../src/types';
+
+vi.mock('../../src/providers/provider-models', () => ({
+  fetchProviderModels: vi.fn(async () => ({ ok: false, models: [] })),
+}));
+
+/**
+ * jsdom implements no layout, so it ships no `Element.prototype.scrollIntoView`
+ * at all. Record every call together with the element it was made ON — "which
+ * row got scrolled into view" is the observable the ticket's second half is
+ * about, and it is the only way to tell "anchored on the selection" apart from
+ * "scrolled something, anything".
+ */
+interface ScrollCall {
+  element: Element;
+  options: unknown;
+}
+
+type ScrollableProto = { scrollIntoView?: (options?: unknown) => void };
+
+let scrollCalls: ScrollCall[] = [];
+let restoreScrollIntoView: () => void = () => {};
+
+function installScrollRecorder(): void {
+  scrollCalls = [];
+  const proto = Element.prototype as unknown as ScrollableProto;
+  const owned = Object.prototype.hasOwnProperty.call(
+    Element.prototype,
+    'scrollIntoView',
+  );
+  const original = proto.scrollIntoView;
+  proto.scrollIntoView = function (this: Element, options?: unknown) {
+    scrollCalls.push({ element: this, options });
+  };
+  restoreScrollIntoView = () => {
+    if (owned) proto.scrollIntoView = original;
+    else delete proto.scrollIntoView;
+  };
+}
+
+function scrolledElements(): Element[] {
+  return scrollCalls.map((call) => call.element);
+}
+
+const baseConfig: AppConfig = {
+  mode: 'daemon',
+  apiKey: '',
+  apiProtocol: 'anthropic',
+  apiVersion: '',
+  baseUrl: 'https://api.anthropic.com',
+  model: 'claude-sonnet-4-5',
+  apiProviderBaseUrl: 'https://api.anthropic.com',
+  apiProtocolConfigs: {},
+  agentId: 'codex',
+  skillId: null,
+  designSystemId: null,
+  onboardingCompleted: true,
+  mediaProviders: {},
+  agentModels: {},
+  agentCliEnv: {},
+};
+
+/** A catalog longer than the compact list's six-row cap, so the selection the
+ *  specs pick is genuinely below the fold on open. */
+const LONG_CATALOG: AgentModelOption[] = Array.from({ length: 18 }, (_, index) => ({
+  id: `model-${index}`,
+  label: `Model ${index}`,
+  enabled: true,
+}));
+
+const longCatalogAgent: AgentInfo = {
+  id: 'codex',
+  name: 'Codex CLI',
+  bin: 'codex',
+  available: true,
+  version: '1.0.0',
+  models: LONG_CATALOG,
+};
+
+/** Mirrors the home composer's wiring: the switcher does not own persistence,
+ *  the picked model flows back in as config. */
+function CompactSwitcher({ initialConfig }: { initialConfig?: Partial<AppConfig> }) {
+  const [config, setConfig] = useState<AppConfig>({ ...baseConfig, ...initialConfig });
+  const persistedRef = useRef(config);
+  return (
+    <InlineModelSwitcher
+      config={config}
+      agents={[longCatalogAgent]}
+      providerModelsCache={{}}
+      compact
+      daemonLive
+      onModeChange={vi.fn()}
+      onAgentChange={vi.fn()}
+      onAgentModelChange={(agentId, choice) => {
+        const next: AppConfig = {
+          ...persistedRef.current,
+          agentModels: {
+            ...(persistedRef.current.agentModels ?? {}),
+            [agentId]: choice,
+          },
+        };
+        persistedRef.current = next;
+        setConfig(next);
+      }}
+      onApiProtocolChange={vi.fn()}
+      onApiModelChange={vi.fn()}
+      onOpenSettings={vi.fn()}
+    />
+  );
+}
+
+function openCompactSwitcher(): HTMLElement {
+  fireEvent.click(screen.getByTestId('inline-model-switcher-chip'));
+  return screen.getByTestId('inline-model-switcher-popover');
+}
+
+function compactRow(modelId: string): HTMLElement {
+  return screen.getByTestId(`inline-model-switcher-compact-model-${modelId}`);
+}
+
+beforeEach(() => {
+  installScrollRecorder();
+});
+
+afterEach(() => {
+  restoreScrollIntoView();
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('compact home model list — opening lands on the model in effect', () => {
+  it('marks the model in effect selected and scrolls it into view', () => {
+    render(<CompactSwitcher initialConfig={{ agentModels: { codex: { model: 'model-14' } } }} />);
+
+    const popover = openCompactSwitcher();
+    const selected = within(popover).getByTestId(
+      'inline-model-switcher-compact-model-model-14',
+    );
+
+    // Half one: the list says which model is in effect.
+    expect(selected.getAttribute('aria-checked')).toBe('true');
+    // Half two: and puts it where the user can see it, without having to hunt.
+    expect(scrolledElements()).toContain(selected);
+    expect(scrollCalls.find((call) => call.element === selected)?.options).toEqual({
+      block: 'nearest',
+    });
+  });
+
+  it('anchors on the selection only — no other row is scrolled to', () => {
+    render(<CompactSwitcher initialConfig={{ agentModels: { codex: { model: 'model-14' } } }} />);
+
+    openCompactSwitcher();
+
+    const scrolled = scrolledElements();
+    for (const model of LONG_CATALOG) {
+      if (model.id === 'model-14') continue;
+      expect(scrolled, `${model.id} must not be scrolled to`).not.toContain(
+        compactRow(model.id),
+      );
+    }
+  });
+
+  it('does not scroll at all when nothing in the list is selected', () => {
+    // Reverse anchor — first use, or a saved model the catalog no longer
+    // carries. Nothing is in effect inside this list, so nothing may be
+    // yanked into view and nothing may crash.
+    render(
+      <CompactSwitcher
+        initialConfig={{ agentModels: { codex: { model: 'model-that-left-the-catalog' } } }}
+      />,
+    );
+
+    const popover = openCompactSwitcher();
+
+    const rows = within(popover).getAllByRole('radio');
+    expect(rows).toHaveLength(LONG_CATALOG.length);
+    expect(rows.some((row) => row.getAttribute('aria-checked') === 'true')).toBe(false);
+    expect(scrollCalls).toHaveLength(0);
+  });
+});
+
+describe('searchable model picker — opening lands on the model in effect', () => {
+  beforeEach(() => {
+    // An on-screen trigger: jsdom reports a zero rect for everything, which
+    // the picker treats as "no layout yet".
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      x: 120,
+      y: 200,
+      top: 200,
+      right: 360,
+      bottom: 236,
+      left: 120,
+      width: 240,
+      height: 36,
+      toJSON: () => ({}),
+    });
+  });
+
+  function openPicker(): HTMLElement {
+    fireEvent.click(screen.getByRole('combobox'));
+    return screen.getByTestId('model-popover');
+  }
+
+  it('marks the model in effect selected and scrolls it into view', () => {
+    render(
+      <SearchableModelSelect
+        models={LONG_CATALOG}
+        value="model-14"
+        onChange={vi.fn()}
+        searchPlaceholder="Search models"
+        popoverTestId="model-popover"
+      />,
+    );
+
+    const popover = openPicker();
+    const selected = within(popover)
+      .getAllByRole('option')
+      .find((option) => option.getAttribute('aria-selected') === 'true');
+
+    expect(selected).toBeTruthy();
+    expect(scrolledElements()).toContain(selected);
+  });
+
+  it('brings the selected company into view alongside its model', () => {
+    // The two-level browse (AMR's cross-vendor catalog) scrolls in BOTH panes:
+    // the company rail on the left and that company's models on the right.
+    const crossVendor: AgentModelOption[] = [
+      ...Array.from({ length: 6 }, (_, index) => ({
+        id: `claude-${index}`,
+        label: `Claude ${index}`,
+      })),
+      ...Array.from({ length: 6 }, (_, index) => ({
+        id: `deepseek-${index}`,
+        label: `DeepSeek ${index}`,
+      })),
+    ];
+
+    render(
+      <SearchableModelSelect
+        models={crossVendor}
+        value="deepseek-4"
+        onChange={vi.fn()}
+        groupByCompany
+        searchPlaceholder="Search models"
+        popoverTestId="model-popover"
+      />,
+    );
+
+    const popover = openPicker();
+    const scrolled = scrolledElements();
+    const selectedOption = within(popover)
+      .getAllByRole('option')
+      .find((option) => option.getAttribute('aria-selected') === 'true');
+
+    expect(selectedOption).toBeTruthy();
+    expect(scrolled).toContain(selectedOption);
+    expect(scrolled).toContain(within(popover).getByTestId('model-company-deepseek'));
+    expect(scrolled).not.toContain(within(popover).getByTestId('model-company-claude'));
+  });
+
+  it('does not scroll at all when no listed model is in effect', () => {
+    render(
+      <SearchableModelSelect
+        models={LONG_CATALOG}
+        value=""
+        onChange={vi.fn()}
+        searchPlaceholder="Search models"
+        popoverTestId="model-popover"
+      />,
+    );
+
+    const popover = openPicker();
+
+    expect(within(popover).getAllByRole('option')).toHaveLength(LONG_CATALOG.length);
+    expect(
+      within(popover)
+        .getAllByRole('option')
+        .some((option) => option.getAttribute('aria-selected') === 'true'),
+    ).toBe(false);
+    expect(scrollCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Plane: OPEND-2812 (交互优化 · P1, reported by 叶小艺). No GitHub issue to auto-close.

## Why

Straight off the Plane ticket — this is a reported product paper cut, not something I hit myself:

> **问题**:用户频繁切换模型时,每次都要重新查找上次选中的模型,选择效率低。
> **预期与验收**:打开选择器时**高亮当前／上次选择的模型**,并**滚动定位**到对应位置。

The pain is real and mechanical. Both model lists cap their height and scroll:

- the compact home-composer list at six rows (`.inline-switcher--compact .inline-switcher__agent-grid`, `max-height: 226px`),
- the searchable popover at `max-height: 280px` (and, in the two-level browse, the company rail and models pane scroll separately).

A catalog longer than that cap — OpenDesign/AMR's cross-vendor list is well past it — opened on its **first** row, with the model actually in effect below the fold. Someone switching models several times a session re-scrolls the same list every time to find where they already are.

One thing worth saying because the ticket uses two words for it: **"当前选择" and "上次选择" are the same thing here.** The model in effect is what the chip already displays and what the list already marks selected; there is no separate "last picked" value to track. So this PR introduces **no new state** — it fixes only where the list is scrolled to.

## What users will see

Open the model picker — the chip on the home composer, or the model row in the top-bar switcher — and it now opens **scrolled to the model you are currently using**, instead of at the top of the catalog. The model is still marked as the selected one exactly as before; it is just now on screen without scrolling for it.

For OpenDesign/AMR's two-level company browse, the vendor holding your current model is brought into view in the left rail as well as the model itself on the right.

Nothing moves when there is nothing to move to: a first run, or a saved model the catalog no longer carries, opens the list exactly as it does today.

## Surface area

- [x] **UI** — model picker scroll position in `apps/web` (`InlineModelSwitcher` compact list, and the shared `SearchableModelSelect` used by the top-bar switcher, Settings → Execution, `AvatarMenu`, and BYOK fields)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None**

On the UI/CLI dual-track rule: there is no capability here to expose. This adds no endpoint, no setting and no new user-selectable behavior — it is the scroll offset of a dropdown at the moment it opens, which has no `od` analogue. Model selection itself already goes through the existing config surfaces on both tracks and is untouched.

## Screenshots

Not attached — capturing the entry point needs a local `tools-dev` runtime, and this run was explicitly scoped to not start local services (the machine is memory-constrained with other agents on it). The change is a scroll offset rather than new chrome, so a still frame of the entry point would look identical before and after; what differs is which row is under the fold on open.

To see it by hand: pick a model far down OpenDesign's catalog, close the picker, reopen it. Before this change the list starts at row one and the selected model is below the fold; after it, the selected model is on screen.

## Bug fix verification

- Test path that reproduces it: `apps/web/tests/components/ModelPickerSelectionAnchor.test.tsx`
- Did it go red on `main` and green on this branch? **yes** — 3 of the 6 cases fail on `origin/main` (`expected [] to include <button …>`: nothing is ever scrolled into view), all 6 pass on this branch.

The specs judge observable behavior only — ARIA state (`aria-checked` / `aria-selected`) plus the scroll-positioning call recorded off the elements it was made on. No CSS class assertions, per `apps/web/src/components/chat/AGENTS.md` §5.

Both halves of the ticket are pinned separately, so "highlighted" cannot pass for "in view":

1. the model in effect is marked selected, **and**
2. it is scrolled into its scroller's visible area on open,
3. and no other row is scrolled to (this one is vacuous on `main` and only becomes load-bearing with the fix),
4. **reverse anchor** — with nothing selected (a saved model the catalog dropped, or an empty value), the list must not scroll anywhere and must not throw. Green both before and after; it exists to stop the fix from turning into a blind scroll.

Falsification pass, removing each piece of the implementation independently and re-running:

| removed | result |
| --- | --- |
| `anchorSelectionInView` body neutered | 3 failed / 3 passed |
| the `InlineModelSwitcher` anchor call | 1 failed / 5 passed (compact case only) |
| the `SearchableModelSelect` anchor call | 2 failed / 4 passed (searchable cases only) |
| `data-selected` on the company rail button | 1 failed / 5 passed (two-level case only) |
| restored | 6 passed |

Every line of the change is load-bearing for a specific assertion, and no assertion passes without it.

## Validation

- `pnpm --filter @open-design/web typecheck` → exit 0
- `pnpm guard` → exit 0
- `apps/web` targeted suites (11 files, 250 tests, all passing): `ModelPickerSelectionAnchor`, `modelOptions`, `InlineModelSwitcher`, `InlineModelSwitcher.compact-model-click`, `InlineModelSwitcher.byok-chip-label`, `AvatarMenu`, `ByokModelField`, `SettingsDialog.execution`, `SettingsDialog.top-tier-upgrade`, `ChatPane.switch-model`, `agentModelSelection` — i.e. every existing consumer of the picker, since `SearchableModelSelect` is shared beyond the switcher.
- Not run: the full `apps/web` suite and any browser/E2E pass (no local runtime in this run, see Screenshots).

## Implementation note

`apps/web/src/components/pickerSelectionAnchor.ts` is one small shared helper rather than two copies of the same effect. It takes the container and a selector and scrolls whatever the list itself has marked selected into view with `block: 'nearest'`, so a row already visible does not move and no scroller beyond the list's own is disturbed. It deliberately reads the selection back out of the rendered DOM instead of accepting an element: "which row is selected" is decided once, by the attribute the accessibility tree already exposes, so there is no second copy of that state to drift. Each caller anchors once per open — the popovers re-measure on scroll and resize, and re-anchoring there would yank the list out from under someone browsing it.
