### PR TITLE
fix(daemon): fail blocked OD Next runs before finalization

### DIFF
--- a/apps/daemon/src/run-failure-classification.ts
+++ b/apps/daemon/src/run-failure-classification.ts
@@ -974,6 +974,19 @@ function classifyRunFailureBase(
   }
 
   const errorCode = normalizeCode(input.errorCode ?? input.status.errorCode);
+  if (errorCode === 'OD_NEXT_TASK_BLOCKED') {
+    // The host rejected completion, but this does not establish why the model
+    // failed to satisfy the task contract. Do not infer a provider fault or a
+    // child crash from the blocked reason text (the process may exit zero).
+    return {
+      ...classification('process_exit', 'execution_failed', 'finalize', false, 'none', {
+        evidenceLevel: 'structured_code',
+      }),
+      failure_mechanism: 'unknown',
+      failure_domain: 'unknown',
+      repair_owner: 'unknown',
+    };
+  }
   const text = collectFailureText({ ...input, events });
   const retryableHint = latestRetryable(events);
   // Compute once; used both for the early empty_output guard below and for the

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -12731,6 +12731,23 @@ export async function startServer({
       { allowRetry = true } = {},
     ) => {
       lifecycle.mark('finalize_start');
+      // A clean child exit does not complete a task rejected by the strategy
+      // gate. Reconcile before persisting the message or publishing the Run
+      // terminal event, while retaining the actual process exit code.
+      if (
+        status === 'succeeded'
+        && run.strategyTask?.outcome === 'blocked'
+        && run.strategyTask.activeRunId === run.id
+      ) {
+        status = 'failed';
+        allowRetry = false;
+        const reasonCodes = run.strategyTask.blockedContext?.reasonCodes ?? [];
+        send('error', createSseErrorPayload(
+          'OD_NEXT_TASK_BLOCKED',
+          `The task could not complete${reasonCodes.length ? `: ${reasonCodes.join(', ')}` : '.'}`,
+          { retryable: false, details: { reasonCodes } },
+        ));
+      }
       flushRunMessageEvents(run);
       // Persist the transport-level close mechanism before classifying this
       // attempt. Runtime fatal/stream signals are only known in the close

--- a/apps/daemon/tests/amr-session-resume.test.ts
+++ b/apps/daemon/tests/amr-session-resume.test.ts
@@ -4,7 +4,7 @@ import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { startServer } from '../src/server.js';
 
@@ -53,6 +53,11 @@ describe('AMR (vela) ACP session resume — full server cycle', () => {
   const originalEnv = snapshotEnv();
   let started: StartedServer | null = null;
   let binDir: string | null = null;
+
+  beforeEach(() => {
+    // These fixtures exercise session transport with plain replies, not OD Next state.
+    process.env.OD_NEXT_STRATEGY_ROLLOUT = 'off';
+  });
 
   afterEach(async () => {
     await Promise.resolve(started?.shutdown?.());
@@ -520,6 +525,7 @@ function snapshotEnv(): Record<string, string | undefined> {
     OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
     POSTHOG_KEY: process.env.POSTHOG_KEY,
     POSTHOG_HOST: process.env.POSTHOG_HOST,
+    OD_NEXT_STRATEGY_ROLLOUT: process.env.OD_NEXT_STRATEGY_ROLLOUT,
   };
 }
 

--- a/apps/daemon/tests/codex-model-capability-preflight.test.ts
+++ b/apps/daemon/tests/codex-model-capability-preflight.test.ts
@@ -122,6 +122,8 @@ describe('Codex configured-model capability preflight', () => {
     // success-path case on the transport whose protocol it implements;
     // app-server protocol coverage belongs to the dedicated transport suites.
     process.env.OD_CODEX_TRANSPORT = 'exec-json';
+    // The preflight fixture emits a plain reply without the OD Next task protocol.
+    process.env.OD_NEXT_STRATEGY_ROLLOUT = 'off';
     started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
     await putConfig(started.url, {
       agentId: 'codex',

--- a/apps/daemon/tests/codex-session-resume.test.ts
+++ b/apps/daemon/tests/codex-session-resume.test.ts
@@ -53,6 +53,8 @@ describe('codex native session resume', () => {
   let binDir: string | null = null;
 
   beforeEach(() => {
+    // These plain-reply fixtures exercise native sessions without an OD Next task.
+    process.env.OD_NEXT_STRATEGY_ROLLOUT = 'off';
     // These fixtures implement the legacy `codex exec --json` wire format and
     // assert its argv-level resume contract. Keep this suite on that transport
     // now that production defaults to the app-server JSON-RPC transport.
@@ -470,6 +472,7 @@ function snapshotEnv(): Record<string, string | undefined> {
     OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
     POSTHOG_KEY: process.env.POSTHOG_KEY,
     POSTHOG_HOST: process.env.POSTHOG_HOST,
+    OD_NEXT_STRATEGY_ROLLOUT: process.env.OD_NEXT_STRATEGY_ROLLOUT,
   };
 }
 

--- a/apps/daemon/tests/first-visible-output-mark.test.ts
+++ b/apps/daemon/tests/first-visible-output-mark.test.ts
@@ -225,10 +225,21 @@ describe('first_visible_output is stamped at emission, not at first token', () =
     if (options.strategyRollout === 'active') {
       expect(created.pluginId).toBe('od-next-strategy');
       expect(created.strategyTask).toBeDefined();
+      // The deliberately incomplete state still releases the withheld tail,
+      // but the strategy gate rejects completion before the Run is finalized.
+      expect(run).toMatchObject({
+        status: 'failed',
+        exitCode: 0,
+        errorCode: 'OD_NEXT_TASK_BLOCKED',
+        strategyTask: {
+          outcome: 'blocked',
+          blockedContext: { reasonCodes: ['od_next_protocol_runtime_state_invalid_schema'] },
+        },
+      });
     } else {
       expect(created.strategyTask).toBeUndefined();
+      expect(run.status).toBe('succeeded');
     }
-    expect(run.status).toBe('succeeded');
     const flush = async () => {
       await Promise.resolve(started?.shutdown?.());
     };

--- a/apps/daemon/tests/od-next-automatic-simple-server.test.ts
+++ b/apps/daemon/tests/od-next-automatic-simple-server.test.ts
@@ -2140,6 +2140,57 @@ describe('OD Next automatic production through the real server', () => {
     expect(researchContract).not.toContain('## assistant');
   });
 
+  it('fails a blocked production exit before publishing its Run and message terminal status (OPEND-2953)', async () => {
+    const fixture = await createFixture('repair');
+    await writeFile(`${fixture.logPath}.blocked-production`, '1');
+    queueFixtureIds(fixture);
+    await postRun(started!.url, createRunRequest(fixture, 'Build the lesson deck.'), {
+      'x-od-analytics-device-id': 'device-opend-2953',
+      'x-od-analytics-session-id': 'session-opend-2953',
+      'x-od-analytics-client-type': 'desktop',
+    });
+    const task = await waitForTask(fixture.taskExecutionId, 'blocked');
+    const terminal = await waitForRunTerminal(started!.url, task.latestRunId);
+    expect(terminal).toMatchObject({
+      status: 'failed',
+      exitCode: 0,
+      errorCode: 'OD_NEXT_TASK_BLOCKED',
+      failureCategory: 'process_exit',
+      failureDetail: 'execution_failed',
+      retryable: false,
+      strategyTask: { outcome: 'blocked', terminal: true },
+    });
+    expect(terminal.error).toContain('od_next_protocol_runtime_state_missing');
+    const records = (await readFile(terminal.eventsLogPath, 'utf8')).trim().split('\n')
+      .map((line) => JSON.parse(line));
+    expect(records.filter((event) => event.event === 'end')).toHaveLength(1);
+    expect(records.find((event) => event.event === 'end')?.data).toMatchObject({
+      status: 'failed', code: 0, artifactCount: 0,
+    });
+    expect(records.find((event) => event.data?.type === 'runtime_close')?.data)
+      .toMatchObject({ rpc_close_reason: 'exit_0', status: 'failed', exit_code: 0 });
+    const response = await fetch(
+      `${started!.url}/api/projects/${fixture.projectId}/conversations/${fixture.conversationId}/messages`,
+    );
+    const { messages } = await response.json() as {
+      messages: Array<{ runId?: string; runStatus?: string }>;
+    };
+    expect(messages.find((message) => message.runId === task.latestRunId)?.runStatus).toBe('failed');
+    const [recovery] = await waitForRunAnalyticsRecoveries([task.latestRunId]);
+    expect(recovery?.properties).toMatchObject({
+      result: 'failed',
+      error_code: 'OD_NEXT_TASK_BLOCKED',
+      failure_stage: 'finalize',
+      failure_detail: 'execution_failed',
+      retryable: false,
+      rpc_close_reason: 'exit_0',
+    });
+    for (const mapping of task.runs.slice(0, -1)) {
+      expect((await getRun(started!.url, mapping.runId)).status).toBe('succeeded');
+    }
+    expect(await readProjectInvocations(fixture.logPath, fixture.projectId)).toHaveLength(3);
+  }, 90_000);
+
   it('blocks the durable task when the selected agent exits before publishing a session', async () => {
     const fixture = await createFixture('repair');
     await writeFile(`${fixture.logPath}.fail-start`, '1');
@@ -3046,6 +3097,9 @@ function finish() {
     text = ${JSON.stringify(complexPlan)};
   } else if (stdin.includes('native continuation — contract_repair')) {
     text = ${JSON.stringify(repaired)};
+  } else if (stdin.includes('native continuation — production') && fs.existsSync(logPath + '.blocked-production')) {
+    staleTodoList = true;
+    text = 'Working on the lesson.';
   } else if (stdin.includes('native continuation — production')) {
     fs.writeFileSync(path.join(process.cwd(), 'index.html'), '<!doctype html><title>Production</title>');
     staleTodoList = true;
@@ -3069,6 +3123,15 @@ function finish() {
   }
   console.log(JSON.stringify({ type: 'thread.started', thread_id: ${JSON.stringify(THREAD_ID)} }));
   console.log(JSON.stringify({ type: 'turn.started' }));
+  if (stdin.includes('native continuation — production') && fs.existsSync(logPath + '.blocked-production')) {
+    // Replay the host-observed failure boundary: completed tools and progress text,
+    // no deliverable or Runtime State, then a clean process exit.
+    for (let i = 0; i < 2; i++) console.log(JSON.stringify({ type: 'item.completed', item: {
+      id: 'tool-' + i, type: 'mcp_tool_call', server: 'tasks', tool: 'TodoWrite',
+      arguments: { todos: [{ content: 'Build the lesson', status: 'in_progress' }] },
+      result: { content: [{ type: 'text', text: 'Updated task list' }] }, status: 'completed',
+    } }));
+  }
   if (staleTodoList) {
     // Observed on real turns: the deliverable is written, but the LAST plan
     // snapshot the agent emits still carries unchecked items.

--- a/apps/daemon/tests/opencode-session-resume.test.ts
+++ b/apps/daemon/tests/opencode-session-resume.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { startServer } from '../src/server.js';
 
@@ -48,6 +48,11 @@ describe('opencode native session resume', () => {
   const originalEnv = snapshotEnv();
   let started: StartedServer | null = null;
   let binDir: string | null = null;
+
+  beforeEach(() => {
+    // These fixtures exercise session transport with plain replies, not OD Next state.
+    process.env.OD_NEXT_STRATEGY_ROLLOUT = 'off';
+  });
 
   afterEach(async () => {
     await Promise.resolve(started?.shutdown?.());
@@ -290,6 +295,7 @@ function snapshotEnv(): Record<string, string | undefined> {
     OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
     POSTHOG_KEY: process.env.POSTHOG_KEY,
     POSTHOG_HOST: process.env.POSTHOG_HOST,
+    OD_NEXT_STRATEGY_ROLLOUT: process.env.OD_NEXT_STRATEGY_ROLLOUT,
   };
 }
 

--- a/apps/daemon/tests/run-failure-classification.test.ts
+++ b/apps/daemon/tests/run-failure-classification.test.ts
@@ -117,6 +117,24 @@ function classify(
 }
 
 describe('classifyRunFailure', () => {
+  it('keeps a blocked task non-retryable without attributing its cause to a clean child exit', () => {
+    expect(classifyRunFailure({
+      result: 'failed',
+      status: { status: 'failed', errorCode: 'OD_NEXT_TASK_BLOCKED', exitCode: 0 },
+      events: [errorEvent('OD_NEXT_TASK_BLOCKED', 'upstream unavailable', false)],
+    })).toMatchObject({
+      failure_category: 'process_exit',
+      failure_detail: 'execution_failed',
+      failure_stage: 'finalize',
+      failure_mechanism: 'unknown',
+      failure_domain: 'unknown',
+      repair_owner: 'unknown',
+      evidence_level: 'structured_code',
+      retryable: false,
+      user_action: 'none',
+    });
+  });
+
   it('does not classify successful runs as failures', () => {
     expect(
       classifyRunFailure({

--- a/apps/daemon/tests/run-resume-on-failure.test.ts
+++ b/apps/daemon/tests/run-resume-on-failure.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { startServer } from '../src/server.js';
 
@@ -51,6 +51,11 @@ describe('resume-on-failure runtime', () => {
   const originalEnv = snapshotEnv();
   let started: StartedServer | null = null;
   let binDir: string | null = null;
+
+  beforeEach(() => {
+    // These plain-reply fixtures exercise failure recovery without an OD Next task.
+    process.env.OD_NEXT_STRATEGY_ROLLOUT = 'off';
+  });
 
   afterEach(async () => {
     await Promise.resolve(started?.shutdown?.());
@@ -247,6 +252,7 @@ function snapshotEnv(): Record<string, string | undefined> {
     OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
     POSTHOG_KEY: process.env.POSTHOG_KEY,
     POSTHOG_HOST: process.env.POSTHOG_HOST,
+    OD_NEXT_STRATEGY_ROLLOUT: process.env.OD_NEXT_STRATEGY_ROLLOUT,
   };
 }
 

--- a/apps/daemon/tests/run-retry-runtime.test.ts
+++ b/apps/daemon/tests/run-retry-runtime.test.ts
@@ -4,7 +4,7 @@ import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { startServer } from '../src/server.js';
 
@@ -53,6 +53,11 @@ describe('same-run retry runtime', () => {
   const originalEnv = snapshotEnv();
   let started: StartedServer | null = null;
   let binDir: string | null = null;
+
+  beforeEach(() => {
+    // These plain-reply fixtures exercise transport retries without an OD Next task.
+    process.env.OD_NEXT_STRATEGY_ROLLOUT = 'off';
+  });
 
   afterEach(async () => {
     await Promise.resolve(started?.shutdown?.());
@@ -656,6 +661,7 @@ function snapshotEnv(): Record<string, string | undefined> {
     OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
     POSTHOG_KEY: process.env.POSTHOG_KEY,
     POSTHOG_HOST: process.env.POSTHOG_HOST,
+    OD_NEXT_STRATEGY_ROLLOUT: process.env.OD_NEXT_STRATEGY_ROLLOUT,
     OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS: process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS,
     OD_CHAT_RUN_FIRST_OUTPUT_TIMEOUT_MS: process.env.OD_CHAT_RUN_FIRST_OUTPUT_TIMEOUT_MS,
     OD_CHAT_RUN_INACTIVITY_KILL_GRACE_MS: process.env.OD_CHAT_RUN_INACTIVITY_KILL_GRACE_MS,

--- a/e2e/specs/dialog/main.spec.ts
+++ b/e2e/specs/dialog/main.spec.ts
@@ -201,6 +201,9 @@ describe('dialog main spec', () => {
         },
         status,
       });
+    }, {
+      // This fixture emits generic artifact output, not OD Next protocol blocks.
+      env: { OD_NEXT_STRATEGY_ROLLOUT: 'off' },
     });
   }, 180_000);
 });

--- a/e2e/tests/amr/logout-state-persistence.test.ts
+++ b/e2e/tests/amr/logout-state-persistence.test.ts
@@ -95,6 +95,9 @@ describe('AMR logout state persistence', () => {
             headers: { ...AMR_TEST_WORKSPACE_HEADERS },
           }),
         ).resolves.toMatch(/AMR_AUTH_REQUIRED/);
+      }, {
+        // This fixture tests authentication with plain ACP output.
+        env: { OD_NEXT_STRATEGY_ROLLOUT: 'off' },
       });
     });
   });

--- a/e2e/tests/amr/relogin-required.test.ts
+++ b/e2e/tests/amr/relogin-required.test.ts
@@ -101,6 +101,9 @@ describe('AMR relogin-required run failures', () => {
           headers: { ...AMR_TEST_WORKSPACE_HEADERS },
           timeoutMs: 20_000,
         });
+      }, {
+        // The preflight fixture emits plain ACP output without strategy state.
+        env: { OD_NEXT_STRATEGY_ROLLOUT: 'off' },
       });
     });
   });
@@ -151,6 +154,9 @@ describe('AMR relogin-required run failures', () => {
             headers: { ...AMR_TEST_WORKSPACE_HEADERS },
             timeoutMs: 20_000,
           });
+        }, {
+          // The preflight fixture emits plain ACP output without strategy state.
+          env: { OD_NEXT_STRATEGY_ROLLOUT: 'off' },
         });
       },
     );

--- a/e2e/tests/amr/turn.test.ts
+++ b/e2e/tests/amr/turn.test.ts
@@ -423,6 +423,9 @@ describe('AMR chat-run end-to-end', () => {
         );
         expect(anyAssistant).toBeTruthy();
       }
+    }, {
+      // This fixture tests ACP streaming, not the OD Next task protocol.
+      env: { OD_NEXT_STRATEGY_ROLLOUT: 'off' },
     });
   }, 180_000);
 
@@ -629,6 +632,8 @@ describe('AMR chat-run end-to-end', () => {
         },
         {
           env: {
+            // Keep wallet settlement on the fixture's generic ACP turn.
+            OD_NEXT_STRATEGY_ROLLOUT: 'off',
             FAKE_VELA_SPAWN_ENV_LOG: spawnEnvLog,
             FAKE_VELA_BALANCE_FILE: balanceStateFile,
             FAKE_VELA_SETTLED_TEAM_BALANCE_USD: '17.50',

--- a/e2e/tests/dialog/retry-after-stop.test.ts
+++ b/e2e/tests/dialog/retry-after-stop.test.ts
@@ -181,6 +181,9 @@ describe('dialog retry after stop', () => {
       expect(assistant2!.startedAt).toBe(t1);
       expect(assistant2!.startedAt!).toBeGreaterThan(stoppedAt);
       expect(assistant2!.endedAt).toBe(finishedAt);
+    }, {
+      // This fixture emits generic artifact output, not OD Next protocol blocks.
+      env: { OD_NEXT_STRATEGY_ROLLOUT: 'off' },
     });
   }, 180_000);
 });

--- a/e2e/tests/tools-dev/sandbox-mode.test.ts
+++ b/e2e/tests/tools-dev/sandbox-mode.test.ts
@@ -186,6 +186,8 @@ describe('tools-dev sandbox mode smoke', () => {
       },
       {
         env: {
+          // The sandbox fixture emits generic artifacts without strategy state.
+          OD_NEXT_STRATEGY_ROLLOUT: 'off',
           OD_E2E_SANDBOX_CAPTURE_PATH: capturePath,
           OD_SANDBOX_MODE: '1',
         },


### PR DESCRIPTION
Related: [OPEND-2953](https://plane.powerformer.net/open-design/browse/OPEND-2953/)

## Why

A Windows prerelease lesson-deck task stopped without a deliverable. The strategy gate correctly blocked it with `od_next_protocol_runtime_state_missing`, but the child process exited zero, so the physical Run and saved message still reported success. This produced conflicting completion/failure UI and a successful `run_finished` record for the rejected production stage.

Reconcile the current Run with the strategy gate before finalization. A blocked task now produces `OD_NEXT_TASK_BLOCKED`, a failed terminal state, and non-retryable finalization classification. Preserve the actual exit code and blocked reason codes. Successful planning/clarification handoffs, completed tasks, prior failures, and cancellation keep their existing semantics; artifact count is not a success/failure heuristic.

The failure mechanism and responsible service remain unknown. This fixes the host status discrepancy; it does not establish or repair the cause of Vertex's reasoning-only completion, change provider token limits, or replay the task.

## What users will see

When an OD Next task is blocked after its agent exits cleanly, its final assistant message reports failure instead of showing a successful completion. The existing failure UI and CLI/API consumers receive the same failed Run state, including after message reload. The daemon does not automatically replay the blocked run.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — new root dependency
- [x] **Default behavior change** — changes what existing users experience
- [ ] **None** — internal refactor, docs, tests, or translation update only

API is checked for corrected terminal semantics and the new error code in the existing error envelope; no DTO shape or endpoint changes. No UI components, CLI commands, or flags change. Both surfaces consume the existing shared daemon API.

## Screenshots

No UI component changes. The original screenshot is attached to OPEND-2953. Verification here exercises the daemon HTTP/SSE and persisted message boundary; browser rendering and Windows packaged release validation were not run.

## Bug fix verification

- Regression: [daemon regression test](https://github.com/Siri-Ray/open-design/blob/7d31362933/apps/daemon/tests/od-next-automatic-simple-server.test.ts#L2143) — “fails a blocked production exit before publishing its Run and message terminal status (OPEND-2953)”.
- Red on upstream main `00c12c6451d9248c11a5c5122714e4d0b9f5709c`: the actual server returned `succeeded`, null failure fields, and a blocked task. Green after the source change.
- The synthetic Codex fixture exercises the shared host boundary: successful request/repair stages, completed TodoWrite calls, progress text, no deliverable/Runtime State, then exit zero. It does not claim to reproduce Gemini/Vertex's token-level behavior.
- Assertions cover one failed SSE end, exit code zero, blocked reason, saved message status, failed run analytics, successful preceding stages, and exactly three child invocations with no replay. The classification test prevents narrative text from inventing a provider fault or retry.

## Validation

- `corepack pnpm guard` — passed.
- `corepack pnpm typecheck` — passed across the workspace.
- `corepack pnpm --filter @open-design/daemon exec vitest run tests/od-next-automatic-simple-server.test.ts tests/run-failure-classification.test.ts tests/services/run-analytics-lifecycle.test.ts tests/observability/main-run-observation.test.ts tests/runtimes/run-terminal-reconciliation.test.ts tests/langfuse-bridge.test.ts` — 317 tests passed.
- `corepack pnpm --filter @open-design/daemon exec vitest run tests/observability/task-observation-rollout.test.ts tests/observability/task-observation-aggregation.test.ts` — 65 tests passed.
- `git diff --check` — passed.
- Remote CI, Windows packaged verification, and release validation are pending; no deployment or production data rewrite.
