### PR TITLE
feat(web): wire up the ChatPanel observability that was never called

### DIFF
--- a/apps/web/src/analytics/client.ts
+++ b/apps/web/src/analytics/client.ts
@@ -16,6 +16,7 @@ import {
   setExceptionTrackingContext,
 } from './error-tracking';
 import { pinFirstSessionForCapture } from './identity';
+import { registerChatReplaySessionSource } from '../observability/chat-context';
 import { coalescedGet } from '../lib/coalesced-get';
 
 interface AnalyticsContext {
@@ -353,6 +354,15 @@ export async function getAnalyticsClient(
         },
 
         loaded: (instance) => {
+          // Hand the chat-observability correlation block its replay-session
+          // reader. This is the ONLY place it can come from: we load
+          // posthog-js through `await import('posthog-js')`, and the ESM
+          // build — unlike the landing page's `array.js` snippet — never
+          // publishes itself as `window.posthog`. Without this line every
+          // `replay_session_id` on a `client_chat_*` event is silently
+          // undefined while the wiring looks complete. See the trap
+          // documented on `registerChatReplaySessionSource`.
+          registerChatReplaySessionSource(() => instance.get_session_id());
           lastRegisterPayload = {
             event_schema_version: EVENT_SCHEMA_VERSION,
             env: telemetryEnv,

--- a/apps/web/src/analytics/provider.tsx
+++ b/apps/web/src/analytics/provider.tsx
@@ -29,6 +29,7 @@ import {
 } from './client';
 import { APP_VERSION_PLACEHOLDER } from './app-version';
 import { patchExceptionTrackingAppVersion } from './error-tracking';
+import { setChatCorrelation } from '../observability/chat-context';
 import type { AnalyticsConfigureGlobals } from '@open-design/contracts/analytics';
 import {
   detectClientType,
@@ -106,7 +107,17 @@ async function loadRuntimeAppVersion(): Promise<string | null> {
       try {
         const res = await fetch('/api/version');
         if (!res.ok) return null;
-        const body = (await res.json()) as { version?: { version?: string } };
+        const body = (await res.json()) as {
+          version?: { version?: string; channel?: string };
+        };
+        // The daemon has always answered with `channel` alongside `version`
+        // (see `resolveAppVersionInfo`); we simply dropped it on the floor.
+        // It is the one dimension that separates "the packaged stable build
+        // is janky" from "a dev daemon is janky", so a chat-health dashboard
+        // without it cannot tell a real regression from local noise. Stamped
+        // before the early return below so a daemon that reports a channel but
+        // no version still contributes it.
+        setChatCorrelation({ release_channel: body?.version?.channel });
         const next = body?.version?.version;
         if (!next) return null;
         runtimeAppVersion = next;

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -65,6 +65,7 @@ import {
   runAgentProviderId,
 } from '../analytics/run-task';
 import { amrHandoffDeviceId, attributedAmrUrl, recordAmrEntry } from '../analytics/amr-attribution';
+import { setChatCorrelation } from '../observability/chat-context';
 import {
   chatSurfaceSample,
   openChatSurface,
@@ -2821,6 +2822,25 @@ export function ChatPane({
       meta: item.meta,
     });
   };
+
+  /*
+   * 这块面板此刻在显示**哪个项目的哪场对话**。
+   *
+   * 设在 ChatPane 自己身上,而不是某一个宿主里 —— 同一个组件挂在三处:
+   * `ProjectView`、`DesignSystemFlow`、`workspace/SideChatTab`。只在其中一处设,
+   * 另外两处发出去的每一条 `client_chat_*` 都是没有项目、没有会话的孤儿事件,
+   * 而三处用的是同一套观测模块、同一块看板。这两个 id 早就作为 props 递进来了,
+   * 组件边界才是它们共同的、唯一的落点。
+   *
+   * 必须排在下面那条 openChatSurface 的 effect **前面**:开面时那一发
+   * `conversation_open` 取样会展开这个块,晚一步它就是空的。
+   */
+  useEffect(() => {
+    setChatCorrelation({
+      conversation_id: activeConversationId ?? undefined,
+      project_id: projectId ?? undefined,
+    });
+  }, [activeConversationId, projectId]);
 
   /*
    * 把这块转录交给 chat-health 看着(`client_chat_first_paint` /

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -65,6 +65,11 @@ import {
   runAgentProviderId,
 } from '../analytics/run-task';
 import { amrHandoffDeviceId, attributedAmrUrl, recordAmrEntry } from '../analytics/amr-attribution';
+import {
+  chatSurfaceSample,
+  openChatSurface,
+  type ChatSurfaceHandle,
+} from '../observability/chat-health';
 import { useI18n, useT } from '../i18n';
 import { startersForProduct, type ProductType } from '../onboarding/recommendation';
 import { starterCopyFor } from '../onboarding/starter-copy';
@@ -1407,6 +1412,20 @@ export function ChatPane({
    * 只是此刻长得一样。见 `buildChatRenderItems` 的注释。
    */
   const chatRenderItems = useMemo(() => buildChatRenderItems(displayMessages), [displayMessages]);
+  /** Live handle on the chat-health surface, for the effects that feed it. */
+  const chatSurfaceRef = useRef<ChatSurfaceHandle | null>(null);
+  const chatVirtualized = isChatVirtualized(chatRenderItems);
+  /**
+   * 这场对话背后**agent 事件的总条数**。
+   *
+   * 首屏耗时单独一个数字是没法归因的:3 秒到底是「消息多」还是「每条消息底下
+   * 挂了几百条工具事件」,只有这个数能分开。所以它和 `markFirstPaint` 必须同批
+   * 落地 —— 只有耗时没有它,那个耗时就只是个不能下钻的读数。
+   */
+  const chatStreamEventCount = useMemo(
+    () => displayMessages.reduce((total, message) => total + (message.events?.length ?? 0), 0),
+    [displayMessages],
+  );
   /**
    * 每一轮各自那张升级卡:key = 那一轮助手消息的 id,value = **结束那一刻**的余额。
    *
@@ -2803,10 +2822,64 @@ export function ChatPane({
     });
   };
 
+  /*
+   * 把这块转录交给 chat-health 看着(`client_chat_first_paint` /
+   * `client_chat_dom_growth` / `client_chat_memory_pressure` /
+   * `client_chat_stream_health` 四条的宿主)。
+   *
+   * 依赖只有两项,各自防一个真实的死法:
+   *   - `tab`:不是聊天页时整块是条件渲染的,`logRef.current` 是 null。
+   *     漏了它,从别的页回到聊天页永远接不上观察者。
+   *   - `activeConversationId`:那个 div **不带 conversation key**,换会话
+   *     React 复用同一个 DOM 节点。所以「换会话要重开」这件事没有任何
+   *     节点层面的信号,只能靠这条依赖。
+   *
+   * `openChatSurface` 自己会先 detach 上一块再建新的,cleanup 再 detach 一次
+   * 是幂等的 —— 两套观察者并存这件事在模块那一侧就已经不可能。
+   */
+  useEffect(() => {
+    if (tab !== 'chat') return undefined;
+    const el = logRef.current;
+    if (!el) return undefined;
+    const handle = openChatSurface({
+      element: el,
+      messageCount: displayMessages.length,
+      virtualized: chatVirtualized,
+      streamEventCount: chatStreamEventCount,
+    });
+    chatSurfaceRef.current = handle;
+    // 开局先取一个基线。没有它,DOM/heap 曲线的第一个点要等 60 秒的定时器,
+    // 而「打开就已经很大」和「开着开着长大了」是两个不同的故事。
+    chatSurfaceSample('conversation_open');
+    return () => {
+      chatSurfaceRef.current = null;
+      handle.detach();
+    };
+    // 计数由下面那条 effect 持续推给 handle;这里只认「换会话 / 换标签页」
+    // 这两件真的需要换一块被观察对象的事。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeConversationId, tab]);
+
+  useEffect(() => {
+    const handle = chatSurfaceRef.current;
+    if (!handle) return;
+    handle.setMessageCount(displayMessages.length);
+    handle.setVirtualized(chatVirtualized);
+    handle.setStreamEventCount(chatStreamEventCount);
+  }, [chatStreamEventCount, chatVirtualized, displayMessages.length]);
+
   useEffect(() => {
     const el = logRef.current;
     if (!el || didInitialScrollRef.current || displayMessages.length === 0) return;
     didInitialScrollRef.current = true;
+    // 第一条消息在屏幕上了 —— 这才是「用户读得到」的那一刻,也是首屏耗时的
+    // 终点。模块自己保证幂等(只有第一次会上报),所以 StrictMode 的双跑
+    // 造不出一个假的、更快的样本。
+    // 行数按 chat-health 自己数 `dom_growth` 那一套算(日志容器的直接子元素),
+    // 两个事件用同一个定义,才比得起来。
+    chatSurfaceRef.current?.markFirstPaint({
+      renderedRowCount: el.querySelectorAll(':scope > *').length,
+    });
     requestAnimationFrame(() => {
       // If the last assistant message contains a question form, scroll to
       // the form instead of the bottom, so the user sees the form first.
@@ -5621,7 +5694,7 @@ function ChatRows({
     }
     return byMessageId;
   }, [messages]);
-  const virtualized = items.length > CHAT_MESSAGE_VIRTUALIZE_THRESHOLD;
+  const virtualized = isChatVirtualized(items);
   const virtualWindow = useMeasuredVirtualWindow(items, {
     enabled: virtualized,
     containerRef: scrollContainerRef,
@@ -5905,6 +5978,18 @@ function buildChatRenderItems(messages: ChatMessage[]): ChatRenderItem[] {
     });
   }
   return items;
+}
+
+/**
+ * 转录此刻**走不走虚拟窗口**。
+ *
+ * 一个判据,两个消费者:`ChatRows` 按它决定怎么画,chat-health 按它上报
+ * `virtualized`。写成两处 `items.length > 阈值` 今天读起来一模一样,
+ * 等这条规则长出第二个条件的那天就会分家 —— 那时埋点描述的是渲染层
+ * **已经不用了**的那种模式,而看板上没有任何东西会喊。
+ */
+function isChatVirtualized(items: ChatRenderItem[]): boolean {
+  return items.length > CHAT_MESSAGE_VIRTUALIZE_THRESHOLD;
 }
 
 /**

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -2580,6 +2580,21 @@ export function ChatPane({
       area: 'chat_panel',
       element: 'run_failed_toast',
       error_code: failedRunErrorEvent.code,
+      /*
+       * 卡上那句话**到底是哪一句**,以及它是不是兜底那句。
+       *
+       * `error_code` 回答的是「daemon 说这是什么错」,回答不了「用户读到了什么」——
+       * 这两件事之间隔着一张映射表,而映射表**总会少一行**
+       * (`resolveRunErrorCardDescription` 的注释把这件事写死了:表可以短一行,
+       * 判据不能)。少那一行的时候用户看到的是一句空洞的「任务失败了」,
+       * 这正是最该被量出来的一格。
+       *
+       * 判据现成:`runFailureUi.messageKey` 为 null 就是「表里没有这条文案」
+       * (`amr-guidance.ts` 的 `RunErrorCardDescription`)。
+       * 兜底那一格**必须有自己的值而不是缺字段** —— 缺了,兜底率的分母就没了。
+       */
+      message_key: runFailureUi?.messageKey ?? 'generic_fallback',
+      failure_category: failedRunErrorEvent.failureCategory ?? 'unknown',
       project_id: projectId ?? '',
       project_kind: projectKindForTracking,
       conversation_id: activeConversationId,
@@ -2591,9 +2606,11 @@ export function ChatPane({
     analytics.track,
     displayError,
     failedRunErrorEvent?.code,
+    failedRunErrorEvent?.failureCategory,
     projectId,
     projectKindForTracking,
     retryAssistant,
+    runFailureUi?.messageKey,
   ]);
   const importedFolderArtifacts = useMemo(
     () =>

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -105,6 +105,7 @@ import type {
   TrackingRunRecoveryActionType,
 } from '@open-design/contracts/analytics';
 import { useAnalytics } from '../analytics/provider';
+import { setChatCorrelation } from '../observability/chat-context';
 import {
   trackByokPreflightBlocked,
   trackComposerBarClick,
@@ -3931,6 +3932,15 @@ export function ProjectView({
             : normalizeConversationMessageOrder(list),
         );
         setMessagesInitialized(true);
+        // The conversation the chat panel is actually showing, stamped only
+        // once its transcript has landed. Every `client_chat_*` event spreads
+        // this block, and without it a slow-open or a memory-pressure report
+        // names no conversation and no project — which is the difference
+        // between "P95 first paint is 9s" and a row a triager can pull up.
+        setChatCorrelation({
+          conversation_id: activeConversationId,
+          project_id: project.id,
+        });
         setAttachedComments([]);
         setArtifact(null);
         setError(null);

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -105,7 +105,6 @@ import type {
   TrackingRunRecoveryActionType,
 } from '@open-design/contracts/analytics';
 import { useAnalytics } from '../analytics/provider';
-import { setChatCorrelation } from '../observability/chat-context';
 import {
   trackByokPreflightBlocked,
   trackComposerBarClick,
@@ -3932,15 +3931,6 @@ export function ProjectView({
             : normalizeConversationMessageOrder(list),
         );
         setMessagesInitialized(true);
-        // The conversation the chat panel is actually showing, stamped only
-        // once its transcript has landed. Every `client_chat_*` event spreads
-        // this block, and without it a slow-open or a memory-pressure report
-        // names no conversation and no project — which is the difference
-        // between "P95 first paint is 9s" and a row a triager can pull up.
-        setChatCorrelation({
-          conversation_id: activeConversationId,
-          project_id: project.id,
-        });
         setAttachedComments([]);
         setArtifact(null);
         setError(null);

--- a/apps/web/src/observability/chat-health.ts
+++ b/apps/web/src/observability/chat-health.ts
@@ -156,6 +156,24 @@ export function openChatSurface(input: {
   activeSurface?.detach();
   const surface = new ChatSurface(input);
   activeSurface = surface;
+  // Adopt the run that is already streaming, if there is one.
+  //
+  // A surface is not created once per run — it is recreated every time the
+  // user switches conversation or leaves and returns to the Chat tab, and
+  // `chatSurfaceRunStarted` only ever reaches the surface that happened to
+  // exist when the provider fired it. So a surface opened MID-RUN started life
+  // believing nothing was running: its jank window stayed shut and every long
+  // task until the next run start was dropped on the floor. That is precisely
+  // the stretch a user is watching — they came back to the tab to see
+  // something generate.
+  //
+  // The in-flight run is read from the correlation context rather than a
+  // second flag kept here: `chat-interaction.ts` already derives its whole
+  // `streaming` breakdown the same way, and one source cannot disagree with
+  // itself. Nothing is double counted — `runCount` and the window clock are
+  // per-surface, and the surface this opens on was constructed a line ago.
+  const inFlightRunId = chatCorrelation().run_id;
+  if (inFlightRunId != null) surface.runStarted(inFlightRunId);
   return surface;
 }
 

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -87,6 +87,7 @@ import {
 } from '../artifacts/strip';
 import { trackRunProgress, trackRunStart, trackRunTerminal } from '../observability/stuck-run';
 import { setChatCorrelation } from '../observability/chat-context';
+import { chatSurfaceRunEnded, chatSurfaceRunStarted } from '../observability/chat-health';
 import { markUpstreamActivity } from '../runtime/chat/upstream-activity';
 import { IN_FLIGHT_TOOL_INPUT_MARKER, IN_FLIGHT_TOOL_OUTPUT_KEY } from '../runtime/tool-events';
 
@@ -1165,6 +1166,11 @@ export async function streamViaDaemon({
       client_type: detectClientType(),
     });
     openChatRunCorrelation(runId, agentId);
+    // Opens the chat-health jank window for this run. `client_chat_stream_health`
+    // only counts long tasks that landed inside one, so a run with no opener
+    // contributes nothing at all — idle-time jank belongs to `client_long_task`.
+    // No-ops when no chat surface is mounted.
+    chatSurfaceRunStarted(runId);
     notifyRunsChanged();
     emitRunStatus('queued');
     await consumeDaemonRun({
@@ -1200,6 +1206,7 @@ export async function reattachDaemonRun(options: DaemonReattachOptions): Promise
   // either); only the correlation is being closed here, deliberately, so this
   // change adds no new event.
   openChatRunCorrelation(options.runId, options.agentId);
+  chatSurfaceRunStarted(options.runId);
   await consumeDaemonRun({
     ...options,
     onRunStatus: (status) => {
@@ -1715,6 +1722,9 @@ async function consumeDaemonRun(options: DaemonReattachOptions): Promise<void> {
     // the run that just ended, so every stall in the rest of the chain would
     // be filed under the wrong run id.
     openChatRunCorrelation(runId, options.agentId);
+    // Miss this one and every long task in the rest of the chain is billed to
+    // the run that already ended.
+    chatSurfaceRunStarted(runId);
     options.onRunCreated?.(runId, result.strategyTask);
   }
 }
@@ -2373,6 +2383,10 @@ async function consumeDaemonPhysicalRun({
     // is a no-op for unknown runIds.
     trackRunTerminal(runId, endStatus ?? (canceled ? 'canceled' : 'unknown'));
     closeChatRunCorrelation();
+    // Closes and reports the jank window. Skipping it does not lose the window
+    // — the next run start flushes it — but it does report `run_completed:
+    // false` for a run that finished cleanly.
+    chatSurfaceRunEnded(runId);
   }
 }
 

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -86,8 +86,37 @@ import {
   type PersistedArtifactFileRef,
 } from '../artifacts/strip';
 import { trackRunProgress, trackRunStart, trackRunTerminal } from '../observability/stuck-run';
+import { setChatCorrelation } from '../observability/chat-context';
 import { markUpstreamActivity } from '../runtime/chat/upstream-activity';
 import { IN_FLIGHT_TOOL_INPUT_MARKER, IN_FLIGHT_TOOL_OUTPUT_KEY } from '../runtime/tool-events';
+
+/**
+ * A run is streaming into the chat panel exactly between these two calls.
+ *
+ * Every `client_chat_*` event spreads `chatCorrelation()`, and
+ * `chat-interaction.ts` derives its whole `streaming` breakdown from whether
+ * that block carries a `run_id` — it maintains no second flag precisely so
+ * the two can never disagree. That makes this pair load-bearing rather than
+ * decorative: with no opener, `streaming` is false for the entire life of the
+ * page and `client_chat_interaction_latency` reports every stall as happening
+ * at rest; with no closer it would stay true forever and report the mirror
+ * image. Neither call may be added without the other.
+ *
+ * `agent_id` rides along on the opener because it is the one dimension the
+ * run-creation sites actually hold. `model_id` is deliberately absent: it is
+ * not in scope at either call, and stamping a guess would be worse than the
+ * gap. An absent `agentId` CLEARS the field rather than leaving the previous
+ * run's agent standing (see `setChatCorrelation`'s merge rule) — a reattach
+ * whose message never persisted a runtime must not inherit an identity.
+ */
+function openChatRunCorrelation(runId: string, agentId: string | undefined): void {
+  setChatCorrelation({ run_id: runId, agent_id: agentId });
+}
+
+/** Closes the window opened by `openChatRunCorrelation`. */
+function closeChatRunCorrelation(): void {
+  setChatCorrelation({ run_id: undefined });
+}
 
 const MAX_TRANSCRIPT_MESSAGE_CHARS = 12_000;
 const LARGE_TOOL_RESULT_CHARS = 8_000;
@@ -1135,6 +1164,7 @@ export async function streamViaDaemon({
       conversation_id: conversationId ?? undefined,
       client_type: detectClientType(),
     });
+    openChatRunCorrelation(runId, agentId);
     notifyRunsChanged();
     emitRunStatus('queued');
     await consumeDaemonRun({
@@ -1163,6 +1193,13 @@ export async function streamViaDaemon({
 }
 
 export async function reattachDaemonRun(options: DaemonReattachOptions): Promise<void> {
+  // Reattach is a run start as far as the chat panel is concerned — it is the
+  // path a page refresh takes back onto a run that is still in flight, and the
+  // jank it is about to stream in is exactly the jank worth correlating. This
+  // path has never had a run-start signal of its own (no `trackRunStart`
+  // either); only the correlation is being closed here, deliberately, so this
+  // change adds no new event.
+  openChatRunCorrelation(options.runId, options.agentId);
   await consumeDaemonRun({
     ...options,
     onRunStatus: (status) => {
@@ -1673,6 +1710,11 @@ async function consumeDaemonRun(options: DaemonReattachOptions): Promise<void> {
       conversation_id: options.conversationId ?? undefined,
       client_type: detectClientType(),
     });
+    // The next physical run of a strategy-task chain is a run start like any
+    // other. Skipping it here would leave the correlation block pointing at
+    // the run that just ended, so every stall in the rest of the chain would
+    // be filed under the wrong run id.
+    openChatRunCorrelation(runId, options.agentId);
     options.onRunCreated?.(runId, result.strategyTask);
   }
 }
@@ -2330,6 +2372,7 @@ async function consumeDaemonPhysicalRun({
     // hit the daemon for an already-finished run), trackRunTerminal
     // is a no-op for unknown runIds.
     trackRunTerminal(runId, endStatus ?? (canceled ? 'canceled' : 'unknown'));
+    closeChatRunCorrelation();
   }
 }
 

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -1165,12 +1165,17 @@ export async function streamViaDaemon({
       conversation_id: conversationId ?? undefined,
       client_type: detectClientType(),
     });
-    openChatRunCorrelation(runId, agentId);
-    // Opens the chat-health jank window for this run. `client_chat_stream_health`
-    // only counts long tasks that landed inside one, so a run with no opener
-    // contributes nothing at all — idle-time jank belongs to `client_long_task`.
-    // No-ops when no chat surface is mounted.
+    // Chat-health first, correlation second — the same rule as the terminal
+    // path below. `runStarted` flushes any window a previous run left open
+    // (its terminal event never arrived), and that flush belongs to the OLD
+    // run, so it has to happen before the block is repointed at this one.
+    //
+    // Opening the window is what makes `client_chat_stream_health` possible at
+    // all: it only counts long tasks that landed inside one, and idle-time
+    // jank belongs to `client_long_task`. No-ops when no chat surface is
+    // mounted.
     chatSurfaceRunStarted(runId);
+    openChatRunCorrelation(runId, agentId);
     notifyRunsChanged();
     emitRunStatus('queued');
     await consumeDaemonRun({
@@ -1205,8 +1210,8 @@ export async function reattachDaemonRun(options: DaemonReattachOptions): Promise
   // path has never had a run-start signal of its own (no `trackRunStart`
   // either); only the correlation is being closed here, deliberately, so this
   // change adds no new event.
-  openChatRunCorrelation(options.runId, options.agentId);
   chatSurfaceRunStarted(options.runId);
+  openChatRunCorrelation(options.runId, options.agentId);
   await consumeDaemonRun({
     ...options,
     onRunStatus: (status) => {
@@ -1721,10 +1726,10 @@ async function consumeDaemonRun(options: DaemonReattachOptions): Promise<void> {
     // other. Skipping it here would leave the correlation block pointing at
     // the run that just ended, so every stall in the rest of the chain would
     // be filed under the wrong run id.
-    openChatRunCorrelation(runId, options.agentId);
     // Miss this one and every long task in the rest of the chain is billed to
     // the run that already ended.
     chatSurfaceRunStarted(runId);
+    openChatRunCorrelation(runId, options.agentId);
     options.onRunCreated?.(runId, result.strategyTask);
   }
 }
@@ -2382,11 +2387,22 @@ async function consumeDaemonPhysicalRun({
     // hit the daemon for an already-finished run), trackRunTerminal
     // is a no-op for unknown runIds.
     trackRunTerminal(runId, endStatus ?? (canceled ? 'canceled' : 'unknown'));
-    closeChatRunCorrelation();
-    // Closes and reports the jank window. Skipping it does not lose the window
-    // — the next run start flushes it — but it does report `run_completed:
-    // false` for a run that finished cleanly.
+    /*
+     * ORDER IS THE POINT, and it is the same defect this whole change exists
+     * to remove.
+     *
+     * `chatSurfaceRunEnded` does not merely bookkeep — it FLUSHES the jank
+     * window, and `client_chat_stream_health` spreads `chatCorrelation()` on
+     * its way out. Clear the correlation first and that event ships with an
+     * empty `run_id`: a chat event that cannot name the run it measured.
+     *
+     * One rule covers both ends of a run: the chat-health call goes FIRST,
+     * because it is the one that can emit; the correlation mutation goes
+     * second. `trackRunTerminal` is unaffected either way — it carries its own
+     * context object and never reads the chat correlation block.
+     */
     chatSurfaceRunEnded(runId);
+    closeChatRunCorrelation();
   }
 }
 

--- a/apps/web/tests/components/ChatPane.chat-health-surface.test.tsx
+++ b/apps/web/tests/components/ChatPane.chat-health-surface.test.tsx
@@ -1,0 +1,256 @@
+// @vitest-environment jsdom
+//
+// `chat-health.ts` has answered four questions since #7518 — how long until
+// the user can read the conversation, is the DOM growing without bound, who is
+// about to OOM, how janky is the UI while a run streams — and has never been
+// called by anything but its own unit spec. All four tiles were empty in
+// production.
+//
+// These specs pin the WIRING, from the outside: the chat log gets a monitor
+// when the panel mounts, a fresh one when the user switches conversation, and
+// none at all once the panel goes away. Every assertion reads the beacons the
+// module actually sends, never a spy on the module — a spy would go green on a
+// call that emitted nothing.
+
+import { cleanup, render } from '@testing-library/react';
+import { forwardRef } from 'react';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ChatPane } from '../../src/components/ChatPane';
+import {
+  clearExceptionTrackingContext,
+  setExceptionTrackingContext,
+} from '../../src/analytics/error-tracking';
+import {
+  __resetChatHealthForTest,
+  chatSurfaceSample,
+} from '../../src/observability/chat-health';
+import type { AppConfig, ChatMessage } from '../../src/types';
+
+const translate = (key: string, vars?: Record<string, string | number>) => {
+  if (vars && Object.keys(vars).length > 0) {
+    return `${key} ${Object.values(vars).join(' ')}`;
+  }
+  return key;
+};
+
+vi.mock('../../src/i18n', () => ({
+  useI18n: () => ({ locale: 'en', setLocale: () => undefined, t: translate }),
+  useT: () => translate,
+}));
+
+vi.mock('../../src/components/AssistantMessage', () => ({
+  AssistantMessage: ({ message }: { message: ChatMessage }) => (
+    <div data-testid={`assistant-${message.id}`}>{message.content}</div>
+  ),
+}));
+
+vi.mock('../../src/components/ChatComposer', () => ({
+  ChatComposer: forwardRef((_props, _ref) => <div data-testid="composer" />),
+}));
+
+vi.mock('../../src/analytics/events', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/analytics/events')>();
+  return {
+    ...actual,
+    trackChatPanelClick: vi.fn(),
+    trackRunFailedToastSurfaceView: vi.fn(),
+  };
+});
+
+const fetchMock = vi.fn();
+const ORIGINAL_FETCH = globalThis.fetch;
+
+beforeAll(() => {
+  const store = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      clear: () => store.clear(),
+      getItem: (key: string) => store.get(key) ?? null,
+      removeItem: (key: string) => store.delete(key),
+      setItem: (key: string, value: string) => store.set(key, value),
+    },
+  });
+});
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(new Response('', { status: 200 }));
+  globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  setExceptionTrackingContext({
+    apiKey: 'phc_test',
+    host: 'https://us.i.posthog.com',
+    distinctId: 'chat-health-surface-test',
+  });
+  __resetChatHealthForTest();
+});
+
+afterEach(() => {
+  cleanup();
+  __resetChatHealthForTest();
+  clearExceptionTrackingContext();
+  globalThis.fetch = ORIGINAL_FETCH;
+  vi.clearAllMocks();
+});
+
+function safetyEvents(name: string): Array<Record<string, unknown>> {
+  const decoded: Array<{ event?: string; properties?: Record<string, unknown> }> = [];
+  for (const call of fetchMock.mock.calls) {
+    const init = call[1] as RequestInit | undefined;
+    if (typeof init?.body !== 'string') continue;
+    try {
+      decoded.push(JSON.parse(init.body) as { event?: string; properties?: Record<string, unknown> });
+    } catch {
+      // not a telemetry beacon
+    }
+  }
+  return decoded.filter((e) => e.event === name).map((e) => e.properties ?? {});
+}
+
+function userMessage(id: string, events?: unknown[]): ChatMessage {
+  return {
+    id,
+    role: 'user',
+    content: 'hello',
+    createdAt: 1,
+    ...(events ? { events } : {}),
+  } as unknown as ChatMessage;
+}
+
+function assistantMessage(id: string, eventCount: number): ChatMessage {
+  return {
+    id,
+    role: 'assistant',
+    content: 'sure',
+    createdAt: 2,
+    events: Array.from({ length: eventCount }, (_, i) => ({
+      kind: 'tool',
+      label: `tool-${i}`,
+    })),
+  } as unknown as ChatMessage;
+}
+
+function chatPane(props: {
+  messages: ChatMessage[];
+  activeConversationId: string;
+}) {
+  return (
+    <ChatPane
+      messages={props.messages}
+      streaming={false}
+      error={null}
+      projectId="project-1"
+      projectFiles={[]}
+      onEnsureProject={async () => 'project-1'}
+      onSend={vi.fn()}
+      onStop={vi.fn()}
+      conversations={[
+        { projectId: 'project-1', id: 'conv-1', title: 'One', createdAt: 1, updatedAt: 1 },
+        { projectId: 'project-1', id: 'conv-2', title: 'Two', createdAt: 1, updatedAt: 1 },
+      ]}
+      activeConversationId={props.activeConversationId}
+      messagesConversationId={props.activeConversationId}
+      onSelectConversation={vi.fn()}
+      onDeleteConversation={vi.fn()}
+      config={{ agentId: 'claude', agentCliEnv: {} } as unknown as AppConfig}
+    />
+  );
+}
+
+describe('ChatPane — chat-health surface lifecycle', () => {
+  it('starts monitoring the chat log as soon as the panel is on screen', () => {
+    render(chatPane({ messages: [userMessage('m1')], activeConversationId: 'conv-1' }));
+
+    // The opening baseline. Without it the DOM/heap curve's first point waits
+    // 60s, and "already huge on open" is indistinguishable from "grew while
+    // open".
+    const samples = safetyEvents('client_chat_dom_growth');
+    expect(samples).toHaveLength(1);
+    expect(samples[0]?.sample_reason).toBe('conversation_open');
+  });
+
+  it('measures first paint against the transcript it actually rendered', () => {
+    render(
+      chatPane({
+        messages: [userMessage('m1'), assistantMessage('m2', 7)],
+        activeConversationId: 'conv-1',
+      }),
+    );
+
+    const paints = safetyEvents('client_chat_first_paint');
+    expect(paints).toHaveLength(1);
+    expect(paints[0]?.message_count).toBe(2);
+    // Ships with markFirstPaint or the duration is a number nobody can
+    // attribute: a slow open is either "many messages" or "one message with
+    // hundreds of tool events behind it", and only this separates them.
+    expect(paints[0]?.stream_event_count).toBe(7);
+    expect(paints[0]?.virtualized).toBe(false);
+    expect(typeof paints[0]?.duration_ms).toBe('number');
+  });
+
+  it('reports the same virtualization verdict the renderer used', () => {
+    // Reverse anchor for the case above. The threshold lives in one predicate
+    // now; if telemetry ever grew its own copy this pair would stay green
+    // while the two drifted, so both sides of the threshold are pinned.
+    const many = Array.from({ length: 90 }, (_, i) => userMessage(`m${i}`));
+    render(chatPane({ messages: many, activeConversationId: 'conv-1' }));
+
+    const paints = safetyEvents('client_chat_first_paint');
+    expect(paints).toHaveLength(1);
+    expect(paints[0]?.virtualized).toBe(true);
+    expect(paints[0]?.message_count).toBe(90);
+  });
+
+  it('re-opens on a conversation switch even though React keeps the same node', () => {
+    // The chat log carries no conversation key, so React reuses the very same
+    // element across a switch. There is therefore NO node-level signal that
+    // the surface should be replaced — only the conversation id, which is why
+    // it has to be an effect dependency. This spec is the witness: it asserts
+    // node identity is unchanged AND that a second surface opened anyway.
+    const { container, rerender } = render(
+      chatPane({ messages: [userMessage('m1')], activeConversationId: 'conv-1' }),
+    );
+    const first = container.querySelector('[data-testid="chat-log"]');
+    expect(first).toBeTruthy();
+
+    rerender(chatPane({ messages: [userMessage('m9')], activeConversationId: 'conv-2' }));
+    const second = container.querySelector('[data-testid="chat-log"]');
+
+    expect(second).toBe(first);
+    const reasons = safetyEvents('client_chat_dom_growth').map((s) => s.sample_reason);
+    expect(reasons).toEqual(['conversation_open', 'conversation_open']);
+  });
+
+  it('lets go of the surface when the panel unmounts', () => {
+    // The leak this guards: observers and a 60s interval outliving the log
+    // they were watching. `chatSurfaceSample` is the module's own "is anything
+    // attached?" seam — after teardown it must have nothing to talk to.
+    const { unmount } = render(
+      chatPane({ messages: [userMessage('m1')], activeConversationId: 'conv-1' }),
+    );
+    expect(safetyEvents('client_chat_dom_growth')).toHaveLength(1);
+
+    unmount();
+    chatSurfaceSample('interval');
+
+    expect(safetyEvents('client_chat_dom_growth')).toHaveLength(1);
+  });
+
+  it('keeps exactly one surface attached across a re-open', () => {
+    // Reverse anchor for the teardown above: a detach that also cleared a
+    // LIVE surface (or a re-open that left the old one running) would show up
+    // here as zero or two samples from one call.
+    const { rerender } = render(
+      chatPane({ messages: [userMessage('m1')], activeConversationId: 'conv-1' }),
+    );
+    rerender(chatPane({ messages: [userMessage('m1')], activeConversationId: 'conv-2' }));
+
+    fetchMock.mockClear();
+    chatSurfaceSample('interval');
+
+    const samples = safetyEvents('client_chat_dom_growth');
+    expect(samples).toHaveLength(1);
+    expect(samples[0]?.sample_reason).toBe('interval');
+  });
+});

--- a/apps/web/tests/components/ChatPane.chat-health-surface.test.tsx
+++ b/apps/web/tests/components/ChatPane.chat-health-surface.test.tsx
@@ -168,6 +168,12 @@ describe('ChatPane — chat-health surface lifecycle', () => {
     const samples = safetyEvents('client_chat_dom_growth');
     expect(samples).toHaveLength(1);
     expect(samples[0]?.sample_reason).toBe('conversation_open');
+    // Correlation is set by ChatPane itself, so it is already on the very
+    // first beacon the surface sends — whichever of the three hosts mounted
+    // the panel. An event ordering that stamped it later would leave this one
+    // anonymous.
+    expect(samples[0]?.project_id).toBe('project-1');
+    expect(samples[0]?.conversation_id).toBe('conv-1');
   });
 
   it('measures first paint against the transcript it actually rendered', () => {
@@ -218,8 +224,14 @@ describe('ChatPane — chat-health surface lifecycle', () => {
     const second = container.querySelector('[data-testid="chat-log"]');
 
     expect(second).toBe(first);
-    const reasons = safetyEvents('client_chat_dom_growth').map((s) => s.sample_reason);
-    expect(reasons).toEqual(['conversation_open', 'conversation_open']);
+    const samples = safetyEvents('client_chat_dom_growth');
+    expect(samples.map((s) => s.sample_reason)).toEqual([
+      'conversation_open',
+      'conversation_open',
+    ]);
+    // …and the second one names the conversation the user switched TO, not
+    // the one they left.
+    expect(samples[1]?.conversation_id).toBe('conv-2');
   });
 
   it('lets go of the surface when the panel unmounts', () => {

--- a/apps/web/tests/components/ChatPane.run-failed-toast-message-key.test.tsx
+++ b/apps/web/tests/components/ChatPane.run-failed-toast-message-key.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+//
+// `run_failed_toast` records that a user was shown a failure card. Until now
+// it carried only `error_code` — the daemon's name for what went wrong — and
+// nothing about what the user actually READ.
+//
+// Those are two different facts separated by a mapping table, and the table is
+// always one row short: `resolveRunErrorCardDescription` says so in as many
+// words ("a lookup table can always be one row short"). When it is short, the
+// card falls back to a blank "the task failed" with no diagnosis — which is
+// the single worst impression this surface can produce, and the one we could
+// not count.
+//
+// So `message_key` names the sentence, and `generic_fallback` names its
+// absence. The fallback case must report a VALUE, not an omitted field: a rate
+// needs a denominator, and an omitted key drops the fallback impressions out
+// of the very count meant to measure them.
+
+import { cleanup, render } from '@testing-library/react';
+import { forwardRef } from 'react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { ChatPane } from '../../src/components/ChatPane';
+import { trackRunFailedToastSurfaceView } from '../../src/analytics/events';
+import type { AppConfig, ChatMessage } from '../../src/types';
+
+const translate = (key: string, vars?: Record<string, string | number>) => {
+  if (vars && Object.keys(vars).length > 0) {
+    return `${key} ${Object.values(vars).join(' ')}`;
+  }
+  return key;
+};
+
+vi.mock('../../src/i18n', () => ({
+  useI18n: () => ({ locale: 'en', setLocale: () => undefined, t: translate }),
+  useT: () => translate,
+}));
+
+vi.mock('../../src/components/ChatComposer', () => ({
+  ChatComposer: forwardRef((_props, _ref) => <div data-testid="composer" />),
+}));
+
+vi.mock('../../src/analytics/events', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/analytics/events')>();
+  return {
+    ...actual,
+    trackChatPanelClick: vi.fn(),
+    trackRunFailedToastSurfaceView: vi.fn(),
+    trackRunRecoveryActionClick: vi.fn(),
+    trackRunRecoveryActionSurfaceView: vi.fn(),
+  };
+});
+
+beforeAll(() => {
+  const store = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      clear: () => store.clear(),
+      getItem: (key: string) => store.get(key) ?? null,
+      removeItem: (key: string) => store.delete(key),
+      setItem: (key: string, value: string) => store.set(key, value),
+    },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function failedMessage(
+  code: string,
+  failureCategory?: string,
+): ChatMessage {
+  return {
+    id: 'msg-failed',
+    role: 'assistant',
+    content: 'Partial work.',
+    createdAt: 1,
+    runId: 'run-1',
+    runStatus: 'failed',
+    agentId: 'claude',
+    events: [
+      {
+        kind: 'status',
+        label: 'error',
+        detail: 'upstream said something unhelpful',
+        code,
+        ...(failureCategory ? { failureCategory } : {}),
+      },
+    ],
+  } as unknown as ChatMessage;
+}
+
+function renderChat(message: ChatMessage) {
+  return render(
+    <ChatPane
+      messages={[message]}
+      streaming={false}
+      error={null}
+      projectId="project-1"
+      projectFiles={[]}
+      onEnsureProject={async () => 'project-1'}
+      onSend={vi.fn()}
+      onStop={vi.fn()}
+      onRetry={vi.fn()}
+      conversations={[
+        { projectId: 'project-1', id: 'conv-1', title: 'Current', createdAt: 1, updatedAt: 1 },
+      ]}
+      activeConversationId="conv-1"
+      onSelectConversation={vi.fn()}
+      onDeleteConversation={vi.fn()}
+      config={{ agentId: 'claude', agentCliEnv: {} } as unknown as AppConfig}
+    />,
+  );
+}
+
+function reportedProps(): Record<string, unknown> {
+  const mock = vi.mocked(trackRunFailedToastSurfaceView);
+  expect(mock).toHaveBeenCalledTimes(1);
+  return mock.mock.calls[0]![1] as unknown as Record<string, unknown>;
+}
+
+describe('run_failed_toast — which sentence the user read', () => {
+  it('names the mapped copy when the table has a line for this failure', () => {
+    // AGENT_CLI_SESSION_REFUSED is mapped: the card renders a real diagnosis
+    // ("change the CLI build, then retry"), not the blank apology.
+    renderChat(failedMessage('AGENT_CLI_SESSION_REFUSED'));
+
+    expect(reportedProps().message_key).toBe('chat.runError.cliSessionRefusedMessage');
+  });
+
+  it('reports generic_fallback — a value, not a gap — when the table has none', () => {
+    // The impression that matters most: the user was told their task failed
+    // and given nothing else. Omitting the field here would erase exactly the
+    // numerator AND the denominator of the fallback rate.
+    renderChat(failedMessage('AGENT_EXECUTION_FAILED'));
+
+    const props = reportedProps();
+    expect(props.message_key).toBe('generic_fallback');
+    expect(Object.keys(props)).toContain('message_key');
+  });
+
+  it('carries the daemon classification when the failure event has one', () => {
+    renderChat(failedMessage('AGENT_EXECUTION_FAILED', 'upstream_unavailable'));
+
+    expect(reportedProps().failure_category).toBe('upstream_unavailable');
+  });
+
+  it("falls back to the enum's own unknown rather than dropping the field", () => {
+    // Reverse anchor for the previous case: a run whose error event carries no
+    // classification must still report a category, or the breakdown silently
+    // loses those impressions instead of showing them as unclassified.
+    renderChat(failedMessage('AGENT_EXECUTION_FAILED'));
+
+    const props = reportedProps();
+    expect(props.failure_category).toBe('unknown');
+    expect(Object.keys(props)).toContain('failure_category');
+  });
+
+  it('still reports the code and the run identity it always did', () => {
+    // Positive control: without this, deleting the whole call would keep every
+    // assertion above from ever running its subject.
+    renderChat(failedMessage('AGENT_CLI_SESSION_REFUSED'));
+
+    const props = reportedProps();
+    expect(props.error_code).toBe('AGENT_CLI_SESSION_REFUSED');
+    expect(props.element).toBe('run_failed_toast');
+    expect(props.run_id).toBe('run-1');
+    expect(props.conversation_id).toBe('conv-1');
+  });
+});

--- a/apps/web/tests/components/workspace/SideChatTab.chat-correlation.test.tsx
+++ b/apps/web/tests/components/workspace/SideChatTab.chat-correlation.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+//
+// `ChatPane` has three hosts — `ProjectView`, `DesignSystemFlow` and this one,
+// `workspace/SideChatTab`. They all render the same panel, feed the same
+// observability modules, and land on the same dashboard.
+//
+// The first cut of this wiring set `conversation_id` / `project_id` inside
+// ProjectView, after its transcript request resolved. Every `client_chat_*`
+// event from the other two hosts therefore went out naming no project and no
+// conversation — an orphan row on the same tile, indistinguishable from a
+// genuinely un-correlated one. Both hosts were already passing the two ids in
+// as props; the component boundary is where they belong.
+//
+// This spec renders the REAL ChatPane inside a non-ProjectView host and reads
+// the beacon, not the module state: an event that goes out anonymous is the
+// failure, so the assertion has to be on the event.
+
+import { cleanup, render } from '@testing-library/react';
+import { forwardRef } from 'react';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SideChatTab } from '../../../src/components/workspace/SideChatTab';
+import {
+  clearExceptionTrackingContext,
+  setExceptionTrackingContext,
+} from '../../../src/analytics/error-tracking';
+import { __resetChatContextForTest } from '../../../src/observability/chat-context';
+import { __resetChatHealthForTest } from '../../../src/observability/chat-health';
+import type { AppConfig, ChatMessage, Conversation } from '../../../src/types';
+
+const translate = (key: string) => key;
+
+vi.mock('../../../src/i18n', () => ({
+  useI18n: () => ({ locale: 'en', setLocale: () => undefined, t: translate }),
+  useT: () => translate,
+}));
+
+vi.mock('../../../src/components/Icon', () => ({
+  Icon: () => <span data-testid="icon" />,
+}));
+
+vi.mock('../../../src/components/AssistantMessage', () => ({
+  AssistantMessage: ({ message }: { message: ChatMessage }) => (
+    <div data-testid={`assistant-${message.id}`}>{message.content}</div>
+  ),
+}));
+
+vi.mock('../../../src/components/ChatComposer', () => ({
+  ChatComposer: forwardRef((_props, _ref) => <div data-testid="composer" />),
+}));
+
+vi.mock('../../../src/analytics/events', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/analytics/events')>();
+  return {
+    ...actual,
+    trackChatPanelClick: vi.fn(),
+    trackRunFailedToastSurfaceView: vi.fn(),
+  };
+});
+
+vi.mock('../../../src/components/workspace/useConversationChat', () => ({
+  useConversationChat: () => ({
+    messages: [
+      { id: 'm1', role: 'user', content: 'hello', createdAt: 1 },
+    ] as ChatMessage[],
+    streaming: false,
+    loading: false,
+    sendDisabled: true,
+    error: null,
+    onSend: vi.fn(),
+    onStop: vi.fn(),
+  }),
+}));
+
+const fetchMock = vi.fn();
+const ORIGINAL_FETCH = globalThis.fetch;
+
+beforeAll(() => {
+  const store = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      clear: () => store.clear(),
+      getItem: (key: string) => store.get(key) ?? null,
+      removeItem: (key: string) => store.delete(key),
+      setItem: (key: string, value: string) => store.set(key, value),
+    },
+  });
+});
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(new Response('', { status: 200 }));
+  globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  setExceptionTrackingContext({
+    apiKey: 'phc_test',
+    host: 'https://us.i.posthog.com',
+    distinctId: 'side-chat-correlation-test',
+  });
+  __resetChatHealthForTest();
+  __resetChatContextForTest();
+});
+
+afterEach(() => {
+  cleanup();
+  __resetChatHealthForTest();
+  __resetChatContextForTest();
+  clearExceptionTrackingContext();
+  globalThis.fetch = ORIGINAL_FETCH;
+  vi.clearAllMocks();
+});
+
+function safetyEvents(name: string): Array<Record<string, unknown>> {
+  const decoded: Array<{ event?: string; properties?: Record<string, unknown> }> = [];
+  for (const call of fetchMock.mock.calls) {
+    const init = call[1] as RequestInit | undefined;
+    if (typeof init?.body !== 'string') continue;
+    try {
+      decoded.push(JSON.parse(init.body) as { event?: string; properties?: Record<string, unknown> });
+    } catch {
+      // not a telemetry beacon
+    }
+  }
+  return decoded.filter((e) => e.event === name).map((e) => e.properties ?? {});
+}
+
+const conversations = [
+  {
+    id: 'conv-side',
+    title: 'Side chat',
+    createdAt: 1,
+    updatedAt: 1,
+    projectId: 'project-side',
+    messageCount: 1,
+    sessionMode: 'design',
+  },
+] as unknown as Conversation[];
+
+function renderSideChat() {
+  return render(
+    <SideChatTab
+      projectId="project-side"
+      conversationId="conv-side"
+      config={{ mode: 'daemon', agentCliEnv: {} } as unknown as AppConfig}
+      agentsById={new Map()}
+      locale="en"
+      projectFiles={[]}
+      conversations={conversations}
+      onSelectConversation={vi.fn()}
+      onDeleteConversation={vi.fn()}
+    />,
+  );
+}
+
+describe('SideChatTab — chat telemetry knows which conversation it is in', () => {
+  it('stamps the project and conversation on the events it emits', () => {
+    renderSideChat();
+
+    const samples = safetyEvents('client_chat_dom_growth');
+    expect(samples).toHaveLength(1);
+    expect(samples[0]?.project_id).toBe('project-side');
+    expect(samples[0]?.conversation_id).toBe('conv-side');
+  });
+
+  it('carries the same identity on first paint', () => {
+    // First paint is the event a triager reaches for when someone says the
+    // panel was slow to open; without these two it names no subject at all.
+    renderSideChat();
+
+    const paints = safetyEvents('client_chat_first_paint');
+    expect(paints).toHaveLength(1);
+    expect(paints[0]?.project_id).toBe('project-side');
+    expect(paints[0]?.conversation_id).toBe('conv-side');
+  });
+});

--- a/apps/web/tests/observability/chat-correlation-boot.test.ts
+++ b/apps/web/tests/observability/chat-correlation-boot.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The two boot-time halves of the chat correlation block.
+ *
+ * `replay_session_id` and `release_channel` are the fields that turn a
+ * `client_chat_*` row from a number into something a triager can act on — one
+ * opens the session replay, the other separates "the packaged stable build is
+ * janky" from "a dev daemon is janky". Both had a producer sitting one line
+ * away from a value that was already in hand, and neither was ever called.
+ *
+ * `registerChatReplaySessionSource` in particular is a trap with no failure
+ * mode: we load posthog-js through `await import('posthog-js')`, whose ESM
+ * build never publishes itself as `window.posthog`, so the global-lookup
+ * fallback silently returns undefined forever and every replay link on the
+ * dashboard is dead while the code reads as implemented.
+ */
+
+let lastRegisterPayload: Record<string, unknown> | null = null;
+
+vi.mock('posthog-js', () => {
+  const stub = {
+    init: (_key: string, config: Record<string, unknown>) => {
+      const loaded = config.loaded as ((i: unknown) => void) | undefined;
+      loaded?.(stub);
+      return stub;
+    },
+    register: (payload: Record<string, unknown>) => {
+      lastRegisterPayload = payload;
+    },
+    setPersonProperties: () => undefined,
+    opt_in_capturing: () => undefined,
+    opt_out_capturing: () => undefined,
+    reset: () => undefined,
+    identify: () => undefined,
+    get_session_id: () => 'replay-sess-1',
+  };
+  return { default: stub };
+});
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+beforeEach(() => {
+  lastRegisterPayload = null;
+  vi.resetModules();
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    if (url.endsWith('/api/analytics/config')) {
+      return new Response(
+        JSON.stringify({
+          enabled: true,
+          env: 'local_development',
+          key: 'phc_test_key',
+          host: 'https://us.i.posthog.com',
+          installationId: 'install-123',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }
+    if (url.endsWith('/api/version')) {
+      return new Response(
+        JSON.stringify({
+          version: {
+            version: '1.2.3',
+            channel: 'prerelease',
+            packaged: true,
+            platform: 'darwin',
+            arch: 'arm64',
+          },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }
+    return new Response('not found', { status: 404 });
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  vi.restoreAllMocks();
+});
+
+describe('chat correlation — boot-time identity', () => {
+  it('takes the replay session id from the posthog instance, not from a global', async () => {
+    const { getAnalyticsClient } = await import('../../src/analytics/client');
+    const { chatCorrelation } = await import('../../src/observability/chat-context');
+
+    // No `window.posthog` on purpose: that is exactly the shape production
+    // runs in, and the shape the global-lookup fallback cannot serve.
+    expect((globalThis as { posthog?: unknown }).posthog).toBeUndefined();
+
+    await getAnalyticsClient({
+      anonymousId: 'anon-1',
+      sessionId: 'sess-1',
+      clientType: 'web',
+      locale: 'en',
+      appVersion: '1.2.3',
+    });
+
+    expect(lastRegisterPayload).not.toBeNull();
+    expect(chatCorrelation().replay_session_id).toBe('replay-sess-1');
+  });
+
+  it('keeps the release channel the daemon already answers with', async () => {
+    const { resolveAppVersionForCapture } = await import('../../src/analytics/provider');
+    const { chatCorrelation } = await import('../../src/observability/chat-context');
+
+    await resolveAppVersionForCapture('0.0.0');
+
+    expect(chatCorrelation().release_channel).toBe('prerelease');
+  });
+});

--- a/apps/web/tests/observability/chat-correlation-wiring.test.ts
+++ b/apps/web/tests/observability/chat-correlation-wiring.test.ts
@@ -1,0 +1,349 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearExceptionTrackingContext,
+  setExceptionTrackingContext,
+} from '../../src/analytics/error-tracking';
+import {
+  __resetChatContextForTest,
+  chatCorrelation,
+} from '../../src/observability/chat-context';
+import {
+  __resetChatInteractionForTest,
+  installChatInteractionObserver,
+} from '../../src/observability/chat-interaction';
+import { reattachDaemonRun, streamViaDaemon } from '../../src/providers/daemon';
+
+/**
+ * These specs are about WIRING, not about the observability modules.
+ *
+ * `chat-context.ts` and `chat-interaction.ts` both already have unit specs and
+ * both are green — because those specs call `setChatCorrelation()` themselves.
+ * In production nobody did. The result was a dashboard that looked healthy
+ * while being wrong in a specific, self-consistent way: the
+ * `client_chat_interaction_latency` event derives `streaming` from
+ * `chatCorrelation().run_id`, so with no producer the flag was false on every
+ * event ever sent, and the panel read "every chat stall happens while the app
+ * sits idle".
+ *
+ * So every assertion below drives a REAL production entry point
+ * (`streamViaDaemon` / `reattachDaemonRun`) and reads the correlation back out
+ * the way an outgoing event would. A spec that reached for
+ * `setChatCorrelation` itself would re-create the exact hole it exists to
+ * close.
+ */
+
+const fetchMock = vi.fn();
+const ORIGINAL_FETCH = globalThis.fetch;
+
+let eventCallbacks: Array<(list: { getEntries: () => unknown[] }) => void> = [];
+
+class FakePerformanceObserver {
+  static supportedEntryTypes = ['event', 'longtask'];
+  private readonly cb: (list: { getEntries: () => unknown[] }) => void;
+  constructor(cb: (list: { getEntries: () => unknown[] }) => void) {
+    this.cb = cb;
+  }
+  observe(options: { type?: string }): void {
+    if (options?.type === 'event') eventCallbacks.push(this.cb);
+  }
+  disconnect(): void {
+    eventCallbacks = eventCallbacks.filter((c) => c !== this.cb);
+  }
+  takeRecords(): unknown[] {
+    return [];
+  }
+}
+
+/** A slow keystroke inside the chat composer, as the browser would report it. */
+function emitSlowInteraction(target: Element): void {
+  for (const cb of eventCallbacks) {
+    cb({ getEntries: () => [{ name: 'keydown', duration: 640, target, entryType: 'event' }] });
+  }
+}
+
+/** Safety-telemetry beacons, decoded off the transport `reportSafetyEvent` uses. */
+function safetyEvents(name: string): Array<Record<string, unknown>> {
+  const decoded: Array<{ event?: string; properties?: Record<string, unknown> }> = [];
+  for (const call of fetchMock.mock.calls) {
+    const init = call[1] as RequestInit | undefined;
+    if (typeof init?.body !== 'string') continue;
+    try {
+      decoded.push(JSON.parse(init.body) as { event?: string; properties?: Record<string, unknown> });
+    } catch {
+      // Not a telemetry beacon (run-create bodies land here too).
+    }
+  }
+  return decoded.filter((e) => e.event === name).map((e) => e.properties ?? {});
+}
+
+function composerTarget(): Element {
+  const composer = document.createElement('div');
+  composer.setAttribute('data-testid', 'chat-composer');
+  const textarea = document.createElement('textarea');
+  composer.appendChild(textarea);
+  document.body.append(composer);
+  return textarea;
+}
+
+function sseResponse(text: string): Response {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(text));
+        controller.close();
+      },
+    }),
+    { status: 200, headers: { 'content-type': 'text/event-stream' } },
+  );
+}
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 202,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function daemonHandlers(onDelta?: () => void) {
+  return {
+    onDelta: vi.fn(onDelta),
+    onDone: vi.fn(),
+    onError: vi.fn(),
+    onAgentEvent: vi.fn(),
+  };
+}
+
+const strategy = {
+  id: 'od-next-strategy',
+  version: '2.0.0',
+  packageHash: 'a'.repeat(64),
+  snapshotId: 'snapshot-1',
+};
+
+const requestProjection = {
+  taskExecutionId: 'task-1',
+  strategy,
+  inputStage: 'request',
+  outcome: 'running',
+  route: 'full_plan',
+  executionMode: null,
+  activeRunId: 'run-request',
+  terminal: false,
+};
+
+const productionProjection = {
+  ...requestProjection,
+  inputStage: 'production',
+  outcome: 'running',
+  executionMode: 'simple',
+  activeRunId: 'run-production',
+  nextRunId: 'run-production',
+};
+
+const completedProjection = {
+  ...productionProjection,
+  outcome: 'completed',
+  terminal: true,
+  nextRunId: undefined,
+};
+
+beforeEach(() => {
+  eventCallbacks = [];
+  document.body.innerHTML = '';
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(new Response('', { status: 200 }));
+  globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  setExceptionTrackingContext({
+    apiKey: 'phc_test',
+    host: 'https://us.i.posthog.com',
+    distinctId: 'chat-correlation-wiring-test',
+  });
+  (globalThis as unknown as { PerformanceObserver: unknown }).PerformanceObserver =
+    FakePerformanceObserver;
+  __resetChatContextForTest();
+  __resetChatInteractionForTest();
+});
+
+afterEach(() => {
+  __resetChatContextForTest();
+  __resetChatInteractionForTest();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  clearExceptionTrackingContext();
+  globalThis.fetch = ORIGINAL_FETCH;
+  document.body.innerHTML = '';
+});
+
+describe('chat correlation — run lifecycle', () => {
+  it('names the run while it streams and lets go of it when it ends', async () => {
+    const seen: Array<{ run_id?: string; agent_id?: string }> = [];
+    const handlers = daemonHandlers(() => {
+      const { run_id, agent_id } = chatCorrelation();
+      seen.push({ run_id, agent_id });
+    });
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/runs') return jsonResponse({ runId: 'run-live' });
+      if (url === '/api/runs/run-live/events') {
+        return sseResponse(
+          'event: stdout\ndata: {"chunk":"hi"}\n\nevent: end\ndata: {"code":0,"status":"succeeded"}\n\n',
+        );
+      }
+      return new Response('', { status: 200 });
+    });
+
+    await streamViaDaemon({
+      agentId: 'claude',
+      history: [{ id: '1', role: 'user', content: 'go' }],
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    // Mid-run: the block a `client_chat_*` event would have spread.
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen[0]?.run_id).toBe('run-live');
+    expect(seen[0]?.agent_id).toBe('claude');
+    // Terminal: released, so nothing after the run is attributed to it. This
+    // half matters more than the first — a run id that is never let go makes
+    // every later event claim a run that finished hours ago, and makes
+    // `streaming` permanently true.
+    expect(chatCorrelation().run_id).toBeUndefined();
+  });
+
+  it('re-points at the next run of a strategy-task chain instead of the one that ended', async () => {
+    // A chained run is a run start like any other. Miss it and every stall in
+    // the rest of the chain is filed under the run that already finished.
+    const seen: string[] = [];
+    const handlers = daemonHandlers(() => {
+      const id = chatCorrelation().run_id;
+      if (id && seen[seen.length - 1] !== id) seen.push(id);
+    });
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/runs') {
+        return jsonResponse({
+          runId: 'run-request',
+          taskExecutionId: 'task-1',
+          strategyTask: requestProjection,
+        });
+      }
+      if (url === '/api/runs/run-request/events') {
+        return sseResponse(
+          `event: stdout\ndata: {"chunk":"plan"}\n\nevent: end\ndata: ${JSON.stringify({
+            code: 0,
+            status: 'succeeded',
+            strategyTask: productionProjection,
+          })}\n\n`,
+        );
+      }
+      if (url === '/api/runs/run-production/events') {
+        return sseResponse(
+          `event: stdout\ndata: {"chunk":"build"}\n\nevent: end\ndata: ${JSON.stringify({
+            code: 0,
+            status: 'succeeded',
+            strategyTask: completedProjection,
+          })}\n\n`,
+        );
+      }
+      return new Response('', { status: 200 });
+    });
+
+    await streamViaDaemon({
+      agentId: 'mock',
+      history: [{ id: '1', role: 'user', content: 'go' }],
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    expect(seen).toEqual(['run-request', 'run-production']);
+    expect(chatCorrelation().run_id).toBeUndefined();
+  });
+
+  it('correlates a run picked back up after a refresh', async () => {
+    // Reattach is how a reload gets back onto a run that is still in flight —
+    // the moment the panel is most likely to be janky, and the one path with
+    // no run-start signal of its own.
+    const seen: Array<{ run_id?: string; agent_id?: string }> = [];
+    const handlers = daemonHandlers(() => {
+      const { run_id, agent_id } = chatCorrelation();
+      seen.push({ run_id, agent_id });
+    });
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/runs/run-resumed/events') {
+        return sseResponse(
+          'event: stdout\ndata: {"chunk":"back"}\n\nevent: end\ndata: {"code":0,"status":"succeeded"}\n\n',
+        );
+      }
+      return new Response('', { status: 200 });
+    });
+
+    await reattachDaemonRun({
+      agentId: 'codex',
+      runId: 'run-resumed',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    expect(seen[0]?.run_id).toBe('run-resumed');
+    expect(seen[0]?.agent_id).toBe('codex');
+    expect(chatCorrelation().run_id).toBeUndefined();
+  });
+});
+
+describe('client_chat_interaction_latency — the streaming breakdown', () => {
+  it('calls a mid-run stall streaming and an idle one not', async () => {
+    // THE reason this change exists. `streaming` is the whole point of the
+    // event ("the same UI can be fine at rest and unusable mid-run"), and with
+    // no producer for `run_id` it was false on every event in production — a
+    // self-consistent, wrong story. Both directions are asserted on purpose:
+    // a "fix" that hard-wired `streaming` to true would pass the first half
+    // and fail the second.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const target = composerTarget();
+    installChatInteractionObserver();
+
+    const handlers = daemonHandlers(() => {
+      emitSlowInteraction(target);
+      // Close the 30s reporting window from inside the run.
+      vi.advanceTimersByTime(30_000);
+    });
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/runs') return jsonResponse({ runId: 'run-live' });
+      if (url === '/api/runs/run-live/events') {
+        return sseResponse(
+          'event: stdout\ndata: {"chunk":"hi"}\n\nevent: end\ndata: {"code":0,"status":"succeeded"}\n\n',
+        );
+      }
+      return new Response('', { status: 200 });
+    });
+
+    await streamViaDaemon({
+      agentId: 'claude',
+      history: [{ id: '1', role: 'user', content: 'go' }],
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    // The same interaction, on the same element, once the run is over.
+    emitSlowInteraction(target);
+    vi.advanceTimersByTime(30_000);
+
+    const events = safetyEvents('client_chat_interaction_latency');
+    expect(events).toHaveLength(2);
+    expect(events[0]?.streaming).toBe(true);
+    expect(events[0]?.run_id).toBe('run-live');
+    expect(events[0]?.agent_id).toBe('claude');
+    expect(events[1]?.streaming).toBe(false);
+    expect(events[1]?.run_id).toBeUndefined();
+  });
+});

--- a/apps/web/tests/observability/chat-health-wiring.test.ts
+++ b/apps/web/tests/observability/chat-health-wiring.test.ts
@@ -1,0 +1,250 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearExceptionTrackingContext,
+  setExceptionTrackingContext,
+} from '../../src/analytics/error-tracking';
+import { __resetChatContextForTest } from '../../src/observability/chat-context';
+import {
+  __resetChatHealthForTest,
+  openChatSurface,
+} from '../../src/observability/chat-health';
+import { streamViaDaemon } from '../../src/providers/daemon';
+
+/**
+ * `client_chat_stream_health` is the one chat-health event that is EMITTED by
+ * the run lifecycle rather than by a timer, which gives it two failure modes
+ * the other three do not have — and both were live in the first cut of this
+ * wiring:
+ *
+ *   1. The flush happens inside `chatSurfaceRunEnded`, and the event spreads
+ *      `chatCorrelation()`. Clearing the correlation first shipped the event
+ *      with an empty `run_id` — a chat event that cannot name the run it just
+ *      measured, which is the exact defect this whole change exists to remove.
+ *
+ *   2. A surface is recreated on every conversation switch and every return to
+ *      the Chat tab, but `chatSurfaceRunStarted` only ever reached the surface
+ *      that existed when the provider fired it. A surface opened mid-run
+ *      therefore believed nothing was running, kept its window shut, and threw
+ *      away every long task until the next run started — the exact stretch a
+ *      user is watching when they come back to see something generate.
+ *
+ * Both are asserted through the beacons the module actually sends, driven from
+ * the real `streamViaDaemon` entry point.
+ */
+
+const fetchMock = vi.fn();
+const ORIGINAL_FETCH = globalThis.fetch;
+
+let longTaskCallbacks: Array<(list: { getEntries: () => unknown[] }) => void> = [];
+
+class FakePerformanceObserver {
+  static supportedEntryTypes = ['longtask', 'event'];
+  private readonly cb: (list: { getEntries: () => unknown[] }) => void;
+  constructor(cb: (list: { getEntries: () => unknown[] }) => void) {
+    this.cb = cb;
+  }
+  observe(options: { type?: string }): void {
+    if (options?.type === 'longtask') longTaskCallbacks.push(this.cb);
+  }
+  disconnect(): void {
+    longTaskCallbacks = longTaskCallbacks.filter((c) => c !== this.cb);
+  }
+  takeRecords(): unknown[] {
+    return [];
+  }
+}
+
+function emitLongTask(durationMs: number): void {
+  const entry = { duration: durationMs, startTime: 0, name: 'self', entryType: 'longtask' };
+  for (const cb of [...longTaskCallbacks]) cb({ getEntries: () => [entry] });
+}
+
+function safetyEvents(name: string): Array<Record<string, unknown>> {
+  const decoded: Array<{ event?: string; properties?: Record<string, unknown> }> = [];
+  for (const call of fetchMock.mock.calls) {
+    const init = call[1] as RequestInit | undefined;
+    if (typeof init?.body !== 'string') continue;
+    try {
+      decoded.push(JSON.parse(init.body) as { event?: string; properties?: Record<string, unknown> });
+    } catch {
+      // not a telemetry beacon
+    }
+  }
+  return decoded.filter((e) => e.event === name).map((e) => e.properties ?? {});
+}
+
+function chatLogElement(): HTMLElement {
+  const log = document.createElement('div');
+  log.setAttribute('data-testid', 'chat-log');
+  log.appendChild(document.createElement('div'));
+  document.body.append(log);
+  return log;
+}
+
+function sseResponse(text: string): Response {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(text));
+        controller.close();
+      },
+    }),
+    { status: 200, headers: { 'content-type': 'text/event-stream' } },
+  );
+}
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 202,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function daemonHandlers(onDelta?: () => void) {
+  return {
+    onDelta: vi.fn(onDelta),
+    onDone: vi.fn(),
+    onError: vi.fn(),
+    onAgentEvent: vi.fn(),
+  };
+}
+
+function serveOneRun(): void {
+  fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url === '/api/runs') return jsonResponse({ runId: 'run-live' });
+    if (url === '/api/runs/run-live/events') {
+      return sseResponse(
+        'event: stdout\ndata: {"chunk":"hi"}\n\nevent: end\ndata: {"code":0,"status":"succeeded"}\n\n',
+      );
+    }
+    return new Response('', { status: 200 });
+  });
+}
+
+async function runOneTurn(handlers: ReturnType<typeof daemonHandlers>): Promise<void> {
+  await streamViaDaemon({
+    agentId: 'claude',
+    history: [{ id: '1', role: 'user', content: 'go' }],
+    signal: new AbortController().signal,
+    handlers,
+  });
+}
+
+beforeEach(() => {
+  longTaskCallbacks = [];
+  document.body.innerHTML = '';
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(new Response('', { status: 200 }));
+  globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  setExceptionTrackingContext({
+    apiKey: 'phc_test',
+    host: 'https://us.i.posthog.com',
+    distinctId: 'chat-health-wiring-test',
+  });
+  (globalThis as unknown as { PerformanceObserver: unknown }).PerformanceObserver =
+    FakePerformanceObserver;
+  __resetChatHealthForTest();
+  __resetChatContextForTest();
+});
+
+afterEach(() => {
+  __resetChatHealthForTest();
+  __resetChatContextForTest();
+  vi.restoreAllMocks();
+  clearExceptionTrackingContext();
+  globalThis.fetch = ORIGINAL_FETCH;
+  document.body.innerHTML = '';
+});
+
+describe('client_chat_stream_health — the flush must still know its run', () => {
+  it('names the run it just measured', async () => {
+    // The terminal path clears the correlation AND flushes the jank window.
+    // Do them in the wrong order and this event goes out anonymous — the very
+    // shape of bug the rest of this change removes.
+    openChatSurface({ element: chatLogElement(), messageCount: 1, virtualized: false });
+    serveOneRun();
+
+    await runOneTurn(daemonHandlers(() => emitLongTask(320)));
+
+    const health = safetyEvents('client_chat_stream_health');
+    expect(health).toHaveLength(1);
+    expect(health[0]?.run_id).toBe('run-live');
+    expect(health[0]?.agent_id).toBe('claude');
+    expect(health[0]?.run_completed).toBe(true);
+    expect(health[0]?.long_task_count).toBe(1);
+  });
+
+  it('still lets go of the run once the flush is done', async () => {
+    // Reverse anchor for the reordering: moving the chat-health call ahead of
+    // the correlation clear must not skip the clear. Without this, "carries a
+    // run id" would also pass on an implementation that never releases it —
+    // which is the mirror-image bug, and the one that makes `streaming` true
+    // forever.
+    openChatSurface({ element: chatLogElement(), messageCount: 1, virtualized: false });
+    serveOneRun();
+
+    await runOneTurn(daemonHandlers(() => emitLongTask(320)));
+
+    fetchMock.mockClear();
+    // A second surface opened after the run is over must find nothing in
+    // flight to adopt, so its window stays shut and a stray long task is
+    // attributed to nobody.
+    openChatSurface({ element: chatLogElement(), messageCount: 1, virtualized: false });
+    emitLongTask(900);
+
+    expect(safetyEvents('client_chat_stream_health')).toHaveLength(0);
+  });
+});
+
+describe('a surface opened mid-run adopts the run', () => {
+  it('keeps measuring after the user leaves the tab and comes back', async () => {
+    // Three long tasks, split by a surface swap in the middle: one before, two
+    // after. Without adoption the second surface never opens a window and the
+    // last two are dropped on the floor — exactly the stretch the user came
+    // back to watch.
+    const el = chatLogElement();
+    openChatSurface({ element: el, messageCount: 1, virtualized: false });
+    serveOneRun();
+
+    let swapped = false;
+    await runOneTurn(
+      daemonHandlers(() => {
+        if (swapped) return;
+        swapped = true;
+        emitLongTask(300);
+        // The user switched conversation (or left Chat and came back): React
+        // hands the same node to a brand-new surface.
+        openChatSurface({ element: el, messageCount: 1, virtualized: false });
+        emitLongTask(400);
+        emitLongTask(500);
+      }),
+    );
+
+    const health = safetyEvents('client_chat_stream_health');
+    expect(health).toHaveLength(2);
+    // The surface that was torn down mid-run keeps what it saw, marked as an
+    // unfinished window.
+    expect(health[0]).toMatchObject({
+      run_id: 'run-live',
+      run_completed: false,
+      long_task_count: 1,
+    });
+    // The surface that took over carries the rest, and sees the run end.
+    expect(health[1]).toMatchObject({
+      run_id: 'run-live',
+      run_completed: true,
+      long_task_count: 2,
+    });
+    // Anti-double-count: three tasks emitted, three accounted for. Adoption
+    // must open a window on the NEW surface only — re-running it against a
+    // surface that already had the run would inflate these.
+    expect(
+      Number(health[0]?.long_task_count) + Number(health[1]?.long_task_count),
+    ).toBe(3);
+  });
+});

--- a/packages/contracts/src/analytics/events/surface-view.ts
+++ b/packages/contracts/src/analytics/events/surface-view.ts
@@ -4,7 +4,7 @@
  */
 import type { TrackingOnboardingFirstLoopStep, TrackingOnboardingProductType, TrackingOnboardingRole, TrackingOnboardingUseCase } from './onboarding.js';
 import type { TrackingRunRecoveryActionType } from './result-events.js';
-import type { TrackingArtifactKind, TrackingCampaignDeliveryMode, TrackingCampaignId, TrackingCampaignUserState, TrackingNewProjectTab, TrackingProjectKind } from './shared-enums.js';
+import type { TrackingArtifactKind, TrackingCampaignDeliveryMode, TrackingCampaignId, TrackingCampaignUserState, TrackingNewProjectTab, TrackingProjectKind, TrackingRunFailureCategory } from './shared-enums.js';
 import type { DesignSystemsPresetBrandPickerSurfaceViewProps } from './ui-click.js';
 import type { WorkspaceSurfaceViewProps } from './workspace.js';
 // ---- surface_view --------------------------------------------------------
@@ -123,6 +123,28 @@ export interface RunFailedToastSurfaceViewProps {
   area: 'chat_panel';
   element: 'run_failed_toast';
   error_code: string;
+  /**
+   * WHICH SENTENCE the user actually read: the i18n key of the mapped copy,
+   * or `generic_fallback` when the mapping table had no line for this failure
+   * and the card fell back to "the task failed".
+   *
+   * Always present, never omitted. The fallback rate — how often we show a
+   * failed user a blank apology instead of a diagnosis — is the whole point,
+   * and a rate needs a denominator: an omitted key would silently drop the
+   * fallback impressions out of the count that is supposed to measure them.
+   *
+   * Not typed as the web's `RunFailureMessageKey` union: that union lives in
+   * `apps/web` and grows every time copy is added, and pinning it here would
+   * make a copy change a contracts change.
+   */
+  message_key: string;
+  /**
+   * The daemon's own classification of the failure, as carried on the run's
+   * error event. `unknown` when the event carries none — the enum's existing
+   * member for exactly that, so the field stays present and the shape stays
+   * one that `run_finished` / `run_recovery_action` can be joined against.
+   */
+  failure_category: TrackingRunFailureCategory;
   project_id: string;
   project_kind: TrackingProjectKind | null;
   conversation_id: string | null;


### PR DESCRIPTION
## Why

**The code has been there since #7518. Nothing ever called it.**

I went to read the ChatPanel observability dashboard and found 13 of its 15 tiles empty. `apps/web/src/observability/chat-health.ts` (first paint / stream health / memory pressure / DOM growth) and `chat-protocol.ts` both export functions with **zero references anywhere in `apps/web/src` outside themselves and their own unit specs**. Over the last 30 days those five events produced **0 rows** in production.

That is the boring half. The dangerous half is the one tile that *does* have data.

`client_chat_interaction_latency` has 2,694 events in the same window — it is wired. But its `streaming` flag is derived, on purpose, from the correlation context:

```ts
// chat-interaction.ts
function isStreaming(): boolean { return chatCorrelation().run_id != null; }
```

…and `setChatCorrelation()` had **no production caller at all**. So `run_id` was never set, `streaming` was `false` on all 2,694 events, and the dashboard reported — confidently, self-consistently, and wrongly — that **every chat stall happens while the app is sitting idle**. `streaming` is the entire point of that event ("the same UI can be fine at rest and unusable mid-run"); with it stuck false the metric was worse than no metric. The same hole also hit the already-wired `client_chat_scroll_frozen`, which was arriving with no project, conversation, agent or run id attached.

This PR wires the producers. Three commits, each with its own red spec, so a rollback can be surgical.

## What users will see

Nothing. No UI, no new user-facing behavior, no new event names in commits 1 and 3 — commit 1 in particular adds **zero** events; it only makes the traffic already being sent tell the truth about itself. Commit 2 adds two properties to an existing consent-gated `surface_view`.

What the *team* sees: chat first-paint / DOM-growth / heap-pressure / stream-health tiles start filling, `streaming` starts splitting into two real populations, and every `client_chat_*` row can be pivoted to a conversation, project, run, agent, release channel and session replay.

### Commit 1 — `feat(web): make chat telemetry name the run it is talking about`

Four producers, each with its value already in hand one line away:

| producer | where |
|---|---|
| `run_id` + `agent_id`, opened | run start in `streamViaDaemon`; the next physical run of a strategy-task chain; `reattachDaemonRun` (the path a page refresh takes back onto an in-flight run) |
| `run_id`, cleared | the same `finally` that settles the stuck-run watchdog |
| `conversation_id` + `project_id` | once `listMessages` resolves in `ProjectView` |
| `release_channel` | `/api/version` — the daemon has always answered with `channel`; web read `version` and dropped the rest |
| `replay_session_id` | handed over from the posthog-js instance inside `loaded()` |

The open/close pair is behind two named helpers because it is genuinely load-bearing in both directions: only an opener and `streaming` is stuck true forever, only a closer and it is stuck false — which is the bug we are here to fix, mirrored.

The replay registration is the subtle one. We load posthog-js via `await import('posthog-js')`, and the ESM build (unlike the landing page's `array.js` snippet) never publishes itself as `window.posthog`. So the "obvious" `globalThis.posthog.get_session_id()` fallback returns `undefined` forever while reading as implemented. `loaded()` is the only possible source.

`model_id` is deliberately left absent — it is not in scope at either run-start site and stamping a guess would be worse than the gap.

### Commit 2 — `feat(analytics): record which failure sentence the user actually read`

`run_failed_toast` recorded `error_code` — the daemon's name for what broke — and nothing about what the user *read*. Those are two different facts with a mapping table between them, and `resolveRunErrorCardDescription` says in as many words that the table can always be one row short. When it is short, the card degrades to a blank "the task failed" with no diagnosis. That is the single worst impression this surface can produce and it was the one we could not count.

- `message_key` — the mapped copy's i18n key, or `generic_fallback` when the table had none. **Always present, never omitted**: the fallback *rate* is what matters, a rate needs a denominator, and an omitted key would drop the fallback impressions out of the very count meant to measure them.
- `failure_category` — the daemon's classification off the run's error event, defaulting to the enum's existing `unknown` member rather than vanishing, so this event stays joinable against `run_finished` and `run_recovery_action`.

Typed as `string` rather than the web's `RunFailureMessageKey` union on purpose: that union lives in `apps/web` and grows with every copy change, and pinning it in contracts would turn "add a sentence" into a contracts change.

Followed the `open-design-tracking` flow: contracts + web + backfilled row 103 of the Feishu 埋点文档 (`MUu2Au`) with both new params.

### Commit 3 — `feat(web): attach the chat-health monitor to the chat log`

Opens a `chat-health` surface on the `.chat-log` element while the Chat tab is showing it, and tears it down when it goes away.

Two effect dependencies, each guarding a real failure mode:

- **`tab`** — the log is conditionally rendered, so `logRef.current` is `null` on the Comments tab. Without it, coming back to Chat never reattaches.
- **`activeConversationId`** — that div carries **no conversation key**, so React reuses the very same DOM node across a switch. There is no node-level signal that the surface should be replaced; the id is the only one there is. The spec pins exactly this: it asserts the node identity is *unchanged* **and** that a second surface opened anyway.

`markFirstPaint` ships together with `setStreamEventCount`, deliberately — a first-paint duration on its own cannot be attributed, because a slow open is either "many messages" or "one message with hundreds of tool events behind it", and only the event count separates them. `rendered_row_count` reuses the same `:scope > *` definition `client_chat_dom_growth` already uses so the two events are comparable.

Also extracts `isChatVirtualized()` so the renderer and the telemetry read one predicate. Two copies of `items.length > THRESHOLD` are identical today and drift the first time the rule grows a second term — at which point the telemetry would be describing a render mode the renderer no longer uses, and nothing would say so.

**`markChatOpenIntent` is deliberately NOT wired here.** The spec suggests hanging it off the two conversation handlers, but that only covers `conversation_switch`: `project_switch` has 10+ navigate sites in `App.tsx` and `cold_boot` passes through no handler at all. The right home is `router.ts` — the single navigation entry point, which can derive the open kind from the route transition. That is its own change. Until then `open_kind` honestly reads `remount` rather than a fabricated `cold_boot`.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — two new required properties on `RunFailedToastSurfaceViewProps` in `packages/contracts`
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

No UI surface is touched, so the dual-track UI/CLI rule does not apply: this is client-side telemetry emission with no user-invocable capability behind it.

## Screenshots

N/A — no UI change.

## Bug fix verification

Each commit carries its own red spec, and each was verified red by **removing that commit's implementation and re-running**, then restored.

| commit | spec | red without the implementation |
|---|---|---|
| 1 | `apps/web/tests/observability/chat-correlation-wiring.test.ts`, `apps/web/tests/observability/chat-correlation-boot.test.ts` | 6 / 6 failed |
| 2 | `apps/web/tests/components/ChatPane.run-failed-toast-message-key.test.tsx` | 4 failed, 1 passed — the 1 is the positive control pinning `error_code` / `run_id`, which must stay green or "the field is missing" would also pass when the whole call is gone |
| 3 | `apps/web/tests/components/ChatPane.chat-health-surface.test.tsx` | 6 / 6 failed |

The headline failure is the production bug itself, reproduced:

```
AssertionError: expected false to be true // Object.is equality
 ❯ tests/observability/chat-correlation-wiring.test.ts:343
   341|     const events = safetyEvents('client_chat_interaction_latency');
   342|     expect(events).toHaveLength(2);
   343|     expect(events[0]?.streaming).toBe(true);
```

Every spec drives a **real production entry point** (`streamViaDaemon` / `reattachDaemonRun` / a rendered `ChatPane`) and reads the beacons the modules actually send. None of them calls `setChatCorrelation` or spies on the observability modules — the existing unit specs are green *because* they call the producer themselves, which is precisely the hole being closed here, and a spy would go green on a call that emitted nothing.

Reverse anchors are included so a "fix" that inverted the constant cannot pass: `streaming` must be **`false`** for an identical interaction on the same element after the run ends; `failure_category` must fall back to `unknown` rather than disappear; the virtualization verdict is pinned on both sides of the 80-message threshold; and the surface must be gone after unmount but present-exactly-once across a re-open.

## Validation

- `pnpm --filter @open-design/web typecheck` → **0**
- `pnpm guard` → **0**
- `pnpm --filter @open-design/contracts build` → 0, `pnpm --filter @open-design/contracts test` → 0 (64 files / 647 tests)
- New specs, 4 files / 17 tests → **0**
- Neighbouring suites, for regressions in the files touched:
  - `tests/components/ChatPane*` → 32 files / 242 tests passed
  - `tests/components/ProjectView*` → 26 files / 432 tests passed
  - `tests/observability` + `tests/providers/sse.test.ts` + analytics suites → 17 files / 332 tests passed

## Adjacent issues

Kept out of this PR on purpose:

1. **`specs/current/chat-panel-observability.md`'s Wiring checklist is stale.** Its line numbers are from the #7518 era and every one of them has drifted. It also **misses three call sites**: the strategy-task chain's next run in `providers/daemon.ts`, the `/api/version` `channel` field, and the `reattachDaemonRun` path (which has no `trackRunStart` either — it is the only run entry point with no run-start signal at all). Worth its own doc-only update; I did not touch the spec here because the checklist wants rewriting, not patching.
2. **`markChatOpenIntent` belongs in `router.ts`**, per commit 3's note above. Until then `open_kind` reads `remount` for every surface.
3. **`chat-protocol.ts` is still entirely unwired** — `reportChatProtocolAnomaly` / `reportChatRecovery` have no production callers, so `client_chat_protocol_anomaly` and `client_chat_recovery` stay at zero. Wiring them means finding the right detection sites in the parse and reconnect paths, which is a different piece of work from this one.
4. **`reattachDaemonRun` emits no `run_started`-family event.** This PR only closes the correlation gap on that path; whether reattach should also produce a run-start signal is a separate product question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQSowXMsTxbEoZyGYfxgyb


## Release routing

Maintainer-authorized exception: include this telemetry change in `release/v0.22.1` via #7939. The maintainer explicitly revised the previous exclusion for this PR only. Other ChatPanel PRs remain excluded unless separately authorized.
