### PR TITLE
fix(sidecar): bound macOS private IPC socket paths

### DIFF
--- a/packages/sidecar/src/stamp.ts
+++ b/packages/sidecar/src/stamp.ts
@@ -154,7 +154,10 @@ export function resolvePrivateIpcPath(stamp: SidecarStamp, platform: NodeJS.Plat
       })()
     : String(process.getuid?.() ?? process.env.USER ?? "unknown");
   const digest = createHash("sha256").update(`${principal}\n${sidecarStampKey(stamp)}`).digest("hex").slice(0, 32);
-  return platform === "win32"
-    ? `\\\\.\\pipe\\open-design-sidecar-${digest}`
-    : join(tmpdir(), `od-sidecar-${principal}`, `${digest}.sock`);
+  if (platform === "win32") return `\\\\.\\pipe\\open-design-sidecar-${digest}`;
+  const endpoint = join(tmpdir(), `od-sidecar-${principal}`, `${digest}.sock`);
+  // macOS sun_path allows 103 path bytes plus a null terminator.
+  return platform === 'darwin' && Buffer.byteLength(endpoint) > 103
+    ? join('/tmp', `od-sidecar-${principal}`, `${digest}.sock`)
+    : endpoint;
 }

--- a/packages/sidecar/tests/private-ipc-path.test.ts
+++ b/packages/sidecar/tests/private-ipc-path.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { lstat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { createJsonIpcServer, requestJsonIpc } from '../src/json-ipc.js';
+import { resolvePrivateIpcPath, SIDECAR_STAMP_FIELDS, type SidecarStamp } from '../src/stamp.js';
+
+vi.mock('node:os', async (importOriginal) => {
+  const os = await importOriginal<typeof import('node:os')>();
+  return { ...os, tmpdir: vi.fn(os.tmpdir) };
+});
+
+const macTmpdir = '/var/folders/44/fmg2qx4n1wl13f0nrcjctpm4hjtjw_/T/';
+const stamp: SidecarStamp = {
+  channel: 'stable',
+  namespace: 'release-stable',
+  source: 'packaged',
+  mode: 'runtime',
+  app: 'daemon',
+};
+
+beforeEach(() => {
+  vi.mocked(tmpdir).mockReturnValue(macTmpdir);
+  vi.stubGlobal('process', { ...process, getuid: () => 555566986 });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('private sidecar IPC paths', () => {
+  it('fits the macOS socket limit with the reported long temp directory and UID', () => {
+    const endpoint = resolvePrivateIpcPath(stamp, 'darwin');
+
+    expect(Buffer.byteLength(endpoint)).toBeLessThanOrEqual(103);
+    expect(endpoint).toMatch(/[\\/]od-sidecar-555566986[\\/][a-f0-9]{32}\.sock$/);
+    expect(resolvePrivateIpcPath(stamp, 'darwin')).toBe(endpoint);
+  });
+
+  it('measures UTF-8 bytes rather than characters', () => {
+    vi.mocked(tmpdir).mockReturnValue(`/tmp/${'\u00e9'.repeat(20)}`);
+
+    expect(Buffer.byteLength(resolvePrivateIpcPath(stamp, 'darwin'))).toBeLessThanOrEqual(103);
+  });
+
+  it('preserves macOS endpoints that already fit', () => {
+    vi.mocked(tmpdir).mockReturnValue('/tmp');
+    const shortEndpoint = resolvePrivateIpcPath(stamp, 'darwin');
+    vi.mocked(tmpdir).mockReturnValue('/var/tmp');
+
+    expect(resolvePrivateIpcPath(stamp, 'darwin')).toBe(join('/var', shortEndpoint));
+  });
+
+  it('preserves a macOS endpoint at the 103-byte boundary', () => {
+    const tempRoot = `/${'a'.repeat(43)}`;
+    vi.mocked(tmpdir).mockReturnValue(tempRoot);
+    const endpoint = resolvePrivateIpcPath(stamp, 'darwin');
+
+    expect(Buffer.byteLength(endpoint)).toBe(103);
+    expect(dirname(endpoint)).toBe(join(tempRoot, 'od-sidecar-555566986'));
+  });
+
+  it('keeps every stamp field and the OS user in the fallback identity', () => {
+    const endpoint = resolvePrivateIpcPath(stamp, 'darwin');
+    for (const field of SIDECAR_STAMP_FIELDS) {
+      expect(resolvePrivateIpcPath({ ...stamp, [field]: 'other' }, 'darwin')).not.toBe(endpoint);
+    }
+    vi.stubGlobal('process', { ...process, getuid: () => 555566987 });
+    expect(resolvePrivateIpcPath(stamp, 'darwin')).not.toBe(endpoint);
+  });
+
+  it('preserves Linux socket paths', () => {
+    vi.mocked(tmpdir).mockReturnValue('/var/tmp');
+
+    expect(dirname(resolvePrivateIpcPath(stamp, 'linux'))).toBe(join('/var/tmp', 'od-sidecar-555566986'));
+  });
+
+  it('keeps Windows named pipes independent of the temporary directory', () => {
+    const endpoint = resolvePrivateIpcPath(stamp, 'win32');
+    vi.mocked(tmpdir).mockReturnValue('/tmp');
+
+    expect(endpoint).toMatch(/^\\\\\.\\pipe\\open-design-sidecar-[a-f0-9]{32}$/);
+    expect(resolvePrivateIpcPath(stamp, 'win32')).toBe(endpoint);
+  });
+
+  it.skipIf(process.platform !== 'darwin')('binds private sockets for two macOS namespaces with a long TMPDIR', async () => {
+    vi.unstubAllGlobals();
+    vi.mocked(tmpdir).mockReturnValue(`${macTmpdir}${'long'.repeat(30)}`);
+    const endpoints = [0, 1].map(() => resolvePrivateIpcPath({ ...stamp, namespace: randomUUID() }));
+    const servers = [];
+    try {
+      for (const [index, socketPath] of endpoints.entries()) {
+        servers.push(await createJsonIpcServer({ socketPath, handler: () => index }));
+        expect((await lstat(dirname(socketPath))).mode & 0o777).toBe(0o700);
+      }
+      for (const [index, endpoint] of endpoints.entries()) {
+        expect(await requestJsonIpc(endpoint, { type: 'status' })).toBe(index);
+      }
+    } finally {
+      await Promise.all(servers.map((server) => server.close()));
+    }
+    for (const endpoint of endpoints) {
+      await expect(lstat(endpoint)).rejects.toMatchObject({ code: 'ENOENT' });
+    }
+  });
+});


### PR DESCRIPTION
Fixes #7985

## Why

I investigated the macOS startup crash reported in #7985. The active sidecar
resolver combines the system temporary directory, UID directory, and 32-character
digest into a 107-byte pathname for the report's inputs. macOS accepts at most
103 pathname bytes, so the daemon cannot bind its private control socket
([Node IPC documentation](https://nodejs.org/download/release/latest-v16.x/docs/api/net.html#identifying-paths-for-ipc-connections),
[Apple socket definition](https://github.com/apple-oss-distributions/xnu/blob/main/bsd/sys/un.h#L74-L78)).

The vulnerable resolver is present in both current main and the reported release:
[0.22.1 resolver](https://github.com/nexu-io/open-design/blob/open-design-v0.22.1/packages/sidecar/src/stamp.ts#L150-L160)
and [its startup caller](https://github.com/nexu-io/open-design/blob/open-design-v0.22.1/packages/sidecar/src/client.ts#L251-L262).
The shorter `resolveAppIpcPath` helper also exists, but the active client calls
`resolvePrivateIpcPath`. This addresses the path distinction raised in the issue
discussion without assuming anything about the reporter's installed bundle.

## What users will see

On macOS, a long temporary-directory path no longer prevents the sidecar from
starting. Only oversized macOS endpoints fall back to `/tmp`; existing endpoints
that fit, Linux paths, and Windows named pipes retain their current behavior.
The fallback preserves the full hash and UID directory, with the transport's
existing 0700 directory and 0600 socket permissions.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — macOS private IPC location falls back when the existing path exceeds the OS limit.
- [ ] **None**

## Screenshots

Not applicable: no UI changes. Native macOS packaged launch verification is pending.

## Bug fix verification

- Regression: `packages/sidecar/tests/private-ipc-path.test.ts`.
- Red on unmodified main: the reported inputs produce `107 > 103`; a multibyte
  temporary directory produces `104 > 103` bytes. Both assertions pass after the fix.
- Coverage includes the exact 103-byte boundary, valid-path compatibility,
  deterministic stamp/user separation, and Windows/Linux behavior.
- A macOS-only test binds two namespace endpoints, checks private directory
  permissions, exchanges real JSON IPC messages, and verifies socket cleanup.
  It is skipped on this Windows host; it has not been counted as a pass.
- Native verification on macOS: run
  `pnpm --filter @open-design/sidecar test tests/private-ipc-path.test.ts`, then
  launch a packaged build with a long `TMPDIR` and confirm daemon startup.

## Validation

- `pnpm guard` — passed.
- `pnpm typecheck` — passed across the full workspace, including root scripts.
- `pnpm --filter @open-design/sidecar build` — passed.
- `pnpm --filter @open-design/sidecar typecheck` — passed for source and tests.
- `pnpm --filter @open-design/sidecar test tests/private-ipc-path.test.ts` — 7 passed,
  1 skipped (native macOS socket test).
- `pnpm --filter @open-design/sidecar test` — 52 passed, 2 skipped, 5 failed in
  Windows lifecycle tests on the first full run.
- Rebuilt unmodified `main@07170f8d2` and reran those same five lifecycle cases:
  3 passed and 2 failed. Restored/rebuilt this fix and repeated the same selection:
  the same 3 passed and the same 2 failed. The new path tests also passed in that
  comparison. This is not a claim that the full suite is green.
- `git diff --check` and scoped source/test review — passed.

This PR is a draft pending native macOS verification and CI/reviewer assessment
of the baseline lifecycle failures below. No macOS packaged launch was performed
on this Windows host.

## Adjacent issues

Two existing Windows lifecycle cases fail identically on upstream and this fix:

- `keeps distribution channels isolated and force-stops only an exact argv stamp`
  — timeout at `tests/convergence.test.ts:789` while waiting for process discovery
  to report no remaining stable generation.
- `re-observes a transient second root before mutating the surviving generation`
  — exceeds the test's 10-second timeout.

The other three first-run failures passed in both isolated comparisons. I have
not changed their timing, assertions, or process implementation as part of this
macOS pathname fix. No unrelated source, dependency, release, or legacy-endpoint
changes are included.
