### PR TITLE
fix(daemon): let a failed media generation reach its run terminal

### DIFF
--- a/apps/daemon/src/routes/media.ts
+++ b/apps/daemon/src/routes/media.ts
@@ -322,6 +322,43 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
       return sendApiError(res, 403, denial.code, denial.message);
     }
 
+    /**
+     * The dual of `attachLateOutputToRunMessage` below: hand the FAILURE back to
+     * the turn that asked for it.
+     *
+     * Every failure path here already knew which run this was — `runId` is right
+     * there in `options.grant`, printed in the `[media]` diagnostic and shipped
+     * to analytics — and none of them wrote it anywhere the run could see. So
+     * the run's terminal verdict came from the agent's exit code alone: the
+     * agent apologises in prose and exits 0, and the turn published
+     * `status: "succeeded"`, `endedWithUnfinishedWork: false`, a green check and
+     * an empty artifact rail while the daemon's own log said the only
+     * deliverable had failed 55s earlier.
+     *
+     * Declared outside the try so BOTH failure paths reach it: the async
+     * provider rejection AND the synchronous dispatch throw below, which marks
+     * the same task failed and would otherwise stay silent for the same reason.
+     *
+     * Best-effort by construction: the task is already marked failed and its
+     * waiters already told, so this must never turn a recorded failure into an
+     * unhandled rejection.
+     */
+    const reportFailureToRun = (taskId: string, error: unknown): void => {
+      const runId = options.grant?.runId;
+      if (!runId || !taskId) return;
+      try {
+        design.runs.noteMediaTaskFailure(runId, {
+          taskId,
+          surface,
+          model,
+          failedAt: Date.now(),
+          error,
+        });
+      } catch (err) {
+        console.warn('[media] run failure association failed', err);
+      }
+    };
+
     let task: ReturnType<typeof createMediaTask> | null = null;
     try {
       const taskId = randomUUID();
@@ -521,6 +558,10 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
             elapsedMs: task.endedAt - task.startedAt,
             error: task.error.message,
           }));
+          // Last, and only after the waiters have been told: the run that asked
+          // for this generation must not be able to report itself complete when
+          // the host just watched its deliverable fail.
+          reportFailureToRun(taskId, task.error);
         })
         .finally(() => proxyDispatcher.close());
 
@@ -549,6 +590,10 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
           elapsedMs: task.endedAt - task.startedAt,
           error: task.error.message,
         }));
+        // Same invariant as the async rejection above: a dispatch that threw
+        // before the provider was ever reached is still a generation this run
+        // asked for and did not get.
+        reportFailureToRun(task.id, task.error);
       }
       throw err;
     }

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -47,6 +47,30 @@ import { normalizeTelemetryAppVersionInfo } from '../app-version.js';
 
 export const TERMINAL_RUN_STATUSES = new Set(['succeeded', 'failed', 'canceled']);
 
+/** How many host-recorded media failures one attempt keeps. A fan-out that
+ *  fails wholesale is still one verdict; the list is evidence, not a log. */
+const MAX_RUN_MEDIA_TASK_FAILURES = 20;
+
+/**
+ * Did the HOST itself watch a piece of this turn's declared work fail?
+ *
+ * The only evidence this predicate accepts is evidence the daemon wrote down
+ * about its own execution: a media generation dispatched under this run's tool
+ * grant that `routes/media.ts` recorded as `failed`. It never reads the model's
+ * output. That boundary is the point — the turn-completion marker, the TodoWrite
+ * snapshot and the closing prose are all the model's account of its own turn,
+ * and an account cannot outrank a failure the host observed. Judging on the
+ * agent's words would also make a copy edit (the S22 apology sentence in
+ * `prompts/media-contract.ts` is verbatim-copied product copy) silently change
+ * a completeness verdict.
+ *
+ * Scoped to the attempt: `prepareRestart` clears the list, so a retry that
+ * finally delivers is judged on its own execution.
+ */
+function runHasHostRecordedDeliveryFailure(run) {
+  return Array.isArray(run?.mediaTaskFailures) && run.mediaTaskFailures.length > 0;
+}
+
 const RUN_STATE_SCHEMA_VERSION = 1;
 
 const DIAGNOSTIC_SOURCE = 'open-design-daemon';
