### PR TITLE
fix(runtime): stop treating bare resource exhaustion as hard quota

### DIFF
--- a/apps/daemon/src/run-failure-classification.ts
+++ b/apps/daemon/src/run-failure-classification.ts
@@ -207,10 +207,11 @@ function isHardQuotaText(text: string): boolean {
   //
   // `quota reached` covers Antigravity's upstream log line:
   //   RESOURCE_EXHAUSTED (code 429): Individual quota reached.
-  // `RESOURCE_EXHAUSTED` catches the same log when the phrase portion is
-  // truncated or arrives separately — it is the gRPC status code that
-  // Antigravity uses exclusively for per-model quota exhaustion.
-  return /\b(session limit|usage limit|limit reached|quota exceeded|quota reached|exceeded your current quota|billing (?:hard )?limit|insufficient[ _-]?(?:quota|credit|credits|funds)|out of credits|no payment method|requires more credits|can only afford)\b|DAILY_LIMIT_EXCEEDED|RESOURCE_EXHAUSTED|用户额度不足|额度不足|预扣费额度失败/i
+  // A bare RESOURCE_EXHAUSTED is not billing evidence: Cursor also emits
+  // `RetriableError: [resource_exhausted] Error` without identifying the
+  // exhausted resource. Let the structured code / generic failure fallback
+  // retain its recovery policy unless an explicit quota phrase is present.
+  return /\b(session limit|usage limit|limit reached|quota exceeded|quota reached|exceeded your current quota|billing (?:hard )?limit|insufficient[ _-]?(?:quota|credit|credits|funds)|out of credits|no payment method|requires more credits|can only afford)\b|DAILY_LIMIT_EXCEEDED|用户额度不足|额度不足|预扣费额度失败/i
     .test(text);
 }
 

