### PR TITLE
fix(collab): stop one upstream 403 from ending the AMR session

### DIFF
--- a/apps/daemon/src/collab/vela-workspace-context.ts
+++ b/apps/daemon/src/collab/vela-workspace-context.ts
@@ -17,7 +17,10 @@ import type {
 } from '@open-design/contracts';
 import {
   markVelaAuthorizationExpired,
+  markVelaAuthorizationRecovered,
   readVelaControlApiContext,
+  readVelaControlApiContextForAuthorityProbe,
+  velaStatusRevokesCredential,
   type VelaControlApiContext,
   type VelaUser,
 } from '../integrations/vela.js';
@@ -859,7 +862,11 @@ export async function fetchVelaWorkspaceDirectory(
   options: VelaWorkspaceContextOptions = {},
 ): Promise<WorkspaceDirectoryFetchResult> {
   const fetchImpl = options.fetch ?? fetch;
-  const readSession = options.readSession ?? readVelaControlApiContext;
+  // This probe is the daemon's credential-authority oracle: it is what marks a
+  // credential expired, and therefore the only thing that can ever unmark it.
+  // It reads the unfiltered session so a previously rejected key gets re-tested
+  // instead of being pinned forever behind its own rejection.
+  const readSession = options.readSession ?? readVelaControlApiContextForAuthorityProbe;
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const configuredEnv = typeof options.configuredEnv === 'function'
     ? options.configuredEnv()
@@ -878,7 +885,7 @@ export async function fetchVelaWorkspaceDirectory(
       signal: controller.signal,
     });
     if (!response.ok) {
-      if (response.status === 401 || response.status === 403) {
+      if (velaStatusRevokesCredential(response.status)) {
         if (!options.readSession) {
           markVelaAuthorizationExpired(process.env, configuredEnv);
         }
@@ -896,7 +903,13 @@ export async function fetchVelaWorkspaceDirectory(
         status: response.status,
       };
     }
-    return { ok: true, items: mapVelaWorkspaceDirectory(await response.json()) };
+    const items = mapVelaWorkspaceDirectory(await response.json());
+    // Upstream accepted this credential, which retires any earlier expiry mark
+    // for it. Without this the reauth flag has no exit other than a logout.
+    if (!options.readSession) {
+      markVelaAuthorizationRecovered(process.env, configuredEnv);
+    }
+    return { ok: true, items };
   } catch {
     return { ok: false, items: [], reason: 'network' };
   } finally {

--- a/apps/daemon/src/integrations/vela-wallet.ts
+++ b/apps/daemon/src/integrations/vela-wallet.ts
@@ -6,6 +6,7 @@ import {
   markVelaAuthorizationExpired,
   readVelaControlApiContext,
   readVelaLoginStatus,
+  velaStatusRevokesCredential,
   type VelaUser,
 } from './vela.js';
 
@@ -141,7 +142,11 @@ export function createVelaWalletSnapshotReader(options: VelaWalletReaderOptions 
         },
         signal: controller.signal,
       });
