### PR TITLE
fix(release): track in-place re-runs in the prerelease card

### DIFF
--- a/tools/release/src/notifications/prerelease-progress-card.ts
+++ b/tools/release/src/notifications/prerelease-progress-card.ts
@@ -51,8 +51,35 @@ type GithubJob = {
   started_at?: unknown;
   completed_at?: unknown;
 };
-type GithubRun = { id?: unknown; name?: unknown; html_url?: unknown; status?: unknown };
-type DispatchedRun = { completed: boolean; id: string; url: string };
+type GithubRun = {
+  id?: unknown;
+  name?: unknown;
+  html_url?: unknown;
+  status?: unknown;
+  conclusion?: unknown;
+  run_attempt?: unknown;
+  updated_at?: unknown;
+};
+type DispatchedRun = {
+  /**
+   * The run is completed AS OF THIS OBSERVATION — never "the run is finished
+   * forever". GitHub re-runs a workflow in place, so no run is ever permanently
+   * terminal and this field has to be re-read, not remembered.
+   */
+  completed: boolean;
+  id: string;
+  url: string;
+  /**
+   * Everything a re-run changes about the run, as one comparable string.
+   *
+   * A re-run increments `run_attempt`, sends `status` back to `in_progress`,
+   * rewrites `conclusion`, and bumps `updated_at` — all under the same run id.
+   * Any one of them can in principle be missed (a whole re-run could land
+   * between two polls, leaving `status`/`conclusion` where they were), so the
+   * fingerprint carries all four and changes if any of them does.
+   */
+  fingerprint: string;
+};
 
 function required(name: string): string {
   const value = process.env[name];
@@ -248,11 +275,43 @@ async function findDispatchedRun(workflowFile: string): Promise<DispatchedRun | 
     if (!name.includes(runMarker)) continue;
     return {
       completed: run.status === "completed",
+      fingerprint: [run.status, run.conclusion, run.run_attempt, run.updated_at]
+        .map((field) => (field == null ? "" : String(field)))
+        .join("|"),
       id: String(run.id),
       url: typeof run.html_url === "string" ? run.html_url : "",
     };
   }
   return null;
