### PR TITLE
feat(guard): check that every design system ships its bundled plugin

### DIFF
--- a/e2e/tests/scripts/check-bundled-design-system-plugins.test.ts
+++ b/e2e/tests/scripts/check-bundled-design-system-plugins.test.ts
@@ -1,0 +1,304 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, test } from "vitest";
+
+import {
+  bundledDesignSystemViolations,
+  KNOWN_UNPAIRED,
+  KNOWN_UNPAIRED_CEILING,
+  expectedRegistrySource,
+  readBundledDesignSystemInput,
+  registrySources,
+  type BundledDesignSystemInput,
+  type BundledPluginFiles,
+} from "../../../scripts/check-bundled-design-system-plugins.ts";
+
+const COMPLETE: BundledPluginFiles = { manifest: "ok", design: "ok" };
+
+function inputFor(options: {
+  brands: readonly string[];
+  bundled: readonly string[];
+  sources?: readonly string[];
+  knownUnpaired?: readonly string[];
+  knownUnpairedCeiling?: number;
+  files?: ReadonlyMap<string, BundledPluginFiles>;
+}): BundledDesignSystemInput {
+  const { brands, bundled, knownUnpaired = [], knownUnpairedCeiling = knownUnpaired.length } = options;
+  return {
+    brands,
+    bundled,
+    filesByBundledSlug: options.files ?? new Map(bundled.map((slug) => [slug, COMPLETE] as const)),
+    registrySources: options.sources ?? bundled.map(expectedRegistrySource),
+    knownUnpaired,
+    knownUnpairedCeiling,
+  };
+}
+
+const only = (violations: string[]): string => {
+  assert.equal(violations.length, 1, `expected one violation, got ${JSON.stringify(violations, null, 2)}`);
+  return violations[0]!;
+};
+
+describe("brand and bundled plugin pairing", () => {
+  test("passes when every brand is paired, complete, and listed once", () => {
+    assert.deepEqual(
+      bundledDesignSystemViolations(inputFor({ brands: ["linear", "vercel"], bundled: ["linear", "vercel"] })),
+      [],
+    );
+  });
+
+  // The #6387 shape: a brand ships on one side only, so its card has nowhere
+  // to link.
+  test("reports a brand that ships no bundled plugin", () => {
+    const violation = only(bundledDesignSystemViolations(inputFor({ brands: ["linear", "kumo"], bundled: ["linear"] })));
+    assert.match(violation, /design-systems\/kumo: no bundled plugin/);
+  });
+
+  // The mirror direction: the marketplace offers a system whose tokens do not
+  // ship. Checking only brand -> bundled leaves this invisible.
+  test("reports a bundled plugin with no brand package", () => {
+    const violation = only(bundledDesignSystemViolations(inputFor({ brands: ["linear"], bundled: ["linear", "ghost"] })));
+    assert.match(violation, /plugins\/_official\/design-systems\/ghost: no brand package/);
+  });
+
+  test("accepts a brand recorded as a known gap", () => {
+    assert.deepEqual(
+      bundledDesignSystemViolations(
+        inputFor({ brands: ["linear", "kumo"], bundled: ["linear"], knownUnpaired: ["kumo"] }),
+      ),
+      [],
+    );
+  });
+
+  test("reports a known-gap entry that is now paired", () => {
+    const violation = only(
+      bundledDesignSystemViolations(inputFor({ brands: ["kumo"], bundled: ["kumo"], knownUnpaired: ["kumo"] })),
+    );
+    assert.match(violation, /kumo is paired now — drop it from KNOWN_UNPAIRED/);
+  });
+
+  // The list records known work; it is not a place to park new gaps. Recording
+  // one more than the ceiling allows fails, so growth cannot pass as a
+  // one-line addition among the existing entries.
+  test("reports a known-gap list that has grown past its ceiling", () => {
+    const violations = bundledDesignSystemViolations(
+      inputFor({
+        brands: ["kumo", "newbrand"],
+        bundled: [],
+        knownUnpaired: ["kumo", "newbrand"],
+        knownUnpairedCeiling: 1,
+      }),
+    );
+    assert.match(only(violations), /KNOWN_UNPAIRED holds 2 brands but KNOWN_UNPAIRED_CEILING is 1/);
+  });
+
+  test("the shipped list is within its own ceiling", () => {
+    assert.ok(
+      KNOWN_UNPAIRED.length <= KNOWN_UNPAIRED_CEILING,
+      `KNOWN_UNPAIRED has ${KNOWN_UNPAIRED.length} entries, ceiling is ${KNOWN_UNPAIRED_CEILING}`,
+    );
+  });
+
+  test("reports a known-gap entry whose brand no longer exists", () => {
+    const violation = only(
+      bundledDesignSystemViolations(
+        inputFor({ brands: ["linear"], bundled: ["linear"], knownUnpaired: ["removed-brand"] }),
+      ),
+    );
+    assert.match(violation, /design-systems\/removed-brand no longer exists/);
+  });
+
+  test("accumulates independent violations rather than reporting the first", () => {
+    const violations = bundledDesignSystemViolations(
+      inputFor({
+        brands: ["linear", "kumo"],
+        bundled: ["linear", "ghost"],
+        sources: [expectedRegistrySource("linear")],
+      }),
+    );
+    assert.equal(violations.length, 3);
+    assert.ok(violations.some((v) => /design-systems\/kumo: no bundled plugin/.test(v)));
+    assert.ok(violations.some((v) => /ghost: no brand package/.test(v)));
+    assert.ok(violations.some((v) => /no entry sources .*design-systems\/ghost/.test(v)));
+  });
+});
+
+describe("bundled plugin completeness", () => {
+  // Existence alone is not enough: an unreadable manifest resolves no detail
+  // page, which is the same user-visible failure as no plugin at all.
+  test.each([
+    ["a missing manifest", { manifest: "missing", design: "ok" }, /missing open-design\.json/],
+    ["an unparseable manifest", { manifest: "unparseable", design: "ok" }, /open-design\.json is not valid JSON/],
+    ["a missing DESIGN.md", { manifest: "ok", design: "missing" }, /missing DESIGN\.md/],
+    ["an empty DESIGN.md", { manifest: "ok", design: "empty" }, /DESIGN\.md is empty/],
+  ] as const)("reports %s", (_label, files, pattern) => {
+    const violation = only(
+      bundledDesignSystemViolations(
+        inputFor({ brands: ["linear"], bundled: ["linear"], files: new Map([["linear", files]]) }),
+      ),
+    );
+    assert.match(violation, pattern);
+  });
+
+  test("reports a bundled plugin whose files could not be read", () => {
+    const violation = only(
+      bundledDesignSystemViolations(inputFor({ brands: ["linear"], bundled: ["linear"], files: new Map() })),
+    );
+    assert.match(violation, /could not read its files/);
+  });
+});
+
+describe("marketplace registry", () => {
+  test("reports a bundled plugin the registry does not offer", () => {
+    const violation = only(
+      bundledDesignSystemViolations(inputFor({ brands: ["linear"], bundled: ["linear"], sources: [] })),
+    );
+    assert.match(violation, /no entry sources ".*design-systems\/linear"/);
+  });
+
+  test("reports a duplicate entry, which would list one system twice", () => {
+    const violation = only(
+      bundledDesignSystemViolations(
+        inputFor({
+          brands: ["linear"],
+          bundled: ["linear"],
+          sources: [expectedRegistrySource("linear"), expectedRegistrySource("linear")],
+        }),
+      ),
+    );
+    assert.match(violation, /2 entries source .*design-systems\/linear/);
+  });
+
+  // A source is only useful if it resolves. Matching the trailing slug alone
+  // accepts another repository, another ref, or a path below the plugin
+  // directory — each of which produces the broken card this check is for.
+  test.each([
+    ["another repository", "github:attacker/evil-fork@main/plugins/_official/design-systems/linear"],
+    ["another ref", "github:nexu-io/open-design@deleted-branch/plugins/_official/design-systems/linear"],
+    ["a traversal prefix", "lol../../../plugins/_official/design-systems/linear"],
+    ["a file below the plugin", "github:nexu-io/open-design@main/plugins/_official/design-systems/linear/DESIGN.md"],
+    ["a trailing slash", "github:nexu-io/open-design@main/plugins/_official/design-systems/linear/"],
+  ])("rejects a source naming %s", (_label, source) => {
+    const violations = bundledDesignSystemViolations(
+      inputFor({ brands: ["linear"], bundled: ["linear"], sources: [source] }),
+    );
+    assert.equal(violations.length, 2);
+    assert.ok(violations.some((v) => /no entry sources/.test(v)));
+    assert.ok(violations.some((v) => /is not a shipped bundled design system/.test(v)));
+  });
+
+  test("reports an entry for a bundled plugin that no longer ships", () => {
+    const violation = only(
+      bundledDesignSystemViolations(
+        inputFor({
+          brands: ["linear"],
+          bundled: ["linear"],
+          sources: [expectedRegistrySource("linear"), expectedRegistrySource("deleted")],
+        }),
+      ),
+    );
+    assert.match(violation, /is not a shipped bundled design system/);
+  });
+
+  test("ignores entries for other plugin categories", () => {
+    assert.deepEqual(
+      bundledDesignSystemViolations(
+        inputFor({
+          brands: ["linear"],
+          bundled: ["linear"],
+          sources: [
+            expectedRegistrySource("linear"),
+            "github:nexu-io/open-design@main/plugins/_official/atoms/build-test",
+            "github:nexu-io/open-design@main/plugins/_official/examples/data-report",
+          ],
+        }),
+      ),
+      [],
+    );
+  });
+});
+
+describe("registry source extraction", () => {
+  test("collects sources in file order and keeps duplicates", () => {
+    assert.deepEqual(registrySources({ plugins: [{ source: "a" }, { source: "b" }, { source: "a" }] }), ["a", "b", "a"]);
+  });
+
+  test("tolerates malformed shapes without throwing", () => {
+    assert.deepEqual(registrySources({}), []);
+    assert.deepEqual(registrySources(null), []);
+    assert.deepEqual(registrySources([]), []);
+    assert.deepEqual(registrySources({ plugins: [null, 7, { source: 42 }, {}] }), []);
+  });
+});
+
+describe("reading the repository", () => {
+  let root: string | undefined;
+
+  afterEach(() => {
+    if (root !== undefined) rmSync(root, { recursive: true, force: true });
+    root = undefined;
+  });
+
+  function fixture(): string {
+    const created = mkdtempSync(path.join(os.tmpdir(), "od-bundled-ds-"));
+    root = created;
+    mkdirSync(path.join(created, "design-systems/linear"), { recursive: true });
+    mkdirSync(path.join(created, "design-systems/_schema"), { recursive: true });
+    writeFileSync(path.join(created, "design-systems/README.md"), "not a brand\n");
+    const plugin = path.join(created, "plugins/_official/design-systems/linear");
+    mkdirSync(plugin, { recursive: true });
+    writeFileSync(path.join(plugin, "open-design.json"), JSON.stringify({ name: "open-design/linear" }));
+    writeFileSync(path.join(plugin, "DESIGN.md"), "# Linear\n");
+    mkdirSync(path.join(created, "plugins/registry/official"), { recursive: true });
+    writeFileSync(
+      path.join(created, "plugins/registry/official/open-design-marketplace.json"),
+      JSON.stringify({ plugins: [{ source: expectedRegistrySource("linear") }] }),
+    );
+    return created;
+  }
+
+  test("excludes _schema and non-directory entries from the brand list", async () => {
+    const input = await readBundledDesignSystemInput(fixture());
+    assert.deepEqual(input.brands, ["linear"]);
+    assert.deepEqual(bundledDesignSystemViolations({ ...input, knownUnpaired: [] }), []);
+  });
+
+  test("reads a parseable manifest and a non-empty DESIGN.md as complete", async () => {
+    const input = await readBundledDesignSystemInput(fixture());
+    assert.deepEqual(input.filesByBundledSlug.get("linear"), { manifest: "ok", design: "ok" });
+  });
+
+  test("classifies an unparseable manifest and an empty DESIGN.md", async () => {
+    const created = fixture();
+    const plugin = path.join(created, "plugins/_official/design-systems/linear");
+    writeFileSync(path.join(plugin, "open-design.json"), "not json {{{");
+    writeFileSync(path.join(plugin, "DESIGN.md"), "   \n");
+    const input = await readBundledDesignSystemInput(created);
+    assert.deepEqual(input.filesByBundledSlug.get("linear"), { manifest: "unparseable", design: "empty" });
+  });
+
+  // A symlinked package still ships, and `Dirent.isDirectory()` is false for a
+  // link — without following it the brand would vanish from the check.
+  test("counts a symlinked brand directory as a brand", async () => {
+    const created = fixture();
+    mkdirSync(path.join(created, "elsewhere/vercel"), { recursive: true });
+    symlinkSync(path.join(created, "elsewhere/vercel"), path.join(created, "design-systems/vercel"), "dir");
+    const input = await readBundledDesignSystemInput(created);
+    assert.deepEqual(input.brands, ["linear", "vercel"]);
+  });
+
+  test("ignores a broken symlink, which points at no package", async () => {
+    const created = fixture();
+    symlinkSync(path.join(created, "nothing-here"), path.join(created, "design-systems/dangling"), "dir");
+    const input = await readBundledDesignSystemInput(created);
+    assert.deepEqual(input.brands, ["linear"]);
+  });
+
+  test("fails with one diagnosis when the registry has no plugins array", async () => {
+    const created = fixture();
+    writeFileSync(path.join(created, "plugins/registry/official/open-design-marketplace.json"), "[]");
+    await assert.rejects(readBundledDesignSystemInput(created), /has no "plugins" array/);
+  });
+});