-      if (response.status === 401 || response.status === 403) {
+      // Only a credential-revoking status may expire the session here. The
+      // wallet poll runs on its own timer, so letting a transient upstream
+      // rejection through would re-pin the daemon into `reauth_required`
+      // even after the workspace-directory probe stopped doing so.
+      if (velaStatusRevokesCredential(response.status)) {
         cache.delete(key);
         markVelaAuthorizationExpired(input.env, input.configuredEnv);
         return unavailableSnapshot({

--- a/apps/daemon/src/integrations/vela.ts
+++ b/apps/daemon/src/integrations/vela.ts
@@ -718,6 +718,33 @@ function velaCredentialRevisionDigest(revision: VelaCredentialRevision): string 
     .slice(0, 20);
 }
 
+/**
+ * Whether an upstream HTTP status is PROOF that the local credential itself is
+ * no longer valid — the only condition under which the daemon may expire it.
+ *
+ * Marking a credential expired is close to irreversible: it pins
+ * `readVelaLoginStatus` at `reauth_required` for as long as that credential is
+ * on disk, and the web shell answers that by replacing the current route with
+ * onboarding. Only an answer that is about the CREDENTIAL earns that.
+ *
+ *  • 401 qualifies. Vela replies `untrusted_caller` when the control key fails
+ *    verification or the profile behind it no longer exists. Nothing but a
+ *    fresh sign-in recovers from it.
+ *  • 403 does NOT qualify. Vela's `getCurrentWorkspaceContext` wraps principal
+ *    resolution in a bare catch, so anything that stops a principal resolving
+ *    surfaces as `403 missing_principal` with the caller's key untouched. The
+ *    case observed in the field is a workspace id and a control key that
+ *    describe DIFFERENT environments: `findWorkspaceAndMember` finds no row,
+ *    raises `workspace_member_required`, and the catch reports 403. Probing
+ *    production confirms the symmetry — prod key + test workspace and test key
+ *    + prod workspace both answer 403, while a nonsense key answers 401 — so
+ *    403 says nothing about the key. Callers must treat it as a retryable
+ *    authority outage and fix the workspace id, not the credential.
+ */
+export function velaStatusRevokesCredential(status: number): boolean {
+  return status === 401;
+}
+
 /** Mark only the currently-active credential revision as rejected upstream. */
 export function markVelaAuthorizationExpired(
   env: NodeJS.ProcessEnv = process.env,
@@ -727,6 +754,27 @@ export function markVelaAuthorizationExpired(
   expiredVelaCredentialRevisions.add(revision);
   const control = readRawVelaControlApiContext(env, configuredEnv);
   if (control) expiredVelaControlKeys.add(velaControlKeyDigest(control.controlKey));
+  return revision;
+}
+
+/**
+ * Record that this credential was ACCEPTED upstream, undoing an earlier
+ * expiry mark for the same revision.
+ *
+ * Without this the expired sets are write-only for the daemon's whole life —
+ * `clearVelaAuthorizationState` runs on logout and nowhere else — so one
+ * rejection outlives the condition that produced it and the user is asked to
+ * sign in again even though their credential works. A 2xx answer to an
+ * authenticated call is the direct evidence that ends that state.
+ */
+export function markVelaAuthorizationRecovered(
+  env: NodeJS.ProcessEnv = process.env,
+  configuredEnv: Record<string, string> = {},
+): string {
+  const revision = velaCredentialRevisionDigest(readVelaCredentialRevision(env, configuredEnv));
+  expiredVelaCredentialRevisions.delete(revision);
+  const control = readRawVelaControlApiContext(env, configuredEnv);
+  if (control) expiredVelaControlKeys.delete(velaControlKeyDigest(control.controlKey));
   return revision;
 }
 
@@ -750,6 +798,26 @@ export function readVelaControlApiContext(
     && expiredVelaControlKeys.has(velaControlKeyDigest(context.controlKey))
   ) return null;
   return context;
+}
+
+/**
+ * Session for the one caller whose job is to RE-TEST a rejected credential.
+ *
+ * `readVelaControlApiContext` hides an expired control key so ordinary
+ * consumers stop using it. Applied to the workspace-directory probe that same
+ * filter is self-sealing: the probe is the only thing that can observe the
+ * credential being accepted again, so hiding the key from it guarantees the
+ * expiry mark is never revisited. This reader hands the probe the raw session
+ * back; every other consumer keeps the filtered view, so a genuinely revoked
+ * credential still reads as unusable everywhere else and simply gets marked
+ * expired again on the probe's next answer.
+ */
+export function readVelaControlApiContextForAuthorityProbe(
+  env: NodeJS.ProcessEnv = process.env,
+  configuredEnv: Record<string, string> = {},
+): VelaControlApiContext | null {
+  return readVelaControlApiContext(env, configuredEnv)
+    ?? readRawVelaControlApiContext(env, configuredEnv);
 }
 
 function readRawVelaControlApiContext(

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1034,7 +1034,10 @@ import {
   createRememberedTeamResourceScopes,
   type RememberedTeamResourceScopeLease,
 } from './collab/remembered-team-resource-scopes.js';
-import { readVelaControlApiContext } from './integrations/vela.js';
+import {
+  readVelaControlApiContext,
+  readVelaControlApiContextForAuthorityProbe,
+} from './integrations/vela.js';
 import {
   fetchBillingCheckoutUrl,
   fetchVelaBillingCatalog,
@@ -3741,8 +3744,12 @@ export async function startServer({
       if (result.ok) workspaceTypes.learn(result.items);
       return result;
     },
+    // Partition on the session `fetchVelaWorkspaceDirectory` actually uses. It
+    // re-tests a credential the daemon previously marked expired, so reading a
+    // filtered session here would file that credential's result under the
+    // signed-out partition and let a genuinely signed-out read hit it.
     identityKey: () => velaWorkspaceDirectoryIdentity(
-      readVelaControlApiContext,
+      readVelaControlApiContextForAuthorityProbe,
       configuredAmrEnv(),
     ),
     onDecision: (input) => recordWorkspaceAuthorityDecision({

--- a/apps/daemon/tests/collab/vela-authorization-expiry-classification.test.ts
+++ b/apps/daemon/tests/collab/vela-authorization-expiry-classification.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Which upstream answers are allowed to expire the LOCAL Vela credential, and
+ * how the daemon gets back out of that state.
+ *
+ * Background: `markVelaAuthorizationExpired` writes the active credential
+ * revision into process-lifetime sets that nothing but an explicit logout ever
+ * emptied. Anything that reaches it therefore pins the daemon into
+ * `reauth_required` — `/api/integrations/vela/status` keeps reporting it, and
+ * the web shell replaces the route with onboarding. So the set of statuses
+ * that reach it has to be exactly the set that PROVES the credential is dead,
+ * and a credential that is demonstrably alive again has to be able to clear
+ * the mark on its own.
+ *
+ * Vela answers 403 `missing_principal` from a bare catch around principal
+ * resolution, so anything that stops a principal resolving surfaces as 403
+ * with the caller's control key untouched. The case observed in the field is a
+ * workspace id and a control key that describe different environments — the
+ * membership row does not exist, `workspace_member_required` is raised, and
+ * the catch reports 403. Probing production confirms the symmetry: prod key +
+ * test workspace and test key + prod workspace both answer 403, while a
+ * nonsense key answers 401. 401 `untrusted_caller` is the only answer that
+ * means "this key does not verify".
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import http from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import express from 'express';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchVelaWorkspaceDirectory } from '../../src/collab/vela-workspace-context.js';
+import { createDevWorkspaceContextProvider } from '../../src/collab/workspace-context.js';
+import {
+  clearVelaAuthorizationState,
+  readVelaLoginStatus,
+} from '../../src/integrations/vela.js';
+import { createVelaWalletSnapshotReader } from '../../src/integrations/vela-wallet.js';
+import { registerCollabContextRoutes } from '../../src/routes/collab-context.js';
+
+const tempDirs: string[] = [];
+let server: http.Server | null = null;
+
+/**
+ * The production-shaped session: a Settings-backed env credential for the
+ * runtime key plus the file profile's control key, which is what the workspace
+ * directory authenticates with. Using the real reader (no `readSession`
+ * injection) is deliberate — the credential-expiry bookkeeping only runs on
+ * the production wiring.
+ */
+function seedSettingsBackedVelaSession(): { configuredEnv: Record<string, string> } {
+  const amrHome = mkdtempSync(join(tmpdir(), 'od-vela-auth-classification-'));
+  tempDirs.push(amrHome);
+  vi.stubEnv('AMR_HOME', amrHome);
+  writeFileSync(
+    join(amrHome, 'config.json'),
+    JSON.stringify({
+      profiles: {
+        prod: {
+          apiUrl: 'https://vela.example',
+          controlKey: 'file-control-key',
+        },
+      },
+    }),
+    'utf8',
+  );
+  return {
+    configuredEnv: {
+      VELA_LINK_URL: 'https://settings.example/link',
+      VELA_RUNTIME_KEY: 'settings-runtime-key',
+    },
+  };
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+async function startDirectoryServer(
+  fetchWorkspaceDirectory: () => Promise<
+    Awaited<ReturnType<typeof fetchVelaWorkspaceDirectory>>
+  >,
+) {
+  const app = express();
+  app.use(express.json());
+  registerCollabContextRoutes(app, {
+    workspaceContext: createDevWorkspaceContextProvider(),
+    fetchWorkspaceDirectory,
+  });
+  server = http.createServer(app);
+  await new Promise<void>((resolve) => server!.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('server did not bind');
+  const base = `http://127.0.0.1:${address.port}`;
+  return async (route: string) => {
+    const response = await fetch(`${base}${route}`);
+    return { status: response.status, body: (await response.json()) as Record<string, unknown> };
+  };
+}
+
+afterEach(async () => {
+  if (server) {
+    const toClose = server;
+    server = null;
+    await new Promise<void>((resolve) => toClose.close(() => resolve()));
+  }
+  clearVelaAuthorizationState();
+  vi.unstubAllEnvs();
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('vela credential expiry classification', () => {
+  it('does not expire the credential when the workspace directory answers 403', async () => {
+    const { configuredEnv } = seedSettingsBackedVelaSession();
+
+    await expect(fetchVelaWorkspaceDirectory({
+      configuredEnv,
+      fetch: async () => jsonResponse(403, { error: 'missing_principal' }),
+    })).resolves.toEqual({
+      ok: false,
+      items: [],
+      reason: 'upstream',
+      status: 403,
+    });
+
+    // The credential was never rejected — only the upstream principal lookup
+    // failed — so the session must stay usable and the client must stay put.
+    expect(readVelaLoginStatus(process.env, configuredEnv)).toMatchObject({
+      loggedIn: true,
+      sessionState: 'authenticated',
+    });
+  });
+
+  it('still expires the credential when the workspace directory answers 401', async () => {
+    const { configuredEnv } = seedSettingsBackedVelaSession();
+
+    await expect(fetchVelaWorkspaceDirectory({
+      configuredEnv,
+      fetch: async () => jsonResponse(401, { error: 'untrusted_caller' }),
+    })).resolves.toMatchObject({
+      ok: false,
+      reason: 'unauthorized',
+      status: 401,
+    });
+
+    expect(readVelaLoginStatus(process.env, configuredEnv)).toMatchObject({
+      loggedIn: true,
+      sessionState: 'reauth_required',
+    });
+  });
+
+  it('clears an expired credential mark once the directory accepts it again', async () => {
+    const { configuredEnv } = seedSettingsBackedVelaSession();
+
+    await fetchVelaWorkspaceDirectory({
+      configuredEnv,
+      fetch: async () => jsonResponse(401, { error: 'untrusted_caller' }),
+    });
+    expect(readVelaLoginStatus(process.env, configuredEnv).sessionState)
+      .toBe('reauth_required');
+
+    // The same credential is accepted on the next poll. That is direct proof
+    // the earlier rejection is over, so the daemon must stop demanding a fresh
+    // sign-in without waiting for the user to log out and back in.
+    await expect(fetchVelaWorkspaceDirectory({
+      configuredEnv,
+      fetch: async () => jsonResponse(200, []),
+    })).resolves.toEqual({ ok: true, items: [] });
+
+    expect(readVelaLoginStatus(process.env, configuredEnv).sessionState)
+      .toBe('authenticated');
+  });
+
+  it('serves an upstream 403 to the client as a retryable authority outage', async () => {
+    const { configuredEnv } = seedSettingsBackedVelaSession();
+    const req = await startDirectoryServer(() => fetchVelaWorkspaceDirectory({
+      configuredEnv,
+      fetch: async () => jsonResponse(403, { error: 'missing_principal' }),
+    }));
+
+    // 503 + retryable is the shape the web shell maps to its `unavailable`
+    // lane ("Sync recovering", last workspace preserved). A 401
+    // AMR_AUTH_REQUIRED here is what navigates the user to onboarding.
+    const response = await req('/api/workspace/directory');
+    expect(response.status).toBe(503);
+    expect(response.body).toMatchObject({
+      error: 'WORKSPACE_AUTHORITY_UNAVAILABLE',
+      retryable: true,
+    });
+  });
+
+  it('does not expire the credential when the wallet balance answers 403', async () => {
+    const { configuredEnv } = seedSettingsBackedVelaSession();
+    const reader = createVelaWalletSnapshotReader({
+      fetch: (async () => new Response(JSON.stringify({ error: 'missing_principal' }), {
+        status: 403,
+        headers: { 'content-type': 'application/json' },
+      })) as typeof fetch,
+    });
+
+    await expect(reader.read({ configuredEnv })).resolves.toMatchObject({
+      status: 'unavailable',
+      error: { code: 'upstream' },
+    });
+
+    expect(readVelaLoginStatus(process.env, configuredEnv).sessionState)
+      .toBe('authenticated');
+  });
+});

--- a/apps/daemon/tests/vela-workspace-context.test.ts
+++ b/apps/daemon/tests/vela-workspace-context.test.ts
@@ -198,20 +198,34 @@ describe('createCachedWorkspaceDirectoryFetcher', () => {
     ).resolves.toEqual({ ok: true, items: [] });
   });
 
-  it.each([401, 403])(
-    'preserves an authoritative %s as an expired authorization result',
-    async (status) => {
-      await expect(fetchVelaWorkspaceDirectory({
-        readSession: () => SESSION,
-        fetch: async () => jsonResponse(status, { error: 'unauthenticated' }),
-      })).resolves.toEqual({
-        ok: false,
-        items: [],
-        reason: 'unauthorized',
-        status,
-      });
-    },
-  );
+  it('preserves an authoritative 401 as an expired authorization result', async () => {
+    await expect(fetchVelaWorkspaceDirectory({
+      readSession: () => SESSION,
+      fetch: async () => jsonResponse(401, { error: 'untrusted_caller' }),
+    })).resolves.toEqual({
+      ok: false,
+      items: [],
+      reason: 'unauthorized',
+      status: 401,
+    });
+  });
+
+  // A 403 used to be folded in with the 401 above. B answers `403
+  // missing_principal` from a bare catch around principal resolution, so a
+  // database blip or a slow entitlement lookup arrives with the caller's
+  // credential still perfectly valid — see
+  // `tests/collab/vela-authorization-expiry-classification.test.ts`.
+  it('treats an authoritative 403 as a retryable upstream failure', async () => {
+    await expect(fetchVelaWorkspaceDirectory({
+      readSession: () => SESSION,
+      fetch: async () => jsonResponse(403, { error: 'missing_principal' }),
+    })).resolves.toEqual({
+      ok: false,
+      items: [],
+      reason: 'upstream',
+      status: 403,
+    });
+  });
 
   it('marks the Settings-backed credential revision when the directory rejects its file control key', async () => {
     const amrHome = mkdtempSync(join(tmpdir(), 'od-vela-directory-auth-'));

--- a/apps/web/src/collab/useWorkspaceContext.ts
+++ b/apps/web/src/collab/useWorkspaceContext.ts
@@ -507,6 +507,32 @@ function writeWorkspaceSelection(selection: WorkspaceSelection | null): void {
   }
 }
 
+/**
+ * Drop the workspace identity the daemon just refused, so the next read has to
+ * resolve one from the account directory instead of asserting it again.
+ *
+ * `403 WORKSPACE_ACCESS_DENIED` is an answer about the WORKSPACE, not about the
+ * credential: the daemon looked the claimed workspace/member pair up in the
+ * signed-in account's own membership directory and did not find it. The way a
+ * tab gets there is by still holding ids from a DIFFERENT identity — the
+ * credential and the claimed workspace are not switched atomically, so an
+ * account switch or an `OPEN_DESIGN_AMR_PROFILE` change between environments
+ * leaves the two describing different accounts (upstream, vela answers the
+ * same mismatch with `403 missing_principal`).
+ *
+ * Nothing about that requires a new sign-in, and the ambient revalidation that
+ * hits it is exactly the one that skips the directory (`exactScopeOnly`), so
+ * without this the same rejected claim is re-asserted on every poll forever.
+ * The directory read is healthy throughout and already knows the right answer;
+ * forgetting the claim is what lets the next read reach it.
+ */
+function forgetRejectedWorkspaceClaim(): void {
+  writeWorkspaceSelection(null);
+  // The refused context must not keep authorizing workspace-scoped resource
+  // reads while recovery runs.
+  cachedWorkspaceContext = null;
+}
+
 function selectableWorkspaceItems(items: WorkspaceDirectoryItem[]): WorkspaceDirectoryItem[] {
   return items.filter(
     (item) => item.memberStatus === 'active' && item.lifecycleState !== 'deleted',
@@ -855,7 +881,9 @@ export function useWorkspaceContext(): WorkspaceContextState {
       // state for them.
       const status = (error as { status?: unknown })?.status;
       const unsupported = status === 404;
-      const reauthRequired = status === 401 || status === 403;
+      const reauthRequired = status === 401;
+      const workspaceClaimRejected = status === 403;
+      if (workspaceClaimRejected) forgetRejectedWorkspaceClaim();
       setState({
         context: cachedWorkspaceContext,
         resourceReadIdentity:
@@ -876,7 +904,9 @@ export function useWorkspaceContext(): WorkspaceContextState {
       // An `unsupported` daemon has no workspace endpoint — retrying is
       // pointless. A transient `unavailable` outage arms the shared jittered
       // backoff so the shell recovers on its own without waiting for the 30s
-      // poll or a focus event.
+      // poll or a focus event. A rejected workspace claim retries too: the
+      // claim it was rejected for has just been forgotten, so the next read
+      // asks the directory instead of repeating it.
       if (!unsupported && !reauthRequired) scheduleWorkspaceContextRetry(requestGeneration);
     }
   }, []);

--- a/apps/web/tests/useWorkspaceContext.foreign-workspace-selection.test.tsx
+++ b/apps/web/tests/useWorkspaceContext.foreign-workspace-selection.test.tsx
@@ -1,0 +1,241 @@
+// @vitest-environment jsdom
+
+/**
+ * A tab still claiming a workspace that belongs to a DIFFERENT account.
+ *
+ * This is the shape that left people on the sign-in screen overnight. The
+ * credential and the claimed workspace id are not switched atomically, so an
+ * account switch — or an `OPEN_DESIGN_AMR_PROFILE` flip between prod and test —
+ * leaves the tab holding ids from the previous identity. The daemon verifies
+ * that claim against the account's own membership directory and answers
+ * `403 WORKSPACE_ACCESS_DENIED`; upstream, vela answers the equivalent
+ * `403 missing_principal` when a workspace id and a control key describe
+ * different accounts.
+ *
+ * The ambient revalidation that reaches that state is the one that skips the
+ * directory (`exactScopeOnly`, used while the workspace SSE is connected): it
+ * re-asserts the workspace already in hand rather than listing the account. So
+ * nothing re-picks the workspace, and the claim stays wrong on every poll.
+ *
+ * The directory read is healthy throughout and already lists the right
+ * workspace, so the client holds everything it needs to fix itself. What it
+ * used to do instead was read the 403 as "your credential was rejected", enter
+ * `reauth-required` — the state both `App.tsx` and `EntryShell.tsx` answer by
+ * replacing the route with onboarding — and stop retrying, for a session whose
+ * credential was never in question.
+ */
+
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resetCoalescedGet } from '../src/lib/coalesced-get';
+import {
+  resetWorkspaceContextCache,
+  useWorkspaceContext,
+} from '../src/collab/useWorkspaceContext';
+import {
+  workspaceContextFixture,
+  workspaceDirectoryFixture,
+} from './helpers/workspace-context';
+
+class OpeningEventSource {
+  static instances: OpeningEventSource[] = [];
+
+  readonly url: string;
+  readonly withCredentials = false;
+  readonly CONNECTING = 0;
+  readonly OPEN = 1;
+  readonly CLOSED = 2;
+  readyState = this.CONNECTING;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  private readonly listeners = new Map<string, Set<EventListenerOrEventListenerObject>>();
+
+  constructor(url: string | URL) {
+    this.url = String(url);
+    OpeningEventSource.instances.push(this);
+    queueMicrotask(() => this.open());
+  }
+
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject | null): void {
+    if (!listener) return;
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject | null): void {
+    if (!listener) return;
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  dispatchEvent(event: Event): boolean {
+    for (const listener of this.listeners.get(event.type) ?? []) {
+      if (typeof listener === 'function') listener.call(this, event);
+      else listener.handleEvent(event);
+    }
+    return true;
+  }
+
+  close(): void {
+    this.readyState = this.CLOSED;
+  }
+
+  open(): void {
+    this.readyState = this.OPEN;
+    this.onopen?.(new Event('open'));
+  }
+}
+
+/** The workspace the previous (test-environment) account owned. */
+const FOREIGN = workspaceContextFixture({
+  workspaceId: 'j2ryucc2ynz4gbtq30l80czf',
+  workspaceMemberId: 'member-test',
+  workspaceName: 'Test workspace',
+});
+
+/** The workspace the credential in hand actually owns. */
+const OWNED = workspaceContextFixture({
+  workspaceId: 'm46zutn5p4sgpwenaouxfucs',
+  workspaceMemberId: 'member-prod',
+  workspaceName: 'Prod workspace',
+});
+
+const WORKSPACE_SELECTION_SESSION_KEY = 'od.workspaceSelection.v1';
+/** `WORKSPACE_CONTEXT_SSE_FLOOR_MS`: the exact-scope safety read. */
+const SSE_FLOOR_MS = 120_000;
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function makeDocumentVisible(): void {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => 'visible',
+  });
+}
+
+describe('useWorkspaceContext with a foreign workspace claim', () => {
+  beforeEach(() => {
+    resetCoalescedGet();
+    resetWorkspaceContextCache();
+    makeDocumentVisible();
+    OpeningEventSource.instances = [];
+    vi.stubGlobal('EventSource', OpeningEventSource as unknown as typeof EventSource);
+    // Installed before the hook mounts so the SSE-floor poll it schedules is a
+    // fake timer this test can actually drive.
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+    vi.unstubAllGlobals();
+    resetCoalescedGet();
+    resetWorkspaceContextCache();
+    OpeningEventSource.instances = [];
+    window.sessionStorage.clear();
+  });
+
+  it('re-resolves from the directory instead of demanding a fresh sign-in', async () => {
+    // Phase 1: the tab legitimately holds the test-environment workspace.
+    let account: 'test' | 'prod' = 'test';
+    const claimedWorkspaceIds: string[] = [];
+    const owned = () => (account === 'test' ? FOREIGN : OWNED);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        // `GET /api/workspace/directory` is not workspace-scoped. It answers
+        // 200 with the signed-in account's real memberships throughout — the
+        // whole reason recovery is possible without a new sign-in.
+        if (url === '/api/workspace/directory') {
+          return jsonResponse(workspaceDirectoryFixture([owned()]));
+        }
+        if (url === '/api/workspace/context') {
+          const headers = (init?.headers ?? {}) as Record<string, string>;
+          const claimed = headers['x-od-workspace-id'] ?? '';
+          claimedWorkspaceIds.push(claimed);
+          if (claimed !== owned().workspaceId) {
+            return new Response(
+              JSON.stringify({ error: 'WORKSPACE_ACCESS_DENIED' }),
+              { status: 403, headers: { 'content-type': 'application/json' } },
+            );
+          }
+          return jsonResponse({ context: owned() });
+        }
+        throw new Error(`unexpected fetch ${url}`);
+      }),
+    );
+
+    const flush = async (ms = 1) => {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(ms);
+      });
+    };
+
+    const { result } = renderHook(() => useWorkspaceContext());
+    for (let i = 0; i < 5 && !result.current.context; i += 1) await flush();
+    expect(result.current.context?.workspaceId).toBe(FOREIGN.workspaceId);
+    // The SSE has to be connected: it is what makes the safety read exact-scope
+    // (directory-free), which is how the stale claim survives.
+    expect(OpeningEventSource.instances.length).toBeGreaterThan(0);
+
+    // Phase 2: the credential now belongs to the prod account. Nothing told
+    // this tab, so its next ambient read still asserts the old workspace.
+    account = 'prod';
+    resetCoalescedGet();
+    await flush(SSE_FLOOR_MS + 1);
+    await flush();
+
+    expect(claimedWorkspaceIds.at(-1)).toBe(FOREIGN.workspaceId);
+    // A 403 is an answer about the workspace, not the credential. The shell
+    // belongs in the transient "recovering" lane — never in the one that both
+    // `App.tsx` and `EntryShell.tsx` answer by navigating to onboarding.
+    expect(result.current.failure).toBe('unavailable');
+    // The rejected claim must not survive to be asserted a third time.
+    expect(window.sessionStorage.getItem(WORKSPACE_SELECTION_SESSION_KEY) ?? '')
+      .not.toContain(FOREIGN.workspaceId);
+
+    // Phase 3: recovery is automatic — the retry lists the account again and
+    // lands on the workspace the directory knew all along.
+    for (let i = 0; i < 5 && claimedWorkspaceIds.at(-1) !== OWNED.workspaceId; i += 1) {
+      await flush(30_000);
+    }
+    expect(claimedWorkspaceIds.at(-1)).toBe(OWNED.workspaceId);
+    expect(result.current.context?.workspaceId).toBe(OWNED.workspaceId);
+    expect(result.current.failure).toBeUndefined();
+  });
+
+  it('still reports reauth-required when the daemon rejects the credential itself', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === '/api/workspace/directory') {
+          return jsonResponse(workspaceDirectoryFixture([OWNED]));
+        }
+        if (url === '/api/workspace/context') {
+          return new Response(JSON.stringify({ error: 'AMR_AUTH_REQUIRED' }), {
+            status: 401,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        throw new Error(`unexpected fetch ${url}`);
+      }),
+    );
+
+    const { result } = renderHook(() => useWorkspaceContext());
+    for (let i = 0; i < 5 && !result.current.failure; i += 1) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+    }
+    expect(result.current.failure).toBe('reauth-required');
+  });
+});


### PR DESCRIPTION
## Why

**My use case.** Following up an internal dogfooding report: a colleague left the
client running overnight, opened it the next morning, and got the sign-in screen.
The diagnostic bundle shows the local AMR credential was valid the entire time —
`loggedIn: true`, `sessionState: "authenticated"` in `~/.amr/config.json` — while
the desktop log records three navigations to `od://app/onboarding` at 03:13,
03:30 and 03:32. Nothing about the credential changed overnight; something else
decided it had.

**The pain.** Two separate bugs sit on the same chain, and each one alone is
enough to strand the user:

1. *The daemon treats a 403 as proof the credential is dead.*
   `fetchVelaWorkspaceDirectory` and the wallet reader both branch on
   `status === 401 || status === 403` into `markVelaAuthorizationExpired`, which
   writes the credential revision into two module-level `Set`s. Nothing but
   `POST /api/integrations/vela/logout` ever empties them — no TTL, no retry, no
   recovery — so `readVelaLoginStatus` reports `reauth_required` for the rest of
   the daemon's life. Upstream recovering makes no difference. **Signing in again
   does not really fix it either**, because the condition that set the flag can
   fire again on any poll.

   403 is not evidence about the credential. Vela's `getCurrentWorkspaceContext`
   wraps principal resolution in a bare catch, so anything that stops a principal
   resolving surfaces as `403 missing_principal` with the caller's key untouched.
   The case actually observed here is a **workspace id and a control key from
   different environments**: this machine switched between `prod` and `test` at
   least four times across three accounts, `findWorkspaceAndMember` found no row,
   raised `workspace_member_required`, and the catch reported 403. Probing
   production confirms the symmetry — prod key + test workspace and test key +
   prod workspace both answer 403, a nonsense key answers 401 — so 403 says
   nothing at all about the key.

2. *The web reads the daemon's 403 the same way.* `useWorkspaceContext`
   classified `status === 401 || status === 403` as `failure: 'reauth-required'`,
   which is exactly the state `App.tsx` (`cloudIdentityRejected`) and
   `EntryShell.tsx` (`amrAuthRequired`) answer with
   `navigate({kind:'home', view:'onboarding'}, {replace:true})`. But the daemon's
   403 is `WORKSPACE_ACCESS_DENIED` — "the requested workspace is not available
   to this member", raised by `verifyWorkspaceRequestContext` after checking the
   claim against the account's own directory. It is an answer about the
   *workspace*, not the credential. Worse, `reauth-required` also suppresses the
   retry schedule, and the ambient revalidation that hits this is the one that
   skips the directory (`exactScopeOnly`, used while the workspace SSE is
   connected) — so the same rejected claim is re-asserted on every poll, forever.

The load-bearing observation in both halves: **`GET /api/v1/workspaces` is not
workspace-scoped.** It answers 200 with the correct list under exactly the
mismatch that 403s everything else. The client and the daemon each hold
everything they need to fix themselves; they just never used it.

Production data is clean (all 160k `workspace_members` active, zero users whose
server-side active workspace fails to resolve), so this is a real defect rather
than a live incident.

## What users will see

When the cloud misbehaves, the client stays where it is and shows **"Sync
recovering"** instead of throwing you back to the sign-in page. When the cause is
a workspace left over from another account or environment, the client quietly
re-resolves to the workspace you actually have and carries on — no sign-out, no
re-login, nothing to click.

A credential that genuinely stopped working is unchanged: a 401 still ends the
session and still asks you to sign in again.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — no new endpoint or contract type, but `/api/workspace/directory`, `/api/workspace/active` and `/api/workspace/context` now answer an upstream 403 with `503 WORKSPACE_AUTHORITY_UNAVAILABLE (retryable)` instead of `401 AMR_AUTH_REQUIRED`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [x] **Default behavior change** — an upstream 403 no longer ends the AMR session, and a rejected workspace claim now clears the tab's stored selection instead of demanding a fresh sign-in
- [ ] **None**

## Screenshots

No new UI. The change routes an existing failure into an existing lane: the rail
footer already renders `RailAccountRecoveryTip` ("Sync recovering") for
`failure: 'unavailable'` and `CloudSignInTip` for `reauth-required` — this only
changes which one a 403 reaches.

## Bug fix verification

- Red specs:
  - `apps/daemon/tests/collab/vela-authorization-expiry-classification.test.ts`
  - `apps/web/tests/useWorkspaceContext.foreign-workspace-selection.test.tsx`
- Did they go red before the source change and green after? **yes** — output below.

### Red, before any source change (daemon)

```
 ❯ tests/collab/vela-authorization-expiry-classification.test.ts (5 tests | 4 failed) 93ms
     × does not expire the credential when the workspace directory answers 403 18ms
     × clears an expired credential mark once the directory accepts it again 8ms
     × serves an upstream 403 to the client as a retryable authority outage 54ms
     × does not expire the credential when the wallet balance answers 403 6ms

 FAIL  … > does not expire the credential when the workspace directory answers 403
  {
    "items": [],
    "ok": false,
-   "reason": "upstream",
+   "reason": "unauthorized",
    "status": 403,
  }

 FAIL  … > clears an expired credential mark once the directory accepts it again
AssertionError: expected 'reauth_required' to be 'authenticated'
Expected: "authenticated"
Received: "reauth_required"

 FAIL  … > serves an upstream 403 to the client as a retryable authority outage
AssertionError: expected 401 to be 503
- 503
+ 401

 FAIL  … > does not expire the credential when the wallet balance answers 403
  {
    "error": {
-     "code": "upstream",
+     "code": "unauthorized",
    },
    "status": "unavailable",
  }

 Test Files  1 failed (1)
      Tests  4 failed | 1 passed (5)
```

The one already-green case is the deliberate regression guard: *"still expires
the credential when the workspace directory answers 401"*.

### Red, before any source change (web)

```
 ❯ tests/useWorkspaceContext.foreign-workspace-selection.test.tsx (2 tests | 1 failed) 16ms
     × re-resolves from the directory instead of demanding a fresh sign-in 14ms

 FAIL  … > re-resolves from the directory instead of demanding a fresh sign-in
AssertionError: expected 'reauth-required' to be 'unavailable'
Expected: "unavailable"
Received: "reauth-required"

 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
```

### Removal verification — each implementation piece put back and re-run

Per AGENTS.md, the specs were re-run with each part of the fix reverted
individually, to prove none of them is inert:

| reverted piece | result |
| --- | --- |
| `velaStatusRevokesCredential` back to `401 \|\| 403` (daemon + wallet) | `3 failed \| 2 passed` — the two 403 cases and the route case go red |
| `markVelaAuthorizationRecovered(...)` call removed | `1 failed \| 4 passed` — only the self-heal case goes red |
| `readVelaControlApiContextForAuthorityProbe` back to `readVelaControlApiContext` | `1 failed \| 4 passed` — the self-heal case goes red again, i.e. the probe reader is what makes recovery reachable at all |
| web `reauthRequired` back to `401 \|\| 403` | `expected 'reauth-required' to be 'unavailable'` |
| web `forgetRejectedWorkspaceClaim()` call removed | `expected '{"workspaceId":"j2ryucc2ynz4gbtq30l80czf"…' not to contain 'j2ryucc2ynz4gbtq30l80czf'` |

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/daemon build` — pass (run separately from typecheck; `noUncheckedIndexedAccess` only bites here)
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm --filter @open-design/web test` — pass
- Scoped daemon suites covering every file this touches — `tests/collab/**`,
  `tests/integrations/**`, `tests/vela-workspace-context.test.ts`,
  `tests/collab-context-routes.test.ts`, `tests/collab-cloud.test.ts`,
  `tests/collab-presence-routes.test.ts`,
  `tests/collab-workspace-invalidation-poller.test.ts`,
  `tests/routes/workspace-projects.test.ts` — **79 files / 1332 tests, all pass**
- Not clean, and **not caused by this branch**:
  `apps/daemon/tests/od-next-automatic-simple-server.test.ts` fails with 20s test
  timeouts plus a cascading `The database connection is not open`. Verified
  against the baseline by reverse-applying this branch's `src/` diff and
  re-running the same file: `4 failed | 27 passed` on baseline vs
  `6 failed | 25 passed` on the branch, with a *different* failing subset each
  run. It is a pre-existing flaky/slow file about automatic chains and Build
  Packages, sharing no code with this change.

## Adjacent issues (not fixed here — deliberately out of scope)

- **The root cause: `x-vela-workspace-id` and the control key are not switched
  atomically.** `apps/daemon/src/collab/active-workspace-selection.ts` persists
  `workspace-selection.json` as a bare `{ workspaceId }` with no binding to the
  account, profile, or credential revision it belongs to. Changing account or
  `OPEN_DESIGN_AMR_PROFILE` therefore leaves the previous environment's workspace
  id as the daemon's active workspace, which is what manufactures the 403 in the
  first place. Fixing it properly means stamping the selection with the identity
  it was made under, migrating the on-disk format, and updating every consumer —
  its own PR. This PR makes the resulting 403 recoverable; it does not stop it
  being produced.
- **Vela's bare catch in `services/api/src/resources/auth.ts`.** Collapsing every
  principal-resolution failure into `403 missing_principal` is why a workspace
  mismatch is indistinguishable from a database blip at the HTTP boundary.
  Backend-side, not this repo.
- **`vela billing summary` being SIGKILLed on timeout** and **renderer log
  flooding** were both visible in the same diagnostic bundle. Neither is on this
  chain and neither is touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKjoMhNakUcKZooocqUNFP
