### PR TITLE
fix(amr): continue committed compaction work without replay

### DIFF
--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -7,7 +7,15 @@
  * connectionTest.ts and server.ts (via the acp/ barrel).
  */
 import path from 'node:path';
-import type { ExecutionProfile } from '@open-design/contracts';
+import {
+  AMR_CONTINUATION_ERROR_CODE,
+  isAmrContinuationIncomplete,
+  parseAmrContinuationRecovery,
+  supportsAmrNativeContinuation,
+  type AmrContinuationCursor,
+  type AmrContinuationRecovery,
+  type ExecutionProfile,
+} from '@open-design/contracts';
 import {
   createDsmlArtifactTextSuppressor,
   createToolCallTextSuppressor,
@@ -139,6 +147,7 @@ export interface AttachAcpSessionOptions {
   // `session/new`. The agent verifies the session and, if it is gone, returns a
   // structured `resume_failed` error the caller maps to its reseed path.
   resumeSessionId?: string | null;
+  nativeContinuation?: AmrContinuationCursor | null;
   /** Safe model/session metadata attached to the exact prompt-frame diagnostic. */
   promptBudgetContext?: AcpPromptBudgetContext;
   // Subsegment timing markers for spawn->first-token attribution (#3408 §4).
@@ -201,6 +210,7 @@ export function attachAcpSession({
   modelUnavailableErrorCode,
   completePromptOnTurnEnd = false,
   resumeSessionId,
+  nativeContinuation,
   promptBudgetContext,
   onCliReady,
   onSessionInit,
@@ -249,6 +259,8 @@ export function attachAcpSession({
   // conversation to resume next turn. Distinct from `sessionId`, which is the
   // ACP wrapper id ("vela-opencode-1").
   let durableSessionId: string | null = null;
+  let nativeContinuationSupported = false;
+  let continuationRecovery: AmrContinuationRecovery | null = null;
   let activeModel: string | null = null;
   let modelConfigId: string | null = null;
   let emittedThinkingStart = false;
@@ -888,12 +900,11 @@ export function attachAcpSession({
     expectedId = promptRequestId;
     writeRpc(
       promptRequestId,
-      'session/prompt',
-      {
-        sessionId,
-        prompt: buildPromptBlocks(prompt, [...resourcePaths, ...imagePaths]),
-      },
-      'session/prompt',
+      nativeContinuation ? '_session/continue' : 'session/prompt',
+      nativeContinuation
+        ? { sessionId, continuation: nativeContinuation }
+        : { sessionId, prompt: buildPromptBlocks(prompt, [...resourcePaths, ...imagePaths]) },
+      nativeContinuation ? '_session/continue' : 'session/prompt',
     );
     send('agent', {
       type: 'status',
@@ -1027,6 +1038,19 @@ export function attachAcpSession({
         return;
       }
       const details = rpcErrorData(obj);
+      if (modelUnavailableErrorCode && obj.id === promptRequestId && isAmrContinuationIncomplete(rpcErr, details)) {
+        const recovery = parseAmrContinuationRecovery(details);
+        // Check before fail() flushes incomplete tools into synthetic errors.
+        const toolsCommitted = acpToolRunEventState.size > 0 &&
+          [...acpToolRunEventState.values()].every((tool) => tool.emitted);
+        if (nativeContinuationSupported && toolsCommitted && recovery?.sessionId === durableSessionId) {
+          continuationRecovery = recovery;
+        }
+        fail(rpcErr, { retryable: false, details: {
+          ...asObject(details), kind: 'opencode_continuation_incomplete', code: AMR_CONTINUATION_ERROR_CODE,
+        } });
+        return;
+      }
       const promotedPayload = promotedOpenCodeSessionErrorPayload(details, rpcErr);
       if (promotedPayload) {
         failWithPayload(promotedPayload);
@@ -1291,6 +1315,13 @@ export function attachAcpSession({
       return;
     }
     if (expectedId === 1) {
+      nativeContinuationSupported = !!modelUnavailableErrorCode && supportsAmrNativeContinuation(result);
+      if (nativeContinuation && (!resumeSessionId || !nativeContinuationSupported)) {
+        fail('The agent does not support safe native continuation.', { retryable: false,
+          details: { kind: 'native_continuation_rejected', reason: 'capability_unavailable' } });
+        return;
+      }
+
       const negotiation = velaChildEvidenceConsumer?.negotiate(result);
       if (negotiation?.advertised) {
         send('agent', {
@@ -1351,6 +1382,11 @@ export function attachAcpSession({
       // The durable handle for resuming this session on the next turn.
       durableSessionId =
         typeof result.openCodeSessionId === 'string' ? result.openCodeSessionId : null;
+      if (nativeContinuation && durableSessionId !== resumeSessionId) {
+        fail('The agent loaded a different native session.', { retryable: false,
+          details: { kind: 'native_continuation_rejected', reason: 'session_mismatch' } });
+        return;
+      }
       // session/new acknowledged with a session id = handshake done (#3408 §4).
       if (sessionId) onSessionInit?.();
       const modelConfig = findModelConfigOption(result.configOptions);
@@ -1501,7 +1537,10 @@ export function attachAcpSession({
     // The durable upstream session handle to persist for resume, or null when
     // none was reported (older agents, or a handshake that never established a
     // session). Mirrors pi-rpc's getLastSessionPath().
-    /** Returns the durable upstream session id (e.g. vela's `openCodeSessionId`) to persist for next-turn resume, or `null` when the agent did not report one. */
+    /** Evidence captured before synthetic tool closure; never permits prompt replay. */
+    getContinuationRecovery() {
+      return continuationRecovery;
+    },
     getDurableSessionId() {
       return durableSessionId;
     },

--- a/apps/daemon/src/agent-session-resume.ts
+++ b/apps/daemon/src/agent-session-resume.ts
@@ -509,14 +509,6 @@ const AMR_RESUME_FAILURE_PATTERN = /"kind"\s*:\s*"resume_failed"/;
 const AMR_OPENCODE_EVENT_STREAM_RESUME_FAILURE_PATTERNS: RegExp[] = [
   /opencode SSE ended before prompt completion/i,
   /opencode event stream:\s*opencode SSE ended before prompt completion/i,
-  // vela 0.0.35 (#1847) split the compaction continuation onto its own
-  // request, and worded its EOF differently. Same bridge, same stream, same
-  // "the event stream ended before the prompt finished" — only the phase it
-  // died in is new, so it belongs to the same recoverable class. Until this
-  // line existed the wording matched nothing in the repository, so a
-  // compaction that died mid-continuation could not even reach the re-seed
-  // path and ended the conversation on a hard failure instead.
-  /opencode compaction continuation ended before prompt completion/i,
 ];
 
 /** True when vela's ACP output carries a resume_failed signal. */

--- a/apps/daemon/src/run-failure-classification.ts
+++ b/apps/daemon/src/run-failure-classification.ts
@@ -1,3 +1,4 @@
+import { asObject } from './agent-protocol/acp/json.js';
 import type {
   TrackingRunCancelOrigin,
   TrackingRunFailureCategory,
@@ -14,6 +15,7 @@ import type {
   TrackingRunTerminalTrigger,
 } from '@open-design/contracts/analytics';
 import {
+  AMR_CONTINUATION_ERROR_CODE,
   isMembershipConcurrencyLimitFailure,
   isModelWindowLimitFailure,
 } from '@open-design/contracts';
@@ -984,6 +986,15 @@ function classifyRunFailureBase(
   // signal guard below (a watchdog kill IS a signal, and the reason it was
   // killed outranks the bare signal) and the timeout branch itself.
   const daemonTimeoutVerdict = hasDaemonTimeoutVerdict(events);
+  if (input.agentId === 'amr' && events.some((event) => {
+    if (event.event !== 'error') return false;
+    const data = asObject(event.data);
+    const details = asObject(asObject(data?.error)?.details);
+    return details?.code === AMR_CONTINUATION_ERROR_CODE;
+  })) {
+    return classification('process_exit', 'continuation_incomplete',
+      inferFailureStageFromEvents(events, 'post_tool_resume'), false, 'none');
+  }
   const amrFailure = classifyAmrAccountFailure(text);
   const byokOpenCodeProviderNotFound = isByokOpenCodeProviderNotFoundText(
     input.agentId,

--- a/apps/daemon/src/run-retry-policy.ts
+++ b/apps/daemon/src/run-retry-policy.ts
@@ -107,6 +107,7 @@ export interface PostToolResumeRecoveryInput {
   sideEffects?: RunRetrySideEffectState;
   supportsNativeSessionContinue: boolean;
   hasNativeSession: boolean;
+  hasVerifiedAmrContinuation?: boolean;
 }
 
 export function decidePostToolResumeRecovery(
@@ -143,7 +144,10 @@ export function decidePostToolResumeRecovery(
     !input.supportsNativeSessionContinue ||
     !input.hasNativeSession ||
     !sideEffects.toolCallSeen ||
-    !isPostToolTransientFailure
+    !(isPostToolTransientFailure || (
+      failure?.failure_detail === 'continuation_incomplete' &&
+      failure.failure_stage === 'post_tool_resume' && input.hasVerifiedAmrContinuation === true
+    ))
   ) {
     return null;
   }
@@ -245,6 +249,9 @@ export function decideSafeRunRetry(
 
   const failure = input.failure;
   if (!failure) return suppress('missing_failure_signal');
+  if (failure.failure_detail === 'continuation_incomplete') {
+    return suppress(attemptCount >= retryMaxAttempts ? 'attempt_limit_reached' : 'unsafe_failure_stage');
+  }
   if (failure?.failure_detail === 'hard_quota') return suppress('hard_quota');
   const transientReason = transientSuppressedReason(
     failure.failure_category,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11820,7 +11820,7 @@ export async function startServer({
     // directly. Public chat requests cannot reach this branch.
     const forceInternalResume =
       pendingNativeSessionContinue != null &&
-      runtimeResumesSessionById(def) &&
+      (runtimeResumesSessionById(def) || (def.id === 'amr' && !!pendingNativeSessionContinue.amrContinuation)) &&
       pendingNativeSessionContinue.sessionId.length > 0;
     const agentResumeCtx = forceInternalResume
       ? {
@@ -12791,7 +12791,10 @@ export async function startServer({
         ...runSideEffectsForRun(run),
         cancelRequested: !!run.cancelRequested,
       };
-      const liveSessionId = agentResumeCtx.isResuming
+      const amrContinuationRecovery = def.id === 'amr' ? acpSession?.getContinuationRecovery?.() : null;
+      const liveSessionId = def.resumesSessionViaAcpLoad === true
+        ? acpSession?.getDurableSessionId?.() ?? null
+        : agentResumeCtx.isResuming
         ? agentResumeCtx.resumeSessionId
         : agentCapturesSessionId
           ? capturedSessionId
@@ -12803,7 +12806,8 @@ export async function startServer({
           run.nativeSessionContinueAttemptCount ?? 0,
         totalRetryAttemptCount: run.retryAttemptCount ?? 0,
         sideEffects,
-        supportsNativeSessionContinue: runtimeResumesSessionById(def),
+        supportsNativeSessionContinue: runtimeResumesSessionById(def) || !!amrContinuationRecovery,
+        hasVerifiedAmrContinuation: !!amrContinuationRecovery && amrContinuationRecovery.sessionId === liveSessionId,
         hasNativeSession: !!run.conversationId && !!liveSessionId,
       });
       if (
@@ -12847,6 +12851,7 @@ export async function startServer({
           retry_delay_ms: postToolResumeDecision.retryDelayMs,
         });
         run.nativeSessionContinuePending = {
+          amrContinuation: amrContinuationRecovery?.cursor ?? null,
           sessionId: liveSessionId,
           stablePromptHash: currentStableHash,
           stablePromptSections: currentStableSections,
@@ -15450,6 +15455,7 @@ export async function startServer({
         ...(def.resumesSessionViaAcpLoad === true && agentResumePromptPolicy.resumeSessionId
           ? { resumeSessionId: agentResumePromptPolicy.resumeSessionId }
           : {}),
+        nativeContinuation: forceInternalResume ? pendingNativeSessionContinue?.amrContinuation : null,
         onCliReady: () => noteCliReadyAt(),
         onSessionInit: () => noteSessionInitDoneAt(),
         onPromptComplete: () => clearFirstOutputWatchdog(),
@@ -15944,6 +15950,7 @@ export async function startServer({
       // re-seed the full transcript: one cold turn, never a broken conversation.
       if (
         !run.cancelRequested &&
+        !forceInternalResume &&
         (runtimeResumesSessionById(def) || def.resumesSessionViaAcpLoad === true) &&
         run.conversationId &&
         resolveAgentResumeFailurePolicy({

--- a/apps/daemon/tests/agent-session-resume.test.ts
+++ b/apps/daemon/tests/agent-session-resume.test.ts
@@ -671,22 +671,17 @@ describe('isAmrOpencodeEventStreamResumeFailure', () => {
     ).toBe(true);
   });
 
-  // vela 0.0.35 (#1847) moved the compaction continuation onto its own request
-  // and worded its EOF differently. Before this the phrase matched nothing in
-  // the repository, so the SAME bridge-level stream EOF — one phase later —
-  // could not reach the re-seed path at all and ended the conversation on a
-  // hard failure instead of one transparent cold turn.
-  it('matches the compaction-continuation EOF vela 0.0.35 introduced', () => {
+  it('keeps compaction continuation out of destructive reseed', () => {
     expect(
       isAmrOpencodeEventStreamResumeFailure(
         'json-rpc id 4: opencode event stream: opencode compaction continuation ended before prompt completion',
       ),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isAmrOpencodeEventStreamResumeFailure(
         'opencode compaction continuation ended before prompt completion',
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it('ignores unrelated AMR/opencode output', () => {
@@ -804,7 +799,7 @@ describe('resolveAgentResumeFailurePolicy', () => {
     });
   });
 
-  it('routes the compaction-continuation EOF into the same re-seed recovery', () => {
+  it('never reseeds a compaction continuation failure', () => {
     expect(
       resolveAgentResumeFailurePolicy({
         agentId: 'amr',
@@ -815,10 +810,10 @@ describe('resolveAgentResumeFailurePolicy', () => {
         resumeSessionId: 'ses-old',
       }),
     ).toEqual({
-      resumeFailed: true,
-      clearStaleSession: true,
-      autoReseedFullTranscript: true,
-      reason: 'resume_failed',
+      resumeFailed: false,
+      clearStaleSession: false,
+      autoReseedFullTranscript: false,
+      reason: null,
     });
   });
 

--- a/apps/daemon/tests/amr-session-resume.test.ts
+++ b/apps/daemon/tests/amr-session-resume.test.ts
@@ -65,6 +65,38 @@ describe('AMR (vela) ACP session resume — full server cycle', () => {
     restoreEnv(originalEnv);
   });
 
+  it.each(['success', 'pending', 'legacy', 'missing', 'mismatch', 'limit'])(
+    'safely converges compaction continuation: %s', async (scenario) => {
+      binDir = await mkdtemp(path.join(os.tmpdir(), 'od-amr-continuation-'));
+      const bin = path.join(binDir, 'vela');
+      const fixture = path.join(HERE, 'fixtures', 'fake-vela-continuation.ts');
+      const quote = (value: string) => "'" + value.replaceAll("'", "'\\''") + "'";
+      await writeFile(bin, `#!/bin/sh\nexec ${quote(process.execPath)} ${quote(fixture)} ${quote(scenario)} ${quote(binDir)} "$@"\n`);
+      await chmod(bin, 0o755);
+      clearTelemetryEnv();
+      started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+      await putConfig(started.url, { agentId: 'amr', agentCliEnv: { amr: { VELA_BIN: bin } } });
+      const conversation = await createConversation(started.url);
+      const run = await sendRunAndWait(started.url, conversation, 'write exactly once');
+      expect(run.status, JSON.stringify({ run, events: (await readRunEvents(run.eventsLogPath)).slice(-8) })).toBe(scenario === 'success' ? 'succeeded' : 'failed');
+      const ledger = (await readFile(path.join(binDir, 'ledger.jsonl'), 'utf8')).trim().split('\n')
+        .map((line) => JSON.parse(line));
+      expect(ledger.filter((row) => row.method === 'session/new')).toHaveLength(1);
+      expect(ledger.filter((row) => row.method === 'session/prompt')).toHaveLength(1);
+      expect(await readFile(path.join(binDir, 'tool-executions'), 'utf8')).toBe('write\n');
+      const canAttempt = !['pending', 'legacy'].includes(scenario);
+      expect(ledger.filter((row) => row.method === 'session/load')).toHaveLength(canAttempt ? 1 : 0);
+      const attempts = ledger.filter((row) => row.method === '_session/continue');
+      expect(attempts).toHaveLength(['success', 'limit'].includes(scenario) ? 1 : 0);
+      const events = await readRunEvents(run.eventsLogPath);
+      expect(events.filter((event) => event.event === 'end')).toHaveLength(1);
+      expect(events.filter((event) => event.event === 'run_retry_attempted')).toHaveLength(canAttempt ? 1 : 0);
+      expect(hasDiagnostic(events, { type: 'agent_resume_auto_reseed' })).toBe(false);
+      const final = events.find((event) => event.event === 'run_retry_finished');
+      expect(final?.data).toMatchObject({ retry_result: scenario === 'success' ? 'success' : canAttempt ? 'failed' : 'suppressed' });
+    }, 30_000,
+  );
+
   it('captures the durable handle on turn 1 and resumes it via session/load on turn 2', async () => {
     binDir = await mkdtemp(path.join(os.tmpdir(), 'od-amr-resume-bin-'));
     const logPath = path.join(binDir, 'invocations.jsonl');

--- a/apps/daemon/tests/fixtures/fake-vela-continuation.ts
+++ b/apps/daemon/tests/fixtures/fake-vela-continuation.ts
@@ -1,0 +1,70 @@
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createInterface } from 'node:readline';
+
+const [scenario, directory, ...args] = process.argv.slice(2);
+if (args.includes('--version')) { console.log('0.0.36-test'); process.exit(0); }
+if (args[0] === 'model') {
+  console.log(JSON.stringify({ source: args[1] === 'preset' ? 'preset' : 'remote', data: [{ id: 'deepseek-v4-flash', name: 'Test model' }] }));
+  process.exit(0);
+}
+const log = (value: unknown) => appendFileSync(join(directory!, 'ledger.jsonl'), `${JSON.stringify(value)}\n`);
+const send = (value: unknown) => process.stdout.write(`${JSON.stringify(value)}\n`);
+const session = 'oc-durable-continuation';
+const cursor = { version: 1, userMessageId: 'user-1', assistantMessageId: 'assistant-tool', toolResultsCommitted: true };
+const error = (id: number, data: unknown) => send({ jsonrpc: '2.0', id, error: {
+  code: -32600, message: 'opencode compaction continuation ended before prompt completion', data,
+} });
+const incomplete = {
+  kind: 'opencode_continuation_incomplete', code: 'OPENCODE_COMPACTION_CONTINUATION_INCOMPLETE',
+  runtime: 'opencode', phase: 'post_tool_resume', retryable: false, openCodeSessionId: session, continuation: cursor,
+};
+const update = (value: unknown) => send({ jsonrpc: '2.0', method: 'session/update', params: { sessionId: 'acp-1', update: value } });
+let loaded = false;
+const tool = () => {
+  update({ sessionUpdate: 'tool_call', toolCallId: 'write-once', title: 'Write', kind: 'edit',
+    status: 'in_progress', rawInput: { file_path: 'result.txt', content: 'once' } });
+  if (scenario !== 'pending') update({ sessionUpdate: 'tool_call_update', toolCallId: 'write-once', status: 'completed',
+    content: [{ type: 'content', content: { type: 'text', text: 'written' } }] });
+};
+createInterface({ input: process.stdin }).on('line', (line) => {
+  const request = JSON.parse(line);
+  log({ method: request.method, params: request.params, pid: process.pid });
+  const result = (value: unknown) => send({ jsonrpc: '2.0', id: request.id, result: value });
+  switch (request.method) {
+    case 'initialize':
+      result({ protocolVersion: 1, agentCapabilities: { loadSession: true,
+        ...(scenario === 'legacy' ? {} : { _meta: { 'com.open-design.nativeSessionContinue': { version: 1 } } }) } });
+      break;
+    case 'session/new':
+      result({ sessionId: 'acp-1', openCodeSessionId: session });
+      break;
+    case 'session/load':
+      loaded = true;
+      if (scenario === 'missing') {
+        send({ jsonrpc: '2.0', id: request.id, error: { code: -32600, message: 'session gone',
+          data: { kind: 'resume_failed', retryable: true } } });
+      } else result({ sessionId: 'acp-1', openCodeSessionId: scenario === 'mismatch' ? 'wrong-session' : session });
+      break;
+    case 'session/set_model': case 'session/set_config_option': result({}); break;
+    case 'session/prompt':
+      appendFileSync(join(directory!, 'tool-executions'), 'write\n');
+      writeFileSync(join(directory!, 'original-pid'), String(process.pid));
+      tool();
+      error(request.id, scenario === 'legacy' ? { kind: 'opencode_prompt_error' } : incomplete);
+      break;
+    case '_session/continue': {
+      const previousPid = Number(readFileSync(join(directory!, 'original-pid'), 'utf8'));
+      let previousAlive = false;
+      try { process.kill(previousPid, 0); previousAlive = true; } catch { /* Expected after teardown. */ }
+      if (!loaded || previousAlive || JSON.stringify(request.params.continuation) !== JSON.stringify(cursor) || 'prompt' in request.params) {
+        send({ jsonrpc: '2.0', id: request.id, error: { code: -32600, message: 'unsafe continuation' } });
+        break;
+      }
+      if (scenario === 'limit') { tool(); error(request.id, incomplete); break; }
+      update({ sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'Recovered final reply.' } });
+      result({ stopReason: 'end_turn' });
+      break;
+    }
+  }
+}).on('close', () => process.exit(0));

--- a/apps/daemon/tests/run-retry-policy.test.ts
+++ b/apps/daemon/tests/run-retry-policy.test.ts
@@ -497,3 +497,20 @@ describe('computeRetryBackoffMs', () => {
     }
   });
 });
+
+describe('verified AMR continuation', () => {
+  const failure = { failure_category: 'process_exit', failure_detail: 'continuation_incomplete',
+    failure_stage: 'post_tool_resume', retryable: false } as const;
+  it('uses the native path without authorizing prompt replay', () => {
+    expect(decidePostToolResume({ failure, hasVerifiedAmrContinuation: true })?.retryStrategy).toBe('native_session_continue');
+    expect(decide({ failure }).shouldRetry).toBe(false);
+  });
+  it.each([
+    { hasVerifiedAmrContinuation: false }, { hasNativeSession: false },
+    { supportsNativeSessionContinue: false }, { continuationAttemptCount: 1 },
+    { sideEffects: { toolCallSeen: true, cancelRequested: true } },
+    { failure: { ...failure, failure_stage: 'tool_outstanding' as const } },
+  ])('rejects unsafe or exhausted recovery: %j', (override) => {
+    expect(decidePostToolResume({ failure, hasVerifiedAmrContinuation: true, ...override })).toBeNull();
+  });
+});

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -593,3 +593,27 @@ The engine is agent-agnostic: it iterates `AGENT_DEFS` and reads fields. A commu
   that accept stdin should set `promptViaStdin`; argv-only definitions must declare and
   enforce a prompt budget so Windows' command-line limit fails observably before spawn.
 - **Docker-contained agents.** Some users run Claude Code in a container. Adapter needs a "remote" mode — probably same interface but talks over SSH. Phase 2+.
+
+### AMR compaction continuation (ACP extension v1)
+
+The shared contract lives in `packages/contracts/src/api/amr-continuation.ts`.
+An AMR `initialize` response must advertise both `loadSession` and
+`agentCapabilities._meta["com.open-design.nativeSessionContinue"].version = 1`.
+A structured `OPENCODE_COMPACTION_CONTINUATION_INCOMPLETE` prompt error can
+supply the durable session ID and exact user/assistant message cursor only
+when every observed tool result is terminal. The daemon independently checks
+its tool frames before closing unfinished rows.
+
+The daemon waits for the previous process tree to become quiescent, loads the
+same durable session in a new process, and sends `_session/continue` with only
+that cursor. Vela calls OpenCode's guarded `POST /session/:sessionID/continue`;
+OpenCode rechecks persisted history and committed tools under its serialized
+runner and continues the model loop without inserting a user prompt. This
+requires matching Vela and OpenCode implementations; ordinary `session/load`
+alone is insufficient.
+
+At most one native continuation is allowed per physical Run. Cancellation,
+missing or changed history, outstanding/unknown tools, unsupported versions,
+and exhausted recovery stop with failure. Legacy compaction failure wording
+is classified but never authorizes reseeding or full prompt replay. The same
+daemon behavior serves web and `od` callers through the existing run API.

--- a/packages/contracts/src/analytics/events/shared-enums.ts
+++ b/packages/contracts/src/analytics/events/shared-enums.ts
@@ -366,6 +366,7 @@ export type TrackingRunFailureDetail =
   | 'stream_error'
   | 'exit_nonzero'
   | 'fatal_rpc_error'
+  | 'continuation_incomplete'
   | 'execution_failed'
   | 'user_cancelled'
   | 'unknown';

--- a/packages/contracts/src/api/amr-continuation.ts
+++ b/packages/contracts/src/api/amr-continuation.ts
@@ -1,0 +1,49 @@
+/** ACP extension. A cursor continues persisted work; it never authorizes prompt replay. */
+export const AMR_CONTINUATION_CAPABILITY = 'com.open-design.nativeSessionContinue';
+export const AMR_CONTINUATION_ERROR_CODE = 'OPENCODE_COMPACTION_CONTINUATION_INCOMPLETE';
+
+export interface AmrContinuationCursor {
+  version: 1;
+  userMessageId: string;
+  assistantMessageId: string;
+  toolResultsCommitted: true;
+}
+
+export interface AmrContinuationRecovery {
+  sessionId: string;
+  cursor: AmrContinuationCursor;
+}
+
+const object = (value: unknown): Record<string, unknown> | null =>
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown> : null;
+const identifier = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0 && value.length <= 256;
+
+export function supportsAmrNativeContinuation(initializeResult: unknown): boolean {
+  const capabilities = object(object(initializeResult)?.agentCapabilities);
+  return capabilities?.loadSession === true &&
+    object(object(capabilities._meta)?.[AMR_CONTINUATION_CAPABILITY])?.version === 1;
+}
+
+/** Call only on the RPC failure channel, never on assistant prose. */
+export function isAmrContinuationIncomplete(message: string, data: unknown): boolean {
+  const details = object(data);
+  return details?.code === AMR_CONTINUATION_ERROR_CODE ||
+    /^(?:json-rpc id \d+: )?(?:opencode event stream: )?opencode compaction continuation ended before prompt completion\s*$/i.test(message);
+}
+
+export function parseAmrContinuationRecovery(data: unknown): AmrContinuationRecovery | null {
+  const details = object(data);
+  const cursor = object(details?.continuation);
+  if (details?.code !== AMR_CONTINUATION_ERROR_CODE ||
+      details.kind !== 'opencode_continuation_incomplete' || details.runtime !== 'opencode' ||
+      details.phase !== 'post_tool_resume' || !identifier(details.openCodeSessionId) ||
+      cursor?.version !== 1 || cursor.toolResultsCommitted !== true ||
+      !identifier(cursor.userMessageId) || !identifier(cursor.assistantMessageId)) return null;
+  return {
+    sessionId: details.openCodeSessionId,
+    cursor: { version: 1, userMessageId: cursor.userMessageId,
+      assistantMessageId: cursor.assistantMessageId, toolResultsCommitted: true },
+  };
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -92,3 +92,5 @@ export * from './analytics/events.js';
 export * from './analytics/public-params.js';
 export * from './analytics/observability.js';
 export * from './observability/index.js';
+
+export * from './api/amr-continuation.js';

--- a/packages/contracts/tests/amr-continuation.test.ts
+++ b/packages/contracts/tests/amr-continuation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { AMR_CONTINUATION_CAPABILITY, AMR_CONTINUATION_ERROR_CODE, isAmrContinuationIncomplete,
+  parseAmrContinuationRecovery, supportsAmrNativeContinuation } from '../src/api/amr-continuation.js';
+
+const data = {
+  code: AMR_CONTINUATION_ERROR_CODE, kind: 'opencode_continuation_incomplete', runtime: 'opencode',
+  phase: 'post_tool_resume', retryable: false, openCodeSessionId: 'ses-1',
+  continuation: { version: 1, userMessageId: 'u-1', assistantMessageId: 'a-1', toolResultsCommitted: true },
+};
+describe('AMR native continuation contract v1', () => {
+  it('requires explicit extension negotiation as well as session/load', () => {
+    expect(supportsAmrNativeContinuation({ agentCapabilities: { loadSession: true } })).toBe(false);
+    expect(supportsAmrNativeContinuation({ agentCapabilities: { loadSession: true,
+      _meta: { [AMR_CONTINUATION_CAPABILITY]: { version: 1 } } } })).toBe(true);
+  });
+  it('classifies legacy failure wording without granting continuation', () => {
+    const message = 'json-rpc id 4: opencode event stream: opencode compaction continuation ended before prompt completion';
+    expect(isAmrContinuationIncomplete(message, {})).toBe(true);
+    expect(isAmrContinuationIncomplete(`I saw ${message}`, {})).toBe(false);
+    expect(parseAmrContinuationRecovery({ message })).toBeNull();
+  });
+  it('accepts only complete, versioned, exact-session evidence', () => {
+    expect(parseAmrContinuationRecovery(data)).toEqual({ sessionId: 'ses-1', cursor: data.continuation });
+    for (const patch of [
+      { phase: 'tool_outstanding' }, { openCodeSessionId: '' }, { code: 'other' },
+      { continuation: { ...data.continuation, version: 2 } },
+      { continuation: { ...data.continuation, toolResultsCommitted: false } },
+      { continuation: { ...data.continuation, assistantMessageId: '' } },
+    ]) expect(parseAmrContinuationRecovery({ ...data, ...patch })).toBeNull();
+  });
+});


### PR DESCRIPTION
Related Plane work item: [OPEND-2884](https://plane.powerformer.net/open-design/browse/OPEND-2884/).

## Why

The prerelease incident exposed compaction continuations that ended after tool output without a final model step. While implementing the incident repair, current main also added this failure string to the session-clearing transcript reseed path (#7884). That can repeat committed side effects. Ordinary ACP session/load is insufficient because session/prompt submits a new prompt.

## What users will see

With matching Vela/OpenCode support, an interrupted compaction continuation can finish in the same durable session with at most one internal continuation. Already committed tool results are consumed without resubmitting the original prompt. When tool state is pending/unknown, the session is missing or changed, the capability is unavailable, the user cancels, or the budget is exhausted, the run stops instead of automatically replaying the conversation.

## Surface area

- [ ] **UI** — no new control or page
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var** — no new subcommand, flag or environment variable
- [x] **API / contract** — shared ACP extension cursor and `continuation_incomplete` failure detail
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — compaction failures no longer enter transcript reseeding; verified runtimes can continue committed work
- [ ] **None**

Both web and od callers use the existing run HTTP path and receive the same automatic behavior. No new user action needs a separate surface.

## Screenshots

Not applicable: no UI layout or entry point changes.

## Bug fix verification

- RED on main d54f5cf07d, GREEN here: `apps/daemon/tests/agent-session-resume.test.ts` verifies compaction failure does not request destructive reseeding (two failing baseline assertions).
- `apps/daemon/tests/amr-session-resume.test.ts` drives a real daemon and fake ACP child process through success, pending tool, legacy capability, missing session, mismatched session, and attempt-limit scenarios. All six passed. The fixture checks previous PID exit, exact session/cursor, no prompt on continuation, actual write count = 1, and one final run end.
- Contracts reject missing/version-mismatched evidence and classify legacy wording only on the failure channel. Retry policy covers cancellation, outstanding tools and exhausted budgets.

## Validation

- `corepack pnpm guard` and `corepack pnpm typecheck` passed on final source.
- Contracts suite: 65 files / 659 tests passed.
- Daemon resume, retry, and classification suites: 263 passed / 1 failed initially. The failure exposed a change to the existing retry-origin meaning; that change was reverted and the exact failing regression passed. The resulting source preserves prior retry-origin behavior while retaining the first failure in existing retryOriginalFailure.
- `git diff --check` passed.

## Runtime dependency and acceptance

AMR initialize must advertise loadSession plus `com.open-design.nativeSessionContinue` v1. Only a structured post-tool cursor with complete local tool frames permits recovery. The daemon waits for the old process tree to be quiescent, then loads the same durable session and sends `_session/continue` without prompt/resource blocks. Vela must route this to OpenCode's guarded cursor endpoint; ordinary loadSession alone is not support.

Companion implementations: https://github.com/powerformer/vela/pull/1952 and https://github.com/powerformer/opencode/pull/16. OPEND-2886 owns real binary/package acceptance; the independent Vela binary + synthetic OpenCode protocol harness is 8/8 green on final Vela commit 1acdf79feaf88837763eb3afeb291421603ab76f (binary SHA256 487a9cb1882aa0cc9badb170a51ecf7a86f14c40e0de19694ac57e665cf95cc1), which is not release acceptance. No merge, release, deployment, historical run replay, or SLO denominator change is included.

## Real compaction QA follow-up — 2026-09-16

Paired test entry and cursor correction are now proposed in [Vela #2037](https://github.com/powerformer/vela/pull/2037) (`68f8697d50699b608d3a1b7ecf392ed77d8a05e3`) and [OpenCode #18](https://github.com/powerformer/opencode/pull/18) (`73bfd1e35c9d16d26990bf8a4a5815b7a085f5ed`). This PR's source head remains `6abdde890e233abe07c3df1ed08973709b395fc4`; this follow-up updates its validation/dependency record.

- QA uses `vela agent qa run --runtime opencode` with the paired OpenCode binary. It forces real compaction, waits for committed post-compaction tools, and interrupts before another model step. Ordinary Vela runs strip the injection flag; the explicit entry rejects production Link endpoints. See the [versioned QA runbook](https://github.com/powerformer/vela/blob/68f8697d50699b608d3a1b7ecf392ed77d8a05e3/docs/qa/compaction-recovery.md) for `VELA_BIN` wrapper integration, `VELA_OPENCODE_BIN`, and isolated-home requirements.
- A real test-gateway run with `deepseek-v4.1-flash` passed using built Vela/OpenCode and an ACP driver: requested/summary/compacted/continuation events, structured `post_tool_resume` interruption with committed cursor, transport restart, same durable session, exactly one `session/prompt`, one `session/load`, one `_session/continue`, and final `end_turn`. Persisted history contained exactly two completed Bash append calls and one `QA_DONE` answer; the ledger remained `before\nafter\n` across recovery. Run `113cdf52-64a2-4956-b5dc-830fa3e69326`; session `ses_f57a85091ffeafWVTOBuv5P2cW`.
- The first live run exposed a Vela cursor-parent race: a delayed summary update could move the user pointer. Vela #2037 binds the cursor to the committed assistant's actual parent; the regression was RED before the fix and GREEN afterward. This is separate from the withdrawn claim that this OD PR omitted `hasVerifiedAmrContinuation`.
- Existing config was verified read-only in the catalog and `/v1/models`: effective context budget for this model was 1,048,000 in production and 128,000 in test. Vela forwards it to OpenCode `limit.context` with automatic compaction enabled. No shared configuration was changed; forced QA does not validate natural threshold behavior.

This is real runtime/test-gateway evidence, not Electron automatic-recovery or installed-package acceptance. Keep `needs-validation` until QA runs the host with these exact paired changes and records its safety/negative paths and billing evidence. OPEND-2886 still owns packaged acceptance. The companion runtime manifest/release pin must be selected explicitly for a QA build; these PRs do not publish or deploy a runtime.
