### PR TITLE
fix(tools-pack): make packed Linux start liveness-aware for cold AppImage launches

### DIFF
--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -21,7 +21,7 @@ import {
   stopSidecars,
   type SidecarStamp,
 } from "@open-design/sidecar";
-import { createPackageManagerInvocation, readLogTail } from "@open-design/platform";
+import { createPackageManagerInvocation, isProcessAlive, readLogTail } from "@open-design/platform";
 
 import type { ToolPackConfig } from "./config/index.js";
 import {
@@ -918,14 +918,58 @@ async function resolveReachableLinuxSidecar<T>(
   return probes.find((probe): probe is ReachableLinuxSidecar<T> => probe != null) ?? null;
 }
 
-async function waitForLinuxStatus<T>(stamps: readonly SidecarStamp[], timeoutMs: number): Promise<ReachableLinuxSidecar<T> | null> {
+// Cold first launch: AppImage --appimage-extract-and-run unpacks the image to
+// /tmp before exec'ing the inner electron, then the daemon seeds bundled
+// plugins and the web sidecar boots -- measured well past the old fixed 60s
+// window on desktop hardware, so a fixed timeout kills healthy starts. Both the
+// launch convergence wait and the readiness wait share this budget while the
+// launched process stays alive.
+export const PACKAGED_LINUX_COLD_START_TIMEOUT_MS = 300_000;
+
+export type LinuxLaunchReadiness<T> =
+  | { outcome: "ready"; sidecar: ReachableLinuxSidecar<T> }
+  | { outcome: "exited" }
+  | { outcome: "timeout" };
+
+export type LinuxReadinessWaitOptions = {
+  /** Absolute ceiling; a hung-but-alive launch still surfaces an error. */
+  timeoutMs: number;
+  pollIntervalMs?: number;
+};
+
+/**
+ * Waits for a launched Linux sidecar to report status while its launch process
+ * stays alive. A process that exits before reporting status is a failed start
+ * and fails fast; an alive process is just slow (cold AppImage extraction plus
+ * Electron and sidecar boot can exceed a fixed timeout on first launch) and
+ * keeps waiting until `timeoutMs`, so a hung-but-alive launch still surfaces an
+ * error. `readStatus`/`isLaunchAlive` are injectable for tests.
+ */
+export async function waitForLinuxReadiness<T>(
+  readStatus: () => Promise<ReachableLinuxSidecar<T> | null>,
+  isLaunchAlive: () => boolean | Promise<boolean>,
+  options: LinuxReadinessWaitOptions,
+): Promise<LinuxLaunchReadiness<T>> {
+  const { timeoutMs, pollIntervalMs = 200 } = options;
   const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const active = await resolveReachableLinuxSidecar<T>(stamps, 1_000);
-    if (active != null) return active;
-    await new Promise((r) => setTimeout(r, 200));
+  while (true) {
+    const sidecar = await readStatus();
+    if (sidecar != null) return { outcome: "ready", sidecar };
+    if (!(await isLaunchAlive())) return { outcome: "exited" };
+    if (Date.now() >= deadline) return { outcome: "timeout" };
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
   }
-  return null;
+}
+
+async function waitForLinuxStatus<T>(
+  stamps: readonly SidecarStamp[],
+  options: { rootPid: number; timeoutMs: number },
+): Promise<LinuxLaunchReadiness<T>> {
+  return await waitForLinuxReadiness<T>(
+    async () => await resolveReachableLinuxSidecar<T>(stamps, 1_000),
+    () => isProcessAlive(options.rootPid),
+    { timeoutMs: options.timeoutMs },
+  );
 }
 
 export async function startPackedLinuxApp(config: ToolPackConfig): Promise<LinuxStartResult> {
@@ -965,16 +1009,26 @@ export async function startPackedLinuxApp(config: ToolPackConfig): Promise<Linux
       runtimeRoot: join(config.roots.runtime.namespaceRoot, "runtime"),
     },
     stamp,
-  }, { ownerStamps: launchStamps, timeoutMs: 60_000 });
+  }, { ownerStamps: launchStamps, timeoutMs: PACKAGED_LINUX_COLD_START_TIMEOUT_MS });
 