@@ -562,6 +586,9 @@ function durableRunState(run) {
     artifactCount: Number.isFinite(run.artifactCount) ? run.artifactCount : 0,
     ...(Array.isArray(run.artifactPaths) ? { artifactPaths: run.artifactPaths } : {}),
     endedWithUnfinishedWork: Boolean(run.endedWithUnfinishedWork),
+    ...(runHasHostRecordedDeliveryFailure(run)
+      ? { mediaTaskFailures: run.mediaTaskFailures }
+      : {}),
     ...(typeof run.userPrompt === 'string' ? { userPrompt: run.userPrompt } : {}),
     ...(typeof run.model === 'string' ? { model: run.model } : {}),
     ...(typeof run.resolvedModelId === 'string'
@@ -989,6 +1016,10 @@ export function createChatRunService({
       authenticatedDoneConclusion: false,
       completionMarkerTail: '',
       completionMarkerAwaitingConclusion: false,
+      // Media generations this attempt dispatched that the host itself watched
+      // fail, recorded by `noteMediaTaskFailure` from routes/media.ts. The one
+      // completeness signal on this run that is not the model's self-report.
+      mediaTaskFailures: [],
       endedWithUnfinishedWork: false,
       artifactCount: undefined as number | undefined,
       artifactPaths: undefined as string[] | undefined,
@@ -1061,6 +1092,53 @@ export function createChatRunService({
   const persistState = (run) => {
     if (!run?.statePath) return { ok: false, errorType: 'storage_unavailable' };
     return writeDurableState(run.statePath, durableRunState(run));
+  };
+
+  /**
+   * Hand a failed media generation back to the turn that asked for it.
+   *
+   * The dual of `associateLateRunProducedFile`: that one gives the turn the
+   * bytes a 202 dispatch eventually produced, this one gives it the fact that
+   * the dispatch produced none. Until it existed, `routes/media.ts` knew the
+   * failing task's `run_id` — it printed it in the `[media]` diagnostic and
+   * shipped it to analytics — and told the run nothing, so the turn's verdict
+   * came from the agent's exit code alone and a turn whose only deliverable
+   * failed still published `succeeded` with a green check.
+   *
+   * Additive and idempotent per task id: a task reports at most one failure, and
+   * a re-entrant call (retry, replay, both catch paths firing) must not double
+   * count. Bounded, because a batch fan-out can fail wholesale and this is
+   * evidence, not a log. Recording is accepted whether or not the run is already
+   * terminal — a late failure still belongs in the run's record — but a run that
+   * has already published its terminal frame keeps the verdict it published;
+   * re-deriving completeness after the fact is a separate contract.
+   */
+  const noteMediaTaskFailure = (runId, failure) => {
+    if (typeof runId !== 'string' || !runId) return false;
+    const taskId = typeof failure?.taskId === 'string' ? failure.taskId : '';
+    if (!taskId) return false;
+    const run = get(runId);
+    if (!run) return false;
+    if (!Array.isArray(run.mediaTaskFailures)) run.mediaTaskFailures = [];
+    if (run.mediaTaskFailures.some((recorded) => recorded?.taskId === taskId)) return false;
+    if (run.mediaTaskFailures.length >= MAX_RUN_MEDIA_TASK_FAILURES) return false;
+    run.mediaTaskFailures.push({
+      taskId,
+      ...(typeof failure.surface === 'string' && failure.surface
+        ? { surface: failure.surface }
+        : {}),
+      ...(typeof failure.model === 'string' && failure.model ? { model: failure.model } : {}),
+      failedAt: Number.isFinite(failure.failedAt) ? failure.failedAt : Date.now(),
+      error: failure.error && typeof failure.error === 'object'
+        ? failure.error
+        : { message: 'media generation failed' },
+    });
+    // A run that already went terminal keeps its terminal clock: `updatedAt` is
+    // what `prepareRestart` measures the resume wait against, and a late failure
+    // arriving after the frame was published must not move it.
+    if (!TERMINAL_RUN_STATUSES.has(run.status)) run.updatedAt = Date.now();
+    persistState(run);
+    return true;
   };
 
   const persistTerminalState = (run, lifecycleEvidence = run.terminalLifecycle) => {
@@ -1259,6 +1337,9 @@ export function createChatRunService({
     run.deliverableSyntaxRepair = undefined;
     run.deliverableSyntaxValidation = undefined;
     run.endedWithUnfinishedWork = false;
+    // Host-observed failures belong to the attempt that produced them. A resume
+    // that finally delivers must not inherit the previous attempt's verdict.
+    run.mediaTaskFailures = [];
     run.askUserScanText = '';
     run.authenticatedDoneConclusion = false;
     run.completionMarkerTail = '';
@@ -1405,6 +1486,9 @@ export function createChatRunService({
     retryable: run.retryable ?? null,
     resumable: run.resumable ?? false,
     endedWithUnfinishedWork: !!run.endedWithUnfinishedWork,
+    ...(runHasHostRecordedDeliveryFailure(run)
+      ? { mediaTaskFailures: run.mediaTaskFailures }
+      : {}),
     ...(Number.isFinite(run.artifactCount) ? { artifactCount: run.artifactCount } : {}),
     ...(Array.isArray(run.artifactPaths) ? { artifactPaths: run.artifactPaths } : {}),
     eventsLogPath: run.eventsLogPath ?? null,
@@ -1501,8 +1585,22 @@ export function createChatRunService({
     // it asked on the way out. Truncation stays independent and still wins.
     const endedByAskingUser =
       status === 'succeeded' && turnEndedByAskingUser(run.askUserScanText);
+    // Counter-evidence the host holds against its own turn. It is a term of its
+    // own, deliberately OUTSIDE the marker/todo clause below, because that whole
+    // clause is the agent's account of its own work: the completion marker, the
+    // strategy verdict and the TodoWrite snapshot can each veto "unfinished",
+    // and a run that apologised for a failed generation reached `succeeded` with
+    // a green check because the marker vetoed a `cancelled` todo. A failure the
+    // daemon watched happen is not something the turn's own narration may
+    // overrule — nor may it be read out of that narration (the apology copy is
+    // product copy, changed at will). Gated on `succeeded` for the same reason
+    // the two clauses above are: a run the user stopped is stopped, and one that
+    // already failed carries its verdict in `status`.
+    const hostRecordedDeliveryFailure =
+      status === 'succeeded' && runHasHostRecordedDeliveryFailure(run);
     run.endedWithUnfinishedWork =
       Boolean(run.truncatedMidTurn)
+      || hostRecordedDeliveryFailure
       || (!strategyTaskProvesDelivery(run.strategyTask)
         && !authenticatedDoneProvesDelivery
         && !endedByAskingUser
@@ -1532,6 +1630,9 @@ export function createChatRunService({
       terminalAt,
       resumable: run.resumable ?? false,
       endedWithUnfinishedWork: run.endedWithUnfinishedWork,
+      ...(runHasHostRecordedDeliveryFailure(run)
+        ? { mediaTaskFailures: run.mediaTaskFailures }
+        : {}),
       ...(Number.isFinite(run.artifactCount) ? { artifactCount: run.artifactCount } : {}),
       ...(Array.isArray(run.artifactPaths) ? { artifactPaths: run.artifactPaths } : {}),
       failureCategory: run.failureCategory ?? null,
@@ -2299,6 +2400,7 @@ export function createChatRunService({
     wait,
     emit,
     persistState,
+    noteMediaTaskFailure,
     setAnalyticsRecovery,
     beginAnalyticsDelivery,
     finalizeAnalyticsDelivery,

--- a/apps/daemon/tests/media-failure-reaches-run-terminal.test.ts
+++ b/apps/daemon/tests/media-failure-reaches-run-terminal.test.ts
@@ -1,0 +1,539 @@
+/**
+ * 一轮任务实际失败了,界面却显示「已完成 + 绿勾」。
+ *
+ * 生产现场(用户诊断包 `logs/daemon/latest.log`):daemon 自己**清清楚楚知道**这一轮
+ * 的生图失败了,而且知道它属于哪个 run ——
+ *
+ *     [media] {"event":"failed","task_id":"6393c0cb-…",
+ *              "run_id":"6dc36917-57de-49b9-aef3-d6d6199dd14a",
+ *              "status":400,"elapsed_ms":55194,
+ *              "error":"download media asset ma_kk… failed: … https://…s3…/[REDACTED]"}
+ *
+ * 同一个 run 的 end 事件却是
+ * `{"status":"succeeded","code":0,"artifactCount":0,"endedWithUnfinishedWork":false}`,
+ * 用户看到的是「已完成 1m 33s」+ 绿勾、右侧产物区空的,而正文里模型在道歉说图没
+ * 生成出来。
+ *
+ * 两个洞,同一条不变量的两半:
+ *
+ *   洞 1 —— `routes/media.ts` 的失败路径只做三件事(标 task failed / 发埋点 /
+ *     打日志),**没有任何回写**。`runId` 就在手上(`options.grant.runId`),却只喂给
+ *     了埋点。于是 run 的终态只由子进程退出码决定,agent 道完歉退出 0,就是
+ *     succeeded。
+ *
+ *   洞 2 —— 完成标记(`<od-done key=…/>` + 其后非空文字)对「未完成」有**一票否决
+ *     权**,而判据从不看那段文字说了什么。这一轮里标记后面那段非空文字**恰好就是那句
+ *     道歉**,而那句道歉是**我们自己写进系统提示词、要求模型逐字照抄的**
+ *     (`prompts/media-contract.ts`,设计文档 S22)。也就是说:**道歉本身把「未完成」
+ *     压掉了**。同一轮的最后一次 TodoWrite 里还有一项是 `cancelled` —— 本该算未完成,
+ *     被标记挡掉了。
+ *
+ * 所以这里的判据必须来自 **daemon 自己的事实**(本 run 有它亲眼看着失败的 media
+ * task),**绝不能去解析模型那句话说了什么** —— 文案是产品文案,改一次判据就静默失效。
+ *
+ * 层次:daemon HTTP 边界(`startServer` 起真 daemon,真 `POST /api/chat`,真
+ * `POST /api/tools/media/generate`),provider 是本地起的一个**必定 400** 的
+ * OpenAI 兼容端点。断言全部落在可观察的 run 终态字段上,不碰 CSS/DOM。
+ */
+
+import type http from 'node:http';
+import { createServer } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { promises as fsp } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+/** provider 回一张真 1x1 PNG —— 成功那条对照组要真的写出字节来。 */
+const ONE_BY_ONE_PNG_B64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+/**
+ * 生产那一轮里,模型在完成标记后面写的**就是这句** —— 逐字来自
+ * `apps/daemon/src/prompts/media-contract.ts`(镜像在 contracts 侧)。
+ *
+ * 它出现在这里不是为了被解析,恰恰相反:它在这里是为了证明**没有人解析它**。
+ * 判据换成任何别的句子,结论都必须一模一样。
+ */
+const S22_APOLOGY =
+  '图片没生成出来,不是你的操作有误 —— 这次是 Open Design 自己的问题,我们已经记下了。重试一般能恢复;反复出现的话联系我们。';
+
+let baseUrl: string;
+let server: http.Server;
+let providerServer: http.Server;
+let providerUrl: string;
+const tempDirs: string[] = [];
+
+interface TurnPlan {
+  /** 派发一次媒体生成。`prompt` 以 `fail` 开头时 provider 必定 400。 */
+  media?: { prompt: string; output: string };
+  /** 最后一次 TodoWrite 快照。 */
+  todos?: Array<{ content: string; status: string }>;
+  /** 发一枚**合法**的完成标记(key 从这一轮自己的提示词里读出来)。 */
+  emitDoneMarker?: boolean;
+  /** 标记之后那段非空文字。 */
+  conclusion?: string;
+  /** 不退出,等着被用户取消。 */
+  waitToBeCanceled?: boolean;
+}
+
+/**
+ * 把一份 TurnPlan 编成假 `opencode` 的脚本。
+ *
+ * 完成标记的 key 是**每轮新铸**的 nonce,只出现在这一轮自己的提示词里(经 stdin 送进
+ * 来)。脚本把它读出来再原样发回去 —— 这是唯一能造出「合法完成标记」的办法,也正是
+ * 生产里模型走的那条路。伪造不出来的东西,测试也不该伪造。
+ */
+function agentScript(plan: TurnPlan): string {
+  return `
+const chunks = [];
+process.stdin.on('data', (c) => chunks.push(c));
+process.stdin.on('error', () => {});
+(async () => {
+  await new Promise((resolve) => {
+    process.stdin.on('end', resolve);
+    process.stdin.on('close', resolve);
+    setTimeout(resolve, 5000);
+  });
+  const prompt = Buffer.concat(chunks).toString('utf8');
+  const doneKey = (/<od-done key="([A-Za-z0-9_-]{4,64})"\\/>/.exec(prompt) || [])[1] || '';
+  const emit = (o) => console.log(JSON.stringify(o));
+  const media = ${JSON.stringify(plan.media ?? null)};
+  const todos = ${JSON.stringify(plan.todos ?? null)};
+  emit({ type: 'step_start' });
+
+  let narration = 'donekey=' + doneKey + '=donekey';
+  if (media) {
+    const daemonUrl = process.env.OD_DAEMON_URL;
+    const auth = {
+      'content-type': 'application/json',
+      authorization: 'Bearer ' + process.env.OD_TOOL_TOKEN,
+    };
+    try {
+      const resp = await fetch(daemonUrl + '/api/tools/media/generate', {
+        method: 'POST',
+        headers: auth,
+        body: JSON.stringify({
+          surface: 'image',
+          model: 'custom-image',
+          prompt: media.prompt,
+          output: media.output,
+        }),
+      });
+      const taskId = JSON.parse(await resp.text()).taskId;
+      let status = '';
+      for (let i = 0; i < 40 && status !== 'done' && status !== 'failed'; i += 1) {
+        const waited = await fetch(daemonUrl + '/api/media/tasks/' + taskId + '/wait', {
+          method: 'POST',
+          headers: auth,
+          body: JSON.stringify({ timeoutMs: 1000 }),
+        });
+        status = JSON.parse(await waited.text()).status;
+      }
+      narration += ' mediastatus=' + status + '=mediastatus taskid=' + taskId + '=taskid';
+    } catch (err) {
+      narration += ' dispatcherror=' + String(err && err.message ? err.message : err) + '=dispatcherror';
+    }
+  }
+
+  if (todos) {
+    emit({
+      type: 'tool_use',
+      part: { tool: 'todowrite', callID: 'todo-1', state: { input: { todos } } },
+    });
+  }
+  emit({ type: 'text', part: { text: narration + '\\n' } });
+  ${plan.emitDoneMarker ? `emit({ type: 'text', part: { text: '<od-done key="' + doneKey + '"/>' } });` : ''}
+  ${plan.conclusion ? `emit({ type: 'text', part: { text: ${JSON.stringify(plan.conclusion)} } });` : ''}
+  emit({ type: 'step_finish', part: { tokens: { input: 1, output: 1 } } });
+  ${plan.waitToBeCanceled ? 'await new Promise(() => {});' : 'process.exit(0);'}
+})();
+`;
+}
+
+async function withFakeAgent<T>(script: string, run: () => Promise<T>): Promise<T> {
+  const dir = await fsp.mkdtemp(join(tmpdir(), 'od-media-fail-bin-'));
+  tempDirs.push(dir);
+  const oldPath = process.env.PATH;
+  try {
+    if (process.platform === 'win32') {
+      const runner = join(dir, 'opencode-test-runner.cjs');
+      await fsp.writeFile(runner, script);
+      await fsp.writeFile(join(dir, 'opencode.cmd'), `@echo off\r\nnode "${runner}" %*\r\n`);
+    } else {
+      const bin = join(dir, 'opencode');
+      await fsp.writeFile(bin, `#!/usr/bin/env node\n${script}`);
+      await fsp.chmod(bin, 0o755);
+    }
+    process.env.PATH = `${dir}${delimiter}${oldPath ?? ''}`;
+    return await run();
+  } finally {
+    process.env.PATH = oldPath;
+  }
+}
+
+async function waitFor<T>(
+  probe: () => T | Promise<T>,
+  predicate: (value: T) => boolean,
+  timeoutMs = 20_000,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let last = await probe();
+  while (!predicate(last) && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 50));
+    last = await probe();
+  }
+  return last;
+}
+
+interface StoredMessage {
+  id: string;
+  role: string;
+  runId?: string;
+  runStatus?: string;
+}
+
+interface RunTerminal {
+  runId: string;
+  status: string;
+  exitCode: number | null;
+  endedWithUnfinishedWork: boolean;
+  mediaTaskFailures?: Array<{
+    taskId: string;
+    surface?: string;
+    model?: string;
+    failedAt: number;
+    error: { message: string; status?: number; code?: string };
+  }>;
+  artifactCount?: number;
+}
+
+async function createProject(name: string): Promise<{ projectId: string; conversationId: string }> {
+  const projectId = `proj-${randomUUID()}`;
+  const created = await fetch(`${baseUrl}/api/projects`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id: projectId, name }),
+  });
+  expect(created.ok).toBe(true);
+  const conversations = await fetch(`${baseUrl}/api/projects/${projectId}/conversations`);
+  expect(conversations.ok).toBe(true);
+  const conversationId = ((await conversations.json()) as {
+    conversations: Array<{ id: string }>;
+  }).conversations[0]?.id;
+  expect(conversationId).toBeTruthy();
+  return { projectId, conversationId: conversationId! };
+}
+
+async function readMessages(projectId: string, conversationId: string): Promise<StoredMessage[]> {
+  const res = await fetch(
+    `${baseUrl}/api/projects/${projectId}/conversations/${conversationId}/messages`,
+  );
+  expect(res.ok).toBe(true);
+  return ((await res.json()) as { messages: StoredMessage[] }).messages;
+}
+
+async function readRun(runId: string): Promise<RunTerminal> {
+  const res = await fetch(`${baseUrl}/api/runs/${runId}`);
+  expect(res.ok).toBe(true);
+  return (await res.json()) as RunTerminal;
+}
+
+const TERMINAL = new Set(['succeeded', 'failed', 'canceled']);
+
+/** 跑完一轮,把这一轮**可观察的终态**取回来。 */
+async function runTurn(plan: TurnPlan & { message?: string }): Promise<{
+  terminal: RunTerminal;
+  narration: string;
+  projectId: string;
+}> {
+  const { projectId, conversationId } = await createProject(`media terminal ${randomUUID()}`);
+  const assistantMessageId = `assistant-${randomUUID()}`;
+  const narration = await withFakeAgent(agentScript(plan), async () => {
+    const response = await fetch(`${baseUrl}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agentId: 'opencode',
+        projectId,
+        conversationId,
+        assistantMessageId,
+        message: plan.message ?? '生成一张海报',
+      }),
+    });
+    expect(response.ok).toBe(true);
+    return await response.text();
+  });
+
+  expect(narration, 'the agent could not reach the media dispatcher')
+    .not.toContain('dispatcherror=');
+  if (plan.emitDoneMarker) {
+    const key = /donekey=([0-9a-f]{4,64})=donekey/.exec(narration)?.[1];
+    expect(
+      key,
+      '假 agent 没能从这一轮的提示词里读到 done key,发出去的就不是合法完成标记 —— '
+        + '这条测试的前提不成立',
+    ).toBeTruthy();
+  }
+
+  const message = await waitFor(
+    async () => (await readMessages(projectId, conversationId)).find((m) => m.id === assistantMessageId),
+    (m) => Boolean(m?.runId && m?.runStatus && TERMINAL.has(m.runStatus)),
+  );
+  expect(message?.runId, 'the turn never reached a terminal run').toBeTruthy();
+  return { terminal: await readRun(message!.runId!), narration, projectId };
+}
+
+describe('a media generation the host watched fail reaches its run terminal', () => {
+  beforeAll(async () => {
+    // An OpenAI-compatible image endpoint that fails on demand. 400 is the
+    // production status and is deliberately NOT in the retry set (429/503), so
+    // the failure is one round-trip rather than a timing bet.
+    providerServer = createServer((req, res) => {
+      let body = '';
+      req.on('data', (chunk) => {
+        body += chunk;
+      });
+      req.on('end', () => {
+        let fails = false;
+        try {
+          fails = String(JSON.parse(body)?.prompt ?? '').startsWith('fail');
+        } catch {
+          fails = false;
+        }
+        if (fails) {
+          res.writeHead(400, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({
+            error: { message: 'download media content: Get https://…s3…/[REDACTED]' },
+          }));
+          return;
+        }
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ data: [{ b64_json: ONE_BY_ONE_PNG_B64 }] }));
+      });
+    });
+    await new Promise<void>((done) => providerServer.listen(0, '127.0.0.1', () => done()));
+    const address = providerServer.address();
+    if (!address || typeof address === 'string') throw new Error('provider server has no port');
+    providerUrl = `http://127.0.0.1:${address.port}/v1`;
+
+    // Keep the provider credential out of the shared vitest data dir.
+    const configDir = await fsp.mkdtemp(join(tmpdir(), 'od-media-fail-config-'));
+    tempDirs.push(configDir);
+    vi.stubEnv('OD_MEDIA_CONFIG_DIR', configDir);
+
+    const started = (await startServer({ port: 0, returnServer: true })) as {
+      url: string;
+      server: http.Server;
+    };
+    baseUrl = started.url;
+    server = started.server;
+
+    const configured = await fetch(`${baseUrl}/api/media/config`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        providers: {
+          'custom-image': {
+            apiKey: 'media-failure-test-key',
+            baseUrl: providerUrl,
+            model: 'failing-image-model',
+          },
+        },
+      }),
+    });
+    expect(configured.ok, 'the custom-image provider must be configured').toBe(true);
+  }, 60_000);
+
+  afterAll(async () => {
+    if (server) await new Promise<void>((done) => server.close(() => done()));
+    if (providerServer) await new Promise<void>((done) => providerServer.close(() => done()));
+    for (const dir of tempDirs.splice(0)) {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+    vi.unstubAllEnvs();
+  });
+
+  /**
+   * 洞 1 —— 失败必须回流到 run。
+   *
+   * daemon 在日志里写下 `run_id` 的那一刻就已经知道是哪一轮了;这条测试要的是同一个
+   * 事实出现在这一轮**自己的终态**里,而不是只出现在日志和埋点里。有了它,壳头才有
+   * 东西可依据去渲染真正的错误卡 + 重试,而不是靠模型背台词。
+   */
+  it('records the failed generation on the run that dispatched it', async () => {
+    const { terminal, narration } = await runTurn({
+      media: { prompt: 'fail: a poster nobody will get', output: 'poster.png' },
+    });
+
+    expect(
+      /mediastatus=failed=mediastatus/.test(narration),
+      `媒体任务没有失败,这条测试的前提不成立: ${narration.slice(0, 2000)}`,
+    ).toBe(true);
+    const taskId = /taskid=([0-9a-f-]{36})=taskid/.exec(narration)?.[1];
+
+    expect(terminal.status).toBe('succeeded');
+    expect(terminal.exitCode).toBe(0);
+    expect(
+      terminal.mediaTaskFailures?.map((failure) => failure.taskId),
+      'daemon 亲眼看着这一轮的生图失败了,却没有把这个事实挂回该 run',
+    ).toEqual([taskId]);
+    const failure = terminal.mediaTaskFailures![0]!;
+    expect(failure.surface).toBe('image');
+    expect(failure.model).toBe('custom-image');
+    expect(failure.error.message, '失败原因没有跟着回流,错误卡没有东西可显示').toBeTruthy();
+  }, 90_000);
+
+  /**
+   * 洞 2 —— 完成标记不能在宿主自己握着反证时压掉「未完成」。
+   *
+   * 这条是生产那一轮的**完整复刻**:合法的完成标记 + 标记后面那句我们自己让模型逐字
+   * 照抄的道歉 + 一项 `cancelled` 的 todo。今天的判据只看「标记对得上 key + 后面还有
+   * 非空文字」,于是道歉自己把未完成压成了「已完成 + 绿勾」。
+   */
+  it('does not let the turn-completion marker overrule it', async () => {
+    const { terminal, narration } = await runTurn({
+      media: { prompt: 'fail: the illustration for slide 2', output: 'slide-2.png' },
+      todos: [
+        { content: '梳理版式', status: 'completed' },
+        { content: '生成插图', status: 'completed' },
+        { content: '合成海报', status: 'cancelled' },
+      ],
+      emitDoneMarker: true,
+      conclusion: S22_APOLOGY,
+    });
+
+    expect(/mediastatus=failed=mediastatus/.test(narration)).toBe(true);
+    expect(terminal.status).toBe('succeeded');
+    expect(terminal.exitCode).toBe(0);
+    expect(
+      terminal.endedWithUnfinishedWork,
+      '这一轮的生图失败了,daemon 自己记着,壳头还是报「已完成 + 绿勾」',
+    ).toBe(true);
+  }, 90_000);
+
+  /**
+   * 反向锚点 1 —— 真正成功的一轮不许被牵连。
+   *
+   * 同一条路、同一个 provider、同一枚完成标记,只是生图这次真的成功了。
+   */
+  it('leaves a genuinely delivered turn alone', async () => {
+    const { terminal, narration } = await runTurn({
+      media: { prompt: 'ok: a poster that lands', output: 'delivered.png' },
+      todos: [{ content: '生成海报', status: 'completed' }],
+      emitDoneMarker: true,
+      conclusion: '海报已经生成好了,右侧可以直接看。',
+      message: '生成一张能用的海报',
+    });
+
+    expect(
+      /mediastatus=done=mediastatus/.test(narration),
+      `对照组的媒体任务没有成功,这条锚点不成立: ${narration.slice(0, 2000)}`,
+    ).toBe(true);
+    expect(terminal.status).toBe('succeeded');
+    expect(terminal.endedWithUnfinishedWork).toBe(false);
+    expect(terminal.mediaTaskFailures ?? []).toEqual([]);
+  }, 90_000);
+
+  /**
+   * 反向锚点 2 —— 别把修复做成「有 done 标记也一律不信」。
+   *
+   * 完全没有媒体任务的普通一轮:一项 todo 还开着,但模型发了合法的完成标记。今天这
+   * 一轮读作「已完成」,修完之后必须**一个字节都不变** —— 宿主手里没有任何反证,标记
+   * 的否决权原样保留。这条锚点要是红了,说明修复把所有正常完成的任务都变成了未完成。
+   */
+  it('keeps the marker authoritative when the host holds no counter-evidence', async () => {
+    const { terminal } = await runTurn({
+      todos: [
+        { content: '读一遍现有版式', status: 'completed' },
+        { content: '可选:再补一版配色', status: 'pending' },
+      ],
+      emitDoneMarker: true,
+      conclusion: '版式已经按你说的调好了,配色那一版看你要不要。',
+      message: '帮我调一下版式',
+    });
+
+    expect(terminal.status).toBe('succeeded');
+    expect(
+      terminal.endedWithUnfinishedWork,
+      '没有任何宿主反证的一轮被判成了未完成 —— 修复把完成标记一律不信了',
+    ).toBe(false);
+    expect(terminal.mediaTaskFailures ?? []).toEqual([]);
+  }, 90_000);
+
+  /**
+   * 反向锚点 3 —— 完全没有媒体任务的一轮,行为不变。
+   */
+  it('leaves a plain text-only turn alone', async () => {
+    const { terminal } = await runTurn({
+      conclusion: '这个组件用 flex 就够了。',
+      message: '这个组件该用 grid 还是 flex?',
+    });
+
+    expect(terminal.status).toBe('succeeded');
+    expect(terminal.endedWithUnfinishedWork).toBe(false);
+    expect(terminal.mediaTaskFailures ?? []).toEqual([]);
+  }, 90_000);
+
+  /**
+   * 反向锚点 4 —— 用户主动取消的一轮,行为不变。
+   *
+   * 取消掉的一轮,终态由「谁停的」决定,不由这一轮里失败了什么决定 —— 和完成标记、
+   * 提问收尾那两条已有规则的 `succeeded` 闸门是同一个道理。
+   */
+  it('leaves a user-canceled turn alone', async () => {
+    const { projectId, conversationId } = await createProject(`media cancel ${randomUUID()}`);
+    const assistantMessageId = `assistant-${randomUUID()}`;
+
+    await withFakeAgent(
+      agentScript({
+        media: { prompt: 'fail: something the user will not wait for', output: 'abandoned.png' },
+        waitToBeCanceled: true,
+      }),
+      async () => {
+        const chat = fetch(`${baseUrl}/api/chat`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'opencode',
+            projectId,
+            conversationId,
+            assistantMessageId,
+            message: '生成一张海报',
+          }),
+        }).catch(() => null);
+
+        // Cancel only once the host has actually recorded the failure — the
+        // anchor is "a canceled run keeps its own verdict EVEN THEN", not
+        // "we canceled before there was anything to see".
+        const runId = (await waitFor(
+          async () =>
+            (await readMessages(projectId, conversationId))
+              .find((m) => m.id === assistantMessageId)?.runId ?? null,
+          (id) => Boolean(id),
+        ))!;
+        await waitFor(
+          async () => (await readRun(runId)).mediaTaskFailures ?? [],
+          (failures) => failures.length > 0,
+        );
+
+        const canceled = await fetch(`${baseUrl}/api/runs/${runId}/cancel`, { method: 'POST' });
+        expect(canceled.ok).toBe(true);
+
+        const terminal = await waitFor(
+          () => readRun(runId),
+          (run) => TERMINAL.has(run.status),
+        );
+        expect(terminal.status).toBe('canceled');
+        expect(
+          terminal.endedWithUnfinishedWork,
+          '用户取消的一轮被改判了 —— 反证的 succeeded 闸门没有生效',
+        ).toBe(false);
+        expect((terminal.mediaTaskFailures ?? []).length).toBe(1);
+        await chat;
+      },
+    );
+  }, 90_000);
+});

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -10,7 +10,7 @@ import type {
 } from './comments';
 import type { ResearchOptions } from './research';
 import type { RunContextSelection } from './context.js';
-import type { MediaExecutionPolicy } from './media.js';
+import type { MediaExecutionPolicy, RunMediaTaskFailure } from './media.js';
 import type { AppliedPluginSnapshot } from '../plugins/apply.js';
 import type { McpAuthMode, McpServerConfig, McpTransport } from './mcp';
 import type {
@@ -788,6 +788,12 @@ export interface ChatRunStatusResponse {
    *  Judged by the canonical `todoSnapshotHasUnfinishedWork` predicate so it can
    *  never diverge from the chat footer's `unfinishedTodosFromEvents`. */
   endedWithUnfinishedWork?: boolean;
+  /** Media generations this run dispatched that the DAEMON itself recorded as
+   *  failed. Empty/absent means the host watched none fail — never that the
+   *  agent said so. Present so a terminal turn can render the real failure card
+   *  (with the task's own retryability verdict) instead of leaving the user with
+   *  a green check and an apology in prose. */
+  mediaTaskFailures?: RunMediaTaskFailure[];
   /** Authoritative artifact files created or modified by this run. Mirrors
    *  ChatSseEndPayload.artifactCount and run_finished.artifact_count. */
   artifactCount?: number;

--- a/packages/contracts/src/api/media.ts
+++ b/packages/contracts/src/api/media.ts
@@ -94,6 +94,36 @@ export interface ProjectMediaTaskError {
   nextStep?: MediaFailureNextStep;
 }
 
+/**
+ * A media generation the HOST itself watched fail, attributed to the run that
+ * asked for it.
+ *
+ * The daemon has always known this: `routes/media.ts` writes a `[media]`
+ * `event: "failed"` diagnostic carrying the very `run_id` that dispatched the
+ * task. It just never handed the fact back to the run, so the run's terminal
+ * frame was decided by the agent's exit code alone — the agent exits 0 after
+ * apologising in prose, and the turn published `status: "succeeded"`,
+ * `endedWithUnfinishedWork: false`, a green check, and an empty artifact rail.
+ *
+ * This is host-observed evidence, never a reading of the model's own words.
+ * The apology sentence the media contract asks the model to copy verbatim
+ * (`prompts/media-contract.ts`, design S22) is COPY: it can be rewritten in any
+ * release, and no completeness verdict may depend on what it says.
+ */
+export interface RunMediaTaskFailure {
+  /** The media task's id, so a consumer can fetch its full record. */
+  taskId: string;
+  /** `image` | `video` | `audio`, as requested. Absent if the request never named one. */
+  surface?: string;
+  /** The requested media model id. */
+  model?: string;
+  /** When the host recorded the failure. */
+  failedAt: number;
+  /** The task's own classified error, verbatim — same shape the media task
+   *  endpoints publish, so an error card needs no second vocabulary. */
+  error: ProjectMediaTaskError;
+}
+
 /** Everything a media failure can be classified from. All fields optional. */
 export interface MediaFailureSignal {
   /**

--- a/packages/contracts/src/sse/chat.ts
+++ b/packages/contracts/src/sse/chat.ts
@@ -1,5 +1,6 @@
 import type { LiveArtifactRefreshStatus } from '../api/live-artifacts.js';
 import type { RunFailureAction, RunFailureCategory, RunFailureDetail } from '../api/chat.js';
+import type { RunMediaTaskFailure } from '../api/media.js';
 import type {
   DeliverableSyntaxRepairState,
   DeliverableSyntaxValidationEvidence,
@@ -134,6 +135,13 @@ export interface ChatSseEndPayload {
    *  assistant message so every status surface avoids showing "Completed" for an
    *  incomplete run. Mirrors ChatRunStatusResponse.endedWithUnfinishedWork. */
   endedWithUnfinishedWork?: boolean;
+  /** Media generations this run dispatched that the daemon itself recorded as
+   *  failed. Carried on the terminal frame for the same reason the failure
+   *  classification below is: the chat decides what the finished turn says
+   *  without a status refetch, and "the host watched a generation fail" is the
+   *  one thing that must not be re-derived from the agent's prose.
+   *  Mirrors ChatRunStatusResponse.mediaTaskFailures. */
+  mediaTaskFailures?: RunMediaTaskFailure[];
   /** Daemon failure classification for a `failed` run, so the chat can render
    *  specific guidance straight off the terminal frame without a status refetch.
    *  Mirror ChatRunStatusResponse.failureCategory / failureDetail. */


### PR DESCRIPTION
## Why

A user's diagnostic bundle showed a turn that reported **"已完成 1m 33s" with a green check**, an empty artifact rail, and — in the reply body — the model apologising that the image never got generated. I went in to explain the discrepancy and found the daemon had known the whole time.

From that user's `logs/daemon/latest.log`:

```
[media] {"event":"failed","task_id":"6393c0cb-…","run_id":"6dc36917-57de-49b9-aef3-d6d6199dd14a",
        "status":400,"elapsed_ms":55194,
        "error":"download media asset ma_kk… failed: download media content: Get https://…s3…/[REDACTED]"}
```

The daemon named the failing task **and the run it belonged to**. The very same run's `end` event:

```json
{"status":"succeeded","code":0,"artifactCount":0,"failureCategory":null,"endedWithUnfinishedWork":false}
```

This is a trust-level defect, not a cosmetic one: the product told the user a task succeeded when its own log says the only deliverable failed. A user who trusts the green check does not retry, does not report, and loses the work.

Two holes, two halves of one invariant:

**1. Media failures never flowed back to the run.** In `routes/media.ts`, the success path ends with `attachLateOutputToRunMessage(meta)`, handing the produced bytes back to the turn that asked for them. The failure paths do three things — mark the task `failed`, fire analytics, write the log line above — and **nothing else**. `runId` was right there in `options.grant.runId`; it was handed to telemetry and to no one else. So the run's terminal verdict came from the child's exit code alone, and the agent exits 0 after apologising.

**2. The turn-completion marker had an unconditional veto.** `textHasAuthenticatedDoneConclusion` asks exactly two questions: does the marker's key match this run's nonce, and is there non-empty text after it. **It never looks at what that text says.** In this run the non-empty text after the marker was, verbatim:

> 图片没生成出来,不是你的操作有误 —— 这次是 Open Design 自己的问题,我们已经记下了。重试一般能恢复;反复出现的话联系我们。

That sentence is **ours** — `apps/daemon/src/prompts/media-contract.ts:105` (mirrored in `packages/contracts/src/prompts/media-contract.ts:68`, design S22) instructs the model to copy it verbatim on exactly this failure. So the apology we wrote for a failed generation is what suppressed the "unfinished" signal for that failure. And it was suppressing something real: the run's last TodoWrite had the compose step marked `cancelled`, which on its own already counts as unfinished.

## What users will see

A turn whose image/video/audio generation failed no longer reports itself as finished. Instead of a green check over an empty artifact rail and an apology in the reply text, the turn is marked as having stopped with unfinished work — the same state the chat footer, the project pill and the Pet task centre already use — so the user has a reason to retry instead of a reason to trust it.

Runs that genuinely delivered are untouched: a turn with no failed generation reports "Completed" exactly as before, including turns that end with an open TodoWrite item plus a valid completion marker.

The terminal run record (and the SSE terminal frame) now also carries `mediaTaskFailures` — the failing task's id, surface, model and its own classified error — so a failure card with the task's real retryability verdict has something authoritative to render from, rather than being re-derived from the model's prose.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — `ChatRunStatusResponse.mediaTaskFailures` and `ChatSseEndPayload.mediaTaskFailures` (both additive/optional), plus the new `RunMediaTaskFailure` type in `packages/contracts/src/api/media.ts`
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — a `succeeded` run that dispatched a media generation the daemon recorded as failed now reports `endedWithUnfinishedWork: true`. No opt-in.

Both surfaces stay in sync without new plumbing: `mediaTaskFailures` and `endedWithUnfinishedWork` are fields of the existing `GET /api/runs/:id` status body, which is what both the web run status and `od`'s `--json` run output already read. No new endpoint, no new subcommand.

## Screenshots

Not applicable — no new UI surface. The visible change is which state the existing terminal-status surfaces resolve to, asserted directly on the run's terminal fields in the spec below rather than on rendered markup.

## Bug fix verification

- Test path: `apps/daemon/tests/media-failure-reaches-run-terminal.test.ts`
- Red on `main`, green on this branch: **yes** — and verified per hole, not just as one diff.

The spec runs at the daemon HTTP boundary (`startServer`, real `POST /api/chat`, real `POST /api/tools/media/generate`) against a local OpenAI-compatible provider that returns 400 on demand. 400 is the production status and is deliberately outside the retry set (429/503), so the failure is one round-trip rather than a timing bet. The fake agent reads this turn's done-key nonce out of its own prompt on stdin and echoes the marker back — the only way to produce a *legitimate* completion marker, and exactly the path production takes.

Per-hole falsification (each revert run separately):

| state | hole-1 spec (`records the failed generation…`) | hole-2 spec (`does not let the marker overrule it`) | 4 reverse anchors |
|---|---|---|---|
| both holes reverted (= `main`) | **red** — `expected undefined to deeply equal [Array(1)]` | **red** — `expected false to be true` | green (cancel anchor red, see note) |
| hole 1 reverted only | **red** | **red** | green (cancel anchor red) |
| hole 2 reverted only | green | **red** — `expected false to be true` | all green |
| fix as landed | green | green | all green |

Note: the user-cancel anchor waits for the host to have actually recorded the failure before cancelling — the claim being anchored is "a cancelled run keeps its own verdict *even then*", not "we cancelled before there was anything to see". With hole 1 reverted there is nothing to wait for, so that anchor goes red for the setup, not for the behaviour.

Reverse anchors, all green with the fix:

1. **A genuinely delivered turn** — same route, same provider, same valid marker, generation actually succeeds → `succeeded`, `endedWithUnfinishedWork: false`, `mediaTaskFailures: []`.
2. **No host counter-evidence** — no media task at all, one `pending` todo left open, valid marker + conclusion → still `endedWithUnfinishedWork: false`. This is the anchor against over-fixing: the marker keeps its veto whenever the host holds nothing against the turn. Had the fix been "stop believing the marker", this one goes red.
3. **A plain text-only turn** — no todos, no media → unchanged.
4. **A user-cancelled turn** — cancelled *after* the host recorded a media failure → stays `canceled` with `endedWithUnfinishedWork: false`, i.e. the new term's `succeeded` gate holds, matching how the existing marker and asked-the-user rules are gated.

Every assertion is on observable run terminal fields (`status`, `exitCode`, `endedWithUnfinishedWork`, `mediaTaskFailures`) read back through `GET /api/runs/:id`. No CSS classes, no DOM.

**Where the counter-evidence comes from — and where it deliberately does not.** The new term reads one thing: a media task dispatched under this run's tool grant that `routes/media.ts` itself recorded as failed. It never parses the model's output. That boundary is the point of the whole fix: the completion marker, the strategy verdict and the TodoWrite snapshot are all the agent's account of its own turn, and the sentence that suppressed this run's verdict was product copy we can rewrite in any release. A verdict keyed on copy silently fails the next time the copy changes.

Structurally, the host term sits **outside** the marker/strategy/todo clause rather than as an extra conjunct on the marker. Same outcome — the marker cannot prove delivery when the host holds counter-evidence — but as a conjunct it would have been unreachable code (the clause it guards is already dominated by the new term), i.e. an implementation no test could ever turn red.

Scope guards: the list is cleared by `prepareRestart`, so a resume that finally delivers is judged on its own attempt; recording is idempotent per task id and bounded, so a batch fan-out that fails wholesale is still one verdict; and it is gated on `succeeded`, so a cancelled or already-failed run keeps the verdict it has.

## Validation

- `pnpm typecheck` → exit 0
- `pnpm guard` → exit 0
- `pnpm --filter @open-design/daemon build` → exit 0 (contracts `dist` rebuilt first, since `packages/contracts` changed)
- `apps/daemon` — `vitest run tests/media-failure-reaches-run-terminal.test.ts` → 6/6 passed
- `apps/daemon` — neighbouring suites for the surfaces touched: `tests/runtimes/runs.test.ts`, `tests/late-media-produced-file-association.test.ts` (the dual this fix mirrors), `tests/chat-route.test.ts`, `tests/media-generate-structured-error.test.ts`, `tests/media-wait-safety-output.test.ts` → 171 passed, 0 failed

## Adjacent issues

Held out of this PR on purpose; each wants its own red spec.

- **The upstream cause of this particular failure is backend, not ours.** The 400 comes from vela fetching the generated result out of S3: the pre-signed URL expires after 5 minutes and the command took 55s of a longer sequence, so the fetch lands after expiry. That is a backend fix and is untouched here. This PR is only about the daemon reporting truthfully whatever the outcome was.
- **No failure card yet.** The run terminal now carries `mediaTaskFailures` with each task's classified error and retryability, but `apps/web` has no surface reading it — the visible improvement today is that the turn stops claiming "Completed". Rendering a real failure card with a Retry button off this field (plus its 19 locale strings) is a follow-up.
- **Late failures do not re-open a published terminal.** `noteMediaTaskFailure` records a failure that lands after the run went terminal, but the already-published terminal frame keeps its verdict. Re-deriving completeness after the frame has shipped is a separate contract question — the analogous produced-file path (`associateLateRunProducedFile`) settled it one way for artifacts, and failures deserve the same explicit ruling rather than an implicit one.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQSowXMsTxbEoZyGYfxgyb
