### PR TITLE
fix(diagnostics): retain bounded environment evidence for workspace failures

### DIFF
--- a/apps/daemon/src/collab/vela-workspace-context.ts
+++ b/apps/daemon/src/collab/vela-workspace-context.ts
@@ -1,3 +1,4 @@
+import { getDiagnosticsEvidence, recordDiagnosticFailure } from '../services/diagnostics-evidence.js';
 import { createHash } from 'node:crypto';
 import {
   buildWorkspacePermissions,
@@ -878,6 +879,7 @@ export async function fetchVelaWorkspaceDirectory(
       signal: controller.signal,
     });
     if (!response.ok) {
+      recordDiagnosticFailure({ source: 'workspace-directory', status: response.status, env: process.env });
       if (response.status === 401 || response.status === 403) {
         if (!options.readSession) {
           markVelaAuthorizationExpired(process.env, configuredEnv);
@@ -896,8 +898,11 @@ export async function fetchVelaWorkspaceDirectory(
         status: response.status,
       };
     }
-    return { ok: true, items: mapVelaWorkspaceDirectory(await response.json()) };
-  } catch {
+    const items = mapVelaWorkspaceDirectory(await response.json());
+    getDiagnosticsEvidence()?.observeDirectory(items);
+    return { ok: true, items };
+  } catch (error) {
+    recordDiagnosticFailure({ source: 'workspace-directory', error, timedOut: controller.signal.aborted, env: process.env });
     return { ok: false, items: [], reason: 'network' };
   } finally {
     clearTimeout(timeout);

--- a/apps/daemon/src/diagnostics-export.ts
+++ b/apps/daemon/src/diagnostics-export.ts
@@ -34,6 +34,13 @@ import { agentCliEnvForAgent, readAppConfig } from './app-config.js';
 import { spawnEnvForAgent } from './agents.js';
 import { collectBrowserUseDiscoveryFacts } from './browser/index.js';
 import { readRecentApiFailures } from './http/api-failure-journal.js';
+import {
+  createDiagnosticsEvidence,
+  diagnosticsEvidencePaths,
+  getDiagnosticsEvidence,
+  type DiagnosticsEvidence,
+} from './services/diagnostics-evidence.js';
+import { diagnosticId } from './services/diagnostics-environment.js';
 import { readVelaLoginStatus } from './integrations/vela.js';
 
 interface ResolvedDiagnosticsAgentEnvironment {
@@ -88,6 +95,7 @@ async function resolveDiagnosticsAgentEnvironment(
 }
 
 export interface DiagnosticsHandlerOptions {
+  evidence?: DiagnosticsEvidence;
   /** Sidecar runtime context, present when daemon is launched via tools-dev or packaged sidecar. */
   runtime: SidecarRuntimeContext<LegacySidecarRuntimeLayout> | null;
   /** Project root used to derive crash-report match strings. */
@@ -229,6 +237,7 @@ function resolveDesktopCrashDumpsDir(runtime: SidecarRuntimeContext<LegacySideca
 }
 
 export function createDiagnosticsExportHandler(options: DiagnosticsHandlerOptions): RequestHandler {
+  const evidence = options.evidence ?? getDiagnosticsEvidence() ?? createDiagnosticsEvidence();
   return async (_req, res) => {
     try {
       const versionInfo = await readCurrentAppVersionInfo().catch(() => null);
@@ -248,6 +257,15 @@ export function createDiagnosticsExportHandler(options: DiagnosticsHandlerOption
           xdgDataHome: agentEnvironment.openCodeXdgDataHome ?? process.env.XDG_DATA_HOME ?? null,
         })),
       ];
+      await evidence.refresh();
+      if (options.dataDir) {
+        const paths = diagnosticsEvidencePaths(options.dataDir);
+        for (const [name, absolutePath] of [['latest', paths.current], ['previous', paths.previous]] as const) {
+          if (await shouldListOptionalSource(absolutePath)) sources.push({
+            name: `logs/diagnostics/environment-evidence.${name}.json`, absolutePath, kind: 'json', tailBytes: 256 * 1024,
+          });
+        }
+      }
       const username = safeUsername();
       const crashDumpsDir = resolveDesktopCrashDumpsDir(options.runtime);
 
@@ -288,6 +306,7 @@ export function createDiagnosticsExportHandler(options: DiagnosticsHandlerOption
         },
         sources,
         summaries: {
+          'environment-evidence.json': evidence.snapshot(),
           // Renderer-side scene for the chat scroll freeze. Always written,
           // even when nothing was posted, so an empty slot reads as a stated
           // fact instead of a missing file. See diagnostics-client-evidence.ts.
@@ -317,6 +336,7 @@ export function createDiagnosticsExportHandler(options: DiagnosticsHandlerOption
                 );
                 return {
                   profile: status.profile,
+                  userId: diagnosticId(status.user?.id),
                   loggedIn: status.loggedIn,
                   sessionState: status.sessionState,
                   credentialRevision: status.credentialRevision,

--- a/apps/daemon/src/http/api-failure-journal.ts
+++ b/apps/daemon/src/http/api-failure-journal.ts
@@ -1,3 +1,4 @@
+import { recordDiagnosticFailure } from '../services/diagnostics-evidence.js';
 const MAX_RECENT_API_FAILURES = 100;
 
 export interface RecentApiFailure {
@@ -37,6 +38,7 @@ function diagnosticRouteTemplate(request: ApiFailureToRecord['request']): string
 
 export function recordApiFailure(failure: ApiFailureToRecord): void {
   const { request, ...metadata } = failure;
+  recordDiagnosticFailure({ source: 'local-api', operation: diagnosticRouteTemplate(request), status: failure.status, requestId: failure.requestId });
   failures.push({
     ...metadata,
     method: request?.method?.toUpperCase() ?? 'UNKNOWN',

--- a/apps/daemon/src/integrations/vela-command.ts
+++ b/apps/daemon/src/integrations/vela-command.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import { recordDiagnosticFailure } from '../services/diagnostics-evidence.js';
 import { isAbortedOperationError } from './aborted-error.js';
 
 import {
@@ -248,8 +249,14 @@ export function runVelaCommand(
       if (settled) return;
       settled = true;
       clearTriggers();
-      if ('error' in outcome) reject(outcome.error);
-      else resolve(outcome.stdout);
+      if ('error' in outcome) {
+        if (args[0] === 'team-projects' && args[1] === 'list') {
+          recordDiagnosticFailure({ source: 'team-projects', error: outcome.error, env: childEnv, workspaceId: childEnv.VELA_WORKSPACE_ID });
+        } else if (args[0] === 'resource' && args[1] === 'shared') {
+          recordDiagnosticFailure({ source: 'shared-resources', error: outcome.error, env: childEnv, workspaceId: childEnv.VELA_WORKSPACE_ID });
+        }
+        reject(outcome.error);
+      } else resolve(outcome.stdout);
     };
 
     const terminate = (reason: VelaTerminationReason): void => {

--- a/apps/daemon/src/routes/collab-context.ts
+++ b/apps/daemon/src/routes/collab-context.ts
@@ -1,3 +1,4 @@
+import { getDiagnosticsEvidence, recordDiagnosticFailure } from '../services/diagnostics-evidence.js';
 import type { Express, Request, Response } from 'express';
 import type {
   CollabCloudMemberDirectoryEntry,
@@ -453,12 +454,16 @@ export function registerCollabContextRoutes(app: Express, deps: RegisterCollabCo
           fetchWorkspaceDirectory,
           configuredEnv: configuredEnv(),
         });
-    if (!verified.ok) return sendWorkspaceVerificationFailure(res, verified);
+    if (!verified.ok) {
+      recordDiagnosticFailure({ source: 'workspace-context', status: verified.status });
+      return sendWorkspaceVerificationFailure(res, verified);
+    }
     const enriched = await workspaceContext.resolveExact?.({
       authorization,
       workspaceId: verified.context.workspaceId,
     }).catch(() => null);
     const context = enrichVerifiedWorkspaceContext(verified.context, enriched);
+    getDiagnosticsEvidence()?.observeContext(context);
     const body: WorkspaceContextResponse = { context };
     void deps.observeWorkspace?.(req, context, workspaceGroupProperties(context));
     res.json(body);
@@ -535,6 +540,7 @@ export function registerCollabContextRoutes(app: Express, deps: RegisterCollabCo
       (): WorkspaceDirectoryFetchResult => ({ ok: false, items: [] }),
     );
     if (!directory.ok) {
+      recordDiagnosticFailure({ source: 'local-api', operation: '/api/workspace/directory', status: directory.reason === 'unauthorized' ? 401 : 503 });
       if (directory.reason === 'unauthorized') {
         return sendApiError(
           res,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -713,6 +713,7 @@ import {
   validateTarget as validateRoutineTarget,
 } from './routines.js';
 import { buildMcpInstallPayload } from './mcp-install-info.js';
+import { configureDiagnosticsEvidence } from './services/diagnostics-evidence.js';
 import { createDiagnosticsExportHandler } from './diagnostics-export.js';
 import {
   CHAT_SCROLL_FORENSICS_PATH,
@@ -1342,6 +1343,7 @@ const SANDBOX_MODE_ENABLED = isSandboxModeEnabled(process.env);
 const RUNTIME_DATA_DIR = resolveDataDir(process.env.OD_DATA_DIR, PROJECT_ROOT, {
   requireExplicit: SANDBOX_MODE_ENABLED,
 });
+configureDiagnosticsEvidence(RUNTIME_DATA_DIR);
 const SANDBOX_RUNTIME = resolveSandboxRuntimeConfig(SANDBOX_MODE_ENABLED, RUNTIME_DATA_DIR);
 ensureSandboxRuntimeDirs(SANDBOX_RUNTIME);
 const PLUGIN_LOCKFILE_PATH = path.join(RUNTIME_DATA_DIR, 'od-plugin-lock.json');

--- a/apps/daemon/src/services/diagnostics-environment.ts
+++ b/apps/daemon/src/services/diagnostics-environment.ts
@@ -1,0 +1,141 @@
+import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { networkInterfaces } from 'node:os';
+
+import { parseMacosScutilProxyOutput, parseWindowsInternetSettingsProxyOutput } from '@open-design/platform';
+
+const MAX_CONFIG_LENGTH = 4096;
+
+function fingerprint(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 16);
+}
+
+/** Keep endpoint correlation without exporting credentials, hostnames, paths or PAC URLs. */
+function proxyEndpoint(value: string | undefined) {
+  if (!value) return { configured: false };
+  if (value.length > MAX_CONFIG_LENGTH) return { configured: true, valid: false };
+  try {
+    const url = new URL(value.includes('://') ? value : `http://${value}`);
+    if (!['http:', 'https:', 'socks:', 'socks5:', 'socks5h:'].includes(url.protocol)) {
+      return { configured: true, valid: false };
+    }
+    return {
+      configured: true,
+      valid: true,
+      protocol: url.protocol.slice(0, -1),
+      port: url.port || null,
+      endpointFingerprint: fingerprint(`${url.protocol}//${url.host}`),
+      loopback: ['localhost', '127.0.0.1', '[::1]'].includes(url.hostname),
+      credentialsPresent: Boolean(url.username || url.password),
+    };
+  } catch {
+    return { configured: true, valid: false };
+  }
+}
+
+/** Only this allowlist may enter diagnostics; never serialize an environment object. */
+export function summarizeProxyEnvironment(env: NodeJS.ProcessEnv) {
+  const bypass = (env.NO_PROXY ?? env.no_proxy ?? '').slice(0, MAX_CONFIG_LENGTH);
+  return {
+    http: proxyEndpoint(env.HTTP_PROXY ?? env.http_proxy),
+    https: proxyEndpoint(env.HTTPS_PROXY ?? env.https_proxy),
+    all: proxyEndpoint(env.ALL_PROXY ?? env.all_proxy),
+    noProxy: {
+      configured: Boolean(bypass),
+      wildcard: bypass.trim() === '*',
+      fingerprint: bypass ? fingerprint(bypass) : null,
+    },
+    nodeUseEnvProxy: env.NODE_USE_ENV_PROXY === '1',
+  };
+}
+
+export type DiagnosticProxyEnvironment = ReturnType<typeof summarizeProxyEnvironment>;
+
+export function diagnosticId(value: unknown): string | null {
+  return typeof value === 'string' && /^[a-zA-Z0-9_-]{1,128}$/.test(value) ? value : null;
+}
+
+export type DiagnosticFailureCode = 'timeout' | 'aborted' | 'dns' | 'connection-refused' | 'tls' | 'proxy' | 'http' | 'other';
+
+/** Error text, argv, stdout and stderr can contain secrets. Never retain them. */
+export function diagnosticFailureCode(error: unknown): DiagnosticFailureCode {
+  if (typeof error !== 'object' || error === null) return 'other';
+  const candidate = error as { code?: unknown; name?: unknown; cause?: { code?: unknown } };
+  const code = candidate.code ?? candidate.cause?.code;
+  if (['ETIMEDOUT', 'UND_ERR_CONNECT_TIMEOUT', 'UND_ERR_HEADERS_TIMEOUT', 'UND_ERR_BODY_TIMEOUT'].includes(String(code)) || candidate.name === 'TimeoutError') return 'timeout';
+  if (code === 'ABORT_ERR' || candidate.name === 'AbortError') return 'aborted';
+  if (code === 'ENOTFOUND' || code === 'EAI_AGAIN') return 'dns';
+  if (code === 'ECONNREFUSED') return 'connection-refused';
+  if (['CERT_HAS_EXPIRED', 'DEPTH_ZERO_SELF_SIGNED_CERT', 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'].includes(String(code))) return 'tls';
+  const stderr = (error as { stderr?: unknown }).stderr;
+  const tail = typeof stderr === 'string' ? stderr.slice(-4096) : '';
+  if (/proxyconnect|proxy authentication required/i.test(tail)) return 'proxy';
+  if (/context deadline exceeded|Client\.Timeout/i.test(tail)) return 'timeout';
+  if (/x509:|certificate verify failed/i.test(tail)) return 'tls';
+  if (/no such host/i.test(tail)) return 'dns';
+  return 'other';
+}
+
+export interface SystemEnvironmentSnapshot {
+  sampledAt: string;
+  status: 'collected' | 'unavailable' | 'unsupported';
+  systemProxy: DiagnosticProxyEnvironment | null;
+  pacConfigured: boolean | null;
+  daemonProxy: DiagnosticProxyEnvironment;
+  interfaces: { ipv4: number; ipv6: number } | null;
+}
+
+function runSystemQuery(command: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, { timeout: 1500, killSignal: 'SIGKILL', maxBuffer: 64 * 1024, windowsHide: true, encoding: 'utf8' }, (error, stdout) => {
+      if (error) reject(error);
+      else resolve(stdout);
+    });
+  });
+}
+
+/** On-demand only: no requests to the network, process scans or synchronous subprocesses. */
+export async function collectSystemEnvironment(options: {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  query?: typeof runSystemQuery;
+  interfaces?: typeof networkInterfaces;
+} = {}): Promise<SystemEnvironmentSnapshot> {
+  const platform = options.platform ?? process.platform;
+  const snapshot: SystemEnvironmentSnapshot = {
+    sampledAt: new Date().toISOString(),
+    status: 'unsupported',
+    systemProxy: null,
+    pacConfigured: null,
+    daemonProxy: summarizeProxyEnvironment(options.env ?? process.env),
+    interfaces: null,
+  };
+  try {
+    const counts = { ipv4: 0, ipv6: 0 };
+    for (const addresses of Object.values((options.interfaces ?? networkInterfaces)())) {
+      for (const address of addresses ?? []) {
+        if (address.internal) continue;
+        if (address.family === 'IPv4') counts.ipv4 += 1;
+        if (address.family === 'IPv6') counts.ipv6 += 1;
+      }
+    }
+    snapshot.interfaces = counts;
+    const query = options.query ?? runSystemQuery;
+    if (platform === 'win32') {
+      const output = await query('reg.exe', ['query', String.raw`HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings`]);
+      snapshot.systemProxy = summarizeProxyEnvironment(parseWindowsInternetSettingsProxyOutput({
+        proxyEnable: output, proxyServer: output, proxyOverride: output,
+      }));
+      snapshot.pacConfigured = /AutoConfigURL\s+REG_\w+\s+\S+/i.test(output);
+      snapshot.status = 'collected';
+    } else if (platform === 'darwin') {
+      const output = await query('/usr/sbin/scutil', ['--proxy']);
+      snapshot.systemProxy = summarizeProxyEnvironment(parseMacosScutilProxyOutput(output));
+      snapshot.pacConfigured = /ProxyAutoConfigEnable\s*:\s*1/.test(output);
+      snapshot.status = 'collected';
+    }
+  } catch {
+    snapshot.status = 'unavailable';
+  }
+  return snapshot;
+}

--- a/apps/daemon/src/services/diagnostics-evidence.ts
+++ b/apps/daemon/src/services/diagnostics-evidence.ts
@@ -1,0 +1,261 @@
+import { mkdir, rename, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import {
+  collectSystemEnvironment,
+  diagnosticFailureCode,
+  diagnosticId,
+  summarizeProxyEnvironment,
+  type DiagnosticFailureCode,
+  type DiagnosticProxyEnvironment,
+  type SystemEnvironmentSnapshot,
+} from './diagnostics-environment.js';
+
+const MAX_FAILURES = 100;
+const MAX_BYTES = 256 * 1024;
+const SAMPLE_INTERVAL_MS = 60_000;
+const FLUSH_INTERVAL_MS = 60_000;
+const MAX_WORKSPACES = 50;
+
+type Source = 'workspace-directory' | 'workspace-context' | 'team-projects' | 'shared-resources' | 'local-api';
+type Workspace = { workspaceId: string | null; memberId: string | null; workspaceType: 'team' | 'personal' | null };
+type Failure = Workspace & {
+  source: Source;
+  code: DiagnosticFailureCode;
+  status: number | null;
+  operation: string | null;
+  requestId: string | null;
+  proxySampledAt: string | null;
+  firstAt: string;
+  lastAt: string;
+  count: number;
+  firstEnvironmentAt: string | null;
+  lastEnvironmentAt: string | null;
+  proxyConfiguration: DiagnosticProxyEnvironment | null;
+};
+
+export type FailureInput = {
+  source: Source;
+  operation?: string;
+  requestId?: unknown;
+  error?: unknown;
+  timedOut?: boolean;
+  status?: number;
+  workspaceId?: unknown;
+  memberId?: unknown;
+  workspaceType?: unknown;
+  /** Already-used child env, only summarized on a new group or once per minute. */
+  env?: NodeJS.ProcessEnv;
+};
+
+function workspace(value: { workspaceId?: unknown; memberId?: unknown; workspaceType?: unknown }): Workspace {
+  return {
+    workspaceId: diagnosticId(value.workspaceId),
+    memberId: diagnosticId(value.memberId),
+    workspaceType: value.workspaceType === 'team' || value.workspaceType === 'personal' ? value.workspaceType : null,
+  };
+}
+
+export function diagnosticsEvidencePaths(dataRoot: string) {
+  const directory = join(dataRoot, 'diagnostics');
+  return { directory, current: join(directory, 'environment-evidence.json'), previous: join(directory, 'environment-evidence.previous.json') };
+}
+
+/** One bounded checkpoint, plus the preceding process's checkpoint. No growing log or write queue. */
+export function createEvidenceCheckpointWriter(dataRoot: string): (content: string) => Promise<void> {
+  const paths = diagnosticsEvidencePaths(dataRoot);
+  let rotated = false;
+  return async (content) => {
+    if (Buffer.byteLength(content) > MAX_BYTES) throw new Error('diagnostics checkpoint exceeds byte limit');
+    await mkdir(paths.directory, { recursive: true });
+    if (!rotated) {
+      await rename(paths.current, paths.previous).catch((error: NodeJS.ErrnoException) => {
+        if (error.code !== 'ENOENT') throw error;
+      });
+      rotated = true;
+    }
+    const temporary = `${paths.current}.tmp`;
+    await writeFile(temporary, content, { encoding: 'utf8', mode: 0o600 });
+    await rename(temporary, paths.current);
+  };
+}
+
+export function createDiagnosticsEvidence(options: {
+  collect?: () => Promise<SystemEnvironmentSnapshot>;
+  write?: (content: string) => Promise<void>;
+  now?: () => number;
+} = {}) {
+  const now = options.now ?? Date.now;
+  const failures = new Map<string, Failure>();
+  const environments: SystemEnvironmentSnapshot[] = [];
+  let directory: { observedAt: string; truncated: boolean; items: Workspace[] } | null = null;
+  let context: (Workspace & { observedAt: string }) | null = null;
+  let lastSample = -Infinity;
+  let collecting: Promise<void> | null = null;
+  let writing: Promise<void> | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let dirty = false;
+  let closed = false;
+  let writeFailed = false;
+  let droppedGroups = 0;
+  let collectionState: 'not-requested' | 'collecting' | 'settled' | 'unavailable' = 'not-requested';
+
+  function snapshot() {
+    return {
+      schemaVersion: 1,
+      exportedAt: new Date(now()).toISOString(),
+      limits: { failures: MAX_FAILURES, bytes: MAX_BYTES, sampleIntervalMs: SAMPLE_INTERVAL_MS, flushIntervalMs: FLUSH_INTERVAL_MS },
+      coverage: {
+        actualNetworkRoute: 'not-observed', vpn: 'not-determined',
+        workspaceContext: 'last-daemon-response-not-browser-selection',
+        failureEnvironment: 'cached-sample-at-or-before-failure; null-means-not-yet-sampled',
+        persistence: options.write ? (writeFailed ? 'unavailable' : 'periodic-checkpoint') : 'memory-only',
+        droppedGroups,
+        environmentCollection: collectionState,
+      },
+      directory,
+      context,
+      environments: [...environments],
+      failures: Array.from(failures.values(), (entry) => ({ ...entry })),
+    };
+  }
+
+  function serialize(): string {
+    let content = JSON.stringify(snapshot());
+    while (Buffer.byteLength(content) > MAX_BYTES && failures.size > 0) {
+      failures.delete(failures.keys().next().value!);
+      droppedGroups += 1;
+      content = JSON.stringify(snapshot());
+    }
+    return content;
+  }
+
+  function scheduleWrite(): void {
+    dirty = true;
+    if (!options.write || timer || writing || closed) return;
+    timer = setTimeout(() => {
+      timer = null;
+      void flush();
+    }, FLUSH_INTERVAL_MS);
+    timer.unref();
+  }
+
+  async function flush(): Promise<void> {
+    if (writing) return writing;
+    if (!dirty || !options.write) return;
+    dirty = false;
+    const content = serialize();
+    writing = Promise.resolve().then(() => options.write!(content)).then(() => {
+      writeFailed = false;
+    }).catch(() => {
+      writeFailed = true;
+      // Retry at the next bounded interval, never recurse into the error journal.
+      dirty = true;
+    }).finally(() => {
+      writing = null;
+      if (dirty && !closed) scheduleWrite();
+    });
+    return writing;
+  }
+
+  function refresh(): Promise<void> {
+    if (closed) return Promise.resolve();
+    if (collecting) return collecting;
+    if (now() - lastSample < SAMPLE_INTERVAL_MS) return Promise.resolve();
+    lastSample = now();
+    collectionState = 'collecting';
+    collecting = Promise.resolve().then(() => (options.collect ?? collectSystemEnvironment)()).then((environment) => {
+      collectionState = 'settled';
+      environments.push(environment);
+      if (environments.length > 4) environments.shift();
+      scheduleWrite();
+    }).catch(() => {
+      // Collection failure cannot change a business result or invalidate the ZIP.
+      collectionState = 'unavailable';
+    }).finally(() => { collecting = null; });
+    return collecting;
+  }
+
+  return {
+    refresh,
+    flush,
+    snapshot: () => JSON.parse(serialize()) as ReturnType<typeof snapshot>,
+    record(input: FailureInput): void {
+      if (closed) return;
+      const identity = workspace(input);
+      let code: DiagnosticFailureCode = diagnosticFailureCode(input.error);
+      if (input.status) code = 'http';
+      if (input.timedOut) code = 'timeout';
+      const status = Number.isInteger(input.status) && input.status! >= 400 && input.status! <= 599 ? input.status! : null;
+      const operation = input.operation && /^[a-zA-Z0-9/_.:-]{1,160}$/.test(input.operation) ? input.operation : null;
+      const key = `${operation}:${input.source}:${code}:${status}:${identity.workspaceId}:${identity.memberId}:${identity.workspaceType}`;
+      const timestamp = now();
+      const time = new Date(timestamp).toISOString();
+      const environmentAt = environments.at(-1)?.sampledAt ?? null;
+      const existing = failures.get(key);
+      if (existing) {
+        existing.count = Math.min(existing.count + 1, Number.MAX_SAFE_INTEGER);
+        if (input.env && timestamp - Date.parse(existing.proxySampledAt ?? existing.firstAt) >= SAMPLE_INTERVAL_MS) {
+          existing.proxyConfiguration = summarizeProxyEnvironment(input.env);
+          existing.proxySampledAt = time;
+        }
+        existing.lastAt = time;
+        existing.requestId = diagnosticId(input.requestId);
+        existing.lastEnvironmentAt = environmentAt;
+        failures.delete(key);
+        failures.set(key, existing);
+      } else {
+        failures.set(key, {
+          ...identity,
+          source: input.source,
+          code,
+          status,
+          operation,
+          requestId: diagnosticId(input.requestId),
+          proxySampledAt: input.env ? time : null,
+          firstAt: time,
+          lastAt: time,
+          count: 1,
+          firstEnvironmentAt: environmentAt,
+          lastEnvironmentAt: environmentAt,
+          proxyConfiguration: input.env ? summarizeProxyEnvironment(input.env) : null,
+        });
+        if (failures.size > MAX_FAILURES) {
+          failures.delete(failures.keys().next().value!);
+          droppedGroups += 1;
+        }
+      }
+      scheduleWrite();
+      if (!collecting && now() - lastSample >= SAMPLE_INTERVAL_MS) void refresh();
+    },
+    observeDirectory(items: readonly { workspaceId?: unknown; memberId?: unknown; workspaceType?: unknown; workspaceMemberId?: unknown }[]): void {
+      if (closed) return;
+      directory = { observedAt: new Date(now()).toISOString(), truncated: items.length > MAX_WORKSPACES,
+        items: items.slice(0, MAX_WORKSPACES).map((item) => workspace({ ...item, memberId: item.memberId ?? item.workspaceMemberId })) };
+    },
+    observeContext(value: { workspaceId?: unknown; memberId?: unknown; workspaceType?: unknown } | null): void {
+      if (closed) return;
+      context = value ? { ...workspace(value), observedAt: new Date(now()).toISOString() } : null;
+    },
+    close(): void {
+      closed = true;
+      if (timer) clearTimeout(timer);
+      timer = null;
+    },
+  };
+}
+
+export type DiagnosticsEvidence = ReturnType<typeof createDiagnosticsEvidence>;
+let activeEvidence: DiagnosticsEvidence | null = null;
+
+/** Configure once with the daemon's resolved data root; readers never guess it. */
+export function configureDiagnosticsEvidence(dataRoot: string): void {
+  activeEvidence?.close();
+  activeEvidence = createDiagnosticsEvidence({ write: createEvidenceCheckpointWriter(dataRoot) });
+}
+
+export function getDiagnosticsEvidence(): DiagnosticsEvidence | null { return activeEvidence; }
+
+export function recordDiagnosticFailure(input: FailureInput): void {
+  try { activeEvidence?.record(input); } catch { /* Diagnostics must not replace the business failure. */ }
+}

--- a/apps/daemon/tests/diagnostics-export.test.ts
+++ b/apps/daemon/tests/diagnostics-export.test.ts
@@ -1,3 +1,5 @@
+import { createDiagnosticsEvidence, createEvidenceCheckpointWriter } from '../src/services/diagnostics-evidence.js';
+import { collectSystemEnvironment } from '../src/services/diagnostics-environment.js';
 import { chmod, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir, userInfo } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -44,6 +46,47 @@ interface DiagnosticsManifestFile {
 }
 
 describe('diagnostics export handler — non-sidecar launch', () => {
+  it('exports failure-time workspace/proxy evidence and the previous process checkpoint through the existing handler', async () => {
+    const root = join(tmpdir(), `od-diag-environment-${randomUUID()}`);
+    const evidence = createDiagnosticsEvidence({
+      collect: () => collectSystemEnvironment({ platform: 'linux', env: {}, interfaces: () => ({}) }),
+      write: createEvidenceCheckpointWriter(root),
+    });
+    try {
+      const prior = createEvidenceCheckpointWriter(root);
+      await prior(JSON.stringify({ marker: 'prior-process-evidence' }));
+      evidence.observeContext({ workspaceId: 'team-1', memberId: 'member-1', workspaceType: 'team' });
+      evidence.record({ source: 'team-projects', timedOut: true, workspaceId: 'team-1', env: { HTTPS_PROXY: 'http://user:private-password@localhost:7890' } });
+      await evidence.refresh();
+      await evidence.flush();
+      const handler = createDiagnosticsExportHandler({ runtime: null, projectRoot: root, dataDir: root, evidence });
+      const res = mockResponse();
+      await handler({} as never, res as never, () => undefined);
+      expect(res.capturedStatus).toBe(200);
+      const zip = await JSZip.loadAsync(res.capturedPayload!);
+      const current = await zip.file('summary/environment-evidence.json')!.async('string');
+      expect(JSON.parse(current).context).toMatchObject({ workspaceId: 'team-1', memberId: 'member-1', workspaceType: 'team' });
+      expect(JSON.parse(current).failures[0]).toMatchObject({ source: 'team-projects', code: 'timeout', count: 1 });
+      expect(current).not.toContain('private-password');
+      const previous = await zip.file('logs/diagnostics/environment-evidence.previous.json')!.async('string');
+      expect(previous).toContain('prior-process-evidence');
+    } finally { evidence.close(); await rm(root, { recursive: true, force: true }); }
+  });
+
+  it('includes bounded environment and failure evidence in the exported ZIP', async () => {
+    const handler = createDiagnosticsExportHandler({ runtime: null, projectRoot: '/tmp/test-project' });
+    const res = mockResponse();
+    await handler({} as never, res as never, () => undefined);
+    expect(res.capturedStatus).toBe(200);
+    const zip = await JSZip.loadAsync(res.capturedPayload!);
+    const entry = zip.file('summary/environment-evidence.json');
+    expect(entry).not.toBeNull();
+    const summary = JSON.parse(await entry!.async('string'));
+    expect(summary.limits).toMatchObject({ failures: 100, bytes: 262144 });
+    expect(summary.coverage.actualNetworkRoute).toBe('not-observed');
+    expect(summary.coverage.vpn).toBe('not-determined');
+  });
+
   // Reviewer-requested regression spec: `runDaemonCliStartup()` calls
   // `startDaemonRuntime()` without a runtime context, so plain `od` users
   // hit the diagnostics handler with `options.runtime == null`. The bundle

--- a/apps/daemon/tests/integrations/vela-command.test.ts
+++ b/apps/daemon/tests/integrations/vela-command.test.ts
@@ -20,6 +20,7 @@ vi.mock('@open-design/platform', async (importOriginal) => ({
   stopProcesses: stopProcessesMock,
 }));
 
+import * as diagnosticEvidence from '../../src/services/diagnostics-evidence.js';
 import { runVelaCommand } from '../../src/integrations/vela-command.js';
 import {
   runVelaResourceBatchCommand,
@@ -48,6 +49,21 @@ function deferred<T>() {
 }
 
 describe('runVelaCommand', () => {
+  it('records team-list failures with the actual child proxy environment without changing the rejection', async () => {
+    const record = vi.spyOn(diagnosticEvidence, 'recordDiagnosticFailure').mockImplementation(() => undefined);
+    const failure = Object.assign(new Error('upstream failed'), { code: 'ETIMEDOUT' });
+    execFileMock.mockImplementation((_command: string, _args: string[], _options: unknown, callback: (error: Error) => void) => {
+      callback(failure);
+      return { pid: 4321 };
+    });
+    await expect(runVelaCommand(['team-projects', 'list'], { env: {
+      VELA_BIN: process.execPath, OD_DATA_DIR: '', VELA_WORKSPACE_ID: 'team-1', HTTPS_PROXY: 'http://localhost:7890',
+    } })).rejects.toBe(failure);
+    expect(record).toHaveBeenCalledWith(expect.objectContaining({
+      source: 'team-projects', error: failure, workspaceId: 'team-1', env: expect.objectContaining({ HTTPS_PROXY: 'http://localhost:7890' }),
+    }));
+  });
+
   beforeEach(() => {
     execFileMock.mockReset();
     listProcessSnapshotsMock.mockReset();

--- a/apps/daemon/tests/services/diagnostics-evidence.test.ts
+++ b/apps/daemon/tests/services/diagnostics-evidence.test.ts
@@ -1,0 +1,196 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createDiagnosticsEvidence, createEvidenceCheckpointWriter, diagnosticsEvidencePaths } from '../../src/services/diagnostics-evidence.js';
+import { collectSystemEnvironment, diagnosticFailureCode, summarizeProxyEnvironment, type SystemEnvironmentSnapshot } from '../../src/services/diagnostics-environment.js';
+
+function environment(): SystemEnvironmentSnapshot {
+  return { sampledAt: new Date().toISOString(), status: 'collected', systemProxy: summarizeProxyEnvironment({}),
+    daemonProxy: summarizeProxyEnvironment({}), pacConfigured: false, interfaces: { ipv4: 1, ipv6: 0 } };
+}
+
+afterEach(() => vi.useRealTimers());
+
+describe('bounded diagnostics under repeated failures', () => {
+  it('does no collection or disk work for successful workspace observations alone', async () => {
+    vi.useFakeTimers();
+    const collect = vi.fn(async () => environment());
+    const write = vi.fn(async () => undefined);
+    const evidence = createDiagnosticsEvidence({ collect, write });
+    try {
+      for (let i = 0; i < 1000; i++) {
+        evidence.observeDirectory([{ workspaceId: 'team-1', workspaceMemberId: 'member-1', workspaceType: 'team' }]);
+        evidence.observeContext({ workspaceId: 'team-1', memberId: 'member-1', workspaceType: 'team' });
+      }
+      await vi.advanceTimersByTimeAsync(180_000);
+      expect(collect).not.toHaveBeenCalled();
+      expect(write).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally { evidence.close(); }
+  });
+
+  it('coalesces 100,000 failures into one record with one asynchronous sample and one checkpoint per minute', async () => {
+    vi.useFakeTimers();
+    const collect = vi.fn(async () => environment());
+    const write = vi.fn(async (_content: string) => undefined);
+    const evidence = createDiagnosticsEvidence({ collect, write });
+    try {
+      for (let i = 0; i < 100_000; i++) evidence.record({ source: 'team-projects', timedOut: true, workspaceId: 'team-1' });
+      expect(collect).not.toHaveBeenCalled();
+      expect(write).not.toHaveBeenCalled();
+      await evidence.refresh();
+      expect(collect).toHaveBeenCalledTimes(1);
+      expect(evidence.snapshot().failures).toMatchObject([{ count: 100_000, code: 'timeout', firstEnvironmentAt: null }]);
+      expect(vi.getTimerCount()).toBe(1);
+      await vi.advanceTimersByTimeAsync(59_999);
+      expect(write).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(write).toHaveBeenCalledTimes(1);
+      expect(Buffer.byteLength(write.mock.calls[0]![0])).toBeLessThan(262144);
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(write).toHaveBeenCalledTimes(1);
+      expect(collect).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally { evidence.close(); }
+  });
+
+  it('caps distinct groups and directory identities, and does not serialize secrets or messages', async () => {
+    const evidence = createDiagnosticsEvidence({ collect: async () => environment() });
+    try {
+      evidence.observeDirectory(Array.from({ length: 1000 }, (_, i) => ({
+        workspaceId: `workspace-${i}`, workspaceMemberId: `member-${i}`, workspaceType: 'team', workspaceName: 'private-name',
+      })));
+      evidence.observeContext({ workspaceId: 'selected-team', memberId: 'member-1', workspaceType: 'team' });
+      for (let i = 0; i < 10_000; i++) evidence.record({
+        source: 'local-api', status: 503, operation: '/api/projects/:id', requestId: `request-${i}`, workspaceId: `team-${i}`,
+        error: new Error('Authorization: Bearer secret-message'), env: { HTTPS_PROXY: 'http://username:password@private-host:7890/private-path?token=secret-query', OPENAI_API_KEY: 'secret-key' },
+      });
+      await evidence.refresh();
+      const snapshot = evidence.snapshot();
+      expect(snapshot.failures).toHaveLength(100);
+      expect(snapshot.failures[0]!.workspaceId).toBe('team-9900');
+      expect(snapshot.coverage.droppedGroups).toBe(9900);
+      expect(snapshot.directory?.items).toHaveLength(50);
+      expect(snapshot.directory?.truncated).toBe(true);
+      expect(snapshot.directory?.items[0]?.memberId).toBe('member-0');
+      const serialized = JSON.stringify(snapshot);
+      expect(Buffer.byteLength(serialized)).toBeLessThanOrEqual(262144);
+      for (const secret of ['private-name', 'username', 'password', 'private-host', 'private-path', 'secret-query', 'secret-key', 'secret-message']) expect(serialized).not.toContain(secret);
+      expect(snapshot.failures[0]?.proxyConfiguration?.https).toMatchObject({ port: '7890', credentialsPresent: true });
+    } finally { evidence.close(); }
+  });
+
+  it('shares an in-flight collection across failures and exports without a growing promise or write queue', async () => {
+    vi.useFakeTimers();
+    let finish!: (value: SystemEnvironmentSnapshot) => void;
+    const collect = vi.fn(() => new Promise<SystemEnvironmentSnapshot>((resolve) => { finish = resolve; }));
+    let finishWrite!: () => void;
+    const write = vi.fn(() => new Promise<void>((resolve) => { finishWrite = resolve; }));
+    const evidence = createDiagnosticsEvidence({ collect, write });
+    try {
+      const refresh = evidence.refresh();
+      expect(evidence.refresh()).toBe(refresh);
+      await Promise.resolve();
+      for (let i = 0; i < 1000; i++) evidence.record({ source: 'workspace-directory', status: 503 });
+      expect(collect).toHaveBeenCalledTimes(1);
+      finish(environment());
+      await refresh;
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(write).toHaveBeenCalledTimes(1);
+      for (let i = 0; i < 1000; i++) evidence.record({ source: 'workspace-directory', status: 503 });
+      await vi.advanceTimersByTimeAsync(300_000);
+      expect(write).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+      finishWrite();
+      await evidence.flush();
+      expect(vi.getTimerCount()).toBe(1);
+    } finally { evidence.close(); }
+  });
+
+  it('bounds retries after collection and disk failures without emitting recursive diagnostics', async () => {
+    vi.useFakeTimers();
+    const collect = vi.fn(async () => { throw new Error('private collector error'); });
+    const write = vi.fn(async () => { throw new Error('disk full'); });
+    const evidence = createDiagnosticsEvidence({ collect, write });
+    try {
+      evidence.record({ source: 'workspace-context', status: 503 });
+      await evidence.refresh();
+      expect(evidence.snapshot().failures).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(180_000);
+      expect(write).toHaveBeenCalledTimes(3);
+      expect(collect).toHaveBeenCalledTimes(1);
+      expect(evidence.snapshot().coverage.persistence).toBe('unavailable');
+      expect(JSON.stringify(evidence.snapshot())).not.toContain('private collector error');
+    } finally { evidence.close(); }
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('refreshes proxy evidence at most once a minute even during continuous errors', async () => {
+    vi.useFakeTimers();
+    const evidence = createDiagnosticsEvidence({ collect: async () => environment() });
+    try {
+      evidence.record({ source: 'team-projects', env: { HTTPS_PROXY: 'http://localhost:7890' } });
+      for (let i = 0; i < 60; i++) {
+        await vi.advanceTimersByTimeAsync(1000);
+        evidence.record({ source: 'team-projects', env: { HTTPS_PROXY: 'http://localhost:7891' } });
+      }
+      expect(evidence.snapshot().failures[0]?.proxyConfiguration?.https).toMatchObject({ port: '7891' });
+      expect(evidence.snapshot().environments.length).toBeLessThanOrEqual(4);
+    } finally { evidence.close(); }
+  });
+
+  it('checkpoints atomically and preserves the preceding process across restart', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'od-diagnostic-evidence-'));
+    try {
+      const first = createEvidenceCheckpointWriter(root);
+      await first('{"session":1,"count":1}');
+      await first('{"session":1,"count":2}');
+      const second = createEvidenceCheckpointWriter(root);
+      await second('{"session":2}');
+      const paths = diagnosticsEvidencePaths(root);
+      expect(JSON.parse(await readFile(paths.previous, 'utf8'))).toEqual({ session: 1, count: 2 });
+      expect(JSON.parse(await readFile(paths.current, 'utf8'))).toEqual({ session: 2 });
+    } finally { await rm(root, { recursive: true, force: true }); }
+  });
+});
+
+describe('sanitized OS environment sampling', () => {
+  it('classifies bounded CLI stderr without retaining its contents', () => {
+    expect(diagnosticFailureCode({ stderr: 'Get https://user:secret@api.test: proxyconnect tcp: refused' })).toBe('proxy');
+    expect(diagnosticFailureCode({ stderr: 'context deadline exceeded (Client.Timeout exceeded while awaiting headers)' })).toBe('timeout');
+    expect(diagnosticFailureCode({ cause: { code: 'ENOTFOUND' } })).toBe('dns');
+    expect(diagnosticFailureCode({ stderr: 'x509: certificate signed by unknown authority' })).toBe('tls');
+  });
+
+  it('reads Windows configuration asynchronously once, and removes credentials, PAC URL and interface identifiers', async () => {
+    const query = vi.fn(async () => `
+      ProxyEnable REG_DWORD 0x1
+      ProxyServer REG_SZ http://user:secret@127.0.0.1:7890
+      ProxyOverride REG_SZ *.private-domain;localhost
+      AutoConfigURL REG_SZ https://pac.private-domain/config?token=secret
+    `);
+    const snapshot = await collectSystemEnvironment({ platform: 'win32', query, env: { HTTPS_PROXY: 'http://user:secret@proxy.private-domain:8080', SECRET_TOKEN: 'never-export' }, interfaces: () => ({}) });
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[0]).toEqual(['reg.exe', ['query', String.raw`HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings`]]);
+    expect(snapshot).toMatchObject({ status: 'collected', pacConfigured: true, systemProxy: { https: { configured: true, loopback: true, port: '7890' } } });
+    const serialized = JSON.stringify(snapshot);
+    for (const secret of ['private-domain', 'never-export', 'secret', 'AutoConfigURL']) expect(serialized).not.toContain(secret);
+  });
+
+  it('labels failed/unsupported collection and never claims a VPN or an actual network route', async () => {
+    const failed = await collectSystemEnvironment({ platform: 'win32', query: async () => { throw new Error('timeout'); }, interfaces: () => ({}) });
+    expect(failed.status).toBe('unavailable');
+    expect(failed.systemProxy).toBeNull();
+    const query = vi.fn();
+    expect((await collectSystemEnvironment({ platform: 'linux', query, interfaces: () => ({}) })).status).toBe('unsupported');
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('rejects oversized or invalid proxy values instead of retaining arbitrary environment text', () => {
+    expect(summarizeProxyEnvironment({ HTTP_PROXY: 'x'.repeat(1_000_000), HTTPS_PROXY: 'file:///secret' })).toMatchObject({
+      http: { configured: true, valid: false }, https: { configured: true, valid: false },
+    });
+  });
+});

--- a/apps/daemon/tests/vela-workspace-context.test.ts
+++ b/apps/daemon/tests/vela-workspace-context.test.ts
@@ -1,3 +1,4 @@
+import * as diagnosticEvidence from '../src/services/diagnostics-evidence.js';
 import fs, { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -1438,5 +1439,18 @@ describe('createVelaWorkspaceContextProvider — stale pin recovery', () => {
     expect(pin.replaceCalls.length).toBe(0);
     expect(pin.setCalls.length).toBe(0);
     expect(pin.getActiveWorkspaceId()).toBe('ws-team-1');
+  });
+});
+
+
+describe('workspace authority failure evidence', () => {
+  it('records the cloud failure without changing its public result or retaining the credential', async () => {
+    const record = vi.spyOn(diagnosticEvidence, 'recordDiagnosticFailure').mockImplementation(() => undefined);
+    try {
+      const result = await fetchVelaWorkspaceDirectory({ readSession: () => SESSION, fetch: async () => jsonResponse(503, {}) });
+      expect(result).toEqual({ ok: false, items: [], reason: 'upstream', status: 503 });
+      expect(record).toHaveBeenCalledWith(expect.objectContaining({ source: 'workspace-directory', status: 503 }));
+      expect(record.mock.calls[0]![0]).not.toHaveProperty('controlKey');
+    } finally { record.mockRestore(); }
   });
 });

--- a/docs/testing/diagnostics-environment.md
+++ b/docs/testing/diagnostics-environment.md
@@ -1,0 +1,74 @@
+# Environment evidence in diagnostics exports
+
+The existing **Export diagnostics** action and `od diagnostics export --json`
+use the same daemon export endpoint. Its ZIP includes
+`summary/environment-evidence.json` alongside the existing machine, version,
+login-health and log summaries.
+
+## Reading the evidence
+
+- `directory` records up to 50 workspace/member IDs and workspace types from the
+  last successful cloud directory response. `truncated` reports omitted rows.
+- `context` records the last workspace context returned by the daemon. It is
+  **not** an assertion about the currently selected browser tab. Both observations
+  carry timestamps; names, project contents, roles and billing information are omitted.
+- `runtime-health.json` additionally includes the current login's opaque user ID.
+  This is export-time identity; it must not be assumed to identify every historical
+  request in the bundle.
+- `environments` retains four timestamped samples of system proxy configuration,
+  the daemon proxy environment, PAC configuration presence, and non-loopback
+  IPv4/IPv6 address counts. Interface names, addresses and routes are omitted.
+- `failures` coalesces directory/context, team-project CLI, shared-resource CLI,
+  and existing API-journal failures by operation, category, status and available
+  workspace identity. Each group retains a count, first/last times, latest request
+  ID when supplied, and references to cached environment sample times.
+- CLI failures include a sanitized summary of the environment actually supplied
+  to that child. This is **configuration**, not proof of the route used by the
+  request. Proxy endpoint fingerprints allow comparison without revealing the host.
+
+No automatic connectivity probes run. `coverage` explicitly reports that actual
+network routing and VPN state are not determined. First failures can precede the
+first asynchronous OS sample; their environment reference is then null. Referenced
+older samples may have been evicted from the four-sample window.
+
+## Cost and retention
+
+The new collector does no work at daemon startup. Successful workspace observations
+only replace bounded in-memory metadata. Failures update an in-memory group and
+schedule work; they never wait for a subprocess or filesystem write.
+
+- At most 100 failure groups; least recently updated groups are evicted.
+- At most one OS collection in flight, with a minimum 60-second interval.
+- One asynchronous system command per supported OS sample, with a 1.5-second
+  timeout, forced termination and a 64 KiB output limit. Windows reads Internet
+  Settings; macOS reads `scutil --proxy`. Other platforms still report daemon
+  environment and interface counts, with OS proxy discovery marked unsupported.
+- At most one checkpoint write in flight. Dirty state is coalesced; no write queue
+  grows behind a slow disk. Automatic writes and failed-write retries are spaced
+  by at least 60 seconds. No recurring timer remains after a successful clean flush.
+- Each serialized checkpoint is capped at 256 KiB. Current and previous process
+  checkpoints are retained, with one temporary file during atomic replacement
+  (at most 768 KiB of new checkpoint files). The JavaScript heap also has ordinary
+  object overhead; 256 KiB is the serialized evidence budget, not a total heap claim.
+- An abrupt exit can lose the last unflushed minute. This is best-effort support
+  evidence, not a durable audit log. The export also includes the current in-memory
+  state and any available checkpoint files under `logs/diagnostics/` in the ZIP.
+
+Persistence receives the resolved daemon data root. See the repository's
+[Daemon data directory contract](../../AGENTS.md#daemon-data-directory-contract).
+Existing log-file collection limits are unchanged.
+
+## Privacy and verification
+
+The collector uses a field allowlist. It never serializes an environment object,
+error message, command arguments, stdout, stderr, proxy credentials, PAC URL or
+workspace name. A bounded stderr tail may be inspected transiently to categorize
+CLI timeout, proxy, DNS or TLS failures; only the category is retained.
+
+`apps/daemon/tests/services/diagnostics-evidence.test.ts` covers a 100,000-error
+burst, distinct-group and byte limits, idle behavior, collection single-flight,
+slow/failed writes, proxy redaction, and checkpoint rotation. Export tests open
+real ZIPs, verify the added summary and prior checkpoint, and assert redaction.
+Directory and CLI adapter tests verify error evidence without changing business
+results. Windows configuration parsing is exercised with fixtures; it does not
+substitute for Windows-native performance measurements.


### PR DESCRIPTION
Fixes #7946

## Why

A customer support bundle contained repeated workspace-directory and team-project failures but lacked the associated proxy configuration and workspace identity. After a restart, support could not distinguish missing evidence from a healthy environment. This adds bounded diagnostic evidence to the existing export so investigation can use timestamped facts without asking the customer to repeatedly reproduce the incident.

## What users will see

The existing **Export diagnostics** action and `od diagnostics export --json` include an additional environment/failure summary and available current/previous process checkpoints. No new controls are required; both surfaces use the same daemon endpoint.

The summary includes sanitized system/daemon/CLI proxy configuration, PAC presence, interface-family counts, the last observed workspace directory/context, and coalesced failures. Current login user ID is included in runtime health. Credentials, environment dumps, proxy hostnames, PAC URLs and workspace names are omitted. Actual network routing and VPN state are explicitly marked unknown.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new subcommand, flag or environment variable
- [ ] **API / contract** — new endpoint, SSE event or changed shape in `packages/contracts`
- [ ] **Extension point** — new extension entry or protocol change
- [ ] **i18n keys** — added new translations
- [ ] **New top-level dependency** — added root dependency
- [x] **Default behavior change** — existing diagnostics exports contain additional sanitized evidence; failures can create bounded local checkpoints
- [ ] **None** — internal refactor, docs, tests or translations only

The binary ZIP endpoint and CLI syntax are unchanged; the additional JSON files are diagnostic bundle contents, not a new application API/DTO. UI and CLI export parity is preserved through the shared handler.

## Screenshots

Not applicable: the export entry points and UI are unchanged. Validation opened actual exported ZIP files, including one produced through the running daemon and existing CLI.

## Bug fix verification

- Red spec: [diagnostics export handler regression](https://github.com/nexu-io/open-design/blob/5550568f1c44ed06416cde10523e5159613a6ffa/apps/daemon/tests/diagnostics-export.test.ts), `includes bounded environment and failure evidence in the exported ZIP`.
- Red on the untouched source at base `f197844e27`: the environment summary was absent. Green on this branch.
- [Bounded evidence and privacy tests](https://github.com/nexu-io/open-design/blob/5550568f1c44ed06416cde10523e5159613a6ffa/apps/daemon/tests/services/diagnostics-evidence.test.ts) cover failure storms, single-flight collection, byte/group caps, idle behavior, slow/failed disk writes, proxy redaction, classification and checkpoint rotation.
- Directory and CLI integration tests verify that recording evidence preserves the existing error/result contract.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm guard` — passed
- `pnpm typecheck` — passed across the workspace
- Focused daemon suites: diagnostics evidence/export, API failure journal, Vela command, Vela workspace context and collab context routes — **152 tests passed**
- Started a daemon through `pnpm tools-dev start daemon --namespace diag-evidence --json` with an isolated resolved data root; read workspace context, exported via `od diagnostics export ... --json`, opened the ZIP and verified environment/context evidence.
- `pnpm tools-dev logs --namespace diag-evidence --json` confirmed control-plane log paths under `.tmp/tools-dev/diag-evidence/`; stopped the temporary daemon with no remaining processes.
- `git diff --check` — passed

## Performance and limits

- Successful workspace observations only replace bounded memory; they do not schedule sampling or writes.
- At most 100 failure groups and four OS samples. Repeated errors update counts. Serialized evidence/checkpoints are capped at 256 KiB.
- OS sampling is asynchronous, single-flight, at most once per minute; one command with a 1.5-second timeout and bounded output. No automatic network probes or process scans.
- Checkpoints are coalesced and written at most once per minute, with at most one write in flight and no growing queue. Keep current/previous files plus one temporary replacement, at most 768 KiB total. Disk failures do not change business responses.
- Local macOS microbenchmark, latest run under concurrent validation: 100,000 repeated errors took ~177 ms wall/~105 ms CPU, retaining one group (~1.2 KiB serialized); 100,000 distinct identities took ~321 ms wall/~205 ms CPU, retaining 100 groups (~34.7 KiB serialized). Each burst scheduled one collection and performed **zero writes during the burst**. These are local measurements, not Windows performance guarantees.

## Limitations

- Windows proxy parsing uses fixtures; native Windows timing/termination behavior has not been measured on a customer device.
- An abrupt exit can lose the last unflushed minute. Environment samples are bounded and may be unavailable for the first failure or evicted later. All observations carry timestamps and coverage labels.
- The last daemon context response does not assert which browser tab is currently selected. Current login identity must not be applied blindly to historical failures.
- This does not fix the separate IPC/updater failure or claim that a configured proxy caused the customer incident.

See [diagnostic evidence semantics and retention](https://github.com/nexu-io/open-design/blob/5550568f1c44ed06416cde10523e5159613a6ffa/docs/testing/diagnostics-environment.md).
