### PR TITLE
feat(mcp): add OpenCode V2 (opencode2) install target

### DIFF
--- a/apps/daemon/src/mcp-agent-install.ts
+++ b/apps/daemon/src/mcp-agent-install.ts
@@ -47,6 +47,7 @@ export const AGENT_SLUGS = [
   'kiro',
   'trae',
   'opencode',
+  'opencode2',
   'claude-desktop',
 ] as const;
 
@@ -264,6 +265,26 @@ export function planAgentInstall(
           return e;
         })(),
       };
+    case 'opencode2':
+      // OpenCode V2 (invoked as `opencode2`) moved to its own config root
+      // and nests servers one level deeper than V1: `mcp.servers`, not the
+      // flat `mcp` map above. Same per-entry shape as V1 otherwise.
+      return {
+        kind: 'json',
+        slug,
+        configPath: path.join(opencode2ConfigDir(home), 'opencode.json'),
+        keyPath: ['mcp', 'servers'],
+        serverKey: serverName,
+        entry: (() => {
+          const e: Record<string, unknown> = {
+            type: 'local',
+            command: [spec.command, ...spec.args],
+            enabled: true,
+          };
+          if (Object.keys(spec.env).length > 0) e.environment = spec.env;
+          return e;
+        })(),
+      };
     case 'openclaw':
       return {
         kind: 'json',
@@ -363,6 +384,10 @@ export function planAgentInstall(
       throw new Error(`unknown agent slug: ${String(exhaustive)}`);
     }
   }
+}
+
+function opencode2ConfigDir(home: string): string {
+  return process.env.OPENCODE2_CONFIG_DIR ?? path.join(home, '.config', 'opencode2');
 }
 
 function clineConfigPath(home: string, platform: NodeJS.Platform): string {

--- a/apps/daemon/tests/mcp-agent-install.test.ts
+++ b/apps/daemon/tests/mcp-agent-install.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   AGENT_SLUGS,
@@ -24,11 +25,15 @@ const ctx = (platform: NodeJS.Platform = 'linux') => ({
   serverName: 'open-design',
 });
 
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
 describe('agent slug guard', () => {
   it('accepts every documented slug and rejects others', () => {
     for (const s of AGENT_SLUGS) expect(isAgentSlug(s)).toBe(true);
     expect(isAgentSlug('not-an-agent')).toBe(false);
-    expect(AGENT_SLUGS).toHaveLength(17);
+    expect(AGENT_SLUGS).toHaveLength(18);
     expect(isAgentSlug('kiro')).toBe(true);
     expect(isAgentSlug('reasonix')).toBe(true);
     expect(isAgentSlug('raven')).toBe(true);
@@ -78,7 +83,7 @@ describe('JSON-config agents', () => {
   it('cursor merges a stdio entry under mcpServers', () => {
     const plan = planAgentInstall('cursor', SPEC, ctx());
     if (plan.kind !== 'json') throw new Error('expected json');
-    expect(plan.configPath).toBe('/home/u/.cursor/mcp.json');
+    expect(plan.configPath).toBe(path.join('/home/u', '.cursor', 'mcp.json'));
     expect(plan.keyPath).toEqual(['mcpServers']);
     expect(plan.entry).toEqual({
       command: SPEC.command,
@@ -100,6 +105,30 @@ describe('JSON-config agents', () => {
     });
   });
 
+  it('opencode2 nests under mcp.servers at its own config root, same entry shape as V1', () => {
+    const plan = planAgentInstall('opencode2', SPEC, ctx());
+    if (plan.kind !== 'json') throw new Error('expected json');
+    expect(plan.configPath).toBe(
+      path.join('/home/u', '.config', 'opencode2', 'opencode.json')
+    );
+    expect(plan.keyPath).toEqual(['mcp', 'servers']);
+    expect(plan.entry).toEqual({
+      type: 'local',
+      command: [SPEC.command, ...SPEC.args],
+      enabled: true,
+      environment: SPEC.env,
+    });
+  });
+
+  it('opencode2 honors OPENCODE2_CONFIG_DIR to relocate its config root', () => {
+    const customDir = path.join('/custom', 'opencode2-dir');
+    vi.stubEnv('OPENCODE2_CONFIG_DIR', customDir);
+    const plan = planAgentInstall('opencode2', SPEC, ctx());
+    if (plan.kind !== 'json') throw new Error('expected json');
+    expect(plan.configPath).toBe(path.join(customDir, 'opencode.json'));
+    expect(plan.keyPath).toEqual(['mcp', 'servers']);
+  });
+
   it('openclaw nests under mcp.servers', () => {
     const plan = planAgentInstall('openclaw', SPEC_NO_ENV, ctx());
     if (plan.kind !== 'json') throw new Error('expected json');
@@ -110,7 +139,7 @@ describe('JSON-config agents', () => {
   it('kiro merges a stdio entry into the user MCP settings file', () => {
     const plan = planAgentInstall('kiro', SPEC, ctx());
     if (plan.kind !== 'json') throw new Error('expected json');
-    expect(plan.configPath).toBe('/home/u/.kiro/settings/mcp.json');
+    expect(plan.configPath).toBe(path.join('/home/u', '.kiro', 'settings', 'mcp.json'));
     expect(plan.keyPath).toEqual(['mcpServers']);
     expect(plan.serverKey).toBe('open-design');
     expect(plan.entry).toEqual({
@@ -123,7 +152,7 @@ describe('JSON-config agents', () => {
   it('raven plans a stdio entry under tools.mcpServers', () => {
     const plan = planAgentInstall('raven', SPEC, ctx());
     if (plan.kind !== 'json') throw new Error('expected json');
-    expect(plan.configPath).toBe('/home/u/.raven/config.json');
+    expect(plan.configPath).toBe(path.join('/home/u', '.raven', 'config.json'));
     expect(plan.keyPath).toEqual(['tools', 'mcpServers']);
     expect(plan.serverKey).toBe('open-design');
     expect(plan.entry).toEqual({
@@ -173,15 +202,25 @@ describe('JSON-config agents', () => {
     const mac = planAgentInstall('cline', SPEC, ctx('darwin'));
     const linux = planAgentInstall('cline', SPEC, ctx('linux'));
     if (mac.kind !== 'json' || linux.kind !== 'json') throw new Error('expected json');
-    expect(mac.configPath).toContain('Library/Application Support/Code/User');
-    expect(linux.configPath).toContain('.config/Code/User');
+    expect(mac.configPath).toContain(
+      path.join('Library', 'Application Support', 'Code', 'User')
+    );
+    expect(linux.configPath).toContain(path.join('.config', 'Code', 'User'));
     expect(mac.configPath).toContain('saoudrizwan.claude-dev');
   });
 
   it('claude-desktop on macOS writes to Library/Application Support/Claude', () => {
     const plan = planAgentInstall('claude-desktop', SPEC, ctx('darwin'));
     if (plan.kind !== 'json') throw new Error('expected json');
-    expect(plan.configPath).toBe('/home/u/Library/Application Support/Claude/claude_desktop_config.json');
+    expect(plan.configPath).toBe(
+      path.join(
+        '/home/u',
+        'Library',
+        'Application Support',
+        'Claude',
+        'claude_desktop_config.json'
+      )
+    );
     expect(plan.keyPath).toEqual(['mcpServers']);
     expect(plan.serverKey).toBe('open-design');
     expect(plan.entry).toEqual({


### PR DESCRIPTION
## Summary

Adds a separate MCP install target for OpenCode V2, invoked as `opencode2`. V2 moved to its own config root and nests MCP servers one level deeper than V1 (`mcp.servers` instead of the flat `mcp` map). The existing `opencode` (V1) slug and behavior are untouched.

This is an unsolicited/proactive PR — not tied to a tracked issue in this repo. Feel free to close if there's no interest; opening for visibility since the codebase already tracks other opencode2-related work (e.g. #7226, on the runtime/connection-test side, which this PR doesn't overlap with — that one touches `apps/daemon/src/runtimes` and connection-test detection, this one touches only the MCP config installer).

- `AGENT_SLUGS`: added `'opencode2'` alongside `'opencode'`.
- New switch case mirrors V1's entry shape (`command`/`args`/`enabled`/`environment`) but targets `keyPath: ['mcp', 'servers']` at its own config path.
- New `opencode2ConfigDir(home)` helper: defaults to `~/.config/opencode2/opencode.json`, with an `OPENCODE2_CONFIG_DIR` override for users who relocate it, mirroring the override pattern already used by other agents in this same file.

### Also fixed (pre-existing, unrelated to this feature)

5 existing assertions in `mcp-agent-install.test.ts` (`cursor`, `kiro`, `raven`, `cline` x2, `claude-desktop`) hardcoded POSIX-style `/` separators in expected config paths. `path.join()` always follows the real host OS's separator regardless of a test's injected logical `platform` param, so these failed when run on Windows. Confirmed via `git stash`/`pop` that they already failed identically on `main` before this change — fixed by building the expected values with `path.join(...)` too, the same pattern used for the 2 new tests this PR adds.

## Test plan

- [x] `pnpm vitest run tests/mcp-agent-install.test.ts -c vitest.config.ts` → 25/25 passing (18 AGENT_SLUGS, 2 new opencode2 tests, 5 portability fixes)
- [x] `pnpm --filter "@open-design/daemon..." run build` then `pnpm run typecheck` for `apps/daemon` → clean
- [ ] Full unscoped daemon test suite — not used to verify this change: it hangs indefinitely on Windows on a spawn-related issue unrelated to this PR (project CI runs on Linux, where this doesn't reproduce)

🤖 Generated with [Claude Code](https://claude.com/claude-code)