--- a/scripts/check-bundled-design-system-plugins.ts
+++ b/scripts/check-bundled-design-system-plugins.ts
@@ -1,0 +1,277 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * scripts/check-bundled-design-system-plugins.ts
+ *
+ * Guard for the link between a brand package and the bundled plugin that
+ * makes it reachable. A design system ships as `design-systems/<slug>/`, but
+ * its card on /plugins/systems/ opens a detail page only when the same slug
+ * also ships `plugins/_official/design-systems/<slug>/` and the marketplace
+ * registry sources exactly that directory. Nothing enforced that pairing, so
+ * a brand added to one side alone renders a card that links back to the
+ * index (#6387).
+ *
+ * Checks:
+ *  1. pairing — a brand and its bundled plugin exist on both sides;
+ *  2. completeness — the bundled plugin ships a parseable open-design.json
+ *     and a non-empty DESIGN.md, since an unreadable manifest resolves no
+ *     detail page either;
+ *  3. registry — exactly one entry sources each bundled plugin, at its exact
+ *     expected path. A source naming another repository, another ref, or a
+ *     path below the plugin directory does not resolve, so matching only the
+ *     trailing slug would certify the broken card this check exists to catch.
+ *
+ * Run standalone: `pnpm exec tsx scripts/check-bundled-design-system-plugins.ts`
+ * Or as part of `pnpm guard` (registered in scripts/guard.ts).
+ * ─────────────────────────────────────────────────────────────────────── */
+
+import { readFile, readdir, stat } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const BRANDS_DIR = "design-systems";
+const BUNDLED_DIR = "plugins/_official/design-systems";
+const REGISTRY_PATH = "plugins/registry/official/open-design-marketplace.json";
+/**
+ * The registry addresses bundled plugins by their location in this repository
+ * at this ref. Deliberately moving off it rewrites every entry, so pinning it
+ * here turns that into one loud failure rather than silent drift.
+ */
+const EXPECTED_SOURCE_PREFIX = "github:nexu-io/open-design@main";
+/** Not a brand package: the shared token schema the packages validate against. */
+const NON_BRAND_ENTRIES = new Set(["_schema"]);
+
+/**
+ * How many gaps KNOWN_UNPAIRED may hold. Adding a brand to that list without
+ * raising this number fails the check, so growth is a two-line diff naming
+ * itself rather than one slug appended among nine. It cannot stop a determined
+ * edit — nothing in the same file can — but it makes the intent reviewable, and
+ * lowering it as brands are paired is what keeps the list shrinking.
+ */
+export const KNOWN_UNPAIRED_CEILING = 9;
+
+/** Brands with no bundled plugin. Pairing one removes its entry; see check 1. */
+export const KNOWN_UNPAIRED: readonly string[] = [
+  "cisco",
+  "cloudflare-kumo",
+  "hud",
+  "loom",
+  "slack",
+  "tom-modern",
+  "trading-terminal",
+  "webex",
+  "wechat",
+];
+
+/** What check 2 judges, resolved by the caller so the rules stay pure. */
+export type BundledPluginFiles = {
+  manifest: "missing" | "unparseable" | "ok";
+  design: "missing" | "empty" | "ok";
+};
+
+export type BundledDesignSystemInput = {
+  /** Brand slugs under design-systems/, excluding non-brand entries. */
+  brands: readonly string[];
+  /** Slugs shipping a directory under plugins/_official/design-systems/. */
+  bundled: readonly string[];
+  /** Per bundled slug, the state of the files check 2 requires. */
+  filesByBundledSlug: ReadonlyMap<string, BundledPluginFiles>;
+  /** Every `source` string in the marketplace registry, in file order. */
+  registrySources: readonly string[];
+  knownUnpaired?: readonly string[];
+  knownUnpairedCeiling?: number;
+};
+
+export function expectedRegistrySource(slug: string): string {
+  return `${EXPECTED_SOURCE_PREFIX}/${BUNDLED_DIR}/${slug}`;
+}
+
+/** Registry `source` strings, skipping entries that carry none. */
+export function registrySources(registry: unknown): string[] {
+  const plugins =
+    typeof registry === "object" && registry !== null && Array.isArray((registry as { plugins?: unknown }).plugins)
+      ? (registry as { plugins: unknown[] }).plugins
+      : [];
+  const sources: string[] = [];
+  for (const plugin of plugins) {
+    const source = typeof plugin === "object" && plugin !== null ? (plugin as { source?: unknown }).source : undefined;
+    if (typeof source === "string") sources.push(source);
+  }
+  return sources;
+}
+
+/** True for a source that is trying to address a bundled design system. */
+function addressesADesignSystem(source: string): boolean {
+  return source.includes(`/${BUNDLED_DIR}/`);
+}
+
+export function bundledDesignSystemViolations({
+  brands,
+  bundled,
+  filesByBundledSlug,
+  registrySources: sources,
+  knownUnpaired = KNOWN_UNPAIRED,
+  knownUnpairedCeiling = KNOWN_UNPAIRED_CEILING,
+}: BundledDesignSystemInput): string[] {
+  const violations: string[] = [];
+  const brandSet = new Set(brands);
+  const bundledSet = new Set(bundled);
+  const unpaired = new Set(knownUnpaired);
+
+  for (const slug of brands) {
+    if (bundledSet.has(slug) || unpaired.has(slug)) continue;
+    violations.push(
+      `${BRANDS_DIR}/${slug}: no bundled plugin at ${BUNDLED_DIR}/${slug} — its card on /plugins/systems/ links back to the index instead of a detail page`,
+    );
+  }
+
+  for (const slug of bundled) {
+    if (!brandSet.has(slug)) {
+      violations.push(
+        `${BUNDLED_DIR}/${slug}: no brand package at ${BRANDS_DIR}/${slug} — the marketplace offers a design system whose tokens do not ship`,
+      );
+    }
+    const files = filesByBundledSlug.get(slug);
+    if (files === undefined) {
+      violations.push(`${BUNDLED_DIR}/${slug}: could not read its files`);
+      continue;
+    }
+    if (files.manifest === "missing") violations.push(`${BUNDLED_DIR}/${slug}: missing open-design.json`);
+    if (files.manifest === "unparseable") {
+      violations.push(`${BUNDLED_DIR}/${slug}: open-design.json is not valid JSON, so it resolves no detail page`);
+    }
+    if (files.design === "missing") violations.push(`${BUNDLED_DIR}/${slug}: missing DESIGN.md`);
+    if (files.design === "empty") violations.push(`${BUNDLED_DIR}/${slug}: DESIGN.md is empty`);
+  }
+
+  if (knownUnpaired.length > knownUnpairedCeiling) {
+    violations.push(
+      `KNOWN_UNPAIRED holds ${knownUnpaired.length} brands but KNOWN_UNPAIRED_CEILING is ${knownUnpairedCeiling} — pair the brand instead of recording another gap, or say why the gap is growing`,
+    );
+  }
+
+  for (const slug of knownUnpaired) {
+    if (!brandSet.has(slug)) {
+      violations.push(
+        `${BRANDS_DIR}/${slug} no longer exists — drop "${slug}" from KNOWN_UNPAIRED in ${SELF_REPO_PATH}`,
+      );
+    } else if (bundledSet.has(slug)) {
+      violations.push(
+        `${slug} is paired now — drop it from KNOWN_UNPAIRED in ${SELF_REPO_PATH}, which records gaps rather than granting exemptions`,
+      );
+    }
+  }
+
+  const expected = new Map(bundled.map((slug) => [expectedRegistrySource(slug), slug] as const));
+  const occurrences = new Map<string, number>();
+  for (const source of sources) {
+    occurrences.set(source, (occurrences.get(source) ?? 0) + 1);
+  }
+
+  for (const [source, slug] of expected) {
+    const count = occurrences.get(source) ?? 0;
+    if (count === 0) {
+      violations.push(
+        `${REGISTRY_PATH}: no entry sources "${source}" — the bundled plugin ships but the marketplace cannot offer it`,
+      );
+    } else if (count > 1) {
+      violations.push(
+        `${REGISTRY_PATH}: ${count} entries source ${BUNDLED_DIR}/${slug} — the marketplace would list it more than once`,
+      );
+    }
+  }
+
+  for (const source of new Set(sources)) {
+    if (!addressesADesignSystem(source) || expected.has(source)) continue;
+    violations.push(
+      `${REGISTRY_PATH}: entry sources "${source}", which is not a shipped bundled design system — expected one of ${BUNDLED_DIR}/<slug> under ${EXPECTED_SOURCE_PREFIX}`,
+    );
+  }
+
+  return violations;
+}
+
+const SELF_REPO_PATH = "scripts/check-bundled-design-system-plugins.ts";
+
+async function directoryNames(root: string, relativeDir: string): Promise<string[]> {
+  const absolute = path.join(root, relativeDir);
+  const entries = await readdir(absolute, { withFileTypes: true });
+  const names: string[] = [];
+  for (const entry of entries) {
+    // `isDirectory()` is false for a symlink to a directory, and a symlinked
+    // package still ships, so resolve the link before deciding.
+    if (entry.isDirectory()) {
+      names.push(entry.name);
+    } else if (entry.isSymbolicLink()) {
+      try {
+        if ((await stat(path.join(absolute, entry.name))).isDirectory()) names.push(entry.name);
+      } catch {
+        // A broken link points at no package; leave it out.
+      }
+    }
+  }
+  return names.sort();
+}
+
+async function readPluginFiles(root: string, slug: string): Promise<BundledPluginFiles> {
+  const dir = path.join(root, BUNDLED_DIR, slug);
+  let manifest: BundledPluginFiles["manifest"] = "ok";
+  try {
+    JSON.parse(await readFile(path.join(dir, "open-design.json"), "utf8"));
+  } catch (error) {
+    manifest = (error as NodeJS.ErrnoException | undefined)?.code === "ENOENT" ? "missing" : "unparseable";
+  }
+
+  let design: BundledPluginFiles["design"] = "ok";
+  try {
+    if ((await readFile(path.join(dir, "DESIGN.md"), "utf8")).trim().length === 0) design = "empty";
+  } catch {
+    design = "missing";
+  }
+
+  return { manifest, design };
+}
+
+export async function readBundledDesignSystemInput(root: string): Promise<BundledDesignSystemInput> {
+  const brands = (await directoryNames(root, BRANDS_DIR)).filter((name) => !NON_BRAND_ENTRIES.has(name));
+  const bundled = await directoryNames(root, BUNDLED_DIR);
+  const filesByBundledSlug = new Map<string, BundledPluginFiles>();
+  for (const slug of bundled) {
+    filesByBundledSlug.set(slug, await readPluginFiles(root, slug));
+  }
+  const registry: unknown = JSON.parse(await readFile(path.join(root, REGISTRY_PATH), "utf8"));
+  if (typeof registry !== "object" || registry === null || !Array.isArray((registry as { plugins?: unknown }).plugins)) {
+    throw new Error(`${REGISTRY_PATH} has no "plugins" array`);
+  }
+  return { brands, bundled, filesByBundledSlug, registrySources: registrySources(registry) };
+}
+
+export async function checkBundledDesignSystemPlugins(repoRoot: string): Promise<boolean> {
+  let input: BundledDesignSystemInput;
+  try {
+    input = await readBundledDesignSystemInput(repoRoot);
+  } catch (error) {
+    console.error(
+      `Bundled design-system plugin check failed to read the repository: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return false;
+  }
+
+  const violations = bundledDesignSystemViolations(input);
+  if (violations.length > 0) {
+    console.error("Bundled design-system plugin violations:");
+    for (const violation of violations) console.error(`- ${violation}`);
+    return false;
+  }
+
+  const paired = input.brands.filter((slug) => input.bundled.includes(slug)).length;
+  console.log(
+    `Bundled design-system plugin check passed: ${paired} of ${input.brands.length} brands paired and listed in the marketplace registry, ${KNOWN_UNPAIRED.length} known unpaired.`,
+  );
+  return true;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const ok = await checkBundledDesignSystemPlugins(path.resolve(import.meta.dirname, ".."));
+  if (!ok) process.exitCode = 1;
+}

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -12,6 +12,7 @@ import { checkDesignSystemFlagParity } from "./check-design-system-flag-parity.t
 import { checkComponentsManifestExtraction } from "./check-components-manifest-extraction.ts";
 import { checkHtmlPluginPreviewContracts } from "./check-html-plugin-preview-contracts.ts";
 import { checkPluginPreviewManifest } from "./check-plugin-preview-manifest.ts";
+import { checkBundledDesignSystemPlugins } from "./check-bundled-design-system-plugins.ts";
 import {
   checkDesignSystemA1RequiredTokens,
   checkDesignSystemA2DefaultsParity,
@@ -1533,6 +1534,7 @@ const checks: GuardCheck[] = [
   { name: "what's new publish workflow", run: ({ repoRoot: root }) => checkWhatsNewPublishWorkflow(root) },
   { name: "HTML plugin preview contracts", run: ({ repoRoot: root }) => checkHtmlPluginPreviewContracts(root) },
   { name: "plugin preview manifest", run: checkPluginPreviewManifest },
+  { name: "bundled design-system plugins", run: ({ repoRoot: root }) => checkBundledDesignSystemPlugins(root) },
   { name: "design system manifests", run: checkDesignSystemManifests },
   { name: "design system package quality", run: checkDesignSystemPackageQuality },
   { name: "design system component fixture report", run: checkDesignSystemComponentFixtureReport },


### PR DESCRIPTION
Fixes #7923 · enforcement half of #6387 · **must merge after #7755** (see Merge order)

## Why

I came at this from #6387 rather than from the data gap itself. Reading how a brand package becomes reachable, I wanted to know what keeps `design-systems/` and `plugins/_official/design-systems/` in agreement, and the answer is that nothing does — the pairing is a convention that holds only while everyone remembers it.

The cost is visible in the issue that is already tracking it. #6387 enumerated eight unpaired brands on 2026-08-04; there are nine on current `main`, because `cloudflare-kumo` landed on 08-12. #7755 is approved and pairs the other eight, so the hand-written list is one short of the gap before it merges. That is not a problem with that PR — it is what an unenforced invariant does to any list written by hand, and it will do the same to the next one.

This PR deliberately does not touch the data. #7755 owns that; this makes its result durable instead of a snapshot.

## What users will see

Nothing at runtime. This is a repository check.

For contributors, `pnpm guard` fails when a design system is added on one side only, at the point the brand is added rather than when someone notices a card linking back to the index. The failure names the file and says what to do.

## Merge order — please land #7755 first

If this merges first, #7755 fails `pnpm guard` in the merge queue on eight `… is paired now` violations, because pairing a brand requires deleting its `KNOWN_UNPAIRED` entry and that entry lives in a `scripts/` file its author has no reason to open. `main` itself is never broken — guard runs on the queued ref — but it would eject an approved PR over a check that did not exist when it was written.

Landing #7755 first puts that cost where it belongs: this branch rebases, deletes the eight entries, and lowers `KNOWN_UNPAIRED_CEILING`. I will do that and leave the PR in draft until then. I have commented on #7755 so its author is not surprised either way.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — one `scripts/check-*.ts`, its registration in `scripts/guard.ts`, and its tests.

On the UI/CLI dual-track rule: a guard check is not a user-facing capability, so there is no `od` surface. `pnpm guard` is the entry point, as it is for every other check in that registry, and it appears in `pnpm exec tsx scripts/guard.ts --list-checks`.

## Screenshots

Not applicable.

## Bug fix verification

An enforcement gap rather than a bug, so there is no red-on-`main` spec for the check itself: it passes on `main`, which is the point.

What is falsifiable is whether it catches a break. 31 cases in `e2e/tests/scripts/check-bundled-design-system-plugins.test.ts` drive the validator, and I ran each class against the real repository by mutating the tree and reverting:

| repository state | result |
| --- | --- |
| brand with no bundled plugin | fails, naming the brand |
| bundled plugin with no brand package | fails |
| registry entry naming another repo or ref (`github:attacker/fork@main/…/apple`) | fails |
| two entries sourcing one plugin | fails |
| empty or unparseable `open-design.json` | fails |
| `DESIGN.md` missing or empty | fails |
| pairing a brand still listed in `KNOWN_UNPAIRED` | fails, telling you to drop the entry |
| a tenth brand recorded as a known gap | fails on the ceiling |
| registry with no `plugins` array | one diagnosis, not 143 |
| symlinked brand directory | counted, not skipped |
| clean tree | passes |

### What the exception list does and does not guarantee

`KNOWN_UNPAIRED` records today's nine gaps. Two rules keep it from becoming permanent furniture: pairing a listed brand fails until its entry is removed, and `KNOWN_UNPAIRED_CEILING` fails a tenth entry unless the number is raised too.

Neither is a hard guarantee, and I would rather say so than imply otherwise: both constants live in the file being edited, so a determined change can grow the list. What they buy is that growth is a conspicuous, self-describing diff rather than one slug appended among nine.

## Notes for review

- **Registry sources are compared by full path, not by trailing slug.** An earlier revision matched `/design-systems/<slug>$`, which accepted a source naming another repository or ref — a source that resolves nothing, i.e. the exact broken card this check exists to catch. `EXPECTED_SOURCE_PREFIX` pins repo and ref; a deliberate ref move rewrites all 414 entries and this constant with them.
- **Double quotes** in both new files match the five neighbouring `scripts/check-*.ts` files, though `CONTRIBUTING.md` asks for single. Happy to switch if you would rather the doc win.
- **Scope left alone:** `bundledPreinstallCount` is already covered by `apps/daemon/tests/plugins-marketplaces.test.ts`, and the wider registry beyond design systems belongs to a broader invariant than this one.

## Validation

- `pnpm guard` — exit 0, new line: `Bundled design-system plugin check passed: 143 of 152 brands paired and listed in the marketplace registry, 9 known unpaired.`
- `pnpm typecheck` — exit 0
- `pnpm --filter @open-design/e2e exec vitest run tests/scripts/check-bundled-design-system-plugins.test.ts` — 31 passed
- `pnpm --filter @open-design/e2e exec vitest run tests/scripts/guard.test.ts tests/scripts/guard-lib.test.ts` — 20 passed, covering the guard registry and the scripts-architecture rules this module has to satisfy
