### PR TITLE
fix(packaged): wait for updater predecessor before instance discovery

### DIFF
--- a/apps/packaged/src/index.ts
+++ b/apps/packaged/src/index.ts
@@ -178,6 +178,13 @@ async function main(): Promise<void> {
       );
     }
   }
+  // An updater successor must outlive its predecessor before discovering or
+  // bootstrapping a desktop in the same namespace. Otherwise it can focus
+  // the quitting predecessor and exit as an ordinary duplicate launch.
+  if (!headlessRequest.headless && !await waitForLauncherAfterQuit(afterQuit, initialPaths)) {
+    app.exit(1);
+    return;
+  }
   const oppositeDesktop = await inspectExistingDesktopForLauncher(launchStamp, {
     deeplinkUrl: findPackagedDeeplinkArg(process.argv),
     logger: console,
@@ -201,10 +208,6 @@ async function main(): Promise<void> {
     runtimeRoot: initialPaths.runtimeRoot,
   })) {
     app.exit(0);
-    return;
-  }
-  if (!headlessRequest.headless && !await waitForLauncherAfterQuit(afterQuit, initialPaths)) {
-    app.exit(1);
     return;
   }
   const existingDesktop = await inspectExistingDesktopForLauncher(launchStamp, {

--- a/apps/packaged/tests/entry-handoff.test.ts
+++ b/apps/packaged/tests/entry-handoff.test.ts
@@ -1,0 +1,151 @@
+import { readFileSync } from "node:fs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runInNewContext } from "node:vm";
+import { ModuleKind, ScriptTarget, transpileModule } from "typescript";
+import { describe, expect, it } from "vitest";
+import * as launcherProto from "@open-design/launcher-proto";
+import * as release from "@open-design/release";
+import type { SidecarStamp } from "@open-design/sidecar";
+import * as sidecarProto from "@open-design/sidecar-proto";
+
+const require = createRequire(import.meta.url);
+function compile(name: string, entry = false): string {
+  let source = readFileSync(new URL(`../src/${name}.ts`, import.meta.url), "utf8");
+  if (entry) {
+    // Execute the production main body without its process-level fatal handler.
+    // No statement inside main is changed; unexpected dependency calls fail.
+    const boundary = source.indexOf("void main().catch(");
+    if (boundary < 0) throw new Error("packaged entry invocation missing");
+    source = `${source.slice(0, boundary)}\nexport { main };\n`;
+  }
+  return transpileModule(source, { compilerOptions: {
+    module: ModuleKind.CommonJS, target: ScriptTarget.ES2022,
+  } }).outputText;
+}
+const entryCode = compile("index", true);
+const helperCode = compile("launcher-after-quit");
+function evaluate(code: string, modules: Record<string, unknown>, globals: Record<string, unknown> = {}) {
+  const exports: Record<string, unknown> = {};
+  runInNewContext(code, {
+    exports,
+    require: (name: string) => {
+      if (name.startsWith("node:")) return require(name);
+      if (name in modules) return modules[name];
+      return new Proxy({}, { get: (_, property) => {
+        throw new Error(`Unexpected dependency: ${name}.${String(property)}`);
+      } });
+    },
+    console: { info() {}, warn() {}, error() {} },
+    ...globals,
+  });
+  return exports;
+}
+
+type Kind = "visible" | "hidden" | "gone" | "duplicate" | "timeout";
+async function scenario(platform: "darwin" | "win32", channel: "stable" | "prerelease", kind: Kind) {
+  const root = await mkdtemp(join(tmpdir(), "od-entry-handoff-"));
+  const trace: string[] = [];
+  let alive = kind !== "gone";
+  const armed = Promise.withResolvers<void>();
+  const exited = Promise.withResolvers<boolean>();
+  const quit = () => {
+    if (alive) { alive = false; trace.push("old-exit"); }
+    exited.resolve(true);
+  };
+  if (!alive) exited.resolve(true);
+  const namespace = "entry-handoff-test";
+  const version = channel === "stable" ? "0.22.2" : "0.22.2-prerelease.1";
+  const paths = { logsRoot: join(root, "logs"), dataRoot: join(root, "data"), runtimeRoot: join(root, "runtime") };
+  const selected = new Error("selection boundary");
+  const modules: Record<string, unknown> = {
+    "@open-design/launcher-proto": launcherProto,
+    "@open-design/release": release,
+    "@open-design/sidecar-proto": sidecarProto,
+    "@open-design/platform": {
+      waitForProcessExit: async (pid: number) => {
+        expect(pid).toBe(4242);
+        trace.push("wait-armed"); armed.resolve();
+        return kind === "timeout" ? false : exited.promise;
+      },
+      stopProcesses: async () => {
+        trace.push("force-stop");
+        return { remainingPids: [4242], forcedPids: [], stoppedPids: [] };
+      },
+    },
+    "@open-design/sidecar": {
+      readCurrentSidecarStamp: () => null,
+      isCurrentSidecarLauncher: () => false,
+      getSidecarStatus: async (stamp: SidecarStamp) => {
+        trace.push(`inspect:${stamp.app}:${alive}`);
+        if (!alive || stamp.mode !== "runtime") return { state: "stopped" };
+        return { pid: 4242, state: "running", windowVisible: kind !== "hidden",
+          update: { currentVersion: kind === "duplicate" ? version : "0.22.0" }, url: "http://127.0.0.1:1" };
+      },
+      invokeSidecar: async () => { trace.push("show"); return { accepted: true }; },
+      stopSidecar: async () => { quit(); return { remainingPids: [] }; },
+      bootstrapSidecarProcess: async () => { trace.push(`bootstrap:${alive}`); return false; },
+    },
+    "electron": { app: { commandLine: { appendSwitch() {} }, exit: (code: number) => trace.push(`exit:${code}`) } },
+    "@open-design/desktop/main": { applyOsLocaleSwitch() {}, applyLoopbackConnectionLimitSwitch() {} },
+    "./config.js": { readPackagedConfig: async () => ({ namespace, appVersion: version }) },
+    "./headless-runtime.js": { parsePackagedHeadlessRequest: () => ({ headless: false }), runPackagedMcpActionAgainstExistingDaemon: async () => false },
+    "./paths.js": { resolvePackagedNamespacePaths: () => paths },
+    "./launch.js": { createPackagedSecondInstanceHandoff: () => ({}) },
+    "./payload-desktop-launch.js": { findPackagedDeeplinkArg: () => null },
+    "./launcher-runtime.js": { resolvePackagedLauncherRuntime: async (_config: unknown, _paths: unknown, options: { delegated: unknown }) => {
+      expect(alive).toBe(false);
+      expect(options.delegated).toEqual({ generation: 8, version });
+      trace.push("select"); throw selected;
+    } },
+  };
+  modules["./launcher-after-quit.js"] = evaluate(helperCode, modules);
+  const argv = ["electron", "index.js", ...(kind === "duplicate" ? [] : [
+    ...launcherProto.buildLauncherAfterQuitArgs({ targetPid: 4242, timeoutMs: 1000 }),
+    ...launcherProto.buildLauncherDelegatedArgs({ generation: 8, version }),
+  ])];
+  try {
+    const entry = evaluate(entryCode, modules, { process: { argv, env: {}, platform } }) as { main: () => Promise<void> };
+    const running = entry.main().catch(error => { if (error !== selected) throw error; });
+    // Hold the old instance until the wait is armed or the new entry exits.
+    // This exposes the bad ordering without a scheduler-dependent sleep.
+    await Promise.race([armed.promise, running]);
+    if (kind !== "timeout") quit();
+    await running;
+    const log = await readFile(join(paths.logsRoot, "launcher", "after-quit.log"), "utf8");
+    return { trace, log };
+  } finally {
+    quit();
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+describe.each(["darwin", "win32"] as const)("%s packaged update entry", platform => {
+  it.each(["stable", "prerelease"] as const)("waits for the %s old desktop before instance discovery and bootstrap", async channel => {
+    const { trace, log } = await scenario(platform, channel, "visible");
+    expect(trace).toContain("select");
+    expect(trace).not.toContain("show");
+    expect(trace).not.toContain("bootstrap:true");
+    expect(trace.filter(event => event.startsWith("inspect:")).every(event => event.endsWith(":false"))).toBe(true);
+    expect(log).toContain("observed-exit targetPid=4242");
+  });
+  it.each(["hidden", "gone"] as const)("continues when the old desktop is %s", async kind => {
+    expect((await scenario(platform, "stable", kind)).trace).toContain("select");
+  });
+  it("preserves ordinary duplicate-open focus without an updater wait", async () => {
+    const { trace } = await scenario(platform, "stable", "duplicate");
+    expect(trace).toContain("show");
+    expect(trace).toContain("exit:0");
+    expect(trace).not.toContain("wait-armed");
+    expect(trace).not.toContain("select");
+  });
+  it("fails closed when the old process survives timeout and force-stop", async () => {
+    const { trace } = await scenario(platform, "stable", "timeout");
+    expect(trace).toContain("force-stop");
+    expect(trace).toContain("exit:1");
+    expect(trace).not.toContain("show");
+    expect(trace.some(event => /^(inspect|bootstrap|select)/.test(event))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

Open Design 0.22.0/0.22.1 can exit the delegated update payload before it waits for the predecessor PID: instance discovery sees the still-visible old desktop, accepts SHOW, and exits. The old desktop then quits, leaving no new window.

0.22.2 must let the unchanged historical launcher start the target payload and have that target wait before instance discovery and bootstrap.

## What users will see

Clicking “安装并重启” from a clean 0.21.0, 0.22.0, or 0.22.1 Stable installation reliably opens 0.22.2 instead of occasionally leaving both old and new processes exited.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — fixes the existing packaged auto-update restart order
- [ ] **None**

## Screenshots

Not applicable; this changes process ordering, not UI.

## Bug fix verification

- Test path: `apps/packaged/tests/entry-handoff.test.ts`
- Red/green: restoring the pre-fix order fails 6/12 deterministic handoff cases; this commit passes 12/12 on Windows.
- Real Windows acceptance: official released 0.21.0, 0.22.0, and 0.22.1 installers each upgraded directly to the same byte-identical local 0.22.2 candidate three times (9/9). Every round exercised the historical app's actual update popup and install/restart action, observed a distinct visible 0.22.2 payload PID with settled launcher state, then proved an independent installed-outer cold start with another distinct visible 0.22.2 PID.
- Excluded by product decision: disaster recovery for clients already trapped in a failed-cache/attempt state; no legacy IPC compatibility was added to production or the maintained e2e harness.

Candidate SHA-256:

- installer: `3924b99cf82defe138429c102b7ea1e465e1783877536390975b59ac0433e2a6`
- payload: `cb4434060d56e14ff7e0cdd2ebb90d40c7eedc9b160524e30387d4ef473c8b07`

## Validation

- GitHub Actions full CI: https://github.com/nexu-io/open-design/actions/runs/34390154313 — success
- `pnpm --filter @open-design/packaged test -- entry-handoff.test.ts` — 12/12 passed
- `pnpm --filter @open-design/packaged typecheck` — passed
- Stable public-feed re-check: all six `stable/latest` objects returned 200 and remained byte-identical to `stable/versions/0.22.0`; no feed or release mutation was performed

Release signing, publication, and public-feed smoke remain separate controlled release gates.