### PR TITLE
fix(daemon): keep proxy Basic credentials off the export tool-token lane

### DIFF
--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -658,8 +658,15 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
     } = {},
   ): Promise<AuthorizedExportRead | null> {
     const authorization = req.get('authorization');
+    // Only Bearer credentials can be run-scoped tool tokens: that is the sole
+    // shape `bearerTokenFromRequest` parses. A reverse proxy that authenticates
+    // browsers itself (Coolify/Traefik basic auth) forwards its own
+    // `Authorization: Basic ...` header, and claiming those for the tool lane
+    // fails every browser export with TOOL_TOKEN_MISSING. Foreign Bearer
+    // tokens still fail closed inside the registry.
     if (
       typeof authorization === 'string'
+      && /^Bearer\s+/i.test(authorization.trim())
       && !ctx.isApiTokenAuthorization(authorization)
     ) {
       const grant = ctx.auth.authorizeToolRequest(

--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -664,9 +664,13 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
     // `Authorization: Basic ...` header, and claiming those for the tool lane
     // fails every browser export with TOOL_TOKEN_MISSING. Foreign Bearer
     // tokens still fail closed inside the registry.
+    // The scheme is classified independently of whether a token follows it: a
+    // bare `Bearer` (or `Bearer ` trimmed to it) is still a caller reaching for
+    // the tool-token lane and must keep failing closed with TOOL_TOKEN_MISSING
+    // rather than downgrading to browser project authority.
     if (
       typeof authorization === 'string'
-      && /^Bearer\s+/i.test(authorization.trim())
+      && /^Bearer(?:\s|$)/i.test(authorization.trim())
       && !ctx.isApiTokenAuthorization(authorization)
     ) {
       const grant = ctx.auth.authorizeToolRequest(

--- a/apps/daemon/tests/export-tool-token-authority.test.ts
+++ b/apps/daemon/tests/export-tool-token-authority.test.ts
@@ -514,6 +514,28 @@ describe('od export run-scoped project authority', () => {
     expect(archiveResponse.status).toBe(200);
   });
 
+  it.each([
+    ['a malformed Bearer credential with no token', 'Bearer '],
+    ['a bare Bearer scheme', 'Bearer'],
+  ] as const)('fails closed on %s', async (_label, authorization) => {
+    // Given: a Bearer scheme carrying no token. Trimming reduces `Bearer ` to
+    // `Bearer`, so scheme detection must not depend on a token following it.
+    const request = {
+      method: 'POST',
+      headers: { authorization, 'content-type': 'application/json' },
+      body: JSON.stringify({ fileName: 'index.html' }),
+    } as const;
+
+    // When: it reaches an export surface that succeeds headerless.
+    const response = await fetch(`${daemonUrl}/api/projects/${unboundProjectId}/export/image`, request);
+    const body = await response.text();
+
+    // Then: it stays on the tool-token lane and fails closed, rather than
+    // downgrading to the browser project-authority lane.
+    expect(response.status, body).toBe(401);
+    expect(JSON.parse(body)).toMatchObject({ error: { code: 'TOOL_TOKEN_MISSING' } });
+  });
+
   it('still routes foreign Bearer credentials to the run-scoped tool-token lane', async () => {
     // Given: a Bearer credential that is neither the daemon API token nor a minted grant.
     const request = {

--- a/apps/daemon/tests/export-tool-token-authority.test.ts
+++ b/apps/daemon/tests/export-tool-token-authority.test.ts
@@ -490,6 +490,51 @@ describe('od export run-scoped project authority', () => {
     });
   });
 
+  it('treats a forwarded foreign Basic credential as a proxy-authenticated browser request', async () => {
+    // Given: a reverse proxy (Coolify/Traefik basic auth) authenticates the
+    // browser itself and forwards its own credential to the daemon.
+    const proxyCredential = `Basic ${Buffer.from('proxy-user:proxy-pass').toString('base64')}`;
+
+    // When: the browser export and archive surfaces are reached through it.
+    const exportResponse = await fetch(`${daemonUrl}/api/projects/${unboundProjectId}/export/image`, {
+      method: 'POST',
+      headers: { authorization: proxyCredential, 'content-type': 'application/json' },
+      body: JSON.stringify({ fileName: 'index.html' }),
+    });
+    const exportBody = Buffer.from(await exportResponse.arrayBuffer());
+    const archiveResponse = await fetch(`${daemonUrl}/api/projects/${unboundProjectId}/archive`, {
+      headers: { authorization: proxyCredential },
+    });
+    await archiveResponse.arrayBuffer();
+
+    // Then: the header never claims the run-scoped tool lane, so both stay on
+    // project authorization exactly like a header-free browser request.
+    expect(exportResponse.status, exportBody.toString()).toBe(200);
+    expect(exportBody).toEqual(png);
+    expect(archiveResponse.status).toBe(200);
+  });
+
+  it('still routes foreign Bearer credentials to the run-scoped tool-token lane', async () => {
+    // Given: a Bearer credential that is neither the daemon API token nor a minted grant.
+    const request = {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer forged-tool-token',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ fileName: 'index.html' }),
+    } as const;
+
+    // When: it is presented to the same otherwise-headerless export surface.
+    const response = await fetch(`${daemonUrl}/api/projects/${unboundProjectId}/export/image`, request);
+
+    // Then: the tool lane still fails closed instead of downgrading to project auth.
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'TOOL_TOKEN_INVALID' },
+    });
+  });
+
   async function runExportCli(
     requestedProjectId: string,
     outputPath: string,


### PR DESCRIPTION
Fixes #7819

## Why

Reported by @airano-ir, who hit this running OD behind a reverse proxy: on any deployment where the proxy authenticates browsers with its own HTTP Basic credentials and forwards the `Authorization` header to the daemon (Coolify's native HTTP Basic Auth, Traefik `basicAuth` without header stripping), **every** browser export and archive request fails with `401 {"error":{"code":"TOOL_TOKEN_MISSING"}}`. Plain browsing, chat and preview keep working, so it looks like the export feature is broken rather than an auth misroute.

`authorizeExportRead` treats any `Authorization` header that is not `OD_API_TOKEN` as a run-scoped agent tool-token call. But tool tokens are only ever parsed out of a `Bearer` header — `bearerTokenFromRequest` matches `/^Bearer\s+(.+)$/i` and nothing else — so a forwarded `Basic` credential can never satisfy that lane. It is a guaranteed failure, not a race or a config edge. With `OD_DISABLE_API_AUTH=1` (the documented setup when a trusted proxy already authenticates every request) `isApiTokenAuthorization` is always false, so no credential can select the project-auth lane once a proxy forwards a Basic header.

The root-cause analysis and the Bearer-gate approach are @airano-ir's, from the #7819 report; a maintainer confirmed the direction on the issue. This PR adds independent verification and regression coverage.

## What users will see

Behind a reverse proxy that forwards its own Basic credentials, the export and download menu items work again — "Export as standalone HTML", PPTX / PDF / image export, and "Download as .zip". Previously every one of them failed with a 401 and no useful message.

No change for desktop, packaged, or loopback users: the web client sends no `Authorization` header of its own, so those requests never entered this branch. Agent tool-token calls are unaffected — foreign `Bearer` tokens still fail closed with `TOOL_TOKEN_INVALID` / `TOOL_TOKEN_EXPIRED` exactly as before.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — no new endpoint or contract shape; changes which auth lane existing `/api/projects/:id/export*` and `/api/projects/:id/archive*` routes select for a non-Bearer `Authorization` header
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**

All eight affected routes share one helper, so the single gate covers `export/{html,pptx,pdf-image,image}`, the generic `export` route, `archive`, `archive/batch`, and the inline-HTML route.

## Screenshots

n/a — no UI change.

## Bug fix verification

- **Test path that reproduces the bug:** `apps/daemon/tests/export-tool-token-authority.test.ts` → `treats a forwarded foreign Basic credential as a proxy-authenticated browser request`
- **Did the test go red on `main` and green on this branch?** **yes.** On `main` it fails with exactly the reported payload:
  ```
  AssertionError: {"error":{"code":"TOOL_TOKEN_MISSING","message":"tool token is required",
    "details":{"endpoint":"/api/projects/:id/export/:format","operation":"project:export"}}}
    : expected 401 to be 200
  ```
  With the change it passes: export and archive both return 200.

A second test, `still routes foreign Bearer credentials to the run-scoped tool-token lane`, pins the behavior that must **not** change — a forged `Bearer` token still returns `401 TOOL_TOKEN_INVALID`. It passes both with and without the source change, which is the point: it guards against over-correcting the gate into a downgrade path.

## Validation

- `pnpm guard` — pass (exit 0)
- `pnpm --filter @open-design/daemon typecheck` — pass (exit 0)
- `pnpm --filter @open-design/daemon test` (full package suite, 86 min) — **11,322 passed, 34 failed across 13 files, 29 skipped (11,385 tests / 854 files)**

The 34 failures are unrelated to this change and are not caused by it:

- Every export and archive suite passes, including the two new cases.
- The identified failures reproduce on a checkout that does **not** contain this change.
- `tests/integrations/xai/tokens.test.ts` fails because it does `chmod(file, 0o000)` and expects a read to reject; this environment runs as uid 0, and root bypasses permission bits.
- `tests/runtimes/runtime-version-provenance.test.ts` passes 4/4 when run in isolation and fails only alongside other files — pre-existing order dependence, not a behavior change.

**Update:** CI on this PR is authoritative here and is green — `Daemon tests` (all 4 shards), `E2E Vitest`, every `UI P0` shard, `Preflight`, `Static gate` and `Validate workspace` all pass. That confirms the 34 local failures were artifacts of my environment (running as uid 0, plus test-order sensitivity) rather than anything in this change.

Targeted export/archive suites also run individually: `export-tool-token-authority`, `export-tool-token-nonloopback-authority`, `export-inline-route`, `export-cli-routing`, `export-html-cli`, `project-archive`, `deck-export`, `pdf-export` — 122 tests, all passing.