+}
+
+/**
+ * One dispatched lane, re-read every cycle, with its job list refreshed only
+ * when the run itself says something moved.
+ *
+ * GitHub re-runs IN PLACE: `run_attempt` increments and `status` returns to
+ * `in_progress` under the SAME run id. "Completed" is therefore a reading, not
+ * a fact — a watcher that stops looking at a finished run reports the first
+ * attempt's verdict for the rest of its life, which is how a card kept saying
+ * ❌ E2E Vitest · 未通过 after a re-run had already turned that run green.
+ *
+ * The cost of watching for that is nothing new: `findDispatchedRun` is one
+ * list-runs call the lane already made on every cycle before it completed, and
+ * that response already carries every field a re-run touches. Only the
+ * paginated `listJobs` is gated, and only for a run that is both completed and
+ * unchanged since the jobs in hand were read — an in-flight run still re-lists
+ * every cycle, because its jobs move without the run's own fields settling.
+ */
+async function refreshDispatchedLane(
+  workflowFile: string,
+  previousRun: DispatchedRun | null,
+  previousJobs: GithubJob[],
+): Promise<{ run: DispatchedRun | null; jobs: GithubJob[] }> {
+  const run = (await findDispatchedRun(workflowFile)) ?? previousRun;
+  if (run == null) return { jobs: previousJobs, run: null };
+  const unmoved = previousRun != null && previousRun.id === run.id && previousRun.fingerprint === run.fingerprint;
+  if (unmoved && run.completed) return { jobs: previousJobs, run };
+  return { jobs: await listJobs(run.id), run };
 }
 
 const ARTIFACT_BASENAME: Record<PlatformKey, string> = {
@@ -348,24 +407,32 @@ async function collect(previous: Watch): Promise<Watch> {
   // finished with can still carry a stale or absent stamp.
   const publishCompletedAt = isTerminal(publish) ? timingOf(publishJob).completedAt : null;
 
-  // Re-listed every cycle rather than cached, because the run's own
+  // Re-read every cycle rather than cached, because the run's own
   // completion is what tells a MISSING job apart from a job the API has not
   // created yet. A run that has only just started reports a partial job list,
-  // and reading that as "skipped" would fabricate green.
+  // and reading that as "skipped" would fabricate green. A run that already
+  // finished is re-read too — GitHub re-runs it in place, so its verdict can
+  // change under the same run id for as long as this watch is awake.
   let testsRun = previous.testsRun;
   let testsJobs = previous.testsJobs;
-  if (expectTests && !(previous.testsRun?.completed ?? false)) {
-    testsRun = (await findDispatchedRun(testsWorkflowFile)) ?? previous.testsRun;
-    if (testsRun != null) testsJobs = await listJobs(testsRun.id);
+  if (expectTests) {
+    ({ jobs: testsJobs, run: testsRun } = await refreshDispatchedLane(
+      testsWorkflowFile,
+      previous.testsRun,
+      previous.testsJobs,
+    ));
   }
 
   let smokeRun = previous.smokeRun;
   let smokeJobs = previous.smokeJobs;
   // The smoke run is only dispatched once publish succeeds, so do not even look
   // for it before then — an early lookup would only burn API budget.
-  if (expectSmoke && publish === "success" && !(previous.smokeRun?.completed ?? false)) {
-    smokeRun = (await findDispatchedRun(smokeWorkflowFile)) ?? previous.smokeRun;
-    if (smokeRun != null) smokeJobs = await listJobs(smokeRun.id);
+  if (expectSmoke && publish === "success") {
+    ({ jobs: smokeJobs, run: smokeRun } = await refreshDispatchedLane(
+      smokeWorkflowFile,
+      previous.smokeRun,
+      previous.smokeJobs,
+    ));
   }
 
   return {

--- a/tools/release/tests/prerelease-card-rerun.test.ts
+++ b/tools/release/tests/prerelease-card-rerun.test.ts
@@ -1,0 +1,371 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import type { IncomingMessage, Server } from "node:http";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// A GitHub re-run happens IN PLACE. `run_attempt` increments, `status` goes back
+// to `in_progress`, and `conclusion` is rewritten — all under the SAME run id.
+// So a watcher that treats "I once saw this run completed" as a permanent fact
+// stops looking at it and pins the card to the first attempt's verdict forever.
+//
+// Observed in production on nexu-io/open-design run 34333568105
+// (release-prerelease-tests, release/v0.22.1 @ 2779d97): attempt 1 failed E2E
+// Vitest, someone re-ran it, attempt 2 went green at 09:35:09 — and the card's
+// watcher, still in_progress at the time, never moved the row off 未通过.
+//
+// Driven through the real script rather than a unit harness because the bug
+// lives in the poll loop's carry-forward between cycles, which only exists when
+// the script runs for real.
+const releaseRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const watcherScript = join(releaseRoot, "src", "notifications", "prerelease-progress-card.ts");
+
+const ORIGIN_RUN_ID = "4242";
+const TESTS_RUN_ID = "34333568105";
+const SMOKE_RUN_ID = "34333568106";
+const RUN_MARKER = `origin-run ${ORIGIN_RUN_ID}`;
+const RUN_CREATED_AT = "2026-09-09T09:14:15Z";
+
+type JobStub = { name: string; status: string; conclusion: string | null; started_at?: string; completed_at?: string };
+type RunStub = { status: string; conclusion: string | null; run_attempt: number; updated_at: string };
+
+/** One poll cycle's worth of the world, keyed by how many origin polls have happened. */
+type Scenario = {
+  originJobs: JobStub[];
+  testsRun?: RunStub;
+  testsJobs?: JobStub[];
+  smokeRun?: RunStub;
+  smokeJobs?: JobStub[];
+};
+
+type Counters = {
+  /** Job-list calls per run id — the expensive call whose budget the fix must respect. */
+  jobsCalls: Record<string, number>;
+  /** Workflow-run-list calls per workflow file — the cheap per-cycle discovery call. */
+  runListCalls: Record<string, number>;
+  cycles: number;
+  cards: string[];
+};
+
+function done(name: string, conclusion: string): JobStub {
+  return {
+    name,
+    status: "completed",
+    conclusion,
+    started_at: "2026-09-09T09:14:20Z",
+    completed_at: "2026-09-09T09:19:29Z",
+  };
+}
+
+function running(name: string): JobStub {
+  return { name, status: "in_progress", conclusion: null, started_at: "2026-09-09T09:14:20Z" };
+}
+
+async function readBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+/** The card body of one Feishu POST/PATCH: `content` is a JSON *string*. */
+function cardOf(body: string): string {
+  try {
+    const parsed = JSON.parse(body) as { content?: unknown };
+    return typeof parsed.content === "string" ? parsed.content : body;
+  } catch {
+    return body;
+  }
+}
+
+/**
+ * A GitHub + Feishu stub whose world advances one step per origin job-list poll.
+ *
+ * The origin poll is the first thing every `collect()` cycle does, so counting
+ * it gives every later lookup in the same cycle a stable cycle number.
+ */
+async function startStub(scenarios: Scenario[]): Promise<{ counters: Counters; server: Server; url: string }> {
+  const counters: Counters = { cards: [], cycles: 0, jobsCalls: {}, runListCalls: {} };
+  const at = (): Scenario => scenarios[Math.min(counters.cycles, scenarios.length) - 1] ?? scenarios[0]!;
+
+  const server = createServer((request, response) => {
+    const json = (status: number, body: unknown): void => {
+      response.writeHead(status, { "content-type": "application/json" });
+      response.end(JSON.stringify(body));
+    };
+    void readBody(request).then((body) => {
+      const path = (request.url ?? "").split("?")[0] ?? "";
+
+      const jobsMatch = /\/actions\/runs\/(\d+)\/jobs$/.exec(path);
+      if (jobsMatch != null) {
+        const runId = jobsMatch[1] ?? "";
+        if (runId === ORIGIN_RUN_ID) counters.cycles += 1;
+        counters.jobsCalls[runId] = (counters.jobsCalls[runId] ?? 0) + 1;
+        const scenario = at();
+        const jobs =
+          runId === ORIGIN_RUN_ID
+            ? scenario.originJobs
+            : runId === TESTS_RUN_ID
+              ? (scenario.testsJobs ?? [])
+              : (scenario.smokeJobs ?? []);
+        json(200, { jobs, total_count: jobs.length });
+        return;
+      }
+
+      const runsMatch = /\/actions\/workflows\/([^/]+)\/runs$/.exec(path);
+      if (runsMatch != null) {
+        const file = decodeURIComponent(runsMatch[1] ?? "");
+        counters.runListCalls[file] = (counters.runListCalls[file] ?? 0) + 1;
+        const scenario = at();
+        const isTests = file.includes("tests");
+        const run = isTests ? scenario.testsRun : scenario.smokeRun;
+        const id = isTests ? TESTS_RUN_ID : SMOKE_RUN_ID;
+        json(200, {
+          workflow_runs:
+            run == null
+              ? []
+              : [
+                  {
+                    conclusion: run.conclusion,
+                    html_url: `https://github.com/nexu-io/open-design/actions/runs/${id}`,
+                    id: Number(id),
+                    name: `prerelease ${isTests ? "tests" : "smoke"} · 0.22.1-prerelease.12 · ${RUN_MARKER}`,
+                    run_attempt: run.run_attempt,
+                    status: run.status,
+                    updated_at: run.updated_at,
+                  },
+                ],
+        });
+        return;
+      }
+
+      if (/\/actions\/runs\/\d+$/.test(path)) {
+        json(200, { created_at: RUN_CREATED_AT, run_started_at: RUN_CREATED_AT, status: "in_progress" });
+        return;
+      }
+      if (path === "/open-apis/auth/v3/tenant_access_token/internal") {
+        json(200, { code: 0, expire: 7200, tenant_access_token: "t-stub" });
+        return;
+      }
+      if (path === "/open-apis/im/v1/messages") {
+        counters.cards.push(cardOf(body));
+        json(200, { code: 0, data: { message_id: "om_stub" } });
+        return;
+      }
+      if (path.startsWith("/open-apis/im/v1/messages/")) {
+        counters.cards.push(cardOf(body));
+        json(200, { code: 0, data: {} });
+        return;
+      }
+      json(404, { code: 404 });
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address == null || typeof address === "string") throw new Error("stub server has no port");
+  return { counters, server, url: `http://127.0.0.1:${address.port}` };
+}
+
+async function runWatcher(options: {
+  baseUrl: string;
+  expectSmoke: boolean;
+  expectTests: boolean;
+  outputFile: string;
+}): Promise<number> {
+  await writeFile(options.outputFile, "");
+  return await new Promise<number>((resolve, reject) => {
+    const child = spawn(process.execPath, ["--experimental-strip-types", watcherScript], {
+      env: {
+        ...process.env,
+        CARD_POLL_INTERVAL_MS: "10",
+        COMMIT: "2779d97687a0ab84925c3760b240afdb750dad2b",
+        EXPECT_SMOKE: options.expectSmoke ? "true" : "false",
+        EXPECT_TESTS: options.expectTests ? "true" : "false",
+        FEISHU_APP_ID: "cli_stub",
+        FEISHU_APP_SECRET: "secret_stub",
+        FEISHU_BASE_URL: options.baseUrl,
+        FEISHU_RELEASE_CHAT_ID: "oc_stub",
+        GH_TOKEN: "gh_stub",
+        GITHUB_API_URL: options.baseUrl,
+        GITHUB_OUTPUT: options.outputFile,
+        GITHUB_REPOSITORY: "nexu-io/open-design",
+        ORIGIN_RUN_ID,
+        RELEASE_PUBLIC_ORIGIN: "",
+        VERSION: "0.22.1-prerelease.12",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stdout.resume();
+    child.stderr.resume();
+    child.on("error", reject);
+    child.on("close", (code) => resolve(code ?? -1));
+  });
+}
+
+const TESTS_FAMILY_GREEN: JobStub[] = [
+  done("P0 Functional E2E / UI P0 (project-collab)", "success"),
+  done("Daemon tests (1/4)", "success"),
+  done("Verify build (typecheck + tests)", "success"),
+];
+
+/**
+ * Origin lane that keeps the watcher awake until `settleCycle`.
+ *
+ * One platform stays in flight so the watcher cannot finish early — the whole
+ * bug only exists in the window where a lane has finished but the watch has not.
+ */
+function originAt(cycle: number, settleCycle: number, publish: "success" | "running"): JobStub[] {
+  const settled = cycle >= settleCycle;
+  return [
+    done("Build prerelease mac arm64", "success"),
+    settled ? done("Build prerelease mac intel x64", "success") : running("Build prerelease mac intel x64"),
+    publish === "success" || settled
+      ? done("Publish prerelease release", "success")
+      : running("Publish prerelease release"),
+  ];
+}
+
+describe("prerelease card tracks in-place re-runs", () => {
+  let workdir = "";
+  let server: Server | null = null;
+
+  beforeEach(async () => {
+    workdir = await mkdtemp(join(tmpdir(), "cardrerun-"));
+  });
+
+  afterEach(async () => {
+    if (server != null) await new Promise<void>((resolve) => server?.close(() => resolve()));
+    server = null;
+    await rm(workdir, { force: true, recursive: true });
+  });
+
+  it("moves a tests row off 未通过 when the tests run is re-run in place", async () => {
+    // Production shape: the tests run finishes red, is re-run under the same id,
+    // and goes green while the watcher is still awake for the origin lane.
+    const scenarios: Scenario[] = [
+      {
+        originJobs: originAt(1, 4, "running"),
+        testsJobs: [done("E2E Vitest", "failure"), ...TESTS_FAMILY_GREEN],
+        testsRun: { conclusion: "failure", run_attempt: 1, status: "completed", updated_at: "2026-09-09T09:26:17Z" },
+      },
+      {
+        originJobs: originAt(2, 4, "running"),
+        testsJobs: [running("E2E Vitest"), ...TESTS_FAMILY_GREEN],
+        testsRun: { conclusion: null, run_attempt: 2, status: "in_progress", updated_at: "2026-09-09T09:28:51Z" },
+      },
+      {
+        originJobs: originAt(3, 4, "running"),
+        testsJobs: [done("E2E Vitest", "success"), ...TESTS_FAMILY_GREEN],
+        testsRun: { conclusion: "success", run_attempt: 2, status: "completed", updated_at: "2026-09-09T09:35:09Z" },
+      },
+      {
+        originJobs: originAt(4, 4, "success"),
+        testsJobs: [done("E2E Vitest", "success"), ...TESTS_FAMILY_GREEN],
+        testsRun: { conclusion: "success", run_attempt: 2, status: "completed", updated_at: "2026-09-09T09:35:09Z" },
+      },
+    ];
+    const started = await startStub(scenarios);
+    server = started.server;
+
+    expect(
+      await runWatcher({
+        baseUrl: started.url,
+        expectSmoke: false,
+        expectTests: true,
+        outputFile: join(workdir, "cardrerun-tests.txt"),
+      }),
+    ).toBe(0);
+
+    const first = started.counters.cards[0] ?? "";
+    expect(first).toContain("E2E Vitest · 未通过");
+
+    const last = started.counters.cards.at(-1) ?? "";
+    expect(last).toContain("E2E Vitest · 通过");
+    expect(last).not.toContain("E2E Vitest · 未通过");
+  });
+
+  it("moves a smoke row off 未通过 when the smoke run is re-run in place", async () => {
+    const smokeJob = "Smoke prerelease mac arm64";
+    const scenarios: Scenario[] = [
+      {
+        originJobs: originAt(1, 4, "success"),
+        smokeJobs: [done(smokeJob, "failure")],
+        smokeRun: { conclusion: "failure", run_attempt: 1, status: "completed", updated_at: "2026-09-09T09:26:17Z" },
+      },
+      {
+        originJobs: originAt(2, 4, "success"),
+        smokeJobs: [running(smokeJob)],
+        smokeRun: { conclusion: null, run_attempt: 2, status: "in_progress", updated_at: "2026-09-09T09:28:51Z" },
+      },
+      {
+        originJobs: originAt(3, 4, "success"),
+        smokeJobs: [done(smokeJob, "success")],
+        smokeRun: { conclusion: "success", run_attempt: 2, status: "completed", updated_at: "2026-09-09T09:35:09Z" },
+      },
+      {
+        originJobs: originAt(4, 4, "success"),
+        smokeJobs: [done(smokeJob, "success")],
+        smokeRun: { conclusion: "success", run_attempt: 2, status: "completed", updated_at: "2026-09-09T09:35:09Z" },
+      },
+    ];
+    const started = await startStub(scenarios);
+    server = started.server;
+
+    expect(
+      await runWatcher({
+        baseUrl: started.url,
+        expectSmoke: true,
+        expectTests: false,
+        outputFile: join(workdir, "cardrerun-smoke.txt"),
+      }),
+    ).toBe(0);
+
+    const first = started.counters.cards[0] ?? "";
+    expect(first).toContain("macOS (Apple Silicon) packaged smoke · 未通过");
+
+    const last = started.counters.cards.at(-1) ?? "";
+    expect(last).toContain("macOS (Apple Silicon) packaged smoke · 通过");
+    expect(last).not.toContain("macOS (Apple Silicon) packaged smoke · 未通过");
+  });
+
+  it("re-reads a finished run every cycle but re-lists its jobs only when it moved", async () => {
+    // The budget half of the fix. Watching for a re-run costs the list-runs call
+    // the lane already made anyway; the paginated job list is spent only when
+    // the run's own fields say something changed. Without that gate a 140-minute
+    // watch would re-list every finished lane's jobs on every 30s poll.
+    const settled: RunStub = {
+      conclusion: "success",
+      run_attempt: 1,
+      status: "completed",
+      updated_at: "2026-09-09T09:26:17Z",
+    };
+    const testsJobs = [done("E2E Vitest", "success"), ...TESTS_FAMILY_GREEN];
+    const scenarios: Scenario[] = [1, 2, 3, 4, 5].map((cycle) => ({
+      originJobs: originAt(cycle, 5, "running"),
+      testsJobs,
+      testsRun: settled,
+    }));
+    const started = await startStub(scenarios);
+    server = started.server;
+
+    expect(
+      await runWatcher({
+        baseUrl: started.url,
+        expectSmoke: false,
+        expectTests: true,
+        outputFile: join(workdir, "cardrerun-budget.txt"),
+      }),
+    ).toBe(0);
+
+    const cycles = started.counters.cycles;
+    expect(cycles).toBeGreaterThanOrEqual(5);
+    // Kept watching: one cheap list-runs call per cycle, for the whole watch.
+    expect(started.counters.runListCalls["release-prerelease-tests.yml"] ?? 0).toBe(cycles);
+    // Stayed cheap: the run never moved, so its jobs were listed exactly once.
+    expect(started.counters.jobsCalls[TESTS_RUN_ID] ?? 0).toBe(1);
+  });
+});


### PR DESCRIPTION
## Why

**Use case.** Hit this while watching 0.22.1 go through acceptance. `release-prerelease-tests` run [34333568105](https://github.com/nexu-io/open-design/actions/runs/34333568105) (`release/v0.22.1` @ `2779d97`) failed `E2E Vitest` on attempt 1, someone re-ran it, and attempt 2 went green at 09:35:09. The card's watcher (run `34333571435`) was **still `in_progress`** the whole time and never moved that row off ❌ 未通过.

**Pain.** The prerelease card is the acceptance channel's single source of truth for "is this build OK to sign off". Once any dispatched lane completes for the first time, the watcher stops looking at it and the card reports that first verdict for the rest of the release — even though a re-run is exactly what people do when a lane fails. The two outcomes are both bad and both real:

- someone burns time investigating a failure that was fixed and re-run an hour ago, or
- someone learns that the red rows are sometimes lies, and stops trusting the card — which costs us the one thing it exists to do.

**Root cause.** `completed` was treated as a permanent terminal state:

```ts
if (expectTests && !(previous.testsRun?.completed ?? false)) { ... }
```

But GitHub re-runs a workflow **in place**. `run_attempt` increments, `status` goes back to `in_progress`, `conclusion` is rewritten — all under the **same run id**. There is no such thing as a run that will never change again, so "I once observed this completed" is not a fact the watcher may cache. Verified against the production run:

| | attempt 1 | attempt 2 |
| --- | --- | --- |
| run `status` / `conclusion` | `completed` / `failure` | `completed` / `success` |
| `updated_at` | `09:26:17Z` | `09:35:09Z` |
| job `E2E Vitest` | `failure` | `success` (started 09:28:51) |

Both dispatched lanes (tests **and** smoke) carried the same guard; both are fixed.

The comment directly above the tests block already claimed the correct behavior — *"Re-listed every cycle rather than cached"* — while the `if` on the very next line stopped the re-listing on completion. The comment now describes what the code does.

## What users will see

A prerelease card in the acceptance channel now follows a re-run. Re-run a failed `release-prerelease-tests` or `release-prerelease-smoke` while the release is still in flight and the row flips ❌ 未通过 → ⏳ 运行中 → ✅ 通过 in the existing message, along with the card's header count and colour. Previously it stayed red until someone read the Actions tab themselves.

Unchanged: the watcher still stops when everything it watches is terminal *right now*, and still has the same 140-minute budget. A re-run started after the card has closed out cannot be picked up — that is the honest limit of a bounded watcher, not something this PR pretends to solve.

## Surface area

- [x] **None** — release tooling only (`tools/release`). No product surface: no UI, no `od` subcommand, no `/api/*` or `packages/contracts` shape, no i18n key, no new root dependency, and no change to what OD users experience.

## Screenshots

n/a — no UI surface. The user-visible artifact is the Feishu card, and its rendered text is asserted directly in the new spec (`E2E Vitest · 通过`, `macOS (Apple Silicon) packaged smoke · 通过`).

## Bug fix verification

- **Test path:** `tools/release/tests/prerelease-card-rerun.test.ts`
- **Red on `main`, green on this branch:** yes.

The spec drives the **real** watcher script as a subprocess against a stub GitHub + Feishu server, because the defect lives in `collect()`'s carry-forward between poll cycles and only exists when the loop actually runs. The stub advances one step per origin job-list poll and replays the production sequence: `completed/failure` @ attempt 1 → `in_progress` @ attempt 2 → `completed/success` @ attempt 2, with a platform build left in flight so the watcher stays awake — which is the window the whole bug lives in. Three specs: one per lane (tests, smoke) plus one that pins the API budget.

<details>
<summary>Red output on pristine <code>origin/main</code> source (card JSON elided)</summary>

```
 RUN  v4.1.6 /Users/elian/Documents/open-design-wt/card-rerun/tools/release

 ❯ tests/prerelease-card-rerun.test.ts (3 tests | 3 failed) 453ms
     × moves a tests row off 未通过 when the tests run is re-run in place 146ms
     × moves a smoke row off 未通过 when the smoke run is re-run in place 152ms
     × re-reads a finished run every cycle but re-lists its jobs only when it moved 154ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  tests/prerelease-card-rerun.test.ts > prerelease card tracks in-place re-runs > moves a tests row off 未通过 when the tests run is re-run in place
AssertionError: expected '{"config":{"wide_screen_mode":true},"…' to contain 'E2E Vitest · 通过'

Expected: "E2E Vitest · 通过"
Received: <full card JSON, elided>

 ❯ tests/prerelease-card-rerun.test.ts:287:18
    285|
    286|     const last = started.counters.cards.at(-1) ?? "";
    287|     expect(last).toContain("E2E Vitest · 通过");
       |                  ^
    288|     expect(last).not.toContain("E2E Vitest · 未通过");
    289|   });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/3]⎯

 FAIL  tests/prerelease-card-rerun.test.ts > prerelease card tracks in-place re-runs > moves a smoke row off 未通过 when the smoke run is re-run in place
AssertionError: expected '{"config":{"wide_screen_mode":true},"…' to contain 'macOS (Apple Silicon) packaged smoke …'

Expected: "macOS (Apple Silicon) packaged smoke · 通过"
Received: <full card JSON, elided>

 ❯ tests/prerelease-card-rerun.test.ts:331:18
    329|
    330|     const last = started.counters.cards.at(-1) ?? "";
    331|     expect(last).toContain("macOS (Apple Silicon) packaged smoke · 通过"…
       |                  ^
    332|     expect(last).not.toContain("macOS (Apple Silicon) packaged smoke ·…
    333|   });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/3]⎯

 FAIL  tests/prerelease-card-rerun.test.ts > prerelease card tracks in-place re-runs > re-reads a finished run every cycle but re-lists its jobs only when it moved
AssertionError: expected 1 to be 5 // Object.is equality

- Expected
+ Received

- 5
+ 1

 ❯ tests/prerelease-card-rerun.test.ts:367:80
    365|     expect(cycles).toBeGreaterThanOrEqual(5);
    366|     // Kept watching: one cheap list-runs call per cycle, for the whol…
    367|     expect(started.counters.runListCalls["release-prerelease-tests.yml…
       |                                                                                ^
    368|     // Stayed cheap: the run never moved, so its jobs were listed exac…
    369|     expect(started.counters.jobsCalls[TESTS_RUN_ID] ?? 0).toBe(1);

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/3]⎯


 Test Files  1 failed (1)
      Tests  3 failed (3)
```

The first assertion is the production symptom verbatim — the last card the watcher delivered still carries `❌ E2E Vitest · 未通过` in its 验证 block while the run it describes went green.

</details>

The fix has two parts, so each was reverted separately to prove neither half is riding on the other's test:

| Ablation | Result |
| --- | --- |
| **A** — restore the `!completed` guards on both lanes (i.e. `main`'s behavior) | all **3 red** |
| **B1** — drop the fingerprint from the `unmoved` check, so a completed run's jobs are never re-listed | **2 red** (tests + smoke rows) |
| **B2** — drop the `unmoved` gate entirely, so jobs are re-listed unconditionally | **1 red** — `expected 5 to be 1` |
| full fix restored | 3 passed |

(B1 is a deliberately nonsensical half-revert — nobody would compare run ids without the fingerprint — and its two failures land as 5s timeouts rather than assertions, because that shape leaves the lane permanently non-terminal and the watcher never converges. A is the real "remove the fix" ablation and fails fast on the right assertions.)

## Validation

- `pnpm guard` — exit 0
- `pnpm typecheck` — exit 0
- `pnpm --filter @open-design/tools-release test` — 17 files, **156 passed** (3 new; no regressions in the neighbouring card/fallback suites)
- `pnpm --filter @open-design/tools-release build` — exit 0
- Production evidence re-verified by hand against `gh api repos/nexu-io/open-design/actions/runs/34333568105` and `.../attempts/{1,2}/jobs`

> [!IMPORTANT]
> **Do not read this PR's green CI as validation of the change.** No CI job on this PR runs the `tools-release` test suite — see Adjacent issues #3. `ci` covers this diff with `guard` and typecheck only. The local run above is the evidence for the new spec; please weigh it accordingly when reviewing.

---

## API budget

The watcher runs up to 140 minutes at a 30s poll, so "just re-list everything every cycle" was not acceptable. The discriminator question was which run field reliably says "this run moved", and whether we already have it.

**We already have it.** `findDispatchedRun` was always making one `GET /actions/workflows/{file}/runs` call per cycle, and that response carries `status`, `conclusion`, `run_attempt` and `updated_at` for every run — the fields a re-run touches. Nothing new is fetched; the response was simply being under-read.

So the cheap call is now made every cycle (it was only ever skipped *after* completion, which is the bug), and the expensive one — the paginated `listJobs`, up to 5 pages — is gated on a fingerprint of all four fields.

Why all four rather than one:

- **`run_attempt`** is the most reliable single signal — it increments on both "re-run all jobs" and "re-run failed jobs" — and is the one that catches a re-run that completes entirely between two polls, where `status` and `conclusion` could both read unchanged.
- **`status`** catches the common live case (`completed` → `in_progress`) and is what makes the row show ⏳ 运行中 rather than jumping ❌ → ✅.
- **`conclusion`** catches a re-run whose verdict changed.
- **`updated_at`** is the belt-and-braces superset; it moves on anything the other three miss.

Comparing all four costs one string compare and cannot be *less* sensitive than any single field, so there was no reason to pick just one.

**Cost.** Per lane, per cycle, once the run has completed and settled: **+1 list-runs call**, previously 0. Worst case is both lanes settled early across a full 140-minute watch — 280 cycles × 2 lanes ≈ **560 extra calls**, or roughly 240/hour against a 5,000/hour token limit. While a run is in flight the cost is unchanged from `main`. In exchange, a settled lane no longer re-lists its jobs at all, which is what the third spec pins.

**What was deliberately *not* changed:** the watcher's exit condition. It still finishes when every lane it watches is terminal as of that cycle. The distinction that matters is "this observation is terminal" (real, and still what drives the exit) versus "this run is terminal forever" (does not exist on GitHub, and is what the code was wrongly asserting). A bounded watcher cannot see a re-run started after it exits; making the exit condition weaker would just have it idle to its 140-minute timeout on every release and stamp every card 超时.

## Adjacent issues

`grep`ed this file and every neighbour in `tools/release/src/notifications/` for the same shape — a once-observed transition latched as permanent fact. The neighbours (`prerelease-card.ts`, `prerelease-fallback.ts`, `prerelease-fallback-notice.ts`, `feishu.ts`, `feishu-app.ts`, `feishu-notice.ts`) are pure renderers or one-shot scripts with no poll loop to carry state across — their only `sleep()` calls are HTTP retry backoff — so the pattern cannot occur there. Two more instances do live in `prerelease-progress-card.ts`. **Not touched in this PR:**

1. **`publishSucceededAt` latch** (`collect()`): `previous.publishSucceededAt ?? (publish === "success" ? Date.now() : null)` records the first moment publish was seen green and never re-latches. It feeds `smokeDiscoveryExpired`. If the *origin* run is re-run in place more than `CARD_DISCOVERY_GRACE_MS` (20 min) after the first publish success, the smoke discovery window is measured from the stale first success and is therefore already expired — so a freshly re-dispatched smoke run that has not appeared yet would render 🚨 未触发（应运行，但没有被调起）instead of ⏳ 排队中. Same family, different lane, and it needs its own red spec plus a decision about what the whole-round clock should mean across an origin re-run.

2. **`verifiedUrls` Set**: caches "this R2 URL returned 200" for the process lifetime and never re-checks. Structurally the same shape, but benign in practice — the cache is positive-only and a published artifact URL is immutable, so a stale positive would need the object to be deleted mid-release. Listing it for completeness, not proposing a change.

Checked and **clean**: `runCreatedAt` is also cached after its first successful read, but `created_at` genuinely does not change on a re-run (only `run_started_at` does, and it is only the fallback), so that latch is correct.

3. **`tools/release` notification code has no CI test coverage on PRs.** Found while checking whether this PR's green CI meant anything. `pnpm --filter @open-design/tools-release test` appears exactly once in all of `.github/workflows/` — `catalog-validate.yml:57` — and that workflow's `paths:` filter only covers the catalog producer:

   ```yaml
   - "tools/release/src/catalog/**"
   - "tools/release/src/storage/publish-catalog.ts"
   - "tools/release/src/storage/common.ts"
   - "tools/release/src/storage/s3-upload.ts"
   - "tools/release/tests/catalog-*.test.ts"
   - "tools/release/tests/fixtures/catalog/**"
   - "tools/release/package.json"
   ```

   `tools/release/src/notifications/**` matches none of it, so `catalog-validate` did not trigger on this PR. `ci.yml`'s `Workspace unit tests` job runs a fixed list of `--filter` targets that does not include `tools-release`, and `.github/scripts/scopes.py` has no `tools/release` entry at all. Net effect: the prerelease card, the fallback notice and the Feishu clients — 17 test files, 156 tests — run on **no** PR that touches only them. That is plausibly why a defect this mechanical survived in the release path.

   Deliberately **not** fixed here: widening a `paths:` filter or adding a scope is a `.github/` change governed by `.github/AGENTS.md` and the scope-confidence methodology in `specs/current/ci.md`, and it wants its own PR and its own reasoning about which lane should own it — not a drive-by edit inside a bug fix.

## Backport

`backport release/v0.22.1` — this is the release currently in acceptance, and it is the one whose card was observed lying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PbTMU3bKHcu6cmJYy42eF3
