### PR TITLE
fix(pack): approve and validate Linux SQLite bindings

### DIFF
--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -30,6 +30,11 @@ import {
   toolPackSidecarStamp,
 } from "./config/sidecar-stamps.js";
 import { domToPptxBundleResource } from "./dom-to-pptx-resource.js";
+import {
+  assertLinuxAppImageNativeModules,
+  assertLinuxNativeModules,
+  LINUX_NATIVE_INSTALL_POLICY,
+} from './linux/native-modules.js';
 import { copyBundledResourceTrees, linuxResources, packBundledDshRuntime } from "./resources/index.js";
 import { copyOptionalVelaCliBinary } from "./vela-cli.js";
 import { electronBuilderVersionForAppVersion, readRuntimeAppVersion } from "./versioning/index.js";
@@ -534,6 +539,7 @@ async function writeAssembledApp(
   const packageVersion = electronBuilderVersionForAppVersion(version);
   const packageJson = {
     name: "open-design-packaged",
+    ...LINUX_NATIVE_INSTALL_POLICY,
     version: packageVersion,
     private: true,
     main: "main.cjs",
@@ -571,6 +577,7 @@ async function writeAssembledApp(
   );
 
   await runProductionInstall(paths.assembledAppRoot);
+  await assertLinuxNativeModules(paths.assembledAppRoot, join(paths.resourceRoot, 'bin', 'node'));
 }
 
 async function writeLinuxAppImageAppRun(paths: LinuxPaths): Promise<void> {
@@ -720,6 +727,10 @@ export async function packLinux(config: ToolPackConfig): Promise<LinuxPackResult
   await runElectronBuilderLinux(config, paths);
 
   const appImagePath = config.to === "dir" ? null : await findBuiltAppImage(paths);
+  if (config.to !== 'dir') {
+    if (appImagePath == null) throw new Error('Linux build did not produce an AppImage to verify');
+    await assertLinuxAppImageNativeModules(appImagePath);
+  }
   return {
     appImagePath,
     outputRoot: paths.appBuilderOutputRoot,

--- a/tools/pack/src/linux/native-modules.ts
+++ b/tools/pack/src/linux/native-modules.ts
@@ -1,0 +1,72 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+// The assembled app is a separate install root: workspace approvals do not apply.
+export const LINUX_NATIVE_INSTALL_POLICY = {
+  allowScripts: { 'better-sqlite3': true },
+  pnpm: { onlyBuiltDependencies: ['better-sqlite3'] },
+};
+
+const SQLITE_PROBE = `
+const { realpathSync } = require('node:fs');
+const { createRequire } = require('node:module');
+const { isAbsolute, join, relative, sep } = require('node:path');
+const appRoot = realpathSync(process.argv[1]);
+const daemonManifest = realpathSync(join(appRoot, 'node_modules', '@open-design', 'daemon', 'package.json'));
+const daemonRequire = createRequire(daemonManifest);
+const sqliteEntry = realpathSync(daemonRequire.resolve('better-sqlite3'));
+for (const entry of [daemonManifest, sqliteEntry]) {
+  const path = relative(appRoot, entry);
+  if (path === '..' || path.startsWith('..' + sep) || isAbsolute(path)) {
+    throw new Error('SQLite must resolve inside the packaged app: ' + entry);
+  }
+}
+const Database = daemonRequire('better-sqlite3');
+const db = new Database(':memory:');
+try {
+  if (db.prepare('SELECT 42 AS answer').get().answer !== 42) {
+    throw new Error('Packaged SQLite query failed');
+  }
+} finally {
+  db.close();
+}
+`;
+
+/** Loading the JS wrapper alone does not load better_sqlite3.node or check its ABI. */
+export async function assertLinuxNativeModules(appRoot: string, nodeCommand: string): Promise<void> {
+  try {
+    await execFileAsync(nodeCommand, ['-e', SQLITE_PROBE, appRoot], {
+      env: { ...process.env, NODE_OPTIONS: '', NODE_PATH: '' },
+      timeout: 30_000,
+    });
+  } catch (error) {
+    const failure = error as Error & { stderr?: string };
+    throw new Error(
+      `Linux packaged better-sqlite3 cannot open a database with bundled Node (${nodeCommand}): ${failure.stderr?.trim() || failure.message}`,
+      { cause: error },
+    );
+  }
+}
+
+/** Verify the shipped bytes as well as the assembled dependency tree. */
+export async function assertLinuxAppImageNativeModules(appImagePath: string): Promise<void> {
+  const extractedRoot = await mkdtemp(join(tmpdir(), 'od-linux-appimage-'));
+  try {
+    await execFileAsync(appImagePath, ['--appimage-extract'], {
+      cwd: extractedRoot,
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    const resources = join(extractedRoot, 'squashfs-root', 'resources');
+    await assertLinuxNativeModules(
+      join(resources, 'app'),
+      join(resources, 'open-design', 'bin', 'node'),
+    );
+  } finally {
+    await rm(extractedRoot, { recursive: true, force: true });
+  }
+}

--- a/tools/pack/tests/linux/native-modules.test.ts
+++ b/tools/pack/tests/linux/native-modules.test.ts
@@ -1,0 +1,147 @@
+import { chmod, cp, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { assertLinuxAppImageNativeModules, assertLinuxNativeModules } from '@/linux/native-modules.js';
+
+const roots: string[] = [];
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), 'od-linux-native-test-'));
+  roots.push(root);
+  const app = join(root, 'resources', 'app');
+  const daemon = join(app, 'node_modules', '@open-design', 'daemon', 'package.json');
+  await mkdir(dirname(daemon), { recursive: true });
+  await writeFile(daemon, JSON.stringify({ name: '@open-design/daemon' }));
+  return { root, app };
+}
+
+async function sqliteWrapper(app: string, source: string) {
+  const directory = join(app, 'node_modules', 'better-sqlite3');
+  await mkdir(directory, { recursive: true });
+  await writeFile(join(directory, 'index.js'), source);
+  return directory;
+}
+
+function workingWrapper(trace: string, answer = 42) {
+  return `
+const fs = require('node:fs');
+const record = value => fs.appendFileSync(${JSON.stringify(trace)}, value + '\\n');
+module.exports = class Database {
+  constructor(name) { record(name); }
+  prepare(sql) { record(sql); return { get: () => ({ answer: ${answer} }) }; }
+  close() { record('closed'); }
+};
+`;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true })));
+});
+
+describe('Linux packaged SQLite probe', () => {
+  it('opens an in-memory database, runs a query and closes it', async () => {
+    const { root, app } = await fixture();
+    const trace = join(root, 'trace');
+    await sqliteWrapper(app, workingWrapper(trace));
+
+    await assertLinuxNativeModules(app, process.execPath);
+
+    expect(await readFile(trace, 'utf8')).toBe(':memory:\nSELECT 42 AS answer\nclosed\n');
+  });
+
+  it('rejects a wrapper that imports successfully but cannot load its native binding', async () => {
+    const { app } = await fixture();
+    await sqliteWrapper(app, `module.exports = class Database {
+      constructor() { throw new Error('Could not locate better_sqlite3.node'); }
+    };`);
+
+    await expect(assertLinuxNativeModules(app, process.execPath))
+      .rejects.toThrow('Could not locate better_sqlite3.node');
+  });
+
+  it('rejects an invalid native binary', async () => {
+    const { app } = await fixture();
+    const sqlite = await sqliteWrapper(app, `module.exports = class Database {
+      constructor() { require('./better_sqlite3.node'); }
+    };`);
+    await writeFile(join(sqlite, 'better_sqlite3.node'), 'not a native module');
+
+    await expect(assertLinuxNativeModules(app, process.execPath))
+      .rejects.toThrow('Linux packaged better-sqlite3 cannot open a database');
+  });
+
+  it('does not accept a dependency found outside the packaged app', async () => {
+    const { root, app } = await fixture();
+    await sqliteWrapper(root, workingWrapper(join(root, 'ambient-trace')));
+
+    await expect(assertLinuxNativeModules(app, process.execPath))
+      .rejects.toThrow('SQLite must resolve inside the packaged app');
+  });
+
+  it('reports an absent packaged daemon instead of using an ambient install', async () => {
+    const { app } = await fixture();
+    await rm(join(app, 'node_modules', '@open-design', 'daemon'), { recursive: true });
+
+    await expect(assertLinuxNativeModules(app, process.execPath))
+      .rejects.toThrow('Linux packaged better-sqlite3 cannot open a database');
+  });
+
+  it('closes the database when query verification fails', async () => {
+    const { root, app } = await fixture();
+    const trace = join(root, 'trace');
+    await sqliteWrapper(app, workingWrapper(trace, 0));
+
+    await expect(assertLinuxNativeModules(app, process.execPath))
+      .rejects.toThrow('Packaged SQLite query failed');
+    expect(await readFile(trace, 'utf8')).toContain('closed\n');
+  });
+});
+
+describe.skipIf(process.platform !== 'linux')('Linux AppImage native-module verification', () => {
+  async function appImageFixture(failExtraction = false) {
+    const { root, app } = await fixture();
+    const node = join(root, 'resources', 'open-design', 'bin', 'node');
+    await mkdir(dirname(node), { recursive: true });
+    await cp(process.execPath, node);
+    const trace = join(root, 'extraction-path');
+    const appImage = join(root, 'Open Design.AppImage');
+    await writeFile(appImage, `#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+if (process.argv[2] !== '--appimage-extract') process.exit(3);
+fs.writeFileSync(${JSON.stringify(trace)}, process.cwd());
+${failExtraction ? 'process.exit(2);' : `fs.cpSync(${JSON.stringify(join(root, 'resources'))}, path.join(process.cwd(), 'squashfs-root', 'resources'), { recursive: true });`}
+`);
+    await chmod(appImage, 0o755);
+    return { root, app, appImage, trace };
+  }
+
+  it('checks the extracted app with its bundled Node and removes the extraction', async () => {
+    const { root, app, appImage, trace } = await appImageFixture();
+    const sqliteTrace = join(root, 'sqlite-trace');
+    await sqliteWrapper(app, workingWrapper(sqliteTrace));
+
+    await assertLinuxAppImageNativeModules(appImage);
+
+    expect(await readFile(sqliteTrace, 'utf8')).toContain('closed\n');
+    await expect(readFile(await readFile(trace, 'utf8'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('rejects an AppImage missing SQLite and still removes the extraction', async () => {
+    const { appImage, trace } = await appImageFixture();
+
+    await expect(assertLinuxAppImageNativeModules(appImage))
+      .rejects.toThrow('Linux packaged better-sqlite3 cannot open a database');
+    await expect(readFile(await readFile(trace, 'utf8'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('propagates extraction failure and removes its temporary directory', async () => {
+    const { appImage, trace } = await appImageFixture(true);
+
+    await expect(assertLinuxAppImageNativeModules(appImage)).rejects.toThrow();
+    await expect(readFile(await readFile(trace, 'utf8'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});


### PR DESCRIPTION
Refs #3759 and #1788. This fixes the SQLite packaging defect discussed in [this comment](https://github.com/nexu-io/open-design/issues/3759#issuecomment-5608123869); it does not close the broader Linux release-readiness issue.

## Why

Following the CachyOS/AUR report in #3759, I reproduced a native Linux build that completed successfully with Node 26.8.1/npm 12.0.2 but shipped an AppImage without `better_sqlite3.node`. Opening an in-memory database with the Node executable inside that AppImage failed with `Could not locate the bindings file`.

The assembled application is a separate install root. Its generated manifest needs its own install-script approval: npm 12 blocks the SQLite installer without `allowScripts`, and the container's pnpm 10 needs `pnpm.onlyBuiltDependencies`. Both policies approve only `better-sqlite3`.

## What users will see

Linux packages built with npm 12 will include a working SQLite binding. Packaging now fails with a SQLite-specific error if the assembled application or final AppImage cannot open an in-memory database using its bundled Node, instead of reporting a successful build with a broken binding.

The final verification extracts the AppImage into a temporary directory and removes it afterward. This adds extraction time and temporary disk usage to AppImage builds. There are no UI changes or new CLI options.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var** — no new command, flag, or environment variable
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — Linux packaging approves the SQLite installer and rejects unusable bindings before returning success
- [ ] **None**

## Screenshots

Not applicable: this changes packaging behavior, with no UI surface.

## Bug fix verification

- **Actual artifact check: red before the source change, green afterward.** Both native builds used upstream `be0887b39273993d939e83c4768922115f104bed` (0.22.1), Node 26.8.1, npm 12.0.2, and pnpm 10.33.2. Both builds returned exit 0. Extracting each final AppImage and opening SQLite with its bundled Node returned exit 1 on unmodified main and exit 0 with this patch; the patched artifact returned `{ "answer": 42 }`.
- New regression tests: `tools/pack/tests/linux/native-modules.test.ts` (9 tests). They cover opening/querying/closing the database, wrappers that import but cannot load a binding, invalid native bytes, dependencies outside the package, absent daemon dependencies, and extraction cleanup on success and failure. These unit tests use controlled fixtures; the real native/ABI validation comes from the AppImage comparison above.
- The unit helper is new, so there is no claim that the new unit file ran on unchanged main. The pre-change reproduction was the real AppImage smoke test.

To repeat the native artifact check on each revision, first build the tools, then build into a distinct portable namespace. Use Node 26.8.1/npm 12.0.2 for this specific reproduction; repository checks below use the project's Node 24 baseline.

```sh
pnpm --filter @open-design/tools-pack build
pnpm tools-pack linux build --to appimage --portable --namespace sqlite-check --dir /tmp/od-sqlite-check --json
```

Extract the resulting AppImage with `--appimage-extract` in an empty directory. From that directory:

```sh
./squashfs-root/resources/open-design/bin/node -e '
const { createRequire } = require("node:module");
const { resolve } = require("node:path");
const requireDaemon = createRequire(resolve("squashfs-root/resources/app/node_modules/@open-design/daemon/package.json"));
const Database = requireDaemon("better-sqlite3");
const db = new Database(":memory:");
try {
  const row = db.prepare("SELECT 42 AS answer").get();
  if (row.answer !== 42) throw new Error("unexpected SQLite result");
  console.log(row);
} finally { db.close(); }
'
```

## Validation

Repository checks with Node 24.14.1 / pnpm 10.33.2:

- `pnpm guard` — passed
- `pnpm typecheck` — passed
- `pnpm --filter @open-design/tools-pack build` — passed
- `pnpm --filter @open-design/tools-pack test` — 42 files passed; 314 tests passed, 9 skipped
- `git diff --check` — passed

Native Linux AppImages with Node 26.8.1 / npm 12.0.2:

| Revision | Final AppImage SQLite binding | Bundled-Node SQLite query |
| --- | --- | --- |
| Unmodified main | Missing | Failed |
| This patch | Present | Passed; Node ABI 147 |

I also ran **installation-only fixtures** in the standard builder image, using the before/after generated manifest policies and only `better-sqlite3@12.10.0` as the dependency. Fresh installs used the actual production flags (`npm install --omit=dev --no-package-lock` or `pnpm install --prod --no-lockfile --config.node-linker=hoisted`).

| Container fixture | Original policy | Patched policy |
| --- | --- | --- |
| Node 26.8.1 / npm 12.0.2 | Install exits 0, SQLite query fails, binding missing | Install and SQLite query pass |
| Node 24.14.1 / pnpm 10.33.2 | Install exits 0, SQLite query fails, binding missing | Install and SQLite query pass |

Image: `electronuserland/builder:base`, digest `sha256:46af5b849ea89b896e0e28718095df5f5ffc1df7488b0c6e3944b2e7bdf94c44`. Runs used rootless Podman with the packager-generated Docker arguments plus `--userns=keep-id`; the reduced fixtures used the same image. **These fixture results are not a successful full containerized OpenDesign build.**

The distro-provided Node 26/npm 12 reproduction is outside the repository's Node 24 baseline. It establishes the reported packaging defect, not general Node 26 application support. Desktop UI startup was not exercised.

## Adjacent issues

The complete standard container build was attempted on both revisions and failed earlier with `spawn corepack ENOENT` while building the bundled dsh runtime. A controlled baseline retry with `npm_execpath=/tmp/pnpm` passed that step, then production installation failed with `ERR_PNPM_FETCH_404` for `@open-design/release`, requested through `@open-design/packaged@0.22.1`.

These are separate container bootstrap/dependency-resolution defects. They are outside the SQLite install-policy change, and full container AppImage validation remains blocked by them. The PR is a draft to keep that limit visible for review.
