### PR TITLE
Add Felix renderer 模板提炼结果 plugin

### DIFF
--- a/plugins/community/felix-renderer-mtumepmd/SKILL.md
+++ b/plugins/community/felix-renderer-mtumepmd/SKILL.md
@@ -1,0 +1,71 @@
+# Felix renderer 模板提炼结果
+
+本轮读取四个项目的入口、布局及渲染代码；保留源项目，未重渲旧视频。第一份可运行种子来自 `world-births-circle`，不是从空画布猜测布局。
+
+## 已交付
+
+- `felix-births-renderer-seed.html`：自包含圆形分区种子，内嵌原出生人口数据、国旗与现有 Zeno 图标。年份拖动、播放、点击分区、完整表格及 PNG 下载可用。
+- `felix-design-system.md`：新增成品布局变体，并修正原规范把页眉统一上移的坐标。`felix-design-system-v2.md` 为修改前备份。
+- `scripts/verify-felix-seed.cjs`：使用模拟 Canvas 验证状态接口、回退、署名次数与下载动作。
+- `provenance/`：源代码与数据哈希、原数据来源合同、国旗 MIT 许可及原项目的地域缺口审计。
+
+## 已确认架构
+
+正式采用 **一套 Felix Design System＋多个 renderer 模板**。`felix-design-system.md` 是唯一视觉契约；每个 renderer 模板只覆盖一种经过成品验证的图形语法。新项目先选 renderer family，再绑定对应 layout profile，最后接入项目数据与领域规则。
+
+## 三层结构
+
+1. **共用视觉契约**：核心 tokens、字体、作者标识规则、画布尺寸。由 Design System 维护。
+2. **图形布局 profile**：圆图、时间线、分布图、信息图序列各自保留稳定坐标。由模板引用，不能互换算法。
+3. **数据与 renderer**：几何、数据语义和帧时间映射属于具体模板；接口可以统一，后端不必统一。
+
+## 四个来源的处理
+
+| 项目 | 读到的实际实现 | 提炼判断 |
+|---|---|---|
+| world-births-circle | Canvas、冻结拓扑递归面积切分、2023 首次几何校准、整数年国旗排名、40秒帧映射 | 本轮种子；保留全部几何与数据，补 readiness 与严格状态接口 |
+| ai-model-release-layouts | `motion.js` 已有 `felix.ready/describe/render`、分段日历、公司轮换，`full.html` 组合完整数据与 overview | 接口模式可复用；作为下一份时间线模板，不把公司的排期逻辑塞进通用骨架 |
+| china-life-expectancy-animation | SVG 标注 + Canvas 粒子、seeded random、`__renderChinaLifeFrame`、ready/config 标志 | 保留既有绘制，之后加 timeMs → frame 的薄适配；保留9:16与3:4区分 |
+| english-information-access | Python 生成静帧布局；已有10页手绘融合版本，与旧视频不是同一版本 | 保留 Python 渲染路线及定量几何；未来 HTML 只负责预览，不重写图表 |
+
+## 本轮圆图改动
+
+- 保留标题、圆心、半径、年份、数据表与来源位置；不重算数据。
+- 绑定已选冷调炭黑和字体栈，原洲别色只转换到等价 OKLch，不更换分类映射。
+- 删除右上英文署名，放入主体图形右下附近留白，配真实 Zeno SVG；中文仍在原右上基线。
+- 去掉依赖原 `server.py` 的写盘与1200帧上传按钮。PNG 走浏览器下载；视频导出通过确定性接口接入，未承诺已接通 OpenDesign 视频导出。
+- 内嵌数据及 SVG，打开 HTML 不需要原项目服务。图标原始 viewBox 为100×100，保持正方形；国旗沿用原4:3文件与几何。
+- 固定先按2023校准树，再接受任意状态，避免第一张导出的年份影响后续布局。
+
+## 使用接口
+
+```js
+await window.captureReady;
+await window.felix.render({snapshotId: "2012"});
+await window.felix.render({timeMs: 12500});
+const metadata = window.felix.describe();
+```
+
+`ready` 只等待资源和校准；`captureReady` 等待查询参数所选首帧。支持 `?snapshot=1950`、`?timeMs=12500`；`&export=1` 隐藏外围交互并使用1080×1920画布。状态同时含两种选择、时间非法或快照不存在会拒绝。
+
+时间映射保留原作品：40秒、30fps；开头1.5秒停留，年份每秒推进2年，末尾2秒停留。整数年快照与相应时间调用共用绘制函数。当前种子是“出生人口圆图模板”，更换成其他指标需要替换数据合同及领域代码；不能仅替换标题。
+
+## 原数据限制
+
+本轮核验的是模板结构与适配，不是四个项目事实复审。原出生人口数据的藏南同口径分项缺口保持不变，未声称解决。AI 项目文档含未来事件的编辑假设，不应把该事件库直接用作事实模板。信息图中的既有生成插画也不自动成为未来真实人物、机构或产品的替代资产。
+
+## 接入 OpenDesign
+
+在 Integration 的 Skills 标签更新 `dataviz-felix` 时，将本文件的模板选择规则加入适配说明；将圆图 HTML 作为配套模板资源管理。核心视觉规范继续使用 `felix-design-system.md`，不要把数据、完整渲染代码或历史项目路径塞进 Design System。本轮未修改已安装 skill。
+
+## 建议与未完成范围
+
+架构决策已确认，当前无需再决定颜色或字体。圆图已落地；时间线、粒子分布和 Python 信息图只是完成来源判断，尚未提炼成可运行独立模板。下一步优先提炼 AI 时间线，因为它已有最完整的确定性接口。
+
+验证记录：JS 语法通过；模拟 Canvas 下，首帧初始化、同状态不同前序调用、首尾时间映射、非法状态拒绝、署名各一次、表格填充与下载动作通过。模拟字体测量不等于浏览器字形或逐帧视觉验收；未生成新MP4。
+
+预览检查发现初版样式提取误读了模板注释中的标签，已移除多余头部并重新核对唯一 head/style、CSS括号与核心 token。修正后未重复截图；最终视觉仍需在项目预览中复核。
+
+## Provenance
+
+Formalized by OpenDesign from candidate 86b4980c-549c-44fb-b147-5732ad87b24c.

