### PR TITLE
fix(prompts): write next-step suggestions in the run's UI locale

### DIFF
--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -49,6 +49,9 @@ import {
   composeOdNextStrategyRequestPromptV2,
   executionProfileFromStreamFormat,
   INTEGRATIONS_MCP_PATH,
+  normalizePromptLocale,
+  PROMPT_LOCALE_EXEMPT_TERMS_SENTENCE,
+  promptLanguageName,
   SETTINGS_MEDIA_PROVIDERS_PATH,
   type ByokMediaDefaults,
   type ChatSessionMode,
@@ -87,18 +90,14 @@ function renderUiLocalePrompt(
   locale: string | undefined,
   options?: { includeQuickBriefSamples?: boolean },
 ): string {
-  const normalized = locale?.trim();
-  if (!normalized || normalized.toLowerCase() === 'en') return '';
-  const languageName = normalized === 'zh-CN'
-    ? 'Simplified Chinese'
-    : normalized === 'zh-TW'
-      ? 'Traditional Chinese'
-      : normalized;
+  const normalized = normalizePromptLocale(locale);
+  if (!normalized) return '';
+  const languageName = promptLanguageName(normalized);
   const lines = [
     '# UI locale override',
     '',
     `The OpenDesign UI locale for this run is \`${normalized}\` (${languageName}). All user-visible chat prose and generated UI controls must follow this locale, especially \`<question-form>\` titles, question labels, placeholders, and option labels. Keep machine-readable ids and object option \`value\` fields exact and unlocalized.`,
-    `The artifacts you generate must also be in ${languageName}: every piece of user-visible copy in the HTML/React/page/deck you produce — headings, body text, navigation, button and link labels, captions, alt text, and form fields — is written in this language by default. This holds even when a chosen template, plugin, or design system ships its reference/example content in another language: treat that copy as a layout and style reference and translate/adapt it into ${languageName}, do not ship its wording verbatim. Keep brand names, code, and technical identifiers as-is, and honor an explicit user request for a different output language.`,
+    `The artifacts you generate must also be in ${languageName}: every piece of user-visible copy in the HTML/React/page/deck you produce — headings, body text, navigation, button and link labels, captions, alt text, and form fields — is written in this language by default. This holds even when a chosen template, plugin, or design system ships its reference/example content in another language: treat that copy as a layout and style reference and translate/adapt it into ${languageName}, do not ship its wording verbatim. ${PROMPT_LOCALE_EXEMPT_TERMS_SENTENCE}`,
   ];
   // The worked zh-CN quick-brief copy below matches the CLASSIC default
   // discovery form verbatim. The slim charter recipes that form instead of

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -12010,9 +12010,20 @@ export async function startServer({
      * (emit one inline marker the host parses and strips), same "don't narrate
      * this to the user" clause.
      */
+    /*
+     * The run's UI locale rides along (OPEND-2765).
+     *
+     * `# UI locale override` states the same rule, but it lives in
+     * `daemonSystemPrompt` — the cache-stable head, which the payload below
+     * drops whenever `includeStableForPayload` is false. These three markers
+     * are re-sent every turn because of the nonce, so on a resume turn the
+     * marker contract was arriving with no locale attached and the follow-up
+     * suggestions came back in English on a zh-CN run.
+     */
     const hostProtocol = renderChatTurnHostProtocolInstructions(
       typeof run.doneKey === 'string' ? run.doneKey : '',
       'ordinary',
+      typeof locale === 'string' ? locale : undefined,
     );
     /*
      * This turn's follow-up suggestions.
@@ -16733,6 +16744,11 @@ export async function startServer({
               task: strategyTaskAtStart,
               parsed: strategyProtocolResult,
               toolUseCount: strategyToolUseCount,
+              // OPEND-2765: the production stage closes with the keyed host
+              // protocols, whose follow-up suggestions are user-visible prose.
+              ...(typeof chatBody.locale === 'string' && chatBody.locale
+                ? { locale: chatBody.locale }
+                : {}),
               ...(executionPreflight ? { executionPreflight } : {}),
               ...(complexRuntimeEvidence ? { complexRuntimeEvidence } : {}),
               ...(

--- a/apps/daemon/src/strategies/od-next/automatic-simple-production.ts
+++ b/apps/daemon/src/strategies/od-next/automatic-simple-production.ts
@@ -219,6 +219,8 @@ export function prepareAutomaticSimpleProductionRun<
   service: InternalRunCreationService<TMeta, TRun>;
   task: StrategyTaskExecutionRecord;
   createMeta: (instruction: string, taskRunIndex: number) => TMeta;
+  /** Run UI locale; see `prepareAutomaticStrategyContinuation` (OPEND-2765). */
+  locale?: string | undefined;
   updatedAt?: number;
 }): {
   prepared: PreparedInternalRunResult<TRun>;
@@ -240,6 +242,7 @@ export function prepareAutomaticSimpleProductionRun<
     taskRunIndex: task.runs.length,
     planContractHash: task.planContractHash,
     hostProtocolKey,
+    ...(input.locale ? { locale: input.locale } : {}),
   });
   let claimed: StrategyTaskExecutionRecord | null = null;
   const meta = input.createMeta(instruction, task.runs.length);
@@ -303,6 +306,13 @@ export function prepareAutomaticStrategyContinuation<
     deliverableValid: boolean;
   };
   complexRuntimeEvidence?: OdNextComplexRuntimeEvidence;
