### PR TITLE
feat(daemon): retain bounded Write progress diagnostics

### DIFF
--- a/apps/daemon/src/agent-protocol/acp/emission-provenance.ts
+++ b/apps/daemon/src/agent-protocol/acp/emission-provenance.ts
@@ -1,6 +1,8 @@
 /** Out-of-band origin of an ACP bridge emission, never part of its payload. */
 export interface AcpEmissionMeta {
   hostSynthesized?: boolean;
+  /** Private diagnostic evidence does not establish agent liveness. */
+  countsAsProgress?: boolean;
 }
 
 const hostSynthesizedEmissions = new WeakSet<object>();

--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -142,6 +142,8 @@ export interface AttachAcpSessionOptions {
   resumeSessionId?: string | null;
   /** Safe model/session metadata attached to the exact prompt-frame diagnostic. */
   promptBudgetContext?: AcpPromptBudgetContext;
+  /** Parsed non-diagnostic ACP traffic advances the caller's activity clock. */
+  onAgentActivity?: () => void;
   // Subsegment timing markers for spawn->first-token attribution (#3408 §4).
   // `onCliReady` fires once on the first well-formed ACP JSON-RPC message
   // (the CLI is up and speaking the protocol); `onSessionInit` fires once when
@@ -203,6 +205,7 @@ export function attachAcpSession({
   completePromptOnTurnEnd = false,
   resumeSessionId,
   promptBudgetContext,
+  onAgentActivity,
   onCliReady,
   onSessionInit,
   onPromptComplete,
@@ -210,7 +213,10 @@ export function attachAcpSession({
 }: AttachAcpSessionOptions) {
   const runStartedAt = Date.now();
   const writeProgress = createWriteProgressObserver((payload, hostSynthesized) =>
-    send('agent', payload, hostSynthesized ? { hostSynthesized: true } : undefined),
+    send('agent', payload, {
+      countsAsProgress: false,
+      ...(hostSynthesized ? { hostSynthesized: true } : {}),
+    }),
   );
   const toolExecutionLifecycleDeduper = createToolExecutionLifecycleDeduper();
   const effectiveCwd = path.resolve(cwd || process.cwd());
@@ -515,7 +521,6 @@ export function attachAcpSession({
   };
 
   const clearStageTimer = () => {
-    writeProgress.close();
     if (stageTimer) clearTimeout(stageTimer);
     stageTimer = null;
   };
@@ -549,6 +554,7 @@ export function attachAcpSession({
     finished = true;
     fatal = true;
     clearStageTimer();
+    writeProgress.close();
     let terminalOwnedByCaller = false;
     try {
       onTerminal?.('fatal');
@@ -589,6 +595,7 @@ export function attachAcpSession({
     finished = true;
     fatal = true;
     clearStageTimer();
+    writeProgress.close();
     let terminalOwnedByCaller = false;
     try {
       onTerminal?.('fatal');
@@ -941,6 +948,7 @@ export function attachAcpSession({
     emitArtifactTextSuppressionSummary();
     emitUsageIfPresent(usageSource);
     clearStageTimer();
+    writeProgress.close();
     stdin.end();
     let terminalOwnedByCaller = false;
     try {
@@ -1010,6 +1018,7 @@ export function attachAcpSession({
     resetStageTimer('response');
     const obj = candidate;
     if (!obj) return;
+    onAgentActivity?.();
     // First well-formed ACP JSON-RPC message = CLI ready (#3408 §4). Caller
     // dedupes, so re-notifying on later messages is harmless.
     onCliReady?.();
@@ -1454,8 +1463,9 @@ export function attachAcpSession({
     if (promotedPayload) failWithPayload(promotedPayload);
   });
   child.on('close', (code, signal) => {
-    clearStageTimer();
     parser.flush();
+    clearStageTimer();
+    writeProgress.close();
     if (!finished && !aborted && !fatal) {
       const stderrTail = redactSecrets(
         acpStderrTail
@@ -1545,6 +1555,7 @@ export function attachAcpSession({
       aborted = true;
       finished = true;
       clearStageTimer();
+      writeProgress.close();
       if (!child.stdin || child.stdin.destroyed || child.stdin.writableEnded)
         return;
       // Only cancel an established session; before session/new resolves there

--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -7,6 +7,7 @@
  * connectionTest.ts and server.ts (via the acp/ barrel).
  */
 import path from 'node:path';
+import { createWriteProgressObserver } from './write-progress.js';
 import type { ExecutionProfile } from '@open-design/contracts';
 import {
   createDsmlArtifactTextSuppressor,
@@ -208,6 +209,9 @@ export function attachAcpSession({
   onTerminal,
 }: AttachAcpSessionOptions) {
   const runStartedAt = Date.now();
+  const writeProgress = createWriteProgressObserver((payload, hostSynthesized) =>
+    send('agent', payload, hostSynthesized ? { hostSynthesized: true } : undefined),
+  );
   const toolExecutionLifecycleDeduper = createToolExecutionLifecycleDeduper();
   const effectiveCwd = path.resolve(cwd || process.cwd());
   if (!child.stdin || !child.stdout) {
@@ -511,6 +515,7 @@ export function attachAcpSession({
   };
 
   const clearStageTimer = () => {
+    writeProgress.close();
     if (stageTimer) clearTimeout(stageTimer);
     stageTimer = null;
   };
@@ -991,8 +996,19 @@ export function attachAcpSession({
 
   const parser = createJsonLineStream((raw, rawLine) => {
     if (aborted || finished) return;
+    const candidate = asObject(raw);
+    const diagnosticParams = asObject(candidate?.params);
+    const diagnosticUpdate = asObject(diagnosticParams?.update);
+    if (candidate?.method === 'session/update' && diagnosticUpdate?.sessionUpdate === 'write_progress') {
+      if (modelUnavailableErrorCode && promptRequestId !== null && sessionId && diagnosticParams?.sessionId === sessionId) {
+        writeProgress.observe(diagnosticUpdate);
+      }
+      // Even rejected diagnostics must not reset the response watchdog or leak
+      // through generic status projection. These are evidence, not liveness.
+      return;
+    }
     resetStageTimer('response');
-    const obj = asObject(raw);
+    const obj = candidate;
     if (!obj) return;
     // First well-formed ACP JSON-RPC message = CLI ready (#3408 §4). Caller
     // dedupes, so re-notifying on later messages is harmless.

--- a/apps/daemon/src/agent-protocol/acp/write-progress.ts
+++ b/apps/daemon/src/agent-protocol/acp/write-progress.ts
@@ -1,0 +1,226 @@
+/** Private Write diagnostics. No argument text, path, raw ID, or error prose is retained. */
+import type { JsonObject } from './types.js';
+import { acpTelemetryToolCallId } from './updates.js';
+
+const PHASES = new Set([
+  'input_started',
+  'input_progress',
+  'input_ended',
+  'arguments_ready',
+  'validation_failed',
+  'execution_started',
+  'permission_requested',
+  'file_write_started',
+  'file_write_finished',
+  'postprocess_started',
+  'execution_returned',
+  'execution_failed',
+  'result_observed',
+  'stream_failed',
+  'stream_finished',
+  'interrupted',
+]);
+const ERRORS = new Set(['schema_invalid', 'json_invalid', 'tool_error', 'stream_error', 'aborted']);
+const TERMINALS = new Set([
+  'execution_returned',
+  'execution_failed',
+  'validation_failed',
+  'result_observed',
+]);
+const EXECUTION = new Set([
+  'execution_started',
+  'permission_requested',
+  'file_write_started',
+  'file_write_finished',
+  'postprocess_started',
+  ...TERMINALS,
+]);
+const COUNTERS = ['inputBytes', 'deltaCount', 'firstDeltaAtMs', 'lastDeltaAtMs'] as const;
+const FLAGS = ['inputEnded', 'hasContent', 'hasFilePath'] as const;
+
+type Diagnostic = {
+  type: 'diagnostic';
+  name: 'write_progress';
+  source: 'amr-opencode';
+  version: 1;
+  toolCallIdHash: string;
+  messageIdHash: string;
+  phase: string;
+  atMs: number;
+  errorKind?: string;
+} & Partial<Record<(typeof COUNTERS)[number], number>> &
+  Partial<Record<(typeof FLAGS)[number], boolean>>;
+
+export function sanitizeWriteProgress(update: JsonObject): Diagnostic | null {
+  if (update.version !== 1 || typeof update.phase !== 'string' || !PHASES.has(update.phase))
+    return null;
+  for (const key of ['callID', 'messageID'] as const) {
+    if (
+      typeof update[key] !== 'string' ||
+      !update[key] ||
+      Buffer.byteLength(update[key], 'utf8') > 256
+    )
+      return null;
+  }
+  if (typeof update.atMs !== 'number' || !Number.isSafeInteger(update.atMs) || update.atMs <= 0)
+    return null;
+  const diagnostic: Diagnostic = {
+    type: 'diagnostic',
+    name: 'write_progress',
+    source: 'amr-opencode',
+    version: 1,
+    toolCallIdHash: acpTelemetryToolCallId(update.callID as string),
+    messageIdHash: acpTelemetryToolCallId(update.messageID as string),
+    phase: update.phase,
+    atMs: update.atMs,
+  };
+  for (const key of COUNTERS) {
+    const value = update[key];
+    if (value === undefined) continue;
+    if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) return null;
+    diagnostic[key] = value;
+  }
+  for (const key of FLAGS) {
+    if (update[key] === undefined) continue;
+    if (typeof update[key] !== 'boolean') return null;
+    diagnostic[key] = update[key];
+  }
+  if (update.errorKind !== undefined) {
+    if (typeof update.errorKind !== 'string' || !ERRORS.has(update.errorKind)) return null;
+    diagnostic.errorKind = update.errorKind;
+  }
+  return diagnostic;
+}
+
+export function createWriteProgressObserver(
+  emit: (payload: unknown, hostSynthesized: boolean) => void,
+) {
+  type State = {
+    latest: Diagnostic;
+    receivedAtMs: number;
+    executionPhase?: string;
+    settled: boolean;
+    resultObserved: boolean;
+    phases: Set<string>;
+    progressEvents: number;
+    lastProgressAtMs: number;
+    warned: boolean;
+  };
+  // Per prompt limits, including completed calls: bounded memory and log volume.
+  const calls = new Map<string, State>();
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let closed = false;
+  const send = (payload: unknown, hostSynthesized = false) => {
+    try {
+      emit(payload, hostSynthesized);
+    } catch {
+      /* Diagnostics cannot fail the prompt. */
+    }
+  };
+  const snapshot = (state: State, reason: 'no_progress' | 'session_closed') => {
+    send(
+      {
+        ...state.latest,
+        name: 'write_progress_snapshot',
+        reason,
+        receivedAtMs: state.receivedAtMs,
+        silentForMs: Math.max(0, Date.now() - state.receivedAtMs),
+        ...(state.executionPhase ? { executionPhase: state.executionPhase } : {}),
+        // A stream ending or a host timeout is not a confirmed tool result.
+        executionSettled: state.settled,
+        resultObserved: state.resultObserved,
+      },
+      true,
+    );
+  };
+  return {
+    observe(update: JsonObject) {
+      if (closed) return;
+      const fact = sanitizeWriteProgress(update);
+      if (!fact) return;
+      const key = `${fact.messageIdHash}:${fact.toolCallIdHash}`;
+      let state = calls.get(key);
+      if (!state) {
+        if (calls.size >= 64) return;
+        state = {
+          latest: fact,
+          receivedAtMs: Date.now(),
+          settled: false,
+          resultObserved: false,
+          phases: new Set(),
+          progressEvents: 0,
+          lastProgressAtMs: -Infinity,
+          warned: false,
+        };
+        calls.set(key, state);
+      }
+      const now = Date.now();
+      if (fact.phase === 'input_progress') {
+        if (state.progressEvents >= 120 || now - state.lastProgressAtMs < 5000) return;
+        state.progressEvents++;
+        state.lastProgressAtMs = now;
+      } else if (state.phases.has(fact.phase)) return;
+      state.phases.add(fact.phase);
+      state.latest = { ...state.latest, ...fact };
+      state.receivedAtMs = now;
+      state.warned = false;
+      if (EXECUTION.has(fact.phase)) state.executionPhase = fact.phase;
+      if (TERMINALS.has(fact.phase)) state.settled = true;
+      if (fact.phase === 'result_observed') state.resultObserved = true;
+      send({ ...fact, receivedAtMs: now });
+      timer ??= setInterval(() => {
+        for (const item of calls.values()) {
+          if (!item.resultObserved && !item.warned && Date.now() - item.receivedAtMs >= 60_000) {
+            item.warned = true;
+            snapshot(item, 'no_progress');
+          }
+        }
+      }, 30_000);
+      timer.unref();
+    },
+    close() {
+      if (closed) return;
+      closed = true;
+      if (timer) clearInterval(timer);
+      for (const state of calls.values())
+        if (!state.resultObserved) snapshot(state, 'session_closed');
+      calls.clear();
+    },
+  };
+}
+
+/** Revalidate persisted fields at the outbound trace boundary as well. */
+export function projectWriteProgressDiagnostic(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const data = value as JsonObject;
+  if (
+    data.type !== 'diagnostic' ||
+    data.source !== 'amr-opencode' ||
+    (data.name !== 'write_progress' && data.name !== 'write_progress_snapshot')
+  )
+    return null;
+  for (const key of ['toolCallIdHash', 'messageIdHash'] as const) {
+    if (typeof data[key] !== 'string' || !/^acp_[a-f0-9]{24}$/.test(data[key])) return null;
+  }
+  const fact = sanitizeWriteProgress({ ...data, callID: 'redacted', messageID: 'redacted' });
+  if (!fact) return null;
+  const output: Record<string, unknown> = {
+    ...fact,
+    name: data.name,
+    toolCallIdHash: data.toolCallIdHash,
+    messageIdHash: data.messageIdHash,
+  };
+  for (const key of ['receivedAtMs', 'silentForMs'] as const) {
+    if (typeof data[key] === 'number' && Number.isSafeInteger(data[key]) && data[key] >= 0)
+      output[key] = data[key];
+  }
+  if (data.name === 'write_progress_snapshot') {
+    if (data.reason === 'no_progress' || data.reason === 'session_closed')
+      output.reason = data.reason;
+    if (typeof data.executionPhase === 'string' && EXECUTION.has(data.executionPhase))
+      output.executionPhase = data.executionPhase;
+    if (typeof data.executionSettled === 'boolean') output.executionSettled = data.executionSettled;
+    if (typeof data.resultObserved === 'boolean') output.resultObserved = data.resultObserved;
+  }
+  return output;
+}

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -75,6 +75,7 @@ import {
   summarizeRunDiagnosticsForAnalytics,
   type RunDiagnosticsAnalytics,
 } from './run-diagnostics.js';
+import { projectWriteProgressDiagnostic } from './agent-protocol/acp/write-progress.js';
 import { projectToolExecutionLifecycleDiagnostic } from './agent-protocol/acp/tool-execution-lifecycle.js';
 import {
   classifyRunFailure,
@@ -812,6 +813,9 @@ function collectAgentEvents(
         ? projectToolExecutionLifecycleDiagnostic(data)
         : null;
       if (diagnosticName === 'tool_execution_lifecycle' && !toolExecutionLifecycle) continue;
+      const isWriteProgress = diagnosticName === 'write_progress' || diagnosticName === 'write_progress_snapshot';
+      const writeProgress = isWriteProgress ? projectWriteProgressDiagnostic(data) : null;
+      if (isWriteProgress && !writeProgress) continue;
       const index = diagnosticCounts.get(diagnosticName) ?? 0;
       diagnosticCounts.set(diagnosticName, index + 1);
       const promptBudget = promptBudgetAnalyticsFromDiagnostic(
@@ -823,7 +827,7 @@ function collectAgentEvents(
         name: `agent-diagnostic:${diagnosticName}`,
         timestamp,
         input: eventInput('diagnostic'),
-        output: toolExecutionLifecycle ?? {
+        output: writeProgress ?? toolExecutionLifecycle ?? {
           name: diagnosticName,
           ...(typeof data.source === 'string' ? { source: data.source } : {}),
           ...(typeof data.reason === 'string' ? { reason: data.reason } : {}),

--- a/apps/daemon/src/runtimes/chat-run-lifecycle.ts
+++ b/apps/daemon/src/runtimes/chat-run-lifecycle.ts
@@ -170,7 +170,7 @@ export function applyClaudeStreamJsonRunBookkeeping(
  *    edge case.
  *
  * Agent-originated errors are not lost by this: they arrive on the child's
- * stdout/stderr, and those raw-chunk handlers stamp the clock already.
+ * stderr or parsed non-diagnostic ACP frames, which stamp the clock already.
  *
  * This predicate only covers emissions that reach the daemon BEFORE the verdict
  * — `fail()` flushes open tools and only then sends the error. Everything that
@@ -181,11 +181,16 @@ export function applyClaudeStreamJsonRunBookkeeping(
  */
 export function runtimeEmissionCountsAsAgentProgress(
   channel: string,
-  meta?: { hostSynthesized?: boolean },
+  meta?: { hostSynthesized?: boolean; countsAsProgress?: boolean },
 ): boolean {
-  if (channel === 'error') return false;
+  if (channel === 'error' || meta?.countsAsProgress === false) return false;
   if (meta?.hostSynthesized === true) return false;
   return true;
+}
+
+/** ACP must classify complete frames before raw bytes can establish liveness. */
+export function runtimeStdoutCountsAsAgentProgress(streamFormat: string | undefined): boolean {
+  return streamFormat !== 'acp-json-rpc';
 }
 
 export function resolveChatRunShutdownGraceMs() {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -154,6 +154,7 @@ import {
   resolveChatRunFirstOutputTimeoutMs,
   resolveChatRunInactivityTimeoutMs,
   runtimeEmissionCountsAsAgentProgress,
+  runtimeStdoutCountsAsAgentProgress,
   resolveChatRunShutdownGraceMs,
 } from './runtimes/chat-run-lifecycle.js';
 // Shared with `POST /api/runs/:id/steer` so the opening prompt and a B11
@@ -14313,13 +14314,12 @@ export async function startServer({
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
 
-    // Reset the inactivity watchdog on every raw stdout byte so that
-    // structured adapters that buffer partial lines (Codex item.completed,
-    // pi-rpc session/prompt, ACP agent messages) and models that spend a
-    // long time in non-streamed reasoning still keep the run alive.
+    // ACP accounts for activity after frame classification so private Write
+    // diagnostics cannot keep a stalled run alive. Other adapters retain
+    // raw-byte activity while buffering partial lines.
     child.stdout.on('data', (chunk) => {
       childStdoutSeen = true;
-      noteAgentActivity();
+      if (runtimeStdoutCountsAsAgentProgress(def.streamFormat)) noteAgentActivity();
       agentStdoutTail = `${agentStdoutTail}${chunk}`.slice(-2000);
     });
 
@@ -15417,6 +15417,7 @@ export async function startServer({
         knownPromptBudgetModel?.metadata?.contextWindowTokens ?? null;
       acpSession = attachAcpSession({
         child,
+        onAgentActivity: noteAgentActivity,
         prompt: composed,
         cwd: effectiveCwd,
         model: safeModel,

--- a/apps/daemon/tests/acp-write-progress.test.ts
+++ b/apps/daemon/tests/acp-write-progress.test.ts
@@ -1,0 +1,131 @@
+import { expect, test, vi } from 'vitest';
+import {
+  createWriteProgressObserver,
+  sanitizeWriteProgress,
+  projectWriteProgressDiagnostic,
+} from '../src/agent-protocol/acp/write-progress.js';
+const fact = {
+  version: 1,
+  phase: 'input_started',
+  atMs: 100,
+  callID: 'write',
+  messageID: 'assistant',
+};
+
+test('Write metadata is rebuilt from bounded typed fields', () => {
+  const result = sanitizeWriteProgress({
+    ...fact,
+    inputBytes: 0,
+    inputEnded: false,
+    hasContent: false,
+    content: 'SECRET',
+    filePath: '/private/path',
+    errorKind: 'schema_invalid',
+    error: 'private error',
+  });
+  expect(result).toMatchObject({
+    inputBytes: 0,
+    inputEnded: false,
+    hasContent: false,
+    errorKind: 'schema_invalid',
+  });
+  expect(JSON.stringify(result)).not.toMatch(/SECRET|private|"callID"|"messageID"/);
+  for (const invalid of [
+    { version: 2 },
+    { atMs: NaN },
+    { inputBytes: -1 },
+    { deltaCount: Infinity },
+    { hasContent: 'yes' },
+    { phase: 'SECRET' },
+    { callID: 'x'.repeat(257) },
+    { errorKind: 'SECRET' },
+  ]) {
+    expect(sanitizeWriteProgress({ ...fact, ...invalid })).toBeNull();
+  }
+});
+
+test('Write silence snapshots distinguish stream completion from execution and stop after close', async () => {
+  vi.useFakeTimers();
+  try {
+    const events: any[] = [];
+    const observer = createWriteProgressObserver((e) => events.push(e));
+    observer.observe({ ...fact, inputBytes: 44, inputEnded: false });
+    observer.observe({ ...fact, phase: 'stream_finished', inputBytes: 44, inputEnded: false });
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(events.filter((e) => e.reason === 'no_progress')).toHaveLength(1);
+    expect(events.at(-1)).toMatchObject({
+      inputBytes: 44,
+      inputEnded: false,
+      executionSettled: false,
+    });
+    observer.observe({ ...fact, phase: 'execution_returned' });
+    observer.observe({ ...fact, phase: 'result_observed' });
+    observer.observe({ ...fact, phase: 'stream_failed', errorKind: 'stream_error' });
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(events.filter((e) => e.reason === 'no_progress')).toHaveLength(1);
+    observer.close();
+    expect(events.filter((e) => e.reason === 'session_closed')).toHaveLength(0);
+    expect(vi.getTimerCount()).toBe(0);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test('Write diagnostics cap calls, deduplicate phases, and rate limit progress', () => {
+  vi.useFakeTimers();
+  try {
+    const events: unknown[] = [];
+    const observer = createWriteProgressObserver((e) => events.push(e));
+    for (let i = 0; i < 100; i++) observer.observe({ ...fact, callID: String(i) });
+    expect(events).toHaveLength(64);
+    for (let i = 0; i < 100; i++) observer.observe({ ...fact, callID: '0' });
+    expect(events).toHaveLength(64);
+    for (let i = 0; i < 200; i++) {
+      observer.observe({ ...fact, callID: '0', phase: 'input_progress', inputBytes: i });
+      vi.advanceTimersByTime(5000);
+    }
+    expect(
+      events.filter((e: any) => e.phase === 'input_progress' && e.name === 'write_progress'),
+    ).toHaveLength(120);
+    observer.close();
+    const count = events.length;
+    observer.observe(fact);
+    vi.advanceTimersByTime(120_000);
+    expect(events).toHaveLength(count);
+    expect(() => {
+      const broken = createWriteProgressObserver(() => {
+        throw new Error('sink unavailable');
+      });
+      broken.observe(fact);
+      broken.close();
+    }).not.toThrow();
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test('Write trace projection revalidates persisted metadata and never trusts raw IDs', () => {
+  const diagnostic = sanitizeWriteProgress({
+    ...fact,
+    inputBytes: 44,
+    errorKind: 'schema_invalid',
+  });
+  const result = projectWriteProgressDiagnostic({
+    ...diagnostic,
+    content: 'SECRET',
+    stack: '/private/path',
+    callID: 'private-id',
+    phase: 'validation_failed',
+    messageID: 'private-message',
+  });
+  expect(result).toMatchObject({
+    inputBytes: 44,
+    errorKind: 'schema_invalid',
+    phase: 'validation_failed',
+  });
+  expect(JSON.stringify(result)).not.toMatch(/SECRET|private/);
+  expect(
+    projectWriteProgressDiagnostic({ ...diagnostic, toolCallIdHash: '/private/path' }),
+  ).toBeNull();
+  expect(projectWriteProgressDiagnostic({ ...diagnostic, version: 2 })).toBeNull();
+});

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -11,6 +11,7 @@ import {
   acpToolName,
   isAcpPartialRedactToolName,
 } from '../src/agent-protocol/acp/updates.js';
+import { runtimeEmissionCountsAsAgentProgress, runtimeStdoutCountsAsAgentProgress } from '../src/runtimes/chat-run-lifecycle.js';
 import { countNewArtifacts } from '../src/runtimes/run-artifacts.js';
 import { excludeAcpImagePathsAlreadyDeliveredAsResources } from '../src/runtimes/chat-prompt-inputs.js';
 
@@ -4014,4 +4015,96 @@ test('Write diagnostics reject foreign sessions and unknown versions without raw
     events.some((e) => e.name?.startsWith('write_progress') || e.label === 'write_progress'),
   ).toBe(false);
   expect(JSON.stringify(events)).not.toContain('SECRET');
+});
+
+
+test.each(['execution_returned', 'result_observed'])(
+  'Write close flush retains an unterminated %s frame', (phase) => {
+    vi.useFakeTimers();
+    try {
+      const child = new FakeAcpChild();
+      const events: any[] = [];
+      attachAcpSession({
+        child: child as never,
+        prompt: 'hi',
+        modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE',
+        send: (_, payload) => events.push(payload),
+      });
+      writeAcpResult(child, 1, {});
+      writeAcpResult(child, 2, { sessionId: 'session' });
+      const frame = (phase: string) => JSON.stringify({
+        method: 'session/update',
+        params: { sessionId: 'session', update: {
+          sessionUpdate: 'write_progress', version: 1, phase, atMs: 100,
+          callID: 'write', messageID: 'assistant',
+        } },
+      });
+      child.stdout.write(frame('execution_started') + '\n');
+      child.stdout.write(frame(phase));
+      child.emit('close', 1, null);
+      expect(events).toContainEqual(expect.objectContaining({ name: 'write_progress', phase }));
+      const snapshots = events.filter((e) => e.reason === 'session_closed');
+      if (phase === 'result_observed') expect(snapshots).toHaveLength(0);
+      else expect(snapshots).toEqual([expect.objectContaining({ executionSettled: true })]);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  },
+);
+
+test('Write diagnostics do not refresh the progress clock or outer inactivity timer', async () => {
+  vi.useFakeTimers();
+  try {
+    const child = new FakeAcpChild();
+    let lastAgentActivityAt = Date.now();
+    let inactivityTimer: ReturnType<typeof setTimeout>;
+    const timedOut = vi.fn();
+    const noteAgentActivity = () => {
+      lastAgentActivityAt = Date.now();
+      clearTimeout(inactivityTimer);
+      inactivityTimer = setTimeout(timedOut, 1000);
+    };
+    child.stdout.on('data', () => {
+      if (runtimeStdoutCountsAsAgentProgress('acp-json-rpc')) noteAgentActivity();
+    });
+    const session = attachAcpSession({
+      child: child as never,
+      prompt: 'hi',
+      stageTimeoutMs: 0,
+      modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE',
+      onAgentActivity: noteAgentActivity,
+      send: (event, _payload, meta) => {
+        if (runtimeEmissionCountsAsAgentProgress(event, meta)) noteAgentActivity();
+      },
+    });
+    writeAcpResult(child, 1, {});
+    writeAcpResult(child, 2, { sessionId: 'session' });
+    await vi.advanceTimersByTimeAsync(100);
+    // Even an ordinary RPC without a projected agent event is activity.
+    child.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: 999, result: {} }) + '\n');
+    const lastProgress = Date.now();
+    expect(lastAgentActivityAt).toBe(lastProgress);
+    for (let i = 0; i < 4; i++) {
+      await vi.advanceTimersByTimeAsync(200);
+      const frame = JSON.stringify({ method: 'session/update', params: {
+        sessionId: 'session', update: { sessionUpdate: 'write_progress', version: 1,
+          phase: 'input_progress', atMs: Date.now(), callID: 'write', messageID: 'assistant', inputBytes: i },
+      } }) + '\n';
+      // Chunk boundaries cannot turn private diagnostics into activity.
+      child.stdout.write(frame.slice(0, 25));
+      child.stdout.write(frame.slice(25));
+      expect(lastAgentActivityAt).toBe(lastProgress);
+    }
+    await vi.advanceTimersByTimeAsync(199);
+    expect(timedOut).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(timedOut).toHaveBeenCalledOnce();
+    expect(session.hasFatalError()).toBe(false);
+    session.abort();
+    expect(lastAgentActivityAt).toBe(lastProgress);
+    expect(vi.getTimerCount()).toBe(0);
+  } finally {
+    vi.useRealTimers();
+  }
 });

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -3879,3 +3879,139 @@ test('createJsonLineStream still assembles a legitimate multiline JSON response'
 
   assert.deepEqual(received.map((message) => message.id), [5]);
 });
+
+test('Write progress is retained as a private diagnostic without raw payload', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: any }> = [];
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'hi',
+    cwd: '/tmp/test',
+    model: null,
+    modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE',
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session' });
+  child.stdout.write(
+    JSON.stringify({
+      method: 'session/update',
+      params: {
+        sessionId: 'session',
+        update: {
+          sessionUpdate: 'write_progress',
+          version: 1,
+          phase: 'input_started',
+          atMs: 100,
+          callID: 'secret-call',
+          messageID: 'private-message',
+          inputBytes: 0,
+          inputEnded: false,
+          content: 'SECRET',
+        },
+      },
+    }) + '\n',
+  );
+  session.abort();
+  const progress = events.filter((e) => e.payload.name === 'write_progress');
+  expect(progress).toHaveLength(1);
+  expect(progress[0]?.payload).toMatchObject({
+    phase: 'input_started',
+    inputBytes: 0,
+    inputEnded: false,
+  });
+  expect(JSON.stringify(progress)).not.toContain('SECRET');
+  expect(JSON.stringify(progress)).not.toContain('secret-call');
+});
+
+test('Write diagnostics never extend the response timeout or become visible output', async () => {
+  vi.useFakeTimers();
+  try {
+    const child = new FakeAcpChild();
+    const events: Array<{ event: string; payload: any }> = [];
+    const session = attachAcpSession({
+      child: child as never,
+      prompt: 'hi',
+      stageTimeoutMs: 1000,
+      modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE',
+      send: (event, payload) => events.push({ event, payload }),
+    });
+    writeAcpResult(child, 1, {});
+    writeAcpResult(child, 2, { sessionId: 'session' });
+    for (let i = 0; i < 4; i++) {
+      await vi.advanceTimersByTimeAsync(200);
+      child.stdout.write(
+        JSON.stringify({
+          method: 'session/update',
+          params: {
+            sessionId: 'session',
+            update: {
+              sessionUpdate: 'write_progress',
+              version: 1,
+              phase: 'input_progress',
+              atMs: Date.now(),
+              callID: 'write',
+              messageID: 'assistant',
+              inputBytes: i,
+            },
+          },
+        }) + '\n',
+      );
+    }
+    await vi.advanceTimersByTimeAsync(200);
+    expect(session.hasFatalError()).toBe(true);
+    expect(
+      events.some(
+        (e) => e.event === 'error' && e.payload.error.details.kind === 'acp_stage_timeout',
+      ),
+    ).toBe(true);
+    expect(
+      events.some((e) => ['text_delta', 'tool_result', 'tool_in_flight'].includes(e.payload.type)),
+    ).toBe(false);
+    expect(events.filter((e) => e.payload.name === 'write_progress_snapshot')).toHaveLength(1);
+    expect(vi.getTimerCount()).toBe(0);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test('Write diagnostics reject foreign sessions and unknown versions without raw status fallback', () => {
+  const child = new FakeAcpChild();
+  const events: any[] = [];
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'hi',
+    modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE',
+    send: (_, payload) => events.push(payload),
+  });
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session' });
+  for (const [sessionId, version] of [
+    ['foreign', 1],
+    ['session', 2],
+  ]) {
+    child.stdout.write(
+      JSON.stringify({
+        method: 'session/update',
+        params: {
+          sessionId,
+          update: {
+            sessionUpdate: 'write_progress',
+            version,
+            phase: 'input_started',
+            atMs: 100,
+            callID: 'secret',
+            messageID: 'private',
+            content: 'SECRET',
+          },
+        },
+      }) + '\n',
+    );
+  }
+  session.abort();
+  expect(
+    events.some((e) => e.name?.startsWith('write_progress') || e.label === 'write_progress'),
+  ).toBe(false);
+  expect(JSON.stringify(events)).not.toContain('SECRET');
+});

--- a/docs/write-progress-diagnostics.md
+++ b/docs/write-progress-diagnostics.md
@@ -1,0 +1,56 @@
+# Write progress diagnostics
+
+The AMR ACP adapter accepts private version 1 `sessionUpdate: write_progress`
+notifications from Vela only during the active prompt and for its ACP session.
+Vela must also match the OpenCode session and current assistant message before
+forwarding `session.write_progress` events. Older producers provide no coverage;
+absence of these records is not evidence that a Write never started.
+
+The daemon stores sanitized `agent` diagnostics in the existing run event log
+and diagnostics export. The existing Langfuse reliability path receives the same
+allowlisted fields after a second validation. There is no new endpoint, setting,
+telemetry destination, or UI/CLI action.
+
+## Reading the evidence
+
+- `input_started`, `input_progress`, `input_ended`: observed argument stream,
+  cumulative UTF-8 bytes and delta count, and first/last delta timestamps.
+- `arguments_ready`: parsed argument availability; `hasContent` and `hasFilePath`
+  report string-field presence without retaining either value.
+- `validation_failed`: rejected arguments, including the invalid-tool fallback.
+  A generic `tool_error` does not prove JSON parsing versus schema validation.
+- `execution_started`, `permission_requested`, `file_write_started`,
+  `file_write_finished`, `postprocess_started`, `execution_returned`: producer
+  execution boundaries. File write completion does not prove subsequent
+  formatting/LSP work or delivery of a tool result finished.
+- `result_observed`: the processor observed a result/error for the tool call.
+- `stream_finished`, `stream_failed`, `interrupted`: stream evidence, independent
+  of tool execution and result delivery. Stream completion is not tool success.
+
+`write_progress_snapshot` is host evidence. It records the last received facts,
+separate execution phase/result observation, and host-clock `silentForMs` after
+60 seconds without an accepted update or when the ACP session closes. It does
+not classify the root cause, fail the task, or synthesize a successful result.
+Producer `atMs` and delta timestamps must not be subtracted from host timestamps
+when clocks differ. All counters mean observed transport data, not bytes committed
+to disk. Execution and stream events can arrive interleaved.
+
+## Bounds and privacy
+
+Each prompt retains at most 64 message/call pairs. Each pair accepts each phase
+once and up to 120 progress frames, at least five seconds apart. A progress cap
+does not discard a later distinct error/result phase. Snapshots are emitted once
+per observed silence interval plus one on close for calls without a result.
+Missing later progress can therefore also mean capped or incomplete coverage.
+
+IDs are hashed before persistence. Payloads contain fixed phases/error categories,
+booleans, bounded safe integers, and hashes. Argument text, file paths, context,
+error messages and stacks are excluded. Unknown versions or malformed metadata
+are dropped before generic status projection. Vela also writes bounded-category
+error records to its existing stderr with hashed IDs.
+
+Diagnostic frames and snapshots never reset the ACP response or Vela inactivity
+watchdogs, count as visible output, trigger retries/cancellation, or replay Write.
+This change does not identify or repair the underlying stall. Producer, bridge,
+and consumer must ship together for complete evidence; packaging updates and
+Windows packaged acceptance remain separate work.


### PR DESCRIPTION
## Why

A user-supplied Windows diagnostics bundle showed a Write with only `{title: "write"}` followed by 30 minutes without a terminal tool result. The existing evidence establishes an outstanding Write, but cannot locate the wait in argument streaming, validation, filesystem execution, postprocessing, or result delivery. OPEND-2885 needs that evidence before its original root cause can be repaired.

This is a separate observability PR. It does not add changes to the cleanup/cancellation PR #7959 or the corresponding Vela #1951.

## What users will see

With the matching OpenCode producer and Vela bridge installed, exported diagnostics and the existing scrubbed Langfuse trace include Write phase, argument byte/delta counts, field-presence flags, timestamps, and fixed error categories. Host snapshots retain the last evidence after 60 seconds of silence and at session close, distinguishing execution return from observed tool result.

There is no new action or setting. This internal diagnostic capability uses the existing run log/export and reliability trace path; no separate UI/CLI operation applies.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — private version 1 ACP extension, projected into the existing agent diagnostic stream; no new HTTP endpoint or public SDK contract.
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Not applicable: no UI change.

## Bug fix verification

- New regression in `apps/daemon/tests/acp.test.ts`: `Write progress is retained as a private diagnostic without raw payload`. It went red on the main baseline (the frame was dropped) and green on this branch.
- Fake-clock integration proves diagnostic frames do not extend the existing ACP response timeout, create visible output/tool results, or leave timers after close.
- Additional tests cover session/version rejection, privacy, bounded fields/call count/sampling, sink failure isolation, stream-versus-execution state, and revalidation at the outbound trace boundary.

## Validation

- `pnpm guard`: passed.
- `pnpm typecheck`: passed across the repository; daemon typecheck rerun after the trace projection changes passed.
- `pnpm --filter @open-design/daemon build`: passed.
- Daemon Vitest: `tests/acp.test.ts`, `tests/acp-write-progress.test.ts`, `tests/langfuse-bridge.test.ts`: 196 passed.

## Scope, privacy, and integration

The adapter accepts only AMR-discriminated active-session metadata and rebuilds every retained field. Raw IDs are hashed; content, paths, arbitrary metadata, error messages, and stacks are excluded. Unknown versions are dropped before generic status projection. Calls, phase emissions, progress sampling, and silence snapshots are bounded. Langfuse receives a second allowlist validation on the existing reliability path, with no new destination.

No timeout value, retry/replay, cancellation, failure classification, or existing tool-error mapping is changed. The snapshots report observed silence, not a proven disk or provider failure. Capped/unavailable coverage remains possible. This PR does not close OPEND-2885.

Companion bridge: https://github.com/powerformer/vela/pull/1960. Complete evidence also requires the private producer on OpenCode's `powerformer-v1.18.1` branch. Runtime pinning, shipping, and Windows packaged acceptance remain separate. See `docs/write-progress-diagnostics.md` for field semantics and limits.

Private producer PR: https://github.com/powerformer/opencode/pull/17.