--- a/apps/daemon/tests/run-failure-classification.test.ts
+++ b/apps/daemon/tests/run-failure-classification.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { decideSafeRunRetry } from '../src/run-retry-policy.js';
 
 vi.mock('../src/integrations/vela-errors.js', () => ({
   classifyAmrAccountFailure(text: string) {
@@ -2084,8 +2085,8 @@ describe('classifyRunFailure — AMR/vela reclassification out of execution_fail
   // Refs mrcfps blocking comment on PR #7248.  Antigravity emits:
   //   RESOURCE_EXHAUSTED (code 429): Individual quota reached. Contact your
   //   administrator to enable overages. Resets in <H>h<M>m<S>s.
-  // to its log file.  The tightened pattern must recognise both `quota reached`
-  // and the bare `RESOURCE_EXHAUSTED` status code as hard quota exhaustion.
+  // to its log file. The explicit quota phrase remains exhaustion evidence;
+  // the status code alone does not identify which resource was exhausted.
   it('classifies Antigravity "RESOURCE_EXHAUSTED: Individual quota reached" as hard_quota', () => {
     const result = classify(
       'RATE_LIMITED',
@@ -2106,16 +2107,44 @@ describe('classifyRunFailure — AMR/vela reclassification out of execution_fail
     expect(result?.retryable).toBe(false);
   });
 
-  it('classifies bare RESOURCE_EXHAUSTED status code as hard_quota', () => {
-    // Antigravity log may surface the status code alone when the message is
-    // stripped by the log parser.
-    const result = classify(
-      'RATE_LIMITED',
-      'RESOURCE_EXHAUSTED',
-    );
-    expect(result?.failure_category).toBe('rate_limit');
-    expect(result?.failure_detail).toBe('hard_quota');
-    expect(result?.retryable).toBe(false);
+  it('preserves a structured rate limit without inferring hard quota from RESOURCE_EXHAUSTED', () => {
+    const result = classify('RATE_LIMITED', 'RESOURCE_EXHAUSTED');
+    expect(result).toMatchObject({
+      failure_category: 'rate_limit',
+      failure_detail: 'rate_limit_429',
+      retryable: true,
+      user_action: 'retry',
+    });
+  });
+
+  it('keeps the Cursor resource error recoverable without automatically replaying it', () => {
+    const message = 'RetriableError: [resource_exhausted] Error';
+    const result = classifyForAgent('cursor-agent', 'AGENT_EXECUTION_FAILED', message, [
+      { event: 'stderr', data: { chunk: message + '\n' } },
+      errorEvent('AGENT_EXECUTION_FAILED', message, true),
+      runtimeCloseEvent('exit_nonzero'),
+    ]);
+    expect(result).toMatchObject({
+      failure_category: 'process_exit',
+      failure_detail: 'exit_nonzero',
+      retryable: true,
+      user_action: 'retry',
+    });
+    // Retryability exposes recovery to the user; an ambiguous error must not
+    // enter the automatic transient retry allowlist, even before side effects.
+    for (const sideEffects of [{}, { toolCallSeen: true }, { artifactWriteSeen: true }]) {
+      expect(decideSafeRunRetry({
+        result: 'failed', attemptCount: 0, failure: result, sideEffects,
+      })).toMatchObject({ shouldRetry: false, retrySuppressedReason: 'non_retryable_category' });
+    }
+  });
+
+  it('keeps explicit Cursor billing exhaustion non-retryable', () => {
+    const message = 'RetriableError: [resource_exhausted] billing hard limit reached';
+    const result = classifyForAgent('cursor-agent', 'AGENT_EXECUTION_FAILED', message, [
+      errorEvent('AGENT_EXECUTION_FAILED', message, true),
+    ]);
+    expect(result).toMatchObject({ failure_detail: 'hard_quota', retryable: false });
   });
 
   // Advisory phrases from antigravityQuotaGuidance() — these are in the

--- a/apps/daemon/tests/run-failure-classification.test.ts
+++ b/apps/daemon/tests/run-failure-classification.test.ts
@@ -2134,7 +2134,7 @@ describe('classifyRunFailure — AMR/vela reclassification out of execution_fail
     // enter the automatic transient retry allowlist, even before side effects.
     for (const sideEffects of [{}, { toolCallSeen: true }, { artifactWriteSeen: true }]) {
       expect(decideSafeRunRetry({
-        result: 'failed', attemptCount: 0, failure: result, sideEffects,
+        result: 'failed', attemptCount: 0, failure: result!, sideEffects,
       })).toMatchObject({ shouldRetry: false, retrySuppressedReason: 'non_retryable_category' });
     }
   });


### PR DESCRIPTION
Fixes [OPEND-3008](https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/work-items/4cd32008-bfbe-435e-8b87-a829331304a2)

## Why

A reported Cursor failure on OpenDesign 0.22.0 displayed “quota exhausted; retry cannot recover” even though the only upstream message was `RetriableError: [resource_exhausted] Error`. The diagnostic bundle, PostHog, and Langfuse agree that the quota verdict came from a text heuristic, not a structured billing response. A neighboring run succeeded between two such failures; the specific Cursor-side resource constraint remains unknown.

The shared hard-quota matcher had generalized an Antigravity status-code example to every runtime. Remove the bare status-code match while retaining explicit quota/billing phrases and structured rate-limit handling.

## What users will see

The captured Cursor error uses the existing “task interrupted” guidance and manual retry action instead of asserting exhausted funds. Explicit billing exhaustion still uses quota guidance. This does not fix Cursor's upstream failure or add ambiguous errors to the automatic retry allowlist.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new subcommand, flag, or environment variable
- [ ] **API / contract** — new endpoint/event or changed shape
- [ ] **Extension point** — skills, design systems, templates, craft, or protocol
- [ ] **i18n keys** — new translation keys
- [ ] **New top-level dependency**
- [x] **Default behavior change** — shared failure classification and recovery advice
- [ ] **None**

The fix is in the shared daemon classifier consumed by existing HTTP/SSE, UI, and CLI flows. It adds no capability, DTO, UI component, translation key, or CLI flag.

## Screenshots

No UI layout/component changes; this reuses the existing interruption card. The reported entry point is the failed run card below the chat response. Classification and automatic-retry behavior are verified at their owning daemon boundary; no packaged visual acceptance is claimed.

## Bug fix verification

- Red spec: `apps/daemon/tests/run-failure-classification.test.ts`, “keeps the Cursor resource error recoverable without automatically replaying it” and “preserves a structured rate limit without inferring hard quota from RESOURCE_EXHAUSTED”.
- Red on current upstream main (`34ac405bfe`): 2 failed, 175 passed, before the production edit.
- Green on branch: 177 passed across failure-classification and retry-policy suites.
- Explicit Cursor billing exhaustion and Antigravity quota text remain hard quota; ambiguous Cursor failures do not auto-replay, including after tool calls or artifact writes.

## Validation

- `corepack pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/run-failure-classification.test.ts tests/run-retry-policy.test.ts` — 177 passed.
- `corepack pnpm guard` — passed.
- `corepack pnpm typecheck` — passed after building workspace package prerequisites in the fresh worktree.