+  /**
+   * Run UI locale (OPEND-2765). The production stage closes with the keyed
+   * host protocols, and their follow-up-suggestion rule is the only part of
+   * this payload that is user-visible prose. Omitting it made a zh-CN run's
+   * three suggestions come back in English.
+   */
+  locale?: string | undefined;
   updatedAt?: number;
 }): PreparedAutomaticStrategyContinuation<TRun> {
   const complexPlanningReasonCodes = (() => {
@@ -422,6 +432,7 @@ export function prepareAutomaticStrategyContinuation<
           taskRunIndex: input.task.runs.length,
           planContractHash: strategyPlanContractHash(input.parsed.planContract!),
           hostProtocolKey: hostProtocolKey!,
+          ...(input.locale ? { locale: input.locale } : {}),
           ...(nativeBuildPackageBindings.length > 0
             ? { nativeBuildPackageBindings }
             : {}),

--- a/apps/daemon/src/strategies/od-next/initial-prompt-bundle-service.ts
+++ b/apps/daemon/src/strategies/od-next/initial-prompt-bundle-service.ts
@@ -442,6 +442,10 @@ export function createOdNextInitialPromptBundleService(
         renderChatTurnHostProtocolInstructions(
           stringValue(meta.doneKey) ?? '',
           'od_next_request',
+          // Same run locale the Bundle's own system prompt was composed with
+          // (OPEND-2765): the follow-up suggestions are user-visible prose and
+          // must not fall back to English on a localized run.
+          stringValue(locale),
         ).text,
         typeof systemPrompt === 'string' ? systemPrompt : '',
       ].filter(Boolean).join('\n\n---\n\n'),

--- a/apps/daemon/tests/opend-2765-next-step-locale-carriage.test.ts
+++ b/apps/daemon/tests/opend-2765-next-step-locale-carriage.test.ts
@@ -1,0 +1,128 @@
+/**
+ * OPEND-2765 — 红测:`locale` 从 `/api/chat` 一路带到「下一步引导」那段提示词里。
+ *
+ * 单子上的现象是 zh-CN 环境下三条动态建议全是英文。这三条不是 i18n 文件里的固定
+ * 文案,是模型按 `<od-next …>` 协议现写的(`packages/contracts/src/api/next-step-marker.ts`),
+ * 所以判据不能落在「模型是否真的写了中文」—— 那不可控。判据落在**我们控制的那一段**:
+ * 客户端选的 locale 有没有出现在那段协议提示词里。
+ *
+ * 为什么必须在 daemon 这一层再钉一遍(contracts 那边已经钉了渲染函数):
+ * `# UI locale override` 只在**稳定前缀**里,而 `server.ts` 为了保住上游 prompt cache,
+ * resume 轮会整段丢掉它(`includeStableForPayload ? daemonSystemPrompt : ''`);
+ * 带 nonce 的「下一步引导」那段却是**每轮都重发**。也就是说这两段的生命周期不一样,
+ * 只有在真实组装出来的 prompt 上取证,才能证明 locale 真的跟着到了那一段。
+ *
+ * 取证方式:假 agent 把 stdin 收到的完整 prompt 落盘,再从里面把
+ * `Follow-up suggestions:` 这一段单独切出来断言 —— 不能拿整份 prompt 断言,
+ * 因为首轮里稳定前缀自己就带着 `Simplified Chinese`,那样断言永远绿。
+ */
+import type http from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { delimiter, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
+ * 只取「下一步引导」那一段。
+ *
+ * 三段 host protocol 在 `renderChatTurnHostProtocolInstructions` 里用
+ * `\n\n---\n\n` 串起来,所以从 `Follow-up suggestions:` 切到下一个分隔线,
+ * 拿到的就是这条协议自己的正文。
+ */
+function followUpSuggestionsBlock(prompt: string): string {
+  const start = prompt.indexOf('Follow-up suggestions:');
+  if (start < 0) return '';
+  const end = prompt.indexOf('\n---\n', start);
+  return end < 0 ? prompt.slice(start) : prompt.slice(start, end);
+}
+
+describe('OPEND-2765 下一步引导跟随运行 locale', () => {
+  let server: http.Server;
+  let baseUrl: string;
+  let binDir: string;
+  let capturePath: string;
+  const originalPath = process.env.PATH;
+  const originalCapture = process.env.OD_CAPTURE_PROMPT_PATH;
+
+  beforeAll(async () => {
+    binDir = await mkdtemp(join(tmpdir(), 'od-opend2765-'));
+    capturePath = join(binDir, 'prompt.txt');
+    process.env.OD_CAPTURE_PROMPT_PATH = capturePath;
+    const bin = join(binDir, 'opencode');
+    await writeFile(
+      bin,
+      `#!/usr/bin/env node
+const fs = require('node:fs');
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => { input += chunk; });
+process.stdin.on('end', () => {
+  fs.writeFileSync(process.env.OD_CAPTURE_PROMPT_PATH, input, 'utf8');
+  console.log(JSON.stringify({ type: 'text', part: { text: '好了。' } }));
+});
+`,
+      'utf8',
+    );
+    await chmod(bin, 0o755);
+    process.env.PATH = `${binDir}${delimiter}${originalPath ?? ''}`;
+
+    const { startServer } = await import('../src/server.js');
+    const started = (await startServer({ port: 0, returnServer: true })) as {
+      url: string;
+      server: http.Server;
+    };
+    baseUrl = started.url;
+    server = started.server;
+    // 冷启动要扫技能目录 + 设计体系,单跑这个文件时没有别的用例帮忙暖缓存。
+  }, 60_000);
+
+  afterAll(async () => {
+    if (server) await new Promise<void>((resolve) => server.close(() => resolve()));
+    await rm(binDir, { recursive: true, force: true });
+    if (originalPath == null) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+    if (originalCapture == null) delete process.env.OD_CAPTURE_PROMPT_PATH;
+    else process.env.OD_CAPTURE_PROMPT_PATH = originalCapture;
+  });
+
+  async function capturePromptForLocale(locale: string | undefined): Promise<string> {
+    await rm(capturePath, { force: true });
+    const response = await fetch(`${baseUrl}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agentId: 'opencode',
+        conversationId: `opend2765-${randomUUID()}`,
+        message: '做一个 SaaS 落地页。',
+        ...(locale === undefined ? {} : { locale }),
+      }),
+    });
+    expect(response.ok).toBe(true);
+    // SSE 读到底,确保子进程的 stdin 已经关掉、prompt 已经落盘。
+    await response.text();
+    return readFile(capturePath, 'utf8');
+  }
+
+  it('zh-CN 运行:那段协议提示词自己就带上语言要求', async () => {
+    const prompt = await capturePromptForLocale('zh-CN');
+    const block = followUpSuggestionsBlock(prompt);
+
+    // 先证明取证器没取空 —— 空串对任何 toContain 都会红,但对 not.toContain 会假绿,
+    // 下面那条反向锚点依赖这个前提。
+    expect(block).toContain('<od-next key=');
+    expect(block).toContain('Simplified Chinese');
+    expect(block).toContain('zh-CN');
+  }, 60_000);
+
+  it('反向锚点:不带 locale 的运行,这段提示词一个字都不变', async () => {
+    const prompt = await capturePromptForLocale(undefined);
+    const block = followUpSuggestionsBlock(prompt);
+
+    expect(block).toContain('<od-next key=');
+    expect(block).toContain(
+      'Write them in the language the user is speaking, and keep each under 120 characters.',
+    );
+    expect(block).not.toContain('Simplified Chinese');
+  }, 60_000);
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -74,6 +74,7 @@ export * from './sse/chat.js';
 export * from './sse/collab.js';
 export * from './sse/proxy.js';
 export * from './prompts/system.js';
+export * from './prompts/ui-locale.js';
 export * from './prompts/chat-turn-host-protocol.js';
 export * from './prompts/deck-framework.js';
 export * from './prompts/od-next-device-frame.js';

--- a/packages/contracts/src/prompts/chat-turn-host-protocol.ts
+++ b/packages/contracts/src/prompts/chat-turn-host-protocol.ts
@@ -1,6 +1,11 @@
 import { renderArtifactFocusInstruction } from '../api/artifact-focus-marker.js';
 import { renderDoneMarker } from '../api/done-marker.js';
 import { renderNextStepMarkerExample } from '../api/next-step-marker.js';
+import {
+  PROMPT_LOCALE_EXEMPT_TERMS_SENTENCE,
+  normalizePromptLocale,
+  promptLanguageName,
+} from './ui-locale.js';
 
 export type ChatTurnHostProtocolPolicy =
   | 'ordinary'
@@ -33,13 +38,54 @@ function odNextStageGate(policy: ChatTurnHostProtocolPolicy): string {
 }
 
 /**
+ * The output-language rule for the three follow-up suggestions.
+ *
+ * The suggestions are user-visible chat prose — clicking one sends it verbatim
+ * as the user's next message — so they follow the run's UI locale like every
+ * other user-visible string. Two things make this rule need its own sentence
+ * here rather than inheriting the one in `# UI locale override`:
+ *
+ *  · That section rides the cache-stable prompt head, which `server.ts` drops
+ *    on every resume turn to protect the upstream prompt cache. This block is
+ *    re-sent every turn because of its nonce. Inheriting would mean the rule
+ *    is present exactly on the turns that need it least.
+ *  · That section ends with "Keep machine-readable ids and object option
+ *    `value` fields exact and unlocalized" — scoped to `<question-form>`, but
+ *    a marker whose suggestion also travels in a `value="…"` attribute reads
+ *    like it is covered. Saying "user-visible chat prose" here settles it.
+ *
+ * With no locale (or an English one) this returns the original
+ * infer-from-context wording, byte for byte: the fix is "follow the run's
+ * locale", not "always write another language".
+ */
+function nextStepLanguageRule(locale: string | undefined): string {
+  const normalized = normalizePromptLocale(locale);
+  if (!normalized) {
+    return 'Write them in the language the user is speaking, and keep each under 120 characters.';
+  }
+  return [
+    `Write all three in ${promptLanguageName(normalized)}: the OpenDesign UI locale for this`
+    + ` run is \`${normalized}\`, and these three lines are user-visible chat prose, not`
+    + ' machine-readable values. The markers above show the marker format only, not the'
+    + ' output language.',
+    PROMPT_LOCALE_EXEMPT_TERMS_SENTENCE,
+    'Keep each under 120 characters.',
+  ].join('\n');
+}
+
+/**
  * Render the keyed, per-turn protocol that hands a completed model turn back to
  * the chat host. The nonce keeps this text out of every cache-stable prompt
  * head; callers inject it into the request/continuation slice only.
+ *
+ * `locale` is the run's UI locale (`ChatRequest.locale`). Callers that have it
+ * must pass it; see `nextStepLanguageRule` for why this block restates a rule
+ * the stable prompt head already carries.
  */
 export function renderChatTurnHostProtocolInstructions(
   key: string,
   policy: ChatTurnHostProtocolPolicy = 'ordinary',
+  locale?: string | undefined,
 ): ChatTurnHostProtocolInstructions {
   if (!key) {
     return { doneMarker: '', nextSteps: '', artifactFocus: '', text: '' };
@@ -65,7 +111,7 @@ export function renderChatTurnHostProtocolInstructions(
     ]),
     'Rules: exactly three markers, one suggestion in each value attribute, no bullets, no numbering, no trailing punctuation, and no paired opening/closing tag.',
     'Each line is a concrete next action on what THIS turn actually produced, worded so the user could send it verbatim as their next message — not a topic, not a question, not an offer of help.',
-    'Write them in the language the user is speaking, and keep each under 120 characters.',
+    nextStepLanguageRule(locale),
     `This turn's key is ${key}: copy it verbatim, never reuse an earlier one, and never invent one.`,
     'Skip all three markers when the turn produced nothing to iterate on — a greeting, a plain answer, a turn ending in a <question-form> — or when you have no useful suggestion. Omitting them is fine; padding them with filler is not.',
     'The markers are protocol, not prose: do not mention them, do not explain them, and do not wrap them in a code fence.',

--- a/packages/contracts/src/prompts/od-next-strategy.ts
+++ b/packages/contracts/src/prompts/od-next-strategy.ts
@@ -186,6 +186,12 @@ export type OdNextStrategyContinuationV2 =
       planContractHash: string;
       /** Per-run nonce; omitted for non-completing continuation stages. */
       hostProtocolKey?: string;
+      /**
+       * Run UI locale, for the host protocols the production stage closes with
+       * (OPEND-2765). Only the follow-up-suggestion rule reads it; the rest of
+       * this payload is machine structure and stays English.
+       */
+      locale?: string;
       nativeBuildPackageBindings?: readonly {
         buildPackageId: string;
         nativeAgentHandle: string;
@@ -1029,6 +1035,7 @@ export function composeOdNextStrategyContinuationV2(
     const hostProtocol = renderChatTurnHostProtocolInstructions(
       input.hostProtocolKey ?? '',
       'od_next_production',
+      input.locale,
     ).text;
     payload = `# OD Next native continuation — production\n\nContinue this native session and execute the frozen Full Plan bound to \`planContractHash=${requireSha256(input.planContractHash, 'planContractHash')}\`. Use the existing in-session Task Profile, Design Spec, Todo plan, and Build Packages. Do not re-seed or restate their full text, do not choose a new route or execution mode, and do not ask another question. Open Design must be able to identify one runnable entry in the delivered files, otherwise the completed task is rejected: it looks for a root \`index.html\`, then a single root-level html file, then a single file matching the project kind. Lay the deliverable out so exactly one of those resolves.${bindingBlock}\n\n## Closing Runtime State\n\nFinish the delivery response with exactly one ${OD_NEXT_RUNTIME_STATE_BLOCK} block written as plain text between its tags, and no Plan Contract block: schema ${OD_NEXT_RUNTIME_STATE_SCHEMA}, route full_plan, inputStage production, executionMode equal to the mode locked by the accepted Plan Contract, outcome completed once every required deliverable is written (otherwise blocked or canceled), reasonCodes [], and no other fields.${hostProtocol ? `\n\nPlace the Closing Runtime State before any final follow-up markers required by the host protocols below.\n\n${hostProtocol}` : ''}`;
   }

--- a/packages/contracts/src/prompts/system.ts
+++ b/packages/contracts/src/prompts/system.ts
@@ -43,6 +43,7 @@ import {
   type OdNextStrategyRequestRecipeV2,
 } from './od-next-strategy.js';
 import { SETTINGS_MEDIA_PROVIDERS_PATH } from '../settings-nav.js';
+import { normalizePromptLocale, promptLanguageName } from './ui-locale.js';
 
 export const BASE_SYSTEM_PROMPT = OFFICIAL_DESIGNER_PROMPT;
 const ELEVENLABS_VOICE_PROMPT_OPTION_LIMIT = 100;
@@ -75,13 +76,9 @@ const PROMPT_SAFE_HTTP_STATUS_LABELS: Record<string, string> = {
 };
 
 function renderUiLocalePrompt(locale: string | undefined): string {
-  const normalized = locale?.trim();
-  if (!normalized || normalized.toLowerCase() === 'en') return '';
-  const languageName = normalized === 'zh-CN'
-    ? 'Simplified Chinese'
-    : normalized === 'zh-TW'
-      ? 'Traditional Chinese'
-      : normalized;
+  const normalized = normalizePromptLocale(locale);
+  if (!normalized) return '';
+  const languageName = promptLanguageName(normalized);
   const lines = [
     '# UI locale override',
     '',

--- a/packages/contracts/src/prompts/ui-locale.ts
+++ b/packages/contracts/src/prompts/ui-locale.ts
@@ -1,0 +1,51 @@
+/**
+ * The run's UI locale, as prompt text.
+ *
+ * One rule, three readers. `# UI locale override` (the cache-stable prompt
+ * head, mirrored in `apps/daemon/src/prompts/system.ts` and
+ * `packages/contracts/src/prompts/system.ts`) states it for the conversation;
+ * the per-turn follow-up-suggestion protocol restates it because the head is
+ * deliberately dropped on resume turns. Those readers had three private copies
+ * of the same `zh-CN`/`zh-TW` mapping before OPEND-2765, which is how one of
+ * them could drift out of sync with the others without anything failing.
+ */
+
+/**
+ * Trimmed locale tag, or `null` when the run has no locale worth stating.
+ *
+ * English is `null` on purpose rather than `'en'`: the prompts this feeds are
+ * written in English, so naming it adds a rule that says nothing and moves
+ * every affected prompt's bytes for no behavioural gain.
+ */
+export function normalizePromptLocale(locale: string | undefined | null): string | null {
+  const normalized = typeof locale === 'string' ? locale.trim() : '';
+  if (!normalized || normalized.toLowerCase() === 'en') return null;
+  return normalized;
+}
+
+/**
+ * How to name the locale to a model.
+ *
+ * Only the two Chinese tags are spelled out, because those are the two the
+ * product ships copy for and the two a bare tag reads worst for. Every other
+ * locale falls back to its own tag, which models resolve reliably and which
+ * cannot go stale against `apps/web/src/i18n/locales/`.
+ */
+export function promptLanguageName(normalizedLocale: string): string {
+  if (normalizedLocale === 'zh-CN') return 'Simplified Chinese';
+  if (normalizedLocale === 'zh-TW') return 'Traditional Chinese';
+  return normalizedLocale;
+}
+
+/**
+ * The exception every locale rule in this repository carries: a localized
+ * sentence still keeps the words that are names or code.
+ *
+ * OPEND-2765 asks for exactly this — the reported English suggestions are
+ * wrong, but `localStorage` and `CTA` inside them were right. Kept as one
+ * exported constant so the follow-up-suggestion rule and the `# UI locale
+ * override` section cannot disagree about what survives translation.
+ */
+export const PROMPT_LOCALE_EXEMPT_TERMS_SENTENCE =
+  'Keep brand names, code, and technical identifiers as-is, and honor an explicit'
+  + ' user request for a different output language.';

--- a/packages/contracts/tests/opend-2765-next-step-locale.test.ts
+++ b/packages/contracts/tests/opend-2765-next-step-locale.test.ts
@@ -1,0 +1,101 @@
+/**
+ * OPEND-2765 — the three follow-up suggestions must be written in the run's UI
+ * locale.
+ *
+ * Reported on 0.21.1-beta.7 with the UI in `zh-CN` and a Chinese deliverable:
+ * the row under a completed turn came back in English —
+ *
+ *   · "Add an evaluation request form section after the final CTA"
+ *   · "Persist the ROI calculator inputs in localStorage"
+ *   · "Switch the capabilities grid to a two-column layout"
+ *
+ * The third line is near-verbatim this prompt's own example ("Switch the
+ * product cards to a two-column layout"), which is the tell: the only language
+ * rule the follow-up block carried was "write them in the language the user is
+ * speaking" — inference, sat directly under three English examples — while the
+ * run's actual locale lived in `# UI locale override`, a section of the
+ * cache-stable prompt head that `server.ts` deliberately DROPS on every resume
+ * turn (`includeStableForPayload ? daemonSystemPrompt : ''`). The per-turn
+ * slice that carries this marker is re-sent every turn; the locale that
+ * governs it was not.
+ *
+ * These specs pin the seam we control — does the instruction the model reads
+ * name the run's locale — not whether the model then obeys it.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { renderChatTurnHostProtocolInstructions } from '../src/prompts/chat-turn-host-protocol.js';
+
+const KEY = '0123456789abcdef';
+
+describe('OPEND-2765 next-step suggestions follow the run locale', () => {
+  it('names the locale in the per-turn follow-up block for zh-CN', () => {
+    const { nextSteps } = renderChatTurnHostProtocolInstructions(KEY, 'ordinary', 'zh-CN');
+
+    expect(nextSteps).toContain('Follow-up suggestions:');
+    expect(nextSteps).toContain('zh-CN');
+    expect(nextSteps).toContain('Simplified Chinese');
+  });
+
+  it('keeps the mixed-script exception the ticket asks for', () => {
+    // `localStorage` and `CTA` in the reported output are correct as-is; the
+    // ticket only rejects the surrounding English prose. Wording is copied
+    // from the existing `# UI locale override` section rather than invented.
+    const { nextSteps } = renderChatTurnHostProtocolInstructions(KEY, 'ordinary', 'zh-CN');
+
+    expect(nextSteps).toContain('Keep brand names, code, and technical identifiers as-is');
+  });
+
+  it('tells the model the English example is format-only', () => {
+    // The reported third suggestion is a near-copy of the example below it.
+    const { nextSteps } = renderChatTurnHostProtocolInstructions(KEY, 'ordinary', 'zh-CN');
+
+    expect(nextSteps).toContain(
+      `<od-next key="${KEY}" value="Switch the product cards to a two-column layout"/>`,
+    );
+    expect(nextSteps).toContain('marker format only, not the output language');
+  });
+
+  it('carries the locale on both OD Next stage policies too', () => {
+    for (const policy of ['od_next_request', 'od_next_production'] as const) {
+      const { nextSteps } = renderChatTurnHostProtocolInstructions(KEY, policy, 'zh-TW');
+      expect(nextSteps).toContain('Traditional Chinese');
+    }
+  });
+
+  it('falls back to the raw tag for a locale with no spelled-out name', () => {
+    const { nextSteps } = renderChatTurnHostProtocolInstructions(KEY, 'ordinary', 'ja');
+
+    expect(nextSteps).toContain('ja');
+    expect(nextSteps).not.toContain('Simplified Chinese');
+  });
+
+  /*
+   * Reverse anchor. The fix must be "follow the run's locale", never "always
+   * write Chinese" — an English run has to render byte-for-byte what it
+   * rendered before this change, including the inference-based wording that is
+   * correct when no locale was selected.
+   */
+  it('leaves an English or absent locale byte-identical', () => {
+    const noLocale = renderChatTurnHostProtocolInstructions(KEY, 'ordinary');
+
+    expect(noLocale.nextSteps).toContain(
+      'Write them in the language the user is speaking, and keep each under 120 characters.',
+    );
+    expect(noLocale.nextSteps).not.toContain('Simplified Chinese');
+
+    for (const locale of ['en', 'EN', ' en ', '']) {
+      expect(renderChatTurnHostProtocolInstructions(KEY, 'ordinary', locale))
+        .toEqual(noLocale);
+    }
+  });
+
+  it('still emits nothing without a turn key, locale or not', () => {
+    expect(renderChatTurnHostProtocolInstructions('', 'ordinary', 'zh-CN')).toEqual({
+      doneMarker: '',
+      nextSteps: '',
+      artifactFocus: '',
+      text: '',
+    });
+  });
+});


### PR DESCRIPTION
<!-- Plane: OPEND-2765. No GitHub issue is closed by this PR. -->

## Why

OPEND-2765 reports English follow-up suggestions beneath a Chinese deliverable in a Simplified Chinese UI. These are model-generated `<od-next>` values, so changing an i18n key cannot fix them.

The UI-locale rule existed in the stable prompt head, while the keyed follow-up instructions are composed each turn without that locale. Native resume omits the stable head only when its stored hash matches the current head; new sessions and changed hashes send it again. Carrying locale into the per-turn protocol makes suggestion-language guidance explicit without depending on whether the stable prefix is resent. English examples remain format examples.

## What users will see

Generated follow-up suggestions are instructed to use the non-English UI locale, with an explicit request for another output language taking precedence. Technical identifiers such as ROI, CTA, and localStorage stay unchanged. English and absent locales keep the existing infer-from-user wording.

Real-model acceptance now covers Chinese defaults, English defaults, an explicit English override, and an ordinary same-conversation follow-up. This establishes those observed cases, not guaranteed compliance for every future model response.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new command, flag, or environment variable
- [x] **API / contract** — additive optional locale in shared prompt APIs
- [ ] **Extension point** — new entry or protocol for skills/design systems/templates/craft
- [ ] **i18n keys** — new translation keys
- [ ] **New top-level dependency**
- [x] **Default behavior change** — locale instruction for model-generated suggestions
- [ ] **None**

Eleven files: nine source files and two regression specifications. Locale reaches ordinary chat, the OD Next request bundle, and its production continuation. Shared normalization replaces duplicated stable-head formatting. No HTTP/SSE or durable schema changes, new controls, or error copy. Existing UI and CLI callers share daemon prompt composition; there is no new UI-only capability requiring a new CLI command.

## Screenshots

These real Chrome screenshots show the existing suggestion row and generated preview after hard reload. 

**A1 — Chinese UI and default Chinese output:**

<img width="2756" height="1520" alt="A1 Chinese default suggestions after hard reload" src="https://github.com/user-attachments/assets/ab5e2483-f6ec-4eb1-b99d-61b2d44a7585" />

**B — English UI/input:**

<img width="2598" height="1520" alt="B English suggestions after hard reload" src="https://github.com/user-attachments/assets/13c5d5df-09dd-4e5e-a890-15f6ba09ef16" />

**C — Chinese UI with an explicit English final/suggestions requirement:**

<img width="2598" height="1520" alt="C explicit English suggestions after hard reload" src="https://github.com/user-attachments/assets/140faa62-c6a2-4f4b-8723-882047fda693" />

## Bug fix verification

- [Contracts red specification](https://github.com/nexu-io/open-design/blob/aac07361f441f7185977c64efa588a0d26dc8a51/packages/contracts/tests/opend-2765-next-step-locale.test.ts): locale, identifier preservation, format-only examples, OD Next stage policies, unchanged English/absent locale, and missing-key guard.
- [Daemon carriage specification](https://github.com/nexu-io/open-design/blob/aac07361f441f7185977c64efa588a0d26dc8a51/apps/daemon/tests/opend-2765-next-step-locale-carriage.test.ts): captures the child process's actual composed prompt and inspects only the follow-up block, preventing a stable-head match from hiding missing per-turn carriage.
- Original author records: main contracts **5 failed / 2 passed**, daemon **1 failed / 1 passed**; branch green. Withdrawing the renderer restored contracts red; withdrawing only the daemon locale argument restored daemon red. These are historical runs, not fresh validation from this description update.
- Maintainer rerun on exact head `aac07361f441f7185977c64efa588a0d26dc8a51`: **7 contracts + 2 daemon passed**. Those daemon tests create fresh conversations; the real ordinary-resume evidence is separate below.

## Validation

Recorded local guard, root typecheck, and daemon build passed. Original package results were contracts654 tests and selected daemon469 passed/8 skipped; these counts are not added to later reruns. Exact-head remote CI was verified SUCCESS, including Validate workspace and the executed test/UI groups; skipped jobs are not claimed as passes.

Real models and normal runtime, separately from prompt-carriage tests:

| Case | Observed result |
|---|---|
| A1: unchanged Chinese SaaS/ROI/CTA prompt in a fresh empty QA project | Logical task completed; final production `d41220f2-6363-423a-96ca-41a26cfbc65f` produced valid `index.html`; three Chinese suggestions visible and persisted. Three physical runs belong to this one task. Hard reload preserved observed message/run IDs and suggestions. |
| Ordinary follow-up in that same conversation: “把 ROI 计算器的输入保存在 localStorage。” | Separate logical task completed through one request-stage physical run `fbf463a4-0208-4df7-a45f-87232ffc3c6a`, valid `index.html`, three Chinese suggestions, and `nativeSessionRecovery.state=resumed`. Hard reload preserved observed message/run IDs and suggestions. This is ordinary continuation, not another production child of A1. |
| B: English UI and original English SaaS/ROI/CTA request | Production `ecfd6a50-5b4b-40dc-b879-64745412b8dd` completed logically; three English suggestions survived hard reload. |
| C: Chinese UI with explicit English final/suggestions | Production `e547bb82-0ff0-450c-b594-b9e07aee2b36` completed logically; English final and three suggestions survived hard reload. The normal clarification form was answered while retaining the explicit English requirement. |

**Ordinary Chinese continuation after hard reload:**

<img width="2756" height="1520" alt="Chinese ordinary continuation suggestions after hard reload" src="https://github.com/user-attachments/assets/24ab7ca1-fb09-4a09-9824-617b60ffd555" />

The additional in-preview persistence check **failed**: editing the ROI salary from 20000 to 31789 updated its displayed value, but hard reload restored 20000. The generated file saves and reads the same localStorage key. Ordinary previews already provide an in-memory storage fallback ([existing contract](https://github.com/nexu-io/open-design/blob/aac07361f441f7185977c64efa588a0d26dc8a51/apps/web/src/runtime/srcdoc.ts#L1488)); the six related preview/storage files are unchanged between this PR head and main `98f2fd1a46b661e15b06abc6cb5428a8891e736d`. The maintainer accepts the suggestion-language scope independently and retains this preview-persistence limitation as unresolved. No sandbox or storage behavior is changed, and the task API's completed status is not presented as successful browser persistence.

The original A timed out. Its later A-R retry dispatched and persisted Chinese suggestions but ended logically blocked (`od_next_canonical_deliverable_invalid/no_artifact`), despite physically successful runs that reused an old file. Keep those failed observations; they are not completed Chinese acceptance and this PR does not fix the timeout or weaken artifact validation. A1 and the ordinary continuation above are distinct later successful tasks, not relabeled A/A-R results. OPEND-2765 has completed the suggestion-language acceptance; its state will move to QA after the PR actually merges.

Main only. Excluded from `release/v0.22.1`; do not add a backport label or open a release backport without a new explicit maintainer instruction.
