### PR TITLE
fix(acp): send session cancellation as a notification

### DIFF
--- a/apps/daemon/src/agent-protocol/acp/rpc.ts
+++ b/apps/daemon/src/agent-protocol/acp/rpc.ts
@@ -56,6 +56,16 @@ export function sendRpc(
 export function sendRpcResult(writable: RpcWritable, id: JsonRpcId, result: unknown): void {
   writable.write(`${JSON.stringify({ jsonrpc: '2.0', id, result })}\n`);
 }
+
+/** Writes an ACP notification without a request id or an expected response. */
+export function sendRpcNotification(
+  writable: RpcWritable,
+  method: string,
+  params: unknown,
+): void {
+  writable.write(`${JSON.stringify({ jsonrpc: '2.0', method, params })}\n`);
+}
+
 /**
  * Type guard that returns `true` when `value` is a valid JSON-RPC id
  * (a `number` or `string`). Used before replying to incoming requests.

--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -29,6 +29,7 @@ import {
 import { errorMessage, asObject, extractAcpUpdateText, extractAcpStatusDetail } from './json.js';
 import {
   sendRpc,
+  sendRpcNotification,
   sendRpcResult,
   isJsonRpcId,
   rpcErrorMessage,
@@ -1535,8 +1536,7 @@ export function attachAcpSession({
       // is no sessionId to cancel, but we must still close stdin below.
       if (sessionId) {
         try {
-          sendRpc(child.stdin, nextId, 'session/cancel', { sessionId });
-          nextId += 1;
+          sendRpcNotification(child.stdin, 'session/cancel', { sessionId });
         } catch {
           // The caller owns process-signal fallback if the ACP transport is gone.
         }

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -2740,7 +2740,7 @@ test('attachAcpSession preserves literal artifact prose before any write echo is
   assert.deepEqual(textDeltas, [literal]);
 });
 
-test('attachAcpSession exposes abort and sends session cancel after session creation', () => {
+test('attachAcpSession abort sends one session/cancel notification after session creation', () => {
   const child = new FakeAcpChild();
   const writes: string[] = [];
   child.stdin.on('data', (chunk) => writes.push(String(chunk)));
@@ -2766,6 +2766,8 @@ test('attachAcpSession exposes abort and sends session cancel after session crea
   assert.equal(cancelRequests.length, 1);
   const cancelRequest = cancelRequests[0];
   assert.ok(cancelRequest);
+  // ACP cancellation is a notification. Vela rejects an id-bearing request.
+  assert.equal(Object.hasOwn(cancelRequest, 'id'), false);
   assert.deepEqual(cancelRequest.params, { sessionId: 'session-1' });
 });
 


### PR DESCRIPTION
## Why

While investigating OPEND-2885's outstanding Write and timeout recovery, a probe against the packaged Vela/OpenCode pair showed that OD sends `session/cancel` as an id-bearing JSON-RPC request. Vela handles this ACP method as a notification and rejects the request with `-32601 Method not found`. Cancellation therefore relies on stdin EOF/process cleanup instead of reaching the explicit cancellation handler.

Send the cancellation notification without an id. Keep the existing idempotent abort behavior, stdin EOF cleanup, and caller-owned signal fallback. This is a confirmed recovery defect; it does not establish why the original Write stopped progressing. Related execution cleanup is covered separately by https://github.com/powerformer/vela/pull/1951. OPEND-2885 remains open.

## What users will see

Stopping an ACP run reaches the agent's cancellation handler before the existing shutdown fallback. This applies to the shared daemon cancellation path used by existing UI and CLI flows; no new entry point is introduced.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new command, flag, or environment variable
- [ ] **API / contract** — new HTTP/SSE or packages/contracts shape
- [ ] **Extension point** — skills, design systems, templates, craft, or skills protocol
- [ ] **i18n keys** — new translation keys
- [ ] **New top-level dependency** — new root package.json dependency
- [x] **Default behavior change** — existing ACP cancellation now uses the required notification envelope
- [ ] **None** — internal refactor, docs, tests, or translation update only

The changed protocol is the internal daemon-to-agent ACP wire format; HTTP/UI/CLI contracts remain compatible.

## Screenshots

Not applicable: the existing Stop entry point and UI presentation are unchanged.

## Bug fix verification

- Regression: [apps/daemon/tests/acp.test.ts](apps/daemon/tests/acp.test.ts), `attachAcpSession abort sends one session/cancel notification after session creation`.
- RED on main source at `d54f5cf07d35261dce3c8c2e7fc187c6cc9efb86`: cancellation contained an `id` (`true !== false`).
- GREEN after the fix: all 94 tests in that suite pass, including duplicate abort, stdin EOF, startup abort, and in-flight tool handling.
- Real packaged Vela 0.0.35/OpenCode 0.0.0--202609020336 probe: id-bearing cancellation receives -32601; a notification reaches cancellation and returns `cancelled`. Probe uses a local synthetic provider, not production requests.

## Validation

- `corepack pnpm guard` — passed.
- `corepack pnpm typecheck` — passed across the repository.
- `corepack pnpm --filter @open-design/daemon build` — passed.
- `corepack pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/acp.test.ts` — 94 passed.
- Broader ACP/resume suites: `vitest run -c vitest.config.ts acp amr-session-resume` — 19 files / 526 tests passed.
- No Write replay, timeout increase, merge, release, or deployment is included. Cancellation does not prove whether an outstanding Write committed.