--- a/plugins/community/felix-renderer-mtumepmd/open-design.json
+++ b/plugins/community/felix-renderer-mtumepmd/open-design.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "felix-renderer-mtumepmd",
+  "title": "Felix renderer 模板提炼结果",
+  "version": "0.1.0",
+  "description": "本轮读取四个项目的入口、布局及渲染代码；保留源项目，未重渲旧视频。第一份可运行种子来自 `world-births-circle`，不是从空画布猜测布局。",
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject"
+    ]
+  }
+}

--- a/plugins/community/felix-renderer-mtumepmd/references/provenance.json
+++ b/plugins/community/felix-renderer-mtumepmd/references/provenance.json
@@ -1,0 +1,26 @@
+{
+  "candidateId": "86b4980c-549c-44fb-b147-5732ad87b24c",
+  "projectId": "b3741929-d0bf-4909-a2fe-63cff27dd35c",
+  "runId": "6559d3fd-7e0e-4652-b8cb-a8e974e45af6",
+  "conversationId": "e5acfdae-942f-4fd9-a75c-5bf36bde381d",
+  "provenance": {
+    "summary": "Detected from felix-renderer-extraction.md, felix-design-system.md after a successful run.",
+    "detectedAt": 1788989843192
+  },
+  "sourceRefs": [
+    {
+      "kind": "file",
+      "value": "felix-renderer-extraction.md",
+      "label": "felix-renderer-extraction.md",
+      "size": 5662,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "felix-design-system.md",
+      "label": "felix-design-system.md",
+      "size": 13458,
+      "copied": true
+    }
+  ]
+}