-  // 60s ceiling: AppImage --appimage-extract-and-run unpacks ~200MB to /tmp on
-  // first launch before exec'ing the inner electron, which adds substantial
-  // overhead vs mac's direct .app launch.
-  //
-  const active = await waitForLinuxStatus<DesktopStatusSnapshot>(launchStamps, 60_000);
-  if (active == null) {
+  // Cold first launch overhead: AppImage --appimage-extract-and-run unpacks the
+  // image to /tmp before exec'ing the inner electron, then the daemon seeds
+  // bundled plugins and the web sidecar boots -- measured well past the old
+  // fixed 60s window on desktop hardware, so a fixed timeout kills healthy
+  // starts. The wait is liveness-aware instead: fail fast only when the spawned
+  // app process exits before reporting status, keep polling while it is alive,
+  // and cap the wait with a hard ceiling so a hung-but-alive app still surfaces.
+  const active = await waitForLinuxStatus<DesktopStatusSnapshot>(launchStamps, {
+    rootPid: convergence.description.resources.pid,
+    timeoutMs: PACKAGED_LINUX_COLD_START_TIMEOUT_MS,
+  });
+  if (active.outcome !== "ready") {
     await stopSidecars(launchStamps.map((candidate) => ({ stamp: candidate }))).catch(() => undefined);
-    throw new Error(`desktop sidecar did not become ready within 60s for ${config.namespace}`);
+    throw new Error(
+      active.outcome === "exited"
+        ? `desktop sidecar exited before reporting status for ${config.namespace}`
+        : `desktop sidecar did not become ready within ${PACKAGED_LINUX_COLD_START_TIMEOUT_MS / 1000}s for ${config.namespace}`,
+    );
   }
 
   return {
@@ -984,7 +1038,7 @@ export async function startPackedLinuxApp(config: ToolPackConfig): Promise<Linux
     namespace: config.namespace,
     pid: convergence.description.resources.pid,
     source,
-    status: active.status,
+    status: active.sidecar.status,
   };
 }
 
@@ -1267,10 +1321,17 @@ export async function startPackedLinuxHeadless(config: ToolPackConfig): Promise<
     await logHandle.close().catch(() => undefined);
   }
 
-  const active = await waitForLinuxStatus<DesktopStatusSnapshot>(launchStamps, 95_000);
-  if (active == null) {
+  const active = await waitForLinuxStatus<DesktopStatusSnapshot>(launchStamps, {
+    rootPid: child.pid,
+    timeoutMs: 95_000,
+  });
+  if (active.outcome !== "ready") {
     await stopSidecars(launchStamps.map((candidate) => ({ stamp: candidate }))).catch(() => undefined);
-    throw new Error(`headless sidecar did not become ready within 95s for ${config.namespace}`);
+    throw new Error(
+      active.outcome === "exited"
+        ? `headless sidecar exited before reporting status for ${config.namespace}`
+        : `headless sidecar did not become ready within 95s for ${config.namespace}`,
+    );
   }
 
   return {
@@ -1278,7 +1339,7 @@ export async function startPackedLinuxHeadless(config: ToolPackConfig): Promise<
     logPath,
     namespace: config.namespace,
     pid: child.pid,
-    status: active.status,
+    status: active.sidecar.status,
   };
 }
 

--- a/tools/pack/tests/linux.test.ts
+++ b/tools/pack/tests/linux.test.ts
@@ -16,6 +16,9 @@ import {
 } from "@open-design/sidecar-proto";
 import { describe, expect, it, vi } from "vitest";
 
