### PR TITLE
fix(ci): drop four nonexistent labels from PR inactivity blocker set

### DIFF
--- a/.github/workflows/pr-author-inactivity.yml
+++ b/.github/workflows/pr-author-inactivity.yml
@@ -71,12 +71,8 @@ jobs:
               'looper:worker-ready',
               'needs-design-review',
               'needs-maintainer-check',
-              'needs-maintainer-merge',
-              'needs-qa',
-              'needs-qa-validation',
               'needs-product-direction',
               'needs-validation',
-              'ready-to-merge',
               'stale-pr/blocked',
               'stale-pr/maintainer-assisted',
             ]);


### PR DESCRIPTION
Fixes #7848

## Why

`NON_AUTHOR_BLOCKER_LABELS` in `.github/workflows/pr-author-inactivity.yml` named twelve labels, but four of them do not exist in the repository's label registry:

- `needs-maintainer-merge`
- `needs-qa`
- `needs-qa-validation`
- `ready-to-merge`

Because that set is the only way a PR is skipped by the inactivity pass, the four missing entries made those exemption branches unreachable. Verified against the live registry (77 labels) with:

```
gh api repos/nexu-io/open-design/labels --paginate --jq '.[].name'
```

Only the eight remaining labels are present. A repo-wide grep confirms the four removed names are referenced nowhere else under `.github/`, so no automation creates them dynamically.

This takes the issue's "drop the four entries" direction rather than "create the four labels": label creation is not a change this PR can make in-repo, and the existing real labels `needs-maintainer-check` and `needs-validation` already cover those states in practice.

## What users will see

None — contributor-facing automation only. PRs genuinely blocked on a non-author state are still skipped via the eight labels that exist; the dead entries had no effect.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — internal CI/automation cleanup only

## Screenshots

N/A

## Bug fix verification

A red spec was not cheap to add in-repo: the source of truth for whether a label exists is the GitHub label registry, and this repository does not vendor a labels manifest for a test to compare against (a hardcoded allowlist would duplicate that truth and rot). Verification instead:

- Confirmed the four labels are absent from the live registry via authenticated `gh api`, and the other eight are present (re-checked programmatically against the edited set: all 8 valid).
- A guard that every label in `NON_AUTHOR_BLOCKER_LABELS` exists would be a reasonable follow-up but needs either a vendored label manifest or an API-backed check.

## Validation

- `gh api .../labels --paginate` — 8/8 remaining labels exist; the 4 removed labels are absent.
- `js-yaml` parse of the edited workflow — valid YAML.
- `pnpm --dir e2e exec vitest run tests/packaged-smoke-workflow.test.ts` — 83 passed, 1 skipped (includes the assertion that `'needs-maintainer-check'` remains in the inactivity set).