--- a/plugins/community/felix-renderer-mtumepmd/references/source-1-felix-renderer-extraction.md
+++ b/plugins/community/felix-renderer-mtumepmd/references/source-1-felix-renderer-extraction.md
@@ -1,0 +1,67 @@
+# Felix renderer 模板提炼结果
+
+本轮读取四个项目的入口、布局及渲染代码；保留源项目，未重渲旧视频。第一份可运行种子来自 `world-births-circle`，不是从空画布猜测布局。
+
+## 已交付
+
+- `felix-births-renderer-seed.html`：自包含圆形分区种子，内嵌原出生人口数据、国旗与现有 Zeno 图标。年份拖动、播放、点击分区、完整表格及 PNG 下载可用。
+- `felix-design-system.md`：新增成品布局变体，并修正原规范把页眉统一上移的坐标。`felix-design-system-v2.md` 为修改前备份。
+- `scripts/verify-felix-seed.cjs`：使用模拟 Canvas 验证状态接口、回退、署名次数与下载动作。
+- `provenance/`：源代码与数据哈希、原数据来源合同、国旗 MIT 许可及原项目的地域缺口审计。
+
+## 已确认架构
+
+正式采用 **一套 Felix Design System＋多个 renderer 模板**。`felix-design-system.md` 是唯一视觉契约；每个 renderer 模板只覆盖一种经过成品验证的图形语法。新项目先选 renderer family，再绑定对应 layout profile，最后接入项目数据与领域规则。
+
+## 三层结构
+
+1. **共用视觉契约**：核心 tokens、字体、作者标识规则、画布尺寸。由 Design System 维护。
+2. **图形布局 profile**：圆图、时间线、分布图、信息图序列各自保留稳定坐标。由模板引用，不能互换算法。
+3. **数据与 renderer**：几何、数据语义和帧时间映射属于具体模板；接口可以统一，后端不必统一。
+
+## 四个来源的处理
+
+| 项目 | 读到的实际实现 | 提炼判断 |
+|---|---|---|
+| world-births-circle | Canvas、冻结拓扑递归面积切分、2023 首次几何校准、整数年国旗排名、40秒帧映射 | 本轮种子；保留全部几何与数据，补 readiness 与严格状态接口 |
+| ai-model-release-layouts | `motion.js` 已有 `felix.ready/describe/render`、分段日历、公司轮换，`full.html` 组合完整数据与 overview | 接口模式可复用；作为下一份时间线模板，不把公司的排期逻辑塞进通用骨架 |
+| china-life-expectancy-animation | SVG 标注 + Canvas 粒子、seeded random、`__renderChinaLifeFrame`、ready/config 标志 | 保留既有绘制，之后加 timeMs → frame 的薄适配；保留9:16与3:4区分 |
+| english-information-access | Python 生成静帧布局；已有10页手绘融合版本，与旧视频不是同一版本 | 保留 Python 渲染路线及定量几何；未来 HTML 只负责预览，不重写图表 |
+
+## 本轮圆图改动
+
+- 保留标题、圆心、半径、年份、数据表与来源位置；不重算数据。
+- 绑定已选冷调炭黑和字体栈，原洲别色只转换到等价 OKLch，不更换分类映射。
+- 删除右上英文署名，放入主体图形右下附近留白，配真实 Zeno SVG；中文仍在原右上基线。
+- 去掉依赖原 `server.py` 的写盘与1200帧上传按钮。PNG 走浏览器下载；视频导出通过确定性接口接入，未承诺已接通 OpenDesign 视频导出。
+- 内嵌数据及 SVG，打开 HTML 不需要原项目服务。图标原始 viewBox 为100×100，保持正方形；国旗沿用原4:3文件与几何。
+- 固定先按2023校准树，再接受任意状态，避免第一张导出的年份影响后续布局。
+
+## 使用接口
+
+```js
+await window.captureReady;
+await window.felix.render({snapshotId: "2012"});
+await window.felix.render({timeMs: 12500});
+const metadata = window.felix.describe();
+```
+
+`ready` 只等待资源和校准；`captureReady` 等待查询参数所选首帧。支持 `?snapshot=1950`、`?timeMs=12500`；`&export=1` 隐藏外围交互并使用1080×1920画布。状态同时含两种选择、时间非法或快照不存在会拒绝。
+
+时间映射保留原作品：40秒、30fps；开头1.5秒停留，年份每秒推进2年，末尾2秒停留。整数年快照与相应时间调用共用绘制函数。当前种子是“出生人口圆图模板”，更换成其他指标需要替换数据合同及领域代码；不能仅替换标题。
+
+## 原数据限制
+
+本轮核验的是模板结构与适配，不是四个项目事实复审。原出生人口数据的藏南同口径分项缺口保持不变，未声称解决。AI 项目文档含未来事件的编辑假设，不应把该事件库直接用作事实模板。信息图中的既有生成插画也不自动成为未来真实人物、机构或产品的替代资产。
+
+## 接入 OpenDesign
+
+在 Integration 的 Skills 标签更新 `dataviz-felix` 时，将本文件的模板选择规则加入适配说明；将圆图 HTML 作为配套模板资源管理。核心视觉规范继续使用 `felix-design-system.md`，不要把数据、完整渲染代码或历史项目路径塞进 Design System。本轮未修改已安装 skill。
+
+## 建议与未完成范围
+
+架构决策已确认，当前无需再决定颜色或字体。圆图已落地；时间线、粒子分布和 Python 信息图只是完成来源判断，尚未提炼成可运行独立模板。下一步优先提炼 AI 时间线，因为它已有最完整的确定性接口。
+
+验证记录：JS 语法通过；模拟 Canvas 下，首帧初始化、同状态不同前序调用、首尾时间映射、非法状态拒绝、署名各一次、表格填充与下载动作通过。模拟字体测量不等于浏览器字形或逐帧视觉验收；未生成新MP4。
+
+预览检查发现初版样式提取误读了模板注释中的标签，已移除多余头部并重新核对唯一 head/style、CSS括号与核心 token。修正后未重复截图；最终视觉仍需在项目预览中复核。