+const convergeSidecarLaunchMock = vi.hoisted(() => vi.fn(async () => ({
+  description: { resources: { pid: process.pid } },
+})));
 const stopSidecarMock = vi.hoisted(() => vi.fn(async (_stamp?: unknown, _options?: unknown) => ({
   alreadyStopped: true,
   forcedPids: [],
@@ -45,6 +48,7 @@ vi.mock("@open-design/sidecar", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@open-design/sidecar")>();
   return {
     ...actual,
+    convergeSidecarLaunch: convergeSidecarLaunchMock as unknown as typeof actual.convergeSidecarLaunch,
     findSidecarProcesses: vi.fn(async () => []),
     getSidecarStatus: vi.fn(async () => { throw new Error("status unavailable"); }),
     invokeSidecar: vi.fn(async () => { throw new Error("invoke unavailable"); }),
@@ -65,11 +69,14 @@ import {
   renderLinuxAppImageAppRun,
   renderLinuxPackagedMainEntry,
   resolveLinuxLifecycleMode,
+  PACKAGED_LINUX_COLD_START_TIMEOUT_MS,
   resolveProductionInstallCommand,
   shouldRejectLinuxHeadlessInspectOptions,
+  startPackedLinuxApp,
   stopPackedLinuxApp,
   sanitizeNamespace,
   stopPackedLinuxHeadless,
+  waitForLinuxReadiness,
 } from "@/linux.js";
 
 async function pathExists(path: string): Promise<boolean> {
@@ -946,5 +953,154 @@ describe("matchesAppImageProcess", () => {
       installPath,
     );
     expect(ok).toBe(false);
+  });
+});
+
+describe("waitForLinuxReadiness", () => {
+  const readySidecar = { stamp: { app: APP_KEYS.DESKTOP }, status: { namespace: "default" } } as never;
+
+  it("returns ready as soon as the sidecar reports status", async () => {
+    const result = await waitForLinuxReadiness(
+      async () => readySidecar,
+      () => true,
+      { timeoutMs: PACKAGED_LINUX_COLD_START_TIMEOUT_MS, pollIntervalMs: 5 },
+    );
+    expect(result).toEqual({ outcome: "ready", sidecar: readySidecar });
+  });
+
+  it("fails fast with exited when the launch process is gone before reporting status", async () => {
+    const result = await waitForLinuxReadiness(
+      async () => null,
+      () => false,
+      { timeoutMs: PACKAGED_LINUX_COLD_START_TIMEOUT_MS, pollIntervalMs: 5 },
+    );
+    expect(result).toEqual({ outcome: "exited" });
+  });
+
+  it("returns exited when the launch process dies mid-wait", async () => {
+    let alive = true;
+    const result = await waitForLinuxReadiness(
+      async () => {
+        alive = false;
+        return null;
+      },
+      () => alive,
+      { timeoutMs: PACKAGED_LINUX_COLD_START_TIMEOUT_MS, pollIntervalMs: 5 },
+    );
+    expect(result).toEqual({ outcome: "exited" });
+  });
+
+  it("keeps waiting past the old fixed 60s ceiling while the launch process stays alive", async () => {
+    vi.useFakeTimers();
+    try {
+      const startedAt = Date.now();
+      const promise = waitForLinuxReadiness(
+        async () => (Date.now() - startedAt < 70_000 ? null : readySidecar),
+        () => true,
+        { timeoutMs: PACKAGED_LINUX_COLD_START_TIMEOUT_MS, pollIntervalMs: 250 },
+      );
+      await vi.advanceTimersByTimeAsync(71_000);
+      await expect(promise).resolves.toEqual({ outcome: "ready", sidecar: readySidecar });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns timeout at the ceiling while the launch process stays alive", async () => {
+    vi.useFakeTimers();
+    try {
+      const promise = waitForLinuxReadiness(
+        async () => null,
+        () => true,
+        { timeoutMs: 1_000, pollIntervalMs: 250 },
+      );
+      await vi.advanceTimersByTimeAsync(1_500);
+      await expect(promise).resolves.toEqual({ outcome: "timeout" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("startPackedLinuxApp", () => {
+  const status = { app: APP_KEYS.DESKTOP, namespace: "default" } as never;
+
+  async function makeLaunchConfig(): Promise<ToolPackConfig> {
+    const root = await mkdtemp(join(tmpdir(), "od-linux-start-"));
+    const config = makeConfig();
+    config.roots.output.appBuilderRoot = join(root, "builder");
+    config.roots.output.namespaceRoot = join(root, "out");
+    config.roots.runtime.namespaceRoot = join(root, "runtime");
+    config.roots.runtime.namespaceBaseRoot = join(root, "runtime-base");
+    await mkdir(config.roots.output.appBuilderRoot, { recursive: true });
+    await writeFile(join(config.roots.output.appBuilderRoot, "Open Design-1.0.0.AppImage"), "fake");
+    return config;
+  }
+
+  async function withIsolatedHome<T>(run: () => Promise<T>): Promise<T> {
+    const previousHome = process.env.HOME;
+    const home = await mkdtemp(join(tmpdir(), "od-linux-home-"));
+    process.env.HOME = home;
+    try {
+      return await run();
+    } finally {
+      if (previousHome == null) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+    }
+  }
+
+  it("keeps waiting for a slow first launch past the old fixed 60s ceiling while the app process stays alive", async () => {
+    await withIsolatedHome(async () => {
+      const config = await makeLaunchConfig();
+      convergeSidecarLaunchMock.mockResolvedValueOnce({ description: { resources: { pid: process.pid } } });
+      const readyAfterMs = 70_000;
+      const startedAt = Date.now();
+      vi.mocked(getSidecarStatus).mockImplementation(async () => {
+        if (Date.now() - startedAt < readyAfterMs) throw new Error("status unavailable");
+        return status;
+      });
+
+      vi.useFakeTimers();
+      try {
+        let settled = false;
+        const promise = startPackedLinuxApp(config).finally(() => {
+          settled = true;
+        });
+        for (let i = 0; i < 1_000 && !settled; i += 1) {
+          await vi.advanceTimersByTimeAsync(250);
+        }
+        await expect(promise).resolves.toMatchObject({
+          pid: process.pid,
+          source: "built",
+          status,
+        });
+      } finally {
+        vi.useRealTimers();
+        convergeSidecarLaunchMock.mockReset();
+        vi.mocked(getSidecarStatus).mockImplementation(async () => {
+          throw new Error("status unavailable");
+        });
+      }
+    });
+  });
+
+  it("fails fast when the launched app process exits before reporting status", async () => {
+    await withIsolatedHome(async () => {
+      const config = await makeLaunchConfig();
+      convergeSidecarLaunchMock.mockResolvedValueOnce({
+        description: { resources: { pid: 2_147_483_646 } },
+      });
+      vi.mocked(getSidecarStatus).mockImplementation(async () => {
+        throw new Error("status unavailable");
+      });
+
+      try {
+        await expect(startPackedLinuxApp(config)).rejects.toThrow(
+          "desktop sidecar exited before reporting status for default",
+        );
+      } finally {
+        convergeSidecarLaunchMock.mockReset();
+      }
+    });
   });
 });


### PR DESCRIPTION
Refs #728 — Linux cold-start false-fail reported in the thread; supersedes the auto-closed #7015.

## Why

- **Use case:** the #728 thread reports the packed Linux app false-failing its first launch (`desktop sidecar did not become ready within 60s` while the app is still starting). @delight-f hit it on a cold AppImage start; the maintainer asked for the #7015 approach to be re-landed against current code.
- **Pain:** on `main`, `startPackedLinuxApp` waits for the sidecar with a hard 60s ceiling. A cold first launch takes longer: `--appimage-extract-and-run` unpacks ~200MB to /tmp before exec'ing the inner Electron binary, then the daemon seeds bundled plugins and the web sidecar boots. So a launch that is progressing still fails, and a launch that is genuinely dead burns the full ceiling before reporting.

## What users will see

- `tools-pack linux start` no longer fails a cold first launch at 60s — the budget is a named 300s constant (`PACKAGED_LINUX_COLD_START_TIMEOUT_MS`) shared by sidecar convergence and the readiness wait.
- If the launched app process exits early, start fails immediately with the log tail instead of waiting out the budget.
- The headless start path keeps its 95s ceiling but gains the same fail-fast behavior.

## Surface area

- [x] **Default behavior change** — packaged Linux start no longer false-fails at 60s, and real crashes surface immediately (bug fix, no opt-in)

## Screenshots

N/A — no UI.

## Bug fix verification

- Test path that reproduces the bug: `tools/pack/tests/linux.test.ts` → `startPackedLinuxApp > keeps waiting for a slow first launch past the old fixed 60s ceiling while the app process stays alive`
- Did the test go red on `main` and green on this branch? **No** — the test exercises the new outcome-discriminated helper, so it can't compile against `main`'s signature. Verified instead by sabotage on this branch: restoring the old fixed 60s call-site budget makes it fail with the reported error (`promise rejected "Error: desktop sidecar did not become rea…"`); disabling the liveness probe makes `fails fast when the launched app process exits before reporting status` time out. Both are green with the fix.
- New helper tests cover: marker present (ready), process exited (fail fast), slow-but-alive (keeps waiting past the old ceiling), budget exhausted (times out).

## Validation

- `pnpm --filter @open-design/tools-pack typecheck` — pass
- `pnpm --filter @open-design/tools-pack test` — 41 files, 312 passed, 9 skipped, 0 failed
- `pnpm guard` — pass
- Sabotage runs above, to prove the regression tests actually bite.
