### PR TITLE
fix(daemon): recognize linked prototype page delivery

### DIFF
--- a/apps/daemon/src/artifacts/linked-page-delivery.ts
+++ b/apps/daemon/src/artifacts/linked-page-delivery.ts
@@ -1,0 +1,85 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { load } from 'cheerio';
+
+const MAX_PAGES = 64;
+const MAX_PAGE_BYTES = 512 * 1024;
+const MAX_TOTAL_BYTES = 8 * 1024 * 1024;
+const ORIGIN = 'https://opendesign.invalid';
+
+function within(root: string, target: string): boolean {
+  const relative = path.relative(root, target);
+  return relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+}
+
+function pageUrl(relative: string): URL {
+  return new URL(relative.split('/').map(encodeURIComponent).join('/'), `${ORIGIN}/`);
+}
+
+/** Read only project-owned regular files, within a fixed per-page I/O budget. */
+async function readPage(root: string, relative: string): Promise<string | null> {
+  try {
+    const target = await fs.realpath(path.resolve(root, relative));
+    if (!within(root, target)) return null;
+    const handle = await fs.open(target, 'r');
+    try {
+      const stat = await handle.stat();
+      if (!stat.isFile() || stat.size > MAX_PAGE_BYTES) return null;
+      const buffer = Buffer.alloc(stat.size + 1);
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+      if (bytesRead !== stat.size) return null;
+      return buffer.subarray(0, bytesRead).toString('utf8');
+    } finally {
+      await handle.close();
+    }
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A prototype's linked pages belong to its canonical entry. Accept a changed
+ * page only after following real local HTML navigation from that entry; an
+ * unrelated HTML file, external URL, or old untouched page is not delivery.
+ * This reads markup only and never executes scripts or fetches resources.
+ */
+export async function findTouchedLinkedPage(input: {
+  projectRoot: string;
+  entryFile: string;
+  htmlPaths: ReadonlySet<string>;
+  touchedPaths: ReadonlySet<string>;
+}): Promise<string | null> {
+  let root: string;
+  try { root = await fs.realpath(input.projectRoot); } catch { return null; }
+  const pending = [input.entryFile];
+  const seen = new Set(pending);
+  let totalBytes = 0;
+  for (let index = 0; index < pending.length && index < MAX_PAGES; index += 1) {
+    const current = pending[index]!;
+    const html = await readPage(root, current);
+    if (html === null) continue;
+    totalBytes += Buffer.byteLength(html);
+    if (totalBytes > MAX_TOTAL_BYTES) return null;
+    if (input.touchedPaths.has(current)) return current;
+    const $ = load(html);
+    const baseHref = $('base[href]').first().attr('href');
+    let base = pageUrl(current);
+    try { if (baseHref) base = new URL(baseHref, base); } catch { continue; }
+    if (base.origin !== ORIGIN) continue;
+    for (const element of $('a[href], area[href]').toArray()) {
+      const href = $(element).attr('href')?.trim();
+      if (!href || href.startsWith('#') || /^(?:[a-z][a-z\d+.-]*:|\/\/)/i.test(href)) continue;
+      try {
+        const url = new URL(href, base);
+        if (url.origin !== ORIGIN) continue;
+        const relative = decodeURIComponent(url.pathname.slice(1));
+        if (!input.htmlPaths.has(relative) || seen.has(relative)) continue;
+        // Bound queued work too: a page can contain arbitrarily many links.
+        if (seen.size >= MAX_PAGES) break;
+        seen.add(relative);
+        pending.push(relative);
+      } catch { /* An invalid href is not evidence of a local page. */ }
+    }
+  }
+  return null;
+}

--- a/apps/daemon/src/artifacts/successful-run-deliverable-finalization.ts
+++ b/apps/daemon/src/artifacts/successful-run-deliverable-finalization.ts
@@ -42,6 +42,7 @@ export async function finalizeSuccessfulRunDeliverable(input: {
   relatedPaths?: readonly string[];
   repairState?: DeliverableSyntaxRepairState;
   touchedPaths?: string[];
+  baselineEntryFile?: string;
   syntaxFinalizerEnabled?: boolean;
 }): Promise<SuccessfulRunDeliverableFinalizationResult> {
   const deliverable = await validateRunDeliverable({
@@ -53,6 +54,7 @@ export async function finalizeSuccessfulRunDeliverable(input: {
     runStatus: 'succeeded',
     artifactCount: input.artifactCount,
     ...(input.touchedPaths ? { touchedPaths: input.touchedPaths } : {}),
+    ...(input.baselineEntryFile ? { baselineEntryFile: input.baselineEntryFile } : {}),
   });
   if (
     !deliverable.valid
@@ -69,7 +71,7 @@ export async function finalizeSuccessfulRunDeliverable(input: {
       input.projectId,
       input.projectMetadata,
     ),
-    entryFile: deliverable.entryFile,
+    entryFile: deliverable.linkedPage ?? deliverable.entryFile,
     relatedPaths: input.relatedPaths ?? [],
     processTreeQuiescent: input.processTreeQuiescent,
     ...(input.repairState ? { repairState: input.repairState } : {}),

--- a/apps/daemon/src/run-deliverable-validation.ts
+++ b/apps/daemon/src/run-deliverable-validation.ts
@@ -204,8 +204,8 @@ export async function validateRunDeliverable(
     : null;
   const selected = declared
     ? files.find((file) => filePath(file) === declared) ?? null
-    : inferredEntry(files, acceptedKinds)
-      ?? (baselineEntry ? files.find((file) => filePath(file) === baselineEntry) ?? null : null);
+    : (baselineEntry ? files.find((file) => filePath(file) === baselineEntry) ?? null : null)
+      ?? inferredEntry(files, acceptedKinds);
   if (!selected) {
     return { valid: false, validation: 'entry_missing' };
   }

--- a/apps/daemon/src/run-deliverable-validation.ts
+++ b/apps/daemon/src/run-deliverable-validation.ts
@@ -10,6 +10,7 @@ import type {
 } from '@open-design/contracts';
 
 import { listFiles, resolveProjectDir } from './projects.js';
+import { findTouchedLinkedPage } from './artifacts/linked-page-delivery.js';
 
 export type RunDeliverableValidation =
   | 'valid'
@@ -26,6 +27,8 @@ export interface RunDeliverableValidationResult {
   validation: RunDeliverableValidation;
   entryFile?: string;
   artifactKind?: ProjectFileKind;
+  /** Internal syntax-finalization input; entryFile remains the canonical entry. */
+  linkedPage?: string;
 }
 
 interface ValidateRunDeliverableInput {
@@ -37,6 +40,15 @@ interface ValidateRunDeliverableInput {
   /** Exact artifact paths changed by this run. Undefined means the runtime
    *  could not produce a reliable per-file diff (for example contention). */
   touchedPaths?: string[];
+  /** Unambiguous HTML entry observed by the host before this Run wrote files. */
+  baselineEntryFile?: string;
+}
+
+export function inferBaselineHtmlEntry(projectRoot: string, paths: Iterable<string>): string | undefined {
+  const rootHtml = [...paths]
+    .map((file) => path.relative(projectRoot, file).replaceAll(path.sep, '/'))
+    .filter((file) => !file.includes('/') && /\.html?$/i.test(file));
+  return rootHtml.includes('index.html') ? 'index.html' : rootHtml.length === 1 ? rootHtml[0] : undefined;
 }
 
 const PROJECT_KIND_FILE_KINDS: Partial<
@@ -152,8 +164,9 @@ function matchesAcceptedKinds(
  * Resolve and verify the one canonical file a successful run can deliver.
  *
  * `artifactCount` proves this run touched output; it does not prove the
- * project's declared entry still exists. The filesystem-backed file list and
- * a direct readability check are therefore authoritative.
+ * project's declared entry still exists. For prototypes, a changed local page
+ * reachable from that entry also updates the deliverable. The filesystem-backed
+ * file list and a direct readability check are authoritative.
  */
 export async function validateRunDeliverable(
   input: ValidateRunDeliverableInput,
@@ -184,10 +197,15 @@ export async function validateRunDeliverable(
   }
 
   const acceptedKinds = acceptedDeliverableKinds(input.projectMetadata);
+  const isPrototype = projectKind(input.projectMetadata) === 'prototype';
   const declared = safeRelativeFile(input.projectMetadata?.entryFile);
+  const baselineEntry = isPrototype && input.touchedPaths
+    ? safeRelativeFile(input.baselineEntryFile)
+    : null;
   const selected = declared
     ? files.find((file) => filePath(file) === declared) ?? null
-    : inferredEntry(files, acceptedKinds);
+    : inferredEntry(files, acceptedKinds)
+      ?? (baselineEntry ? files.find((file) => filePath(file) === baselineEntry) ?? null : null);
   if (!selected) {
     return { valid: false, validation: 'entry_missing' };
   }
@@ -197,6 +215,7 @@ export async function validateRunDeliverable(
     entryFile,
     artifactKind: selected.kind,
   };
+  let linkedPage: string | null = null;
   if (input.touchedPaths) {
     const touched = new Set(
       input.touchedPaths.flatMap((candidate) => {
@@ -216,11 +235,17 @@ export async function validateRunDeliverable(
       }),
     );
     if (!touched.has(entryFile)) {
-      return {
-        valid: false,
-        validation: 'entry_not_touched',
-        ...facts,
-      };
+      if (isPrototype && selected.kind === 'html') {
+        linkedPage = await findTouchedLinkedPage({
+          projectRoot,
+          entryFile,
+          htmlPaths: new Set(files.filter((file) => file.kind === 'html').map(filePath)),
+          touchedPaths: touched,
+        });
+      }
+      if (!linkedPage) {
+        return { valid: false, validation: 'entry_not_touched', ...facts };
+      }
     }
   }
   if (!matchesAcceptedKinds(acceptedKinds, selected.kind)) {
@@ -251,5 +276,6 @@ export async function validateRunDeliverable(
     valid: true,
     validation: 'valid',
     ...facts,
+    ...(linkedPage ? { linkedPage } : {}),
   };
 }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -586,6 +586,7 @@ import {
   deliverableSyntaxFinalizerEnabled,
   finalizeSuccessfulRunDeliverable,
 } from './artifacts/successful-run-deliverable-finalization.js';
+import { inferBaselineHtmlEntry } from './run-deliverable-validation.js';
 import { recordDeliverableSyntaxDelivery } from './artifacts/deliverable-syntax-metrics.js';
 import {
   POST_TOOL_RESUME_CONTINUATION_PROMPT,
@@ -11393,6 +11394,7 @@ export async function startServer({
     // for ANY agent (not just claude_code). Only for real project runs: a
     // null `cwd` means a no-project run rooted at PROJECT_ROOT, whose churn is
     // not the user's artifacts — those fall back to the tool-stream count.
+    let baselineEntryFile: string | undefined;
     if (run?.id && cwd) {
       try {
         const before = await snapshotProjectArtifactsAsync(cwd);
@@ -11401,6 +11403,7 @@ export async function startServer({
         // do not leave a stale baseline behind for a completed run.
         if (!run.artifactOutcome && !design.runs.isTerminal(run.status)) {
           runArtifactBaselines.remember(run.id, cwd, before);
+          baselineEntryFile = inferBaselineHtmlEntry(cwd, before.keys());
         }
       } catch {
         // Snapshotting is best-effort; finish falls back to the tool-stream count.
@@ -16535,6 +16538,7 @@ export async function startServer({
         }
         await resolveRunArtifactOutcomeBeforeFinishAsync();
         const deliverableFinalization = await finalizeSuccessfulRunDeliverable({
+          ...(run.artifactOutcome?.diff && baselineEntryFile ? { baselineEntryFile } : {}),
           projectsRoot: PROJECTS_DIR,
           projectId: run.projectId ?? null,
           projectMetadata: projectRecord?.metadata,
@@ -16552,9 +16556,41 @@ export async function startServer({
             : {}),
         });
         const { deliverable } = deliverableFinalization;
+        // Adding a second page must not erase an unambiguous pre-run entry.
+        // Retain only a verified baseline identity, without replacing a user's
+        // explicit selection or metadata changed while this Run was executing.
+        if (
+          deliverable.valid && deliverable.linkedPage
+          && deliverable.entryFile === baselineEntryFile
+          && run.artifactOutcome?.diff && run.projectId && cwd
+        ) {
+          try {
+            const current = getProject(db, run.projectId);
+            if (
+              current?.metadata?.kind === 'prototype'
+              && !current.metadata.entryFile
+              && resolveProjectDir(PROJECTS_DIR, current.id, current.metadata) === cwd
+            ) {
+              updateProject(db, current.id, {
+                metadata: { ...current.metadata, entryFile: deliverable.entryFile },
+                updatedAt: SYNC_KEEPS_UPDATED_AT,
+              });
+            }
+          } catch {
+            console.warn('[deliverable] could not retain verified prototype entry');
+          }
+        }
         if (strategyCompletionCandidate) {
           design.runs.setDeliverableValidation?.(run, deliverable);
           deliverableValid = deliverable.valid;
+          if (!deliverable.valid && strategyTaskAtStart) {
+            console.info('[od-next-task] completion evidence rejected', {
+              taskExecutionId: strategyTaskAtStart.taskExecutionId,
+              runId: run.id,
+              inputStage: strategyTaskAtStart.inputStage,
+              validation: deliverable.validation,
+            });
+          }
         }
         // Host-owned syntax finalization is based on physical delivery, not on
         // OD Next strategy identity. It never resumes or prompts the Agent.

--- a/apps/daemon/src/strategies/od-next/coordinator.ts
+++ b/apps/daemon/src/strategies/od-next/coordinator.ts
@@ -686,7 +686,7 @@ export function odNextTurnMayInferProductionCompletion(
  * Recover a Direct Edit completion the agent performed but failed to declare.
  *
  * Observed on real runs: the agent writes the canonical deliverable correctly —
- * `validateRunDeliverable` resolves a root `index.html` that this Run touched —
+ * `validateRunDeliverable` verifies this Run changed the entry or a linked page —
  * then answers in prose without emitting a single machine block. The turn is
  * refused, the logical task lands terminal-`blocked`, and the user is shown a
  * generic failure even though the artifact they asked for is sitting in their

--- a/apps/daemon/tests/artifacts/successful-run-deliverable-finalization.test.ts
+++ b/apps/daemon/tests/artifacts/successful-run-deliverable-finalization.test.ts
@@ -120,6 +120,29 @@ describe('successful physical Run deliverable finalization', () => {
     });
   });
 
+  it('checks the changed linked page while retaining the canonical entry (OPEND-2887)', async () => {
+    const entry = '<!doctype html><a href="catalog.html">Catalog</a>';
+    const source = '<!doctype html><script>const value = ;</script>';
+    const fixture = await projectFixture('index.html', entry);
+    const linkedPage = path.join(fixture.projectsRoot, fixture.projectId, 'catalog.html');
+    await fs.writeFile(linkedPage, source, 'utf8');
+
+    const result = await finalizeSuccessfulRunDeliverable({
+      ...fixture,
+      projectMetadata: { kind: 'prototype', entryFile: 'index.html' },
+      artifactCount: 1,
+      touchedPaths: ['catalog.html'],
+      processTreeQuiescent: true,
+    });
+
+    expect(result).toMatchObject({
+      deliverable: { valid: true, entryFile: 'index.html', linkedPage: 'catalog.html' },
+      syntax: { action: 'warn', reason: 'no_safe_fix' },
+    });
+    await expect(fs.readFile(linkedPage, 'utf8')).resolves.toBe(source);
+    await expect(fs.readFile(fixture.target, 'utf8')).resolves.toBe(entry);
+  });
+
   it('skips syntax mutation when the kill switch is off', async () => {
     const source = '<!doctype html><script>const items = [1, 2;</script>';
     const fixture = await projectFixture('index.html', source);

--- a/apps/daemon/tests/od-next-automatic-simple-server.test.ts
+++ b/apps/daemon/tests/od-next-automatic-simple-server.test.ts
@@ -2213,12 +2213,16 @@ describe('OD Next automatic production through the real server', () => {
     expect(await readProjectInvocations(fixture.logPath, fixture.projectId)).toHaveLength(invocationCount);
   });
 
-  it.each([true, false])('completes a linked child-page write without Runtime State (declared entry: %s, OPEND-2887)', async (declaredEntry) => {
+  it.each([
+    { declaredEntry: true, childFile: 'plant-taxonomy-guide.html' },
+    { declaredEntry: false, childFile: 'plant-taxonomy-guide.html' },
+    { declaredEntry: false, childFile: 'index.html' },
+  ])('completes a linked $childFile write without Runtime State (declared entry: $declaredEntry, OPEND-2887)', async ({ declaredEntry, childFile }) => {
     const fixture = await createFixture('repair');
     const entryFile = 'plant-science-landing.html';
     const upload = await fetch(`${started!.url}/api/projects/${fixture.projectId}/files`, {
       method: 'POST', headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ name: entryFile, content: '<!doctype html><a href="plant-taxonomy-guide.html">分类导览</a>' }),
+      body: JSON.stringify({ name: entryFile, content: `<!doctype html><a href="${childFile}">分类导览</a>` }),
     });
     expect(upload.ok).toBe(true);
     if (declaredEntry) {
@@ -2228,7 +2232,7 @@ describe('OD Next automatic production through the real server', () => {
       });
       expect(update.ok).toBe(true);
     }
-    await writeFile(`${fixture.logPath}.linked-page`, '1');
+    await writeFile(`${fixture.logPath}.linked-page`, childFile);
     queueFixtureIds(fixture);
     const created = await postRun(started!.url, createRunRequest(fixture, 'Build the taxonomy page linked from the existing landing page.'));
     const terminal = await waitForRunTerminal(started!.url, created.runId as string);
@@ -3096,11 +3100,12 @@ function finish() {
   }
   let text;
   if (fs.existsSync(logPath + '.linked-page')) {
+    const childFile = fs.readFileSync(logPath + '.linked-page', 'utf8');
     const edited = fs.existsSync(logPath + '.linked-page-edit');
-    if (edited || !fs.existsSync(path.join(process.cwd(), 'plant-taxonomy-guide.html'))) {
-      fs.writeFileSync(path.join(process.cwd(), 'plant-taxonomy-guide.html'), '<!doctype html><title>Taxonomy</title><a href="plant-science-landing.html">Home</a>' + (edited ? '<p>Updated taxonomy</p>' : ''));
+    if (edited || !fs.existsSync(path.join(process.cwd(), childFile))) {
+      fs.writeFileSync(path.join(process.cwd(), childFile), '<!doctype html><title>Taxonomy</title><a href="plant-science-landing.html">Home</a>' + (edited ? '<p>Updated taxonomy</p>' : ''));
     }
-    text = '已交付 plant-taxonomy-guide.html。';
+    text = '已交付 ' + childFile + '。';
   } else if (mode === 'direct') {
     fs.writeFileSync(path.join(process.cwd(), 'index.html'), '<!doctype html><title>Direct</title>');
     text = ${JSON.stringify(direct)};

--- a/apps/daemon/tests/od-next-automatic-simple-server.test.ts
+++ b/apps/daemon/tests/od-next-automatic-simple-server.test.ts
@@ -2213,6 +2213,65 @@ describe('OD Next automatic production through the real server', () => {
     expect(await readProjectInvocations(fixture.logPath, fixture.projectId)).toHaveLength(invocationCount);
   });
 
+  it.each([true, false])('completes a linked child-page write without Runtime State (declared entry: %s, OPEND-2887)', async (declaredEntry) => {
+    const fixture = await createFixture('repair');
+    const entryFile = 'plant-science-landing.html';
+    const upload = await fetch(`${started!.url}/api/projects/${fixture.projectId}/files`, {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: entryFile, content: '<!doctype html><a href="plant-taxonomy-guide.html">分类导览</a>' }),
+    });
+    expect(upload.ok).toBe(true);
+    if (declaredEntry) {
+      const update = await fetch(`${started!.url}/api/projects/${fixture.projectId}`, {
+        method: 'PATCH', headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ metadata: { kind: 'prototype', entryFile } }),
+      });
+      expect(update.ok).toBe(true);
+    }
+    await writeFile(`${fixture.logPath}.linked-page`, '1');
+    queueFixtureIds(fixture);
+    const created = await postRun(started!.url, createRunRequest(fixture, 'Build the taxonomy page linked from the existing landing page.'));
+    const terminal = await waitForRunTerminal(started!.url, created.runId as string);
+    expect(terminal).toMatchObject({
+      status: 'succeeded', deliverableValid: true, deliverableEntryFile: entryFile,
+      strategyTask: { outcome: 'completed', terminal: true },
+    });
+    const task = getStrategyTaskExecution(database(), terminal.strategyTask!.taskExecutionId)!;
+    expect(task.runs).toHaveLength(1);
+    const invocations = await readProjectInvocations(fixture.logPath, fixture.projectId);
+    expect(invocations).toHaveLength(1);
+    expect(parseOdNextPromptBundleV2(invocations[0]!.stdin).coreSystemPrompt.outputContract)
+      .toContain('Emit exactly one Runtime State block on every response.');
+    const reloaded = await fetch(`${started!.url}/api/projects/${fixture.projectId}/conversations/${fixture.conversationId}/messages`);
+    const { messages } = await reloaded.json() as { messages: Array<{ runId?: string; strategyTaskDelivered?: boolean }> };
+    expect(messages.find((message) => message.runId === task.latestRunId)?.strategyTaskDelivered).toBe(true);
+    const cli = await runOdCli(['run', 'info', task.latestRunId!, '--daemon-url', started!.url, '--json']);
+    expect(JSON.parse(cli.stdout)).toMatchObject({ strategyTask: { outcome: 'completed' } });
+    if (!declaredEntry) {
+      const project = await fetch(`${started!.url}/api/projects/${fixture.projectId}`);
+      expect(await project.json()).toMatchObject({ project: { metadata: { entryFile } } });
+      await writeFile(`${fixture.logPath}.linked-page-edit`, '1');
+    }
+    const followup = await postRun(started!.url, {
+      ...createRunRequest(fixture, declaredEntry ? 'Confirm the delivered page.' : 'Update the taxonomy page.'),
+      userMessageId: `followup-user-${fixture.projectId}`,
+      assistantMessageId: `followup-assistant-${fixture.projectId}`,
+      clientRequestId: `followup-request-${fixture.projectId}`,
+    });
+    const followupTerminal = await waitForRunTerminal(started!.url, followup.runId as string);
+    expect(followupTerminal).toMatchObject(declaredEntry ? {
+      deliverableValid: false, deliverableValidation: 'no_artifact',
+      strategyTask: { outcome: 'blocked', terminal: true },
+    } : {
+      deliverableValid: true, deliverableEntryFile: entryFile,
+      strategyTask: { outcome: 'completed', terminal: true },
+    });
+    expect(followupTerminal.strategyTask!.taskExecutionId).not.toBe(task.taskExecutionId);
+    const resumed = await readProjectInvocations(fixture.logPath, fixture.projectId);
+    expect(resumed).toHaveLength(2);
+    expect(resumed[1]!.argv).toContain('resume');
+  });
+
   it('does not report unfinished work when the task delivered under a stale plan', async () => {
     // QA on project 3ffc55f1: the turn wrote its deliverable and OD Next
     // settled the task `completed`, but the agent's last plan snapshot still
@@ -3036,7 +3095,13 @@ function finish() {
     process.exit(2);
   }
   let text;
-  if (mode === 'direct') {
+  if (fs.existsSync(logPath + '.linked-page')) {
+    const edited = fs.existsSync(logPath + '.linked-page-edit');
+    if (edited || !fs.existsSync(path.join(process.cwd(), 'plant-taxonomy-guide.html'))) {
+      fs.writeFileSync(path.join(process.cwd(), 'plant-taxonomy-guide.html'), '<!doctype html><title>Taxonomy</title><a href="plant-science-landing.html">Home</a>' + (edited ? '<p>Updated taxonomy</p>' : ''));
+    }
+    text = '已交付 plant-taxonomy-guide.html。';
+  } else if (mode === 'direct') {
     fs.writeFileSync(path.join(process.cwd(), 'index.html'), '<!doctype html><title>Direct</title>');
     text = ${JSON.stringify(direct)};
   } else if (mode === 'complex' && stdin.includes('native continuation — production')) {

--- a/apps/daemon/tests/run-deliverable-validation.test.ts
+++ b/apps/daemon/tests/run-deliverable-validation.test.ts
@@ -275,7 +275,8 @@ describe('prototype delivery boundaries', () => {
     const fixture = await projectFixture({
       'landing.html': '<a href="catalog.html">Catalog</a>', 'catalog.html': '<title>Catalog</title>',
     });
-    const input = { ...fixture, runStatus: 'succeeded' as const, artifactCount: 1,
+    const baseInput = { ...fixture, runStatus: 'succeeded' as const, artifactCount: 1 };
+    const input = { ...baseInput,
       touchedPaths: ['catalog.html'], baselineEntryFile: 'landing.html' };
     await expect(validateRunDeliverable({ ...input, projectMetadata: { kind: 'prototype' } }))
       .resolves.toMatchObject({ valid: true, entryFile: 'landing.html', linkedPage: 'catalog.html' });
@@ -283,9 +284,9 @@ describe('prototype delivery boundaries', () => {
       .resolves.toMatchObject({ valid: false, validation: 'entry_missing' });
     await expect(validateRunDeliverable({ ...input, artifactCount: 0, touchedPaths: [], projectMetadata: { kind: 'prototype' } }))
       .resolves.toMatchObject({ valid: false, validation: 'no_artifact' });
-    await expect(validateRunDeliverable({ ...input, baselineEntryFile: undefined, projectMetadata: { kind: 'prototype' } }))
+    await expect(validateRunDeliverable({ ...baseInput, touchedPaths: input.touchedPaths, projectMetadata: { kind: 'prototype' } }))
       .resolves.toMatchObject({ valid: false, validation: 'entry_missing' });
-    await expect(validateRunDeliverable({ ...input, touchedPaths: undefined, projectMetadata: { kind: 'prototype' } }))
+    await expect(validateRunDeliverable({ ...baseInput, baselineEntryFile: input.baselineEntryFile, projectMetadata: { kind: 'prototype' } }))
       .resolves.toMatchObject({ valid: false, validation: 'entry_missing' });
     await expect(validateRunDeliverable({ ...input, projectMetadata: { kind: 'template' } }))
       .resolves.toMatchObject({ valid: false, validation: 'entry_missing' });

--- a/apps/daemon/tests/run-deliverable-validation.test.ts
+++ b/apps/daemon/tests/run-deliverable-validation.test.ts
@@ -264,6 +264,21 @@ describe('linked prototype page delivery (OPEND-2887)', () => {
 });
 
 describe('prototype delivery boundaries', () => {
+  it('keeps the pre-run homepage when a linked index.html is created', async () => {
+    const fixture = await projectFixture({
+      'landing.html': '<a href="index.html">Catalog</a>',
+      'index.html': '<title>Catalog</title>',
+    });
+    const input = {
+      ...fixture, runStatus: 'succeeded' as const, artifactCount: 1,
+      touchedPaths: ['index.html'], baselineEntryFile: 'landing.html',
+    };
+    await expect(validateRunDeliverable({ ...input, projectMetadata: { kind: 'prototype' } }))
+      .resolves.toMatchObject({ valid: true, entryFile: 'landing.html', linkedPage: 'index.html' });
+    await expect(validateRunDeliverable({ ...input, projectMetadata: { kind: 'prototype', entryFile: 'index.html' } }))
+      .resolves.toEqual({ valid: true, validation: 'valid', entryFile: 'index.html', artifactKind: 'html' });
+  });
+
   it('binds a unique pre-run HTML entry, without guessing among existing pages', () => {
     const root = path.resolve('fixture-project');
     expect(inferBaselineHtmlEntry(root, [path.join(root, 'landing.html')])).toBe('landing.html');

--- a/apps/daemon/tests/run-deliverable-validation.test.ts
+++ b/apps/daemon/tests/run-deliverable-validation.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { validateRunDeliverable } from '../src/run-deliverable-validation.js';
+import { inferBaselineHtmlEntry, validateRunDeliverable } from '../src/run-deliverable-validation.js';
 
 const temporaryRoots: string[] = [];
 
@@ -229,5 +229,108 @@ describe('run deliverable validation', () => {
       valid: false,
       validation: 'no_artifact',
     });
+  });
+});
+
+describe('linked prototype page delivery (OPEND-2887)', () => {
+  it('accepts a touched page reachable from the unchanged canonical entry', async () => {
+    const fixture = await projectFixture({
+      'index.html': '<a href="pages/catalog.html?edition=1#plants">Catalog</a>',
+      'pages/catalog.html': '<title>Catalog</title>',
+    });
+    await expect(validateRunDeliverable({
+      ...fixture, runStatus: 'succeeded', artifactCount: 1,
+      touchedPaths: ['pages/catalog.html'],
+      projectMetadata: { kind: 'prototype', entryFile: 'index.html' },
+    })).resolves.toMatchObject({ valid: true, entryFile: 'index.html' });
+  });
+
+  it('follows nested local navigation without accepting a disconnected page', async () => {
+    const fixture = await projectFixture({
+      'index.html': '<a href="pages/catalog.html">Catalog</a>',
+      'pages/catalog.html': '<a href="../index.html">Home</a><a href="plants.html">Plants</a>',
+      'pages/plants.html': '<title>Plants</title>',
+      'unrelated.html': '<title>Unrelated</title>',
+    });
+    const input = {
+      ...fixture, runStatus: 'succeeded' as const, artifactCount: 1,
+      projectMetadata: { kind: 'prototype' as const, entryFile: 'index.html' },
+    };
+    await expect(validateRunDeliverable({ ...input, touchedPaths: ['pages/plants.html'] }))
+      .resolves.toMatchObject({ valid: true });
+    await expect(validateRunDeliverable({ ...input, touchedPaths: ['unrelated.html'] }))
+      .resolves.toMatchObject({ valid: false, validation: 'entry_not_touched' });
+  });
+});
+
+describe('prototype delivery boundaries', () => {
+  it('binds a unique pre-run HTML entry, without guessing among existing pages', () => {
+    const root = path.resolve('fixture-project');
+    expect(inferBaselineHtmlEntry(root, [path.join(root, 'landing.html')])).toBe('landing.html');
+    expect(inferBaselineHtmlEntry(root, [path.join(root, 'landing.html'), path.join(root, 'catalog.html')])).toBeUndefined();
+    expect(inferBaselineHtmlEntry(root, [path.join(root, 'index.html'), path.join(root, 'catalog.html')])).toBe('index.html');
+  });
+
+  it('retains the observed entry when a second page is added, but cannot replace a stale declared entry', async () => {
+    const fixture = await projectFixture({
+      'landing.html': '<a href="catalog.html">Catalog</a>', 'catalog.html': '<title>Catalog</title>',
+    });
+    const input = { ...fixture, runStatus: 'succeeded' as const, artifactCount: 1,
+      touchedPaths: ['catalog.html'], baselineEntryFile: 'landing.html' };
+    await expect(validateRunDeliverable({ ...input, projectMetadata: { kind: 'prototype' } }))
+      .resolves.toMatchObject({ valid: true, entryFile: 'landing.html', linkedPage: 'catalog.html' });
+    await expect(validateRunDeliverable({ ...input, projectMetadata: { kind: 'prototype', entryFile: 'missing.html' } }))
+      .resolves.toMatchObject({ valid: false, validation: 'entry_missing' });
+    await expect(validateRunDeliverable({ ...input, artifactCount: 0, touchedPaths: [], projectMetadata: { kind: 'prototype' } }))
+      .resolves.toMatchObject({ valid: false, validation: 'no_artifact' });
+    await expect(validateRunDeliverable({ ...input, baselineEntryFile: undefined, projectMetadata: { kind: 'prototype' } }))
+      .resolves.toMatchObject({ valid: false, validation: 'entry_missing' });
+    await expect(validateRunDeliverable({ ...input, touchedPaths: undefined, projectMetadata: { kind: 'prototype' } }))
+      .resolves.toMatchObject({ valid: false, validation: 'entry_missing' });
+    await expect(validateRunDeliverable({ ...input, projectMetadata: { kind: 'template' } }))
+      .resolves.toMatchObject({ valid: false, validation: 'entry_missing' });
+  });
+
+  it.each([
+    '<a href="https://example.com/catalog.html">Remote</a>',
+    '<a href="//example.com/catalog.html">Remote</a>',
+    '<base href="https://example.com/"><a href="catalog.html">Remote base</a>',
+    '<!-- <a href="catalog.html">Comment</a> -->',
+    `<script>const html = '<a href="catalog.html">Not markup</a>';</script>`,
+  ])('does not treat external URLs or inert text as delivery: %s', async (entry) => {
+    const fixture = await projectFixture({ 'index.html': entry, 'catalog.html': '<title>Catalog</title>' });
+    await expect(validateRunDeliverable({ ...fixture, runStatus: 'succeeded', artifactCount: 1,
+      touchedPaths: ['catalog.html'], projectMetadata: { kind: 'prototype', entryFile: 'index.html' } }))
+      .resolves.toMatchObject({ valid: false, validation: 'entry_not_touched' });
+  });
+
+  it('resolves local base URLs and URL-encoded page names', async () => {
+    const fixture = await projectFixture({
+      'index.html': '<base href="/pages/"><a href="plant%20guide.html">Guide</a>',
+      'pages/plant guide.html': '<title>Guide</title>',
+    });
+    await expect(validateRunDeliverable({ ...fixture, runStatus: 'succeeded', artifactCount: 1,
+      touchedPaths: ['pages/plant guide.html'], projectMetadata: { kind: 'prototype', entryFile: 'index.html' } }))
+      .resolves.toMatchObject({ valid: true });
+  });
+
+  it('declines navigation evidence that exceeds the page read budget', async () => {
+    const fixture = await projectFixture({
+      'index.html': '<a href="catalog.html">Catalog</a>' + ' '.repeat(512 * 1024),
+      'catalog.html': '<title>Catalog</title>',
+    });
+    await expect(validateRunDeliverable({ ...fixture, runStatus: 'succeeded', artifactCount: 1,
+      touchedPaths: ['catalog.html'], projectMetadata: { kind: 'prototype', entryFile: 'index.html' } }))
+      .resolves.toMatchObject({ valid: false, validation: 'entry_not_touched' });
+  });
+
+  it.skipIf(process.platform === 'win32')('never reads a linked page through a symlink outside the project', async () => {
+    const fixture = await projectFixture({ 'index.html': '<a href="catalog.html">Catalog</a>' });
+    const external = await projectFixture({ 'outside.html': '<title>Outside</title>' });
+    await fs.symlink(path.join(external.projectsRoot, external.projectId, 'outside.html'),
+      path.join(fixture.projectsRoot, fixture.projectId, 'catalog.html'));
+    await expect(validateRunDeliverable({ ...fixture, runStatus: 'succeeded', artifactCount: 1,
+      touchedPaths: ['catalog.html'], projectMetadata: { kind: 'prototype', entryFile: 'index.html' } }))
+      .resolves.toMatchObject({ valid: false, validation: 'entry_not_touched' });
   });
 });


### PR DESCRIPTION
Related work item: [OPEND-2887](https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/b50881bc-e83b-45cf-9079-51908835b163/)

## Why

This follows a user diagnostic bundle where a prototype child page was written successfully, but the OD Next task ended blocked after the agent omitted Runtime State. The host completion fallback only accepted changes to the canonical entry. Writing a page already linked from an unchanged homepage therefore failed delivery validation. Without an explicit entry, adding a second HTML file also made entry inference ambiguous.

The historical bundle lacks entry metadata, so it cannot establish which validation branch ran on that machine. Both branches are reproduced against current main.

- Validate changed prototype pages reachable through local HTML navigation from the canonical entry. Preserve per-run touch evidence and existing coordinator route constraints.
- Retain an unambiguous pre-run entry after verified linked-page delivery, without replacing an explicit selection. Subsequent edits retain the same homepage identity.
- Check syntax on the changed child page and log the bounded delivery-rejection reason.

Traversal reads static local anchors only, with limits of 64 pages, 512 KiB per page and 8 MiB total. Unrelated files, external links and absent write evidence do not qualify. Prompt contracts, automatic repair policy and network-disconnect handling are unchanged. Adjacent #7931 and #7942 concern status/error presentation and finalization policy.

## What users will see

Adding or editing a linked prototype page can complete the OD Next task even when the agent omits Runtime State, provided the existing completion-inference rules allow it. The homepage remains the project entry. A separate confirmation turn that writes nothing cannot borrow the previous task's delivery evidence.

The existing conversation reload and `od run info --json` surfaces consume the same corrected daemon result.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new subcommand, flag or environment variable
- [ ] **API / contract** — new endpoint, SSE event or changed DTO shape
- [ ] **Extension point** — skills, design systems, templates, craft or protocol
- [ ] **i18n keys** — new translation keys
- [ ] **New top-level dependency** — root package.json dependency
- [x] **Default behavior change** — linked prototype-page delivery and retention of an inferred entry
- [ ] **None** — internal refactor, docs, tests or translation only

No UI component, CLI flag or shared response shape changes; both existing surfaces are exercised by the integration test. Cheerio is already a daemon dependency.

## Screenshots

Not applicable: no UI layout or entry point changes. Tests verify persisted conversation delivery and the CLI response.

## Bug fix verification

- [Validator regressions](https://github.com/Siri-Ray/open-design/blob/50550f8f6407482a48b5abd83c7a9af15b3579dc/apps/daemon/tests/run-deliverable-validation.test.ts#L235) and [real-server regressions](https://github.com/Siri-Ray/open-design/blob/50550f8f6407482a48b5abd83c7a9af15b3579dc/apps/daemon/tests/od-next-automatic-simple-server.test.ts#L2216): **red on main `f197844e27`**, green with the fix. The original four cases failed on delivery/task assertions, not environment setup.
- The real-server test uses the shipped HTTP/CLI seams and a synthetic agent that writes HTML but omits Runtime State. It checks prompt-contract presence, conversation reload, native-session resume, distinct task identities, repeated editing and rejection of a no-write confirmation.
- [Syntax regression](https://github.com/Siri-Ray/open-design/blob/50550f8f6407482a48b5abd83c7a9af15b3579dc/apps/daemon/tests/artifacts/successful-run-deliverable-finalization.test.ts#L123) verifies that an unsafe child-page script produces a warning without changing the homepage or child source.
- Boundary coverage includes disconnected pages, cycles, external/base URLs, encoded names, stale entry metadata, unreliable diffs, other project kinds, oversized pages and external symlinks.

## Validation

- `corepack pnpm guard` — passed.
- `corepack pnpm typecheck` — passed; daemon typecheck repeated after entry retention was added, also passed.
- `corepack pnpm --filter @open-design/daemon exec vitest run tests/run-deliverable-validation.test.ts tests/artifacts/successful-run-deliverable-finalization.test.ts tests/strategies/od-next/coordinator.test.ts tests/od-next-automatic-simple-server.test.ts` — 100 passed, 1 existing skip.
- Final entry-retention HTTP/CLI and linked-page regressions — 14 passed; final validator/finalizer/coordinator suites after the additional boundary case — 68 passed, 1 existing skip.
- `git diff --check` — passed. No live provider calls or release/deployment validation.