--- a/plugins/community/felix-renderer-mtumepmd/references/source-2-felix-design-system.md
+++ b/plugins/community/felix-renderer-mtumepmd/references/source-2-felix-design-system.md
@@ -1,0 +1,236 @@
+# Felix Design System
+
+Version: 1.2  
+Status: Ready for OpenDesign integration  
+Primary canvas: 1080 × 1920 portrait
+
+## Purpose
+
+Felix Design System defines the persistent visual contract for Felix data visualizations. It governs color, typography, composition, data marks, bilingual labeling, authorship, motion continuity, and export-safe layout. Data meaning, source handling, research methods, rendering logic, and verification remain the responsibility of the `dataviz-felix` skill.
+
+The visual posture is editorial and evidence-led: cool charcoal structure, restrained typography, generous negative space, and color reserved for data meaning or one deliberate brand accent.
+
+## System boundary
+
+Felix uses one Design System with multiple renderer templates. This document owns the visual rules shared across every template. A renderer template owns its visualization grammar, fixed layout profile, geometry, state mapping, and backend. Project data and domain interpretation remain outside both and are governed by the `dataviz-felix` skill and the project manifest.
+
+Every renderer must name one layout profile from this document. A renderer may add documented series tokens or geometry required by its data semantics, but it must not redefine the six core tokens, typography roles, author identity, or export-safe layout rules.
+
+## Core tokens
+
+Bind these six tokens verbatim in OpenDesign artifacts:
+
+```css
+:root {
+  --bg: oklch(0.145 0.012 230);
+  --surface: oklch(0.205 0.014 230);
+  --fg: oklch(0.942 0.006 170);
+  --muted: oklch(0.690 0.018 220);
+  --border: oklch(0.340 0.014 225);
+  --accent: oklch(0.594 0.223 26.9);
+
+  --font-display: "Iowan Old Style", "Baskerville", "Times New Roman", serif;
+  --font-body: "PingFang SC", "Hiragino Sans GB", "Noto Sans CJK SC", "Microsoft YaHei", sans-serif;
+  --font-mono: "IBM Plex Mono", "SFMono-Regular", "Cascadia Mono", "Menlo", monospace;
+}
+```
+
+The accent is derived from the existing Zeno mark red `#e52629`. The light and dark logo structural colors map to the same cool-neutral family as `--fg` and `--border`; project artifacts should use the OKLch tokens rather than reintroducing raw hex colors.
+
+### Extended semantic colors
+
+These colors support data and interface states. They are not substitutes for the six core tokens.
+
+```css
+:root {
+  --info: oklch(0.710 0.135 235);
+  --success: oklch(0.700 0.145 155);
+  --warning: oklch(0.790 0.145 82);
+  --danger: var(--accent);
+  --data-cyan: oklch(0.770 0.115 205);
+  --data-blue: oklch(0.680 0.160 255);
+  --data-yellow: oklch(0.840 0.145 95);
+  --data-green: oklch(0.730 0.140 155);
+  --data-magenta: oklch(0.690 0.180 345);
+  --data-neutral: oklch(0.720 0.018 220);
+}
+```
+
+Use semantic colors only when the data or state has that meaning. Never use the brand red merely to make an arbitrary series more prominent. When red carries a data meaning such as heat, warning, decline, or the red sector of an official light, omit decorative brand-red accents near the chart.
+
+## Typography
+
+### Roles
+
+- Display: English titles, major years, headline numerics, and short editorial statements.
+- Body: Chinese titles, bilingual labels, annotations, legends, explanatory copy, and source lines.
+- Mono: units, dates, coordinates, algorithm names, parameter values, IDs, and compact metadata.
+
+Chinese remains visually primary when Chinese and English are paired. English supports rather than duplicates the Chinese hierarchy.
+
+### Master-canvas scale
+
+| Role | Size | Line height | Weight | Notes |
+|---|---:|---:|---:|---|
+| Chinese title | 62 px | 1.12 | 600 | Prefer one or two balanced lines |
+| English title | 30 px | 1.20 | 500 | Uppercase only for short labels |
+| Kicker | 20 px | 1.30 | 600 | Mono, tracked 0.10em |
+| Hero metric | 112–176 px | 0.92 | 500 | Display face; tabular numerals where available |
+| Primary data label | 28–36 px | 1.20 | 600 | Keep readable at phone scale |
+| Secondary annotation | 22–26 px | 1.35 | 400 | Use `--muted` only on `--bg` or `--surface` |
+| Source / method | 18–21 px | 1.40 | 400 | Stable wording across video frames |
+| Chinese creator credit | 22–24 px | 1.20 | 500 | One instance, upper right |
+| English creator mark | 22–26 px | 1.20 | 500 | Paired with the Zeno icon |
+
+Avoid a last line containing only one or two Chinese characters or one short English word. Adjust the text column and line break before reducing type size.
+
+## Layout
+
+### Master grid
+
+- Canvas: 1080 × 1920.
+- Editorial column: x = 120–960; width = 840.
+- Header field: choose the source-backed layout profile below; do not move an approved header upward.
+- Title rule: use the selected profile’s fixed coordinate; do not impose a universal y = 286–306.
+- Main visual field: begins at least 48 px below the title rule.
+- Footnote field: keep its first baseline at or above y = 1750.
+- Essential content must remain within x = 120–960 and y = 96–1790.
+- Preview through uniform scaling. Do not recompute master coordinates from the viewport.
+
+### Header anatomy
+
+1. Small bilingual or place-and-topic kicker at upper left.
+2. One Chinese creator credit, `@一尺之棰`, right aligned at x = 960.
+3. Chinese title.
+4. English title.
+5. One full-width structural rule.
+
+Do not add a second English credit in the header. Do not add decorative rules that compete with the title rule.
+
+### Main visual field
+
+- Give the primary graphic at least 64 px of clear space from header and footnotes.
+- Labels belong close to their marks; leaders should be short and unambiguous.
+- Legends explain encodings that cannot be labeled directly. Do not repeat a direct label in a legend.
+- Maps, charts, metrics, and annotations must remain inside the editorial column unless a deliberate full-bleed terrain or atmospheric field sits behind them.
+- A full-bleed field is decorative context; data-bearing boundaries and labels remain within the safe area.
+
+### Footer and source field
+
+- Order: scope → unit/method → source → date/version.
+- Use stable wording across all frames of a video.
+- Keep detailed provenance, mappings, disputes, and transformation audit in the local manifest or README rather than crowding the frame.
+- Do not use a footer slogan unless the task explicitly calls for one.
+
+## Author identity
+
+- Show `@一尺之棰` exactly once in the upper-right header.
+- Show the Zeno vector mark with `zeno.yczc` exactly once in the main visual field.
+- Place the English mark below the title rule and above the first footnote.
+- Prefer a stable, low-information area within or immediately beside the main graphic.
+- Keep it clear of labels, flags, axes, legends, boundaries, data marks, and the visual focus.
+- Use the dark-background logo on dark compositions and the light-background logo on light compositions.
+- Preserve the circle, horizontal rule, and six descending red bars.
+- Icon size: 30–44 px. Gap to `zeno.yczc`: 10–12 px.
+- Never tile, repeat, enlarge, or rotate the mark as a watermark.
+
+In animation, keep the mark stable for the full duration. Move it only through a smooth transition when a changing data layer would otherwise collide with it.
+
+## Data encoding
+
+- Neutral structure uses `--fg`, `--muted`, and `--border`.
+- Category colors belong to data marks and their directly associated values.
+- Use the same data-to-color mapping in stills and animation.
+- Filled areas, points, bars, lines with visible weight, or other explicit marks must carry the data. Empty outlines alone are insufficient.
+- Reserve the highest contrast for the primary data relationship.
+- Use no more than six categorical hues in one view. Above six, group, facet, filter, or label directly.
+- Sequential scales vary lightness monotonically. Diverging scales require a meaningful midpoint.
+- Missing, unknown, estimated, modelled, and observed values must remain distinguishable when those states affect interpretation.
+- Flags, legal boundaries, display geometry, and numeric aggregation are separate semantic layers and require separate validation.
+
+## Accent budget
+
+The brand accent may appear in at most two intentional roles per screen:
+
+1. Zeno mark bars.
+2. One selected headline, active control, or primary action when red does not already encode data.
+
+If the visualization uses red as a data encoding, the Zeno mark is the only decorative brand-red role.
+
+## Motion
+
+- Motion reveals real states, transformations, or documented transitions.
+- Compute each frame from explicit time or snapshot state; never depend on the previously rendered frame.
+- Keep titles, creator identity, source text, and method annotation pixel-stable unless the narrative explicitly changes them.
+- Use one dominant transition grammar per piece: reveal, accumulation, comparison, or spatial movement.
+- Do not animate neutral decoration independently from the data story.
+- Initial phases used for visual rhythm must be documented as artistic parameters when they are not observations.
+- Default finished video: 1080 × 1920, H.264, `yuv420p`, no audio unless requested.
+
+## Interaction states for previews
+
+- Minimum target size: 44 × 44 px.
+- Every focusable element has a visible `:focus-visible` ring using `--accent` with an outer `--bg` separation.
+- Hover and active states change background, border, position, or shadow while preserving foreground contrast.
+- Selected controls may use `--fg` on `--surface`. Primary actions use `--bg` on `--fg`; use `--accent` for the action border, focus ring, or a non-text indicator.
+- Tooltips use `--surface` with `--fg`, a `--border` edge, and no transparency that reduces readability over maps.
+- Disabled controls are the only state allowed to reduce text contrast.
+
+The source brand red does not provide 4.5:1 contrast with either `--bg` or `--fg` at normal text sizes. Do not use it as normal body text or as the background of a solid text button. It remains valid for the Zeno mark, large data marks, borders, focus rings, and other non-text graphics that meet the applicable 3:1 graphical contrast requirement.
+
+## Light-background exception
+
+The default Felix composition is dark. A light variant is permitted only when the subject, publication context, or user request requires it. For a light composition, swap structural roles deliberately:
+
+```css
+.theme-light {
+  --bg: oklch(0.970 0.006 170);
+  --surface: oklch(0.935 0.008 190);
+  --fg: oklch(0.245 0.012 225);
+  --muted: oklch(0.510 0.018 220);
+  --border: oklch(0.820 0.012 210);
+}
+```
+
+The brand accent does not change. Use the light-background Zeno logo whose structural stroke is dark.
+
+## Required artifact contract
+
+Every new Felix HTML renderer should:
+
+- bind the six core tokens exactly;
+- expose deterministic snapshot or time rendering through `window.felix`;
+- keep data, fonts, and assets project-local;
+- include `data-od-id` on inspectable regions and controls;
+- use the same visual mapping for preview, still, and video frames;
+- retain a local data manifest and source attribution;
+- avoid remote image or font dependencies in final exports.
+
+## Pre-delivery visual gate
+
+- No clipping, accidental overlap, unsafe margins, or orphaned short final lines.
+- All bilingual pairs are present, correctly ordered, and legible at phone scale.
+- Title, source text, and authorship remain stable across video frames.
+- Creator names appear no more than once each.
+- Brand red stays within the accent budget and does not conflict with data meaning.
+- Data colors have explicit meanings and match the manifest.
+- Still and animation show the same state identically when given the same data and time.
+- Export dimensions, codec, frame rate, duration, pixel format, and audio state match the requested output.
+
+
+## 已确认作品的布局变体（2026-09-09）
+
+用户确认四个来源项目的整体布局可用；旧署名不作为模板标准。现有作品的布局优先于此前未从成品提取的页眉坐标。新增模板必须明确选择 profile，不把所有图形挤入同一套纵坐标。
+
+| Profile | 来源 | 固定结构 | 范围 |
+|---|---|---|---|
+| births-circle-v1 | world-births-circle/app.js | 眉题 y=224；主标题 y=352；英文 y=396；横线 y=435；圆心 (540,1090)，最大半径390；来源 y=1689/1723 | 当前可运行种子 |
+| release-timeline | ai-model-release-layouts/motion.js | 保留原时间线排布与分章节时间映射；署名从双行改为分区 | 后续独立 SVG 模板 |
+| life-distribution | china-life-expectancy-animation/LAYOUT_SPEC.md | 顶部200px留白；横线 y=427；图表 y=635–1240；来源 y=1685 | 后续 SVG + Canvas 模板；以实际 renderer 复核文档坐标 |
+| editorial-sequence | english-information-access/render_felix.py | 每页1080×1920；按内容选择矩阵、条带、点阵等布局 | 保留 Python 后端；不强制迁移 HTML |
+
+圆图的圆周文字是已确认的有意外扩布局，允许在编辑列之外、画布之内；国别数据标注仍服从其原始几何碰撞检测。此例外不扩展到所有标题和脚注。
+
+圆图种子的英文标识锚点为 (744,1500)，图标36×36，英文基线 y=1526。圆图外缘及环绕标签最下方约 y=1544，但标识所在右侧位置不与圆相交；该位置仅属于此 profile，不得推广为统一水印坐标。
+
+保留原项目分类色映射时，将色值转换为 OKLch 并在项目中登记为 series token；这不改变系统的六个核心 token。不要为套用新色板而改变分类语义。


### PR DESCRIPTION
Add Felix renderer 模板提炼结果 (felix-renderer-mtumepmd) plugin.
Version: 0.1.0
Description: 本轮读取四个项目的入口、布局及渲染代码；保留源项目，未重渲旧视频。第一份可运行种子来自 `world-births-circle`，不是从空画布猜测布局。