### PR TITLE
fix(collab): bind the persisted workspace selection to the identity that made it

### DIFF
--- a/apps/daemon/src/collab/active-workspace-selection.ts
+++ b/apps/daemon/src/collab/active-workspace-selection.ts
@@ -2,8 +2,23 @@ import fs from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 
+import { resolveWorkspaceSelectionIdentity } from './workspace-selection-identity.js';
+
 interface ActiveWorkspaceSelectionFile {
   workspaceId?: unknown;
+  /**
+   * The identity stamp that chose `workspaceId`. Absent in records written
+   * before this field existed; see {@link readAttributedSelection}.
+   */
+  identity?: unknown;
+}
+
+export interface ActiveWorkspaceSelectionStoreOptions {
+  /**
+   * Identity that owns reads and writes of the selection. Defaults to the
+   * account + AMR environment currently configured for this process.
+   */
+  identity?: () => string;
 }
 
 export interface ActiveWorkspaceSelectionStore {
@@ -53,27 +68,73 @@ export function resolveAuthorizedActiveTeamWorkspaceSnapshot(
   };
 }
 
+/** A selection as it sits on disk: an id plus the identity that chose it. */
+interface AttributedSelection {
+  workspaceId: string | null;
+  identity: string | null;
+}
+
+const NO_SELECTION: AttributedSelection = { workspaceId: null, identity: null };
+
+/**
+ * Parse the on-disk record without deciding whether it is usable.
+ *
+ * A record whose `identity` is missing or not a string is an unattributed
+ * legacy record: it may well have been written by the identity reading it, but
+ * it cannot say so. `identity: null` marks that, and every read then treats it
+ * as belonging to nobody.
+ */
+function readAttributedSelection(filePath: string): AttributedSelection {
+  let parsed: ActiveWorkspaceSelectionFile;
+  try {
+    parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as ActiveWorkspaceSelectionFile;
+  } catch {
+    return NO_SELECTION;
+  }
+  const workspaceId = typeof parsed.workspaceId === 'string' && parsed.workspaceId.trim()
+    ? parsed.workspaceId.trim()
+    : null;
+  if (!workspaceId) return NO_SELECTION;
+  const identity = typeof parsed.identity === 'string' && parsed.identity.trim()
+    ? parsed.identity.trim()
+    : null;
+  return { workspaceId, identity };
+}
+
 export function createActiveWorkspaceSelectionStore(
   dataDir: string,
+  options: ActiveWorkspaceSelectionStoreOptions = {},
 ): ActiveWorkspaceSelectionStore {
   const filePath = path.join(dataDir, 'workspace-selection.json');
-  let cached: string | null | undefined;
+  const currentIdentity = options.identity
+    ?? (() => resolveWorkspaceSelectionIdentity());
+  let cached: AttributedSelection | undefined;
   let generation = 0;
   let mutationTail = Promise.resolve();
   const listeners = new Set<(workspaceId: string | null) => void>();
 
+  /**
+   * The selection this process may act on: the stored id, but only while the
+   * identity reading it is the identity that wrote it.
+   *
+   * The identity is re-derived on every read rather than captured once, because
+   * it changes underneath a running daemon — `OPEN_DESIGN_AMR_PROFILE` moves
+   * between environments and a fresh `vela login` rewrites the account. A
+   * mismatch reads as "no selection", which is exactly the state the
+   * directory-driven bootstrap in `resolveCurrent` already handles: it picks a
+   * default from the membership list that the CURRENT credential returned, and
+   * rebinds the file to the current identity on its way through. Announcing the
+   * foreign id instead is what makes Vela answer `403 missing_principal` to
+   * every request until someone re-picks a workspace by hand.
+   *
+   * A foreign record is left on disk rather than unlinked here: reads are
+   * synchronous and unlinking belongs on the serialized mutation queue, and an
+   * inert record costs nothing because the next write overwrites it.
+   */
   const read = (): string | null => {
-    if (cached !== undefined) return cached;
-    try {
-      const raw = fs.readFileSync(filePath, 'utf8');
-      const parsed = JSON.parse(raw) as ActiveWorkspaceSelectionFile;
-      cached = typeof parsed.workspaceId === 'string' && parsed.workspaceId.trim()
-        ? parsed.workspaceId.trim()
-        : null;
-    } catch {
-      cached = null;
-    }
-    return cached;
+    if (cached === undefined) cached = readAttributedSelection(filePath);
+    if (!cached.workspaceId || !cached.identity) return null;
+    return cached.identity === currentIdentity() ? cached.workspaceId : null;
   };
 
   const notify = (workspaceId: string | null) => {
@@ -95,13 +156,17 @@ export function createActiveWorkspaceSelectionStore(
     return result;
   };
 
-  const persist = async (workspaceId: string) => {
+  /**
+   * Write the id together with the identity choosing it, so a later read can
+   * tell whether this record is still its own.
+   */
+  const persist = async (workspaceId: string, identity: string) => {
     await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
     const tempPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
     try {
       await fs.promises.writeFile(
         tempPath,
-        JSON.stringify({ workspaceId }, null, 2),
+        JSON.stringify({ workspaceId, identity }, null, 2),
         'utf8',
       );
       await fs.promises.rename(tempPath, filePath);
@@ -111,10 +176,16 @@ export function createActiveWorkspaceSelectionStore(
     }
   };
 
-  const commit = (workspaceId: string) => {
-    cached = workspaceId;
+  const commit = (workspaceId: string, identity: string) => {
+    cached = { workspaceId, identity };
     generation += 1;
     notify(workspaceId);
+  };
+
+  const forget = () => {
+    cached = NO_SELECTION;
+    generation += 1;
+    notify(null);
   };
 
   return {
@@ -126,16 +197,15 @@ export function createActiveWorkspaceSelectionStore(
       const next = workspaceId.trim();
       if (!next) throw new Error('workspaceId is required');
       await enqueueMutation(async () => {
-        await persist(next);
-        commit(next);
+        const identity = currentIdentity();
+        await persist(next, identity);
+        commit(next, identity);
       });
     },
     async clear() {
       await enqueueMutation(async () => {
         await fs.promises.rm(filePath, { force: true });
-        cached = null;
-        generation += 1;
-        notify(null);
+        forget();
       });
     },
     async clearIf(workspaceId: string) {
@@ -144,9 +214,7 @@ export function createActiveWorkspaceSelectionStore(
       return enqueueMutation(async () => {
         if (read() !== expected) return false;
         await fs.promises.rm(filePath, { force: true });
-        cached = null;
-        generation += 1;
-        notify(null);
+        forget();
         return true;
       });
     },
@@ -156,8 +224,9 @@ export function createActiveWorkspaceSelectionStore(
       if (!next) throw new Error('workspaceId is required');
       await enqueueMutation(async () => {
         if (read() !== expected) return;
-        await persist(next);
-        commit(next);
+        const identity = currentIdentity();
+        await persist(next, identity);
+        commit(next, identity);
       });
 
       // A user switch can queue while the conditional write is in flight.

--- a/apps/daemon/src/collab/workspace-selection-identity.ts
+++ b/apps/daemon/src/collab/workspace-selection-identity.ts
@@ -1,0 +1,51 @@
+import { createHash } from 'node:crypto';
+
+import { readVelaCredentialRevision } from '../integrations/vela.js';
+
+/**
+ * Non-secret stamp naming the account + AMR environment that a locally
+ * persisted choice was made under.
+ *
+ * A workspace id is only meaningful next to the credential it was resolved
+ * with: Vela resolves membership as `findWorkspaceAndMember(workspaceId,
+ * appUserId)`, so the same id carried into another account or another
+ * environment resolves to no row at all. A local record that stores the id
+ * without the identity is therefore not a preference — it is a value that can
+ * silently outlive the only context in which it was valid.
+ *
+ * This reuses {@link readVelaCredentialRevision}, the credential fingerprint
+ * the daemon already derives for cache partitioning, and keeps only the fields
+ * that describe WHO and WHERE:
+ *
+ *  • `authSource` / `profile` — which AMR environment is in play, which is what
+ *    `OPEN_DESIGN_AMR_PROFILE` flips between prod and test;
+ *  • `loggedIn` / `userId` / `userEmail` — which signed-in account;
+ *  • `credentialFingerprint` — a one-way hash of the configured keys and URLs,
+ *    so a Settings-backed env swap that leaves `~/.amr/config.json` untouched
+ *    still reads as a different identity.
+ *
+ * `configMtimeMs` is deliberately excluded. It is part of the cache revision
+ * because a rewrite can change the plan/balance behind an unchanged account,
+ * but it changes on bookkeeping writes that leave the identity alone. Folding
+ * it in here would throw away a valid selection every time vela touched its own
+ * config file — turning a correctness fix into a recurring annoyance.
+ */
+export function resolveWorkspaceSelectionIdentity(
+  env: NodeJS.ProcessEnv = process.env,
+  configuredEnv: Record<string, string> = {},
+): string {
+  const revision = readVelaCredentialRevision(env, configuredEnv);
+  return createHash('sha256')
+    .update(
+      JSON.stringify([
+        revision.authSource,
+        revision.profile,
+        revision.loggedIn,
+        revision.userId,
+        revision.userEmail,
+        revision.credentialFingerprint,
+      ]),
+    )
+    .digest('hex')
+    .slice(0, 20);
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -939,6 +939,7 @@ import { createSqlitePublicFilePublicationStore } from './collab/public-file-pub
 import {
   createActiveWorkspaceSelectionStore,
 } from './collab/active-workspace-selection.js';
+import { resolveWorkspaceSelectionIdentity } from './collab/workspace-selection-identity.js';
 import {
   headerValue,
   resolveOptionalLocalWorkspaceRequestAuthority,
@@ -3691,7 +3692,14 @@ export async function startServer({
       ...(project.metadata ? { metadata: project.metadata } : {}),
     };
   };
-  const activeWorkspace = createActiveWorkspaceSelectionStore(RUNTIME_DATA_DIR);
+  // The restart-default selection is only usable under the identity that made
+  // it, so it is read and written against the account + AMR environment in
+  // play. `configuredAmrEnv` is read lazily (the store never resolves an
+  // identity at construction time) so a Settings-backed account switch — which
+  // rewrites app-config rather than `~/.amr/config.json` — is seen too.
+  const activeWorkspace = createActiveWorkspaceSelectionStore(RUNTIME_DATA_DIR, {
+    identity: () => resolveWorkspaceSelectionIdentity(process.env, configuredAmrEnv()),
+  });
   const teamMirrorPromotionJournalDir = path.join(
     RUNTIME_DATA_DIR,
     'team-mirror-promotions',

--- a/apps/daemon/tests/collab/workspace-selection-identity-binding.test.ts
+++ b/apps/daemon/tests/collab/workspace-selection-identity-binding.test.ts
@@ -1,0 +1,228 @@
+/**
+ * A persisted workspace selection belongs to the identity that made it.
+ *
+ * `workspace-selection.json` is the daemon's restart default: the workspace id
+ * this client last chose. It used to be written as a bare `{ workspaceId }`,
+ * with nothing recording WHICH account or WHICH AMR environment chose it. That
+ * makes the record silently portable across identities it was never valid for:
+ * switch `OPEN_DESIGN_AMR_PROFILE` between prod and test, or sign in as another
+ * account, and the credential changes while the workspace id does not.
+ *
+ * Downstream that is not a cosmetic mismatch. The client keeps announcing the
+ * foreign id, Vela's `findWorkspaceAndMember(workspaceId, appUserId)` finds no
+ * membership row, raises `workspace_member_required`, and the bare catch in
+ * `getCurrentWorkspaceContext` reports it as `403 missing_principal`. Nothing
+ * upstream caches that decision, so every subsequent request repeats it — the
+ * field report is a machine that moved between prod and test several times in
+ * one morning and then answered 403 to everything until the selection was
+ * replaced.
+ *
+ * So the invariant under test is: a stored selection is only usable while the
+ * identity reading it is the identity that wrote it. Anything else — a
+ * different account, a different environment, or a legacy record that cannot
+ * say who wrote it — reads as "no selection", which is the state the normal
+ * directory-driven re-resolution path already knows how to handle.
+ */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createActiveWorkspaceSelectionStore } from '../../src/collab/active-workspace-selection.js';
+
+const tempDirs: string[] = [];
+
+/** Workspace ids from the field report, kept verbatim so the case stays legible. */
+const PROD_WORKSPACE = 'm46zutn5p4sgpwenaouxfucs';
+const TEST_WORKSPACE = 'j2ryucc2ynz4gbtq30l80czf';
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/**
+ * A file-backed AMR session, the shape `vela login` leaves behind. Each profile
+ * carries its own environment URLs, its own keys, and its own signed-in user —
+ * exactly the three axes that make one profile's workspace ids meaningless in
+ * another.
+ */
+function writeAmrConfig(amrHome: string, profiles: Record<string, unknown>): void {
+  writeFileSync(
+    join(amrHome, 'config.json'),
+    JSON.stringify({ profiles }, null, 2),
+    'utf8',
+  );
+}
+
+function prodProfile(): Record<string, unknown> {
+  return {
+    apiUrl: 'https://amr-api.open-design.ai',
+    linkUrl: 'https://link.open-design.ai',
+    controlKey: 'prod-control-key',
+    runtimeKey: 'prod-runtime-key',
+    user: { id: 'user-prod', email: 'prod@example.com' },
+  };
+}
+
+function testProfile(): Record<string, unknown> {
+  return {
+    apiUrl: 'https://amr-api-test.open-design.ai',
+    linkUrl: 'https://link-test.open-design.ai',
+    controlKey: 'test-control-key',
+    runtimeKey: 'test-runtime-key',
+    user: { id: 'user-test', email: 'test@example.com' },
+  };
+}
+
+/** Seeds both environments and points the process at `prod`. */
+function seedBothEnvironments(): string {
+  const amrHome = makeTempDir('od-wsbind-amr-');
+  writeAmrConfig(amrHome, { prod: prodProfile(), test: testProfile() });
+  vi.stubEnv('AMR_HOME', amrHome);
+  vi.stubEnv('OPEN_DESIGN_AMR_PROFILE', 'prod');
+  return amrHome;
+}
+
+function selectionFileOf(root: string): Record<string, unknown> {
+  return JSON.parse(
+    readFileSync(join(root, 'workspace-selection.json'), 'utf8'),
+  ) as Record<string, unknown>;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('persisted workspace selection is bound to the identity that chose it', () => {
+  it('stops handing back a prod selection once the process switches to test', async () => {
+    seedBothEnvironments();
+    const root = makeTempDir('od-wsbind-data-');
+
+    const store = createActiveWorkspaceSelectionStore(root);
+    await store.set(PROD_WORKSPACE);
+    expect(store.get()).toBe(PROD_WORKSPACE);
+
+    // Same machine, same data directory, different environment. The credential
+    // in play is now test's; the prod workspace id has no membership row behind
+    // it, so announcing it is what produces the sustained 403.
+    vi.stubEnv('OPEN_DESIGN_AMR_PROFILE', 'test');
+
+    expect(store.get()).toBeNull();
+    expect(store.snapshot().workspaceId).toBeNull();
+    // A daemon restart under test must not resurrect it from disk either.
+    expect(createActiveWorkspaceSelectionStore(root).get()).toBeNull();
+  });
+
+  it('stops handing back a selection made by a different account on the same profile', async () => {
+    const amrHome = seedBothEnvironments();
+    const root = makeTempDir('od-wsbind-data-');
+
+    const store = createActiveWorkspaceSelectionStore(root);
+    await store.set(PROD_WORKSPACE);
+    expect(store.get()).toBe(PROD_WORKSPACE);
+
+    // A second `vela login` on the same profile: same environment, different
+    // person. Their membership rows are disjoint from the first account's.
+    writeAmrConfig(amrHome, {
+      prod: {
+        ...prodProfile(),
+        controlKey: 'prod-control-key-second-account',
+        runtimeKey: 'prod-runtime-key-second-account',
+        user: { id: 'user-prod-second', email: 'second@example.com' },
+      },
+      test: testProfile(),
+    });
+
+    expect(store.get()).toBeNull();
+    expect(createActiveWorkspaceSelectionStore(root).get()).toBeNull();
+  });
+
+  it('discards a legacy record that cannot say which identity wrote it', () => {
+    seedBothEnvironments();
+    const root = makeTempDir('od-wsbind-data-');
+
+    // The pre-migration on-disk shape. It may well have been written by this
+    // identity, but nothing in it says so, and trusting an unattributable
+    // record is the exact failure this change exists to remove. Discarding it
+    // costs one re-resolution; trusting it costs a persistent 403.
+    writeFileSync(
+      join(root, 'workspace-selection.json'),
+      `${JSON.stringify({ workspaceId: TEST_WORKSPACE }, null, 2)}\n`,
+      'utf8',
+    );
+
+    expect(createActiveWorkspaceSelectionStore(root).get()).toBeNull();
+  });
+
+  it('records the identity alongside the workspace id it selected', async () => {
+    seedBothEnvironments();
+    const root = makeTempDir('od-wsbind-data-');
+
+    await createActiveWorkspaceSelectionStore(root).set(PROD_WORKSPACE);
+
+    const persisted = selectionFileOf(root);
+    expect(persisted.workspaceId).toBe(PROD_WORKSPACE);
+    expect(typeof persisted.identity).toBe('string');
+    expect(persisted.identity).not.toBe('');
+  });
+
+  it('keeps serving the selection across a restart under the unchanged identity', async () => {
+    seedBothEnvironments();
+    const root = makeTempDir('od-wsbind-data-');
+
+    await createActiveWorkspaceSelectionStore(root).set(PROD_WORKSPACE);
+
+    expect(createActiveWorkspaceSelectionStore(root).get()).toBe(PROD_WORKSPACE);
+  });
+
+  it('keeps serving the selection when the AMR config is rewritten without changing the account', async () => {
+    const amrHome = seedBothEnvironments();
+    const root = makeTempDir('od-wsbind-data-');
+
+    const store = createActiveWorkspaceSelectionStore(root);
+    await store.set(PROD_WORKSPACE);
+
+    // A config rewrite that leaves the account and the environment alone —
+    // vela touches this file for its own bookkeeping. Binding to the mtime
+    // instead of the identity would log the user out of their own selection
+    // every time that happened, so the stamp must ignore it.
+    writeFileSync(
+      join(amrHome, 'config.json'),
+      JSON.stringify(
+        { lastUsedAt: new Date().toISOString(), profiles: { prod: prodProfile(), test: testProfile() } },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+
+    expect(store.get()).toBe(PROD_WORKSPACE);
+    expect(createActiveWorkspaceSelectionStore(root).get()).toBe(PROD_WORKSPACE);
+  });
+
+  it('lets the normal re-resolution path claim the file for the new identity', async () => {
+    seedBothEnvironments();
+    const root = makeTempDir('od-wsbind-data-');
+
+    const store = createActiveWorkspaceSelectionStore(root);
+    await store.set(PROD_WORKSPACE);
+
+    vi.stubEnv('OPEN_DESIGN_AMR_PROFILE', 'test');
+
+    // This is how `resolveCurrent` writes a directory-derived bootstrap: it
+    // passes the selection it just read as the expected value. Under a foreign
+    // identity that read is `null`, so the conditional write must succeed
+    // rather than being blocked by the previous environment's leftover.
+    await expect(store.replaceIf(null, TEST_WORKSPACE)).resolves.toBe(TEST_WORKSPACE);
+    expect(store.get()).toBe(TEST_WORKSPACE);
+
+    // ...and going back to prod does not re-expose the test id.
+    vi.stubEnv('OPEN_DESIGN_AMR_PROFILE', 'prod');
+    expect(store.get()).toBeNull();
+  });
+});

--- a/apps/daemon/tests/design-systems/workspace-scope-context-switch.test.ts
+++ b/apps/daemon/tests/design-systems/workspace-scope-context-switch.test.ts
@@ -7,6 +7,7 @@ import type http from 'node:http';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createActiveWorkspaceSelectionStore } from '../../src/collab/active-workspace-selection.js';
 import { startServer } from '../../src/server.js';
 
 type StartedServer = {
@@ -215,14 +216,15 @@ describe('resolveDesignSystemWorkspaceScope — stale local pins are never data-
   let shutdown: (() => Promise<void> | void) | undefined;
 
   beforeAll(async () => {
-    // A stale local pin exactly like a real leftover from a previous identity
-    // — `velaLogout` never clears this file (only a CONFIRMED member-removal
-    // does; see `resolvePinnedWorkspace` in vela-workspace-context.ts).
+    // A stale local pin exactly like a real leftover — `velaLogout` never
+    // clears this file (only a CONFIRMED member-removal does; see
+    // `resolvePinnedWorkspace` in vela-workspace-context.ts). Seeded through
+    // the store rather than by hand-writing JSON so the pin carries this
+    // process's identity stamp and is therefore genuinely readable: a record
+    // the store discards as foreign would satisfy the assertions below without
+    // ever reaching the gate they exist to test.
     const dataDir = process.env.OD_DATA_DIR!;
-    writeFileSync(
-      path.join(dataDir, 'workspace-selection.json'),
-      `${JSON.stringify({ workspaceId: 'ws-stale-pin' }, null, 2)}\n`,
-    );
+    await createActiveWorkspaceSelectionStore(dataDir).set('ws-stale-pin');
     // A design system claimed by the pinned workspace, seeded directly on
     // disk so this suite is independent of the other describe block's state.
     const dsDir = path.join(dataDir, 'design-systems', 'pinned-claim');


### PR DESCRIPTION
## Why

**My use case.** I was following up the field report behind #7922: a machine that moved between the prod and test AMR environments several times in one morning, across three accounts, and by the next day answered `403 missing_principal` to everything — the client had put the user back on the sign-in page and kept them there. #7922 fixes the *symptom* (a single upstream 403 must not be read as "your credential died", and the client re-resolves from the directory). This PR fixes the *cause*: why the client was announcing a workspace that its current credential had never been a member of.

**The pain.** `workspace-selection.json` is the daemon's restart default — the workspace id this client last chose. It was written as a bare `{ workspaceId }`, with **nothing recording which account, which AMR profile, or which credential made that choice**. That makes the record silently portable into identities it was never valid for. Flip `OPEN_DESIGN_AMR_PROFILE` between prod and test, or sign in as a second account, and the credential changes while the workspace id does not.

Downstream that is not cosmetic. Vela resolves membership as `findWorkspaceAndMember(workspaceId, appUserId)`; a foreign id finds no row, raises `workspace_member_required`, and the bare catch in `getCurrentWorkspaceContext` reports it as `403 missing_principal`. Nothing upstream caches that decision, so **every** subsequent request repeats it for as long as the stale id is on disk. Probing production confirms the shape is exactly a mismatch and not a bad key: prod key + test workspace → 403, test key + prod workspace → 403, a nonsense key → 401.

The three ids from the report split cleanly across environments — `m46zutn5p4sgpwenaouxfucs` in prod, `j2ryucc2ynz4gbtq30l80czf` and `c4i73okk4i04x2gd05afot1t` in test — which is what a single unattributed file looks like after a morning of switching.

**Relationship to #7922.** Complementary, and deliberately non-overlapping. #7922 makes a 403 survivable (`velaStatusRevokesCredential`, `markVelaAuthorizationRecovered`, the authority-probe session, and the web-side foreign-selection recovery). This PR keeps the mismatch from being produced in the first place. It touches neither `integrations/vela.ts`, `collab/vela-workspace-context.ts`, nor `apps/web/**`; the only file both PRs open is `apps/daemon/src/server.ts`, at unrelated lines (#7922 changes the `identityKey` of `workspaceExactContextCache`; this changes the construction of `activeWorkspace`). Both should land — with only #7922, a mismatch still costs a full round of degraded requests before the client recovers; with only this one, an unrelated 403 still ends the session.

## What users will see

- **If you use more than one account, or move between the production and test AMR environments on the same machine:** the app no longer gets wedged asking you to sign in again after a switch. Previously it kept announcing the workspace you had picked under the *other* identity, every request was rejected, and you were bounced to the sign-in page until that selection was replaced by hand. Now a workspace you pick is remembered only for the account and environment you picked it in; switch, and the app quietly re-picks from the workspace list your *current* sign-in actually has, exactly as it does on a first launch. Switching back does not restore the earlier identity's pick — the file holds one selection, and the new identity claims it.
- **Everyone, once, on the first launch after upgrading:** the stored selection predates this attribution and cannot say who wrote it, so it is discarded and re-resolved instead of trusted. Most people will not notice — the workspace is re-selected automatically. If your last workspace was a **team** workspace, that first launch lands you on your personal workspace and you re-pick once. Discarding costs one re-selection; trusting an unattributable record costs a persistent 403, so this is the safe default.
- No new UI, no new setting, nothing to click.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — the on-disk shape of `workspace-selection.json` gains an `identity` field, and pre-existing (unattributed) records are discarded on first read, causing one re-resolution per user on upgrade.
- [ ] **None**

## Screenshots

n/a — no UI surface.

## Bug fix verification

- **Test path:** `apps/daemon/tests/collab/workspace-selection-identity-binding.test.ts`
- **Did it go red before the source change and green after?** Yes — twice, once by writing the spec first and once by removing the implementation again.

**1. Red first, against unmodified `origin/main` source:**

```
 ❯ tests/collab/workspace-selection-identity-binding.test.ts (7 tests | 5 failed) 18ms

 FAIL  ... > stops handing back a prod selection once the process switches to test
AssertionError: expected 'm46zutn5p4sgpwenaouxfucs' to be null
 FAIL  ... > stops handing back a selection made by a different account on the same profile
AssertionError: expected 'm46zutn5p4sgpwenaouxfucs' to be null
 FAIL  ... > discards a legacy record that cannot say which identity wrote it
AssertionError: expected 'j2ryucc2ynz4gbtq30l80czf' to be null
 FAIL  ... > records the identity alongside the workspace id it selected
AssertionError: expected 'undefined' to be 'string'
 FAIL  ... > lets the normal re-resolution path claim the file for the new identity
AssertionError: expected 'm46zutn5p4sgpwenaouxfucs' to be 'j2ryucc2ynz4gbtq30l80czf'

 Test Files  1 failed (1)
      Tests  5 failed | 2 passed (7)
```

The 2 that passed from the start are deliberate: they are the "don't break the normal path" guards (a selection survives a restart under an unchanged identity, and survives an AMR-config rewrite that leaves the account alone). A fix that over-invalidated would have turned them red.

**2. Green with the implementation:**

```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

**3. Red again after removing the implementation** (restored `active-workspace-selection.ts` and `server.ts` to `origin/main`, deleted `workspace-selection-identity.ts`, re-ran) — proving the spec is anchored on the change and not passing for free:

```
AssertionError: expected 'm46zutn5p4sgpwenaouxfucs' to be null
AssertionError: expected 'm46zutn5p4sgpwenaouxfucs' to be null
AssertionError: expected 'j2ryucc2ynz4gbtq30l80czf' to be null
AssertionError: expected 'undefined' to be 'string'
AssertionError: expected 'm46zutn5p4sgpwenaouxfucs' to be 'j2ryucc2ynz4gbtq30l80czf'

 Test Files  1 failed | 1 passed (2)
      Tests  5 failed | 7 passed (12)
```

## What changed

- **`apps/daemon/src/collab/workspace-selection-identity.ts` (new).** `resolveWorkspaceSelectionIdentity()` derives a non-secret stamp for "which account + which AMR environment". It reuses the existing `readVelaCredentialRevision` fingerprint rather than inventing a second credential-identity scheme, keeping the fields that describe *who* and *where* (`authSource`, `profile`, `loggedIn`, `userId`, `userEmail`, `credentialFingerprint`) and deliberately dropping `configMtimeMs` — vela rewrites its own config for bookkeeping, and binding to the mtime would throw away a valid selection every time it did.
- **`apps/daemon/src/collab/active-workspace-selection.ts`.** Writes now persist `{ workspaceId, identity }`; reads return the id only while the reading identity is the writing identity. The identity is re-derived per read, not captured at construction, because it changes underneath a live daemon (a profile flip, a fresh `vela login`). A record that is foreign — or unattributed, i.e. legacy — reads as *no selection*, which is the state the directory-driven bootstrap in `resolveCurrent` already handles: it picks a default from the membership list the **current** credential returned and rebinds the file on its way through. The identity resolver is injectable so tests are not at the mercy of the developer's `~/.amr`.
- **`apps/daemon/src/server.ts`.** Constructs the store with the production identity, reading `configuredAmrEnv()` lazily so a Settings-backed account switch (which rewrites app-config, not `~/.amr/config.json`) is seen too.

**Consumers.** `workspace-selection.json` has exactly one reader in the repository — this store — so `read()` is the single choke point and every consumer inherits the gate: `deps.activeWorkspace.get()` twice in `GET /api/workspace/directory` and `set()` in `PUT /api/workspace/active` (`routes/collab-context.ts`), `getActiveWorkspaceId` / `replaceLocalSelection` on the Vela workspace-context provider (`collab/vela-workspace-context.ts`, reached via `server.ts`), and `snapshot()` behind `resolveAuthorizedActiveTeamWorkspaceSnapshot`. I walked both directions — who writes it and who consumes it — rather than patching the one call site the report happened to name. `clearIf`/`replaceIf` were re-checked under a mismatched identity: `clearIf` no-ops (it will not delete another identity's record) and `replaceIf(null, …)` succeeds, which is precisely the re-resolution path.

**One test fixture updated.** `apps/daemon/tests/design-systems/workspace-scope-context-switch.test.ts` hand-wrote a bare `{ workspaceId: 'ws-stale-pin' }` to simulate a leftover pin. Under this change the store would discard it as unattributed, and the suite's assertions ("a stale pin is never data-plane authority") would have passed *vacuously* — green while never reaching the gate they exist to test. It now seeds through the store, so the pin is genuinely readable and the gate is still exercised.

## Adjacent issues

Found while working here; not fixed in this PR, per the one-bug-one-PR rule.

1. **`credentialFingerprint` has a residual blind spot for env-backed sessions.** When `VELA_RUNTIME_KEY` + `VELA_LINK_URL` are set, `readRawVelaCredentialRevision` hashes only those two — not `VELA_CONTROL_KEY` or `VELA_API_URL`. Two Settings-backed sessions differing only in the control key or API URL therefore share a fingerprint. It does not reach the reported case (the profile is part of the stamp, and the field machine was file-backed), and widening it would touch `integrations/vela.ts` — the file #7922 is rewriting — so it is left alone deliberately.
2. **A foreign record is left on disk rather than unlinked.** It is inert (never returned) and the next write overwrites it, but a `~/.amr` restore could resurrect a selection that is no longer reachable through the UI. Unlinking belongs on the serialized mutation queue, not in a synchronous read.
3. **`projectCollabScope` has no production call site.** `server.ts` imports it (line ~956) but never calls it; the only callers are `apps/daemon/tests/collab/team-share-scope.test.ts`. Its `localSelection` input — one of the documented consumers of the persisted selection in `collab/workspace-scope.ts`'s priority list — therefore has no live producer. Either dead code or an unfinished wiring; worth a separate look.
4. **`ActiveWorkspaceSelectionStore.subscribe` has no production subscriber either**, and identity changes do not notify (they change what `get()` returns without a mutation). Harmless today because nothing subscribes; it would need addressing before anything did.

## Validation

- `pnpm guard` — pass (exit 0)
- `pnpm typecheck` — pass (exit 0)
- `pnpm --filter @open-design/daemon build` — pass (exit 0; run separately, since daemon typecheck green does not imply build green under `noUncheckedIndexedAccess`)
- Focused re-run of every suite that touches this store — all green:
  `vitest run tests/collab/workspace-selection-identity-binding.test.ts tests/collab/active-workspace-selection.test.ts tests/vela-workspace-context.test.ts tests/collab-context-routes.test.ts tests/design-systems/workspace-scope-context-switch.test.ts` → `Test Files 5 passed`
- `pnpm --filter @open-design/daemon test` — `Test Files 4 failed | 842 passed | 3 skipped (849)`, `Tests 5 failed | 11141 passed | 135 skipped (11281)`.

**On those 4 failing files — none are from this change.** Every failure is `Test timed out in 20000ms` or `Hook timed out in 10000ms`; the machine was running several vitest processes concurrently. I checked rather than assumed:

- `tests/chat-route.test.ts`, `tests/project-raw-cache.test.ts`, `tests/routes/workspace-projects.test.ts` — **green** when re-run in isolation on this branch. (`workspace-projects` had failed only in its `beforeAll` `startServer` hook, then cascaded into `afterAll`.)
- `tests/od-next-automatic-simple-server.test.ts` — red on this branch *and* red on baseline. I took the baseline on the same machine under the same load by restoring `active-workspace-selection.ts` and `server.ts` to `origin/main`, deleting `workspace-selection-identity.ts`, and rebuilding the daemon: **baseline 2 failed / 29 passed**, branch 4 failed / 27 passed (and 10 failed on an earlier, busier run). The failing test *names* differ on every run, on both sides, and all are timeouts — this file spawns real agent CLIs and takes ~8 minutes on its own. Pre-existing load sensitivity, not a regression. The working tree was restored byte-identically afterwards (`git status` clean against the commit).

No `apps/web` files touched, so the web suites are not in scope for this change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKjoMhNakUcKZooocqUNFP
