### PR TITLE
fix(daemon): prefer direct Copilot CLI during detection

### DIFF
--- a/apps/daemon/src/runtimes/executables.ts
+++ b/apps/daemon/src/runtimes/executables.ts
@@ -201,6 +201,18 @@ function configuredExecutableOverride(
   return executableFilePath(configuredEnv?.[envKey] ?? process.env[envKey]);
 }
 
+function orderPathCandidatesForAgent(agentId: string, candidates: string[]): string[] {
+  if (agentId !== 'copilot') return candidates;
+  const isVsCodeBootstrap = (candidate: string) =>
+    candidate.replace(/\\/g, '/').toLowerCase().includes(
+      '/code/user/globalstorage/github.copilot-chat/copilotcli/',
+    );
+  return [
+    ...candidates.filter((candidate) => !isVsCodeBootstrap(candidate)),
+    ...candidates.filter(isVsCodeBootstrap),
+  ];
+}
+
 export function resolveAmrOpenCodeExecutable(
   env: Record<string, string | undefined> = process.env,
 ): string | null {
@@ -421,10 +433,11 @@ export function inspectAgentExecutableResolution(
       pathCandidates.push(resolved);
     }
   }
+  const orderedPathCandidates = orderPathCandidatesForAgent(def.id, pathCandidates);
   // First hit among what is left. Plain order is not enough on its own — the
   // first file that merely *exists* can be a shim detection already proved
   // dead, which is why those are filtered out above rather than ranked below.
-  const pathResolvedPath: string | null = pathCandidates[0] ?? null;
+  const pathResolvedPath: string | null = orderedPathCandidates[0] ?? null;
   const builtInPath = packagedBuiltInExecutable(def, configuredEnv);
   const appBundlePath = codexAppBundleExecutable(def);
   return {

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -1,7 +1,7 @@
 import { symlinkSync } from 'node:fs';
 import { test, vi } from 'vitest';
 import { homedir } from 'node:os';
-import { dirname, relative, resolve } from 'node:path';
+import { delimiter, dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as platform from '@open-design/platform';
 import {
@@ -508,6 +508,49 @@ test('resolveAgentExecutable supports configured binary overrides for non-Codex 
 
         assert.equal(resolved, configured, `expected ${id} to use ${envKey}`);
       }
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveAgentExecutable prefers a direct Copilot CLI over the VS Code bootstrapper', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-copilot-bin-order-'));
+  try {
+    return withEnvSnapshot(['PATH', 'PATHEXT', 'OD_AGENT_HOME'], () => {
+      const vscodeDir = join(
+        dir,
+        'Code',
+        'User',
+        'globalStorage',
+        'github.copilot-chat',
+        'copilotCli',
+      );
+      const npmDir = join(dir, 'npm');
+      mkdirSync(vscodeDir, { recursive: true });
+      mkdirSync(npmDir, { recursive: true });
+      const windows = process.platform === 'win32';
+      const vscodeBootstrap = join(vscodeDir, windows ? 'copilot.BAT' : 'copilot');
+      const directCli = join(npmDir, windows ? 'copilot.CMD' : 'copilot');
+      writeFileSync(vscodeBootstrap, windows ? '@exit /b 0\n' : '#!/bin/sh\nexit 0\n');
+      writeFileSync(directCli, windows ? '@exit /b 0\n' : '#!/bin/sh\nexit 0\n');
+      if (!windows) {
+        chmodSync(vscodeBootstrap, 0o755);
+        chmodSync(directCli, 0o755);
+      }
+      process.env.PATH = [vscodeDir, npmDir].join(delimiter);
+      process.env.PATHEXT = '.EXE;.BAT;.CMD';
+      process.env.OD_AGENT_HOME = dir;
+
+      assert.equal(
+        resolveAgentExecutable(minimalAgentDef({ id: 'copilot', bin: 'copilot' })),
+        directCli,
+      );
+      rmSync(directCli);
+      assert.equal(
+        resolveAgentExecutable(minimalAgentDef({ id: 'copilot', bin: 'copilot' })),
+        vscodeBootstrap,
+      );
     });
   } finally {
     rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Why

I hit this while using OpenDesign on Windows with the standalone GitHub Copilot CLI installed alongside the VS Code Copilot extension. VS Code's extension-owned bootstrap directory can appear earlier on `PATH`, so the generic first-candidate rule selects that bootstrap instead of the independently installed CLI. Agent detection and launch should prefer the user's direct Copilot installation rather than an extension implementation detail.

## What users will see

Local Agent detection now prefers a directly installed GitHub Copilot CLI when both it and VS Code's Copilot bootstrap are present. If no direct CLI is available, the VS Code bootstrap remains a fallback.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this is a daemon-only executable-resolution change.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/runtimes/env-and-detection.test.ts`
- Did the test go red on `main` and green on this branch? Yes. With upstream ordering restored, the test expected the npm `copilot.CMD` but received VS Code's `github.copilot-chat/copilotCli/copilot.BAT`; the branch passes the same test.

## Validation

- `corepack pnpm guard`
- `corepack pnpm typecheck`
- `corepack pnpm --filter '@open-design/daemon^...' --workspace-concurrency=4 --if-present run build`
- `corepack pnpm exec vitest run -c vitest.config.ts tests/runtimes/env-and-detection.test.ts -t 'resolveAgentExecutable prefers a direct Copilot CLI over the VS Code bootstrapper'`

The full test file also ran on Windows: 52 tests passed, 7 were skipped, and 5 unrelated Windows-host assertions failed outside the added Copilot test.