### PR TITLE
fix(cms): preserve authorized actions and correct modal and hover behavior

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -156,20 +156,34 @@ function configuredAllowedDevHosts(): string[] {
   ]));
 }
 
+/** Files that define the client host contract reported with CMS Test acceptances. */
+export const CMS_HOST_RELEASE_INPUTS = [
+  'apps/web/src/components/touchpoint-component.ts',
+  'apps/web/src/components/touchpoint-static-actions.ts',
+  'apps/web/src/components/TestCampaignModal.tsx',
+  'apps/web/src/components/ProductionCampaignModal.tsx',
+  'apps/web/src/components/ProductionCampaignBadge.tsx',
+  'apps/web/src/components/ProductionCampaignHover.tsx',
+  'apps/web/src/components/HoverTouchpointOverlay.tsx',
+  'apps/web/src/components/HoverTouchpointOverlay.module.css',
+  'packages/contracts/src/touchpoint-component-v2.ts',
+] as const;
+
+export function cmsHostReleaseFingerprint(
+  readFile: (file: (typeof CMS_HOST_RELEASE_INPUTS)[number]) => string | Buffer,
+): string {
+  return `sha256:${CMS_HOST_RELEASE_INPUTS.reduce(
+    (hash, file) => hash.update(file).update('\0').update(readFile(file)),
+    createHash('sha256'),
+  ).digest('hex')}`;
+}
+
 const nextConfig: NextConfig = {
   env: {
     // Embedded in the client at build time. Packaged servers use the already
     // compiled client and need not retain source files to load this config.
     NEXT_PUBLIC_CMS_HOST_RELEASE: existsSync(resolve(WEB_ROOT, 'src/components/touchpoint-component.ts'))
-      ? `sha256:${[
-          'apps/web/src/components/touchpoint-component.ts',
-          'apps/web/src/components/touchpoint-static-actions.ts',
-          'apps/web/src/components/TestCampaignModal.tsx',
-          'apps/web/src/components/ProductionCampaignModal.tsx',
-          'apps/web/src/components/ProductionCampaignBadge.tsx',
-          'apps/web/src/components/ProductionCampaignHover.tsx',
-          'packages/contracts/src/touchpoint-component-v2.ts',
-        ].reduce((hash, file) => hash.update(file).update('\0').update(readFileSync(resolve(WORKSPACE_ROOT, file))), createHash('sha256')).digest('hex')}`
+      ? cmsHostReleaseFingerprint((file) => readFileSync(resolve(WORKSPACE_ROOT, file)))
       : undefined,
   },
   allowedDevOrigins: configuredAllowedDevHosts(),

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -156,16 +156,31 @@ function configuredAllowedDevHosts(): string[] {
   ]));
 }
 
-/** Files that define the client host contract reported with CMS Test acceptances. */
+/**
+ * Direct inputs to the client host contract reported with CMS Test acceptances.
+ *
+ * Keep this closure at the host boundary: the touchpoint adapters and their
+ * presentation assets, the production decision loader, and the app/shell
+ * modules that mount or position those hosts. Broad shared application styles
+ * are intentionally excluded; including the whole app graph would turn an
+ * unrelated shell change into a CMS host release.
+ */
 export const CMS_HOST_RELEASE_INPUTS = [
+  'apps/web/app/layout.tsx',
+  'apps/web/src/App.tsx',
+  'apps/web/src/components/EntryNavRail.tsx',
+  'apps/web/src/components/EntryShell.tsx',
   'apps/web/src/components/touchpoint-component.ts',
   'apps/web/src/components/touchpoint-static-actions.ts',
   'apps/web/src/components/TestCampaignModal.tsx',
+  'apps/web/src/components/TestCampaignModal.module.css',
   'apps/web/src/components/ProductionCampaignModal.tsx',
   'apps/web/src/components/ProductionCampaignBadge.tsx',
+  'apps/web/src/components/ProductionCampaignBadge.module.css',
   'apps/web/src/components/ProductionCampaignHover.tsx',
   'apps/web/src/components/HoverTouchpointOverlay.tsx',
   'apps/web/src/components/HoverTouchpointOverlay.module.css',
+  'apps/web/src/components/production-touchpoint-loader.ts',
   'packages/contracts/src/touchpoint-component-v2.ts',
 ] as const;
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -89,7 +89,6 @@ import {
 import { PrivacyConsentModal } from './components/PrivacyConsentModal';
 import { TestCampaignModal } from './components/TestCampaignModal';
 import { ProductionCampaignModal } from './components/ProductionCampaignModal';
-import { ProductionCampaignHover } from './components/ProductionCampaignHover';
 import {
   daemonIsLive,
   fetchAppVersionInfo,
@@ -5581,10 +5580,6 @@ function AppInner() {
         sessionSubject={amrLoginStatus?.user?.id ?? null}
       />
       <ProductionCampaignModal
-        authenticated={isAmrSessionAuthenticated(amrLoginStatus)}
-        sessionSubject={amrLoginStatus?.user?.id ?? null}
-      />
-      <ProductionCampaignHover
         authenticated={isAmrSessionAuthenticated(amrLoginStatus)}
         sessionSubject={amrLoginStatus?.user?.id ?? null}
       />

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -168,6 +168,7 @@ import { resolveDeepSeekV4FlashCampaignAudience } from '../campaigns/deepseek-v4
 import { useDeepSeekV4FlashCampaignVisibility } from '../campaigns/use-deepseek-v4-flash-campaign';
 import { WorkbenchCampaignBadge } from './WorkbenchCampaignBadge';
 import { canRenderProductionCampaignBadge, ProductionCampaignBadge } from './ProductionCampaignBadge';
+import { ProductionCampaignHover } from './ProductionCampaignHover';
 import {
   beginWorkspaceScopedRead,
   workspaceIdentityCacheKey,
@@ -1698,7 +1699,7 @@ export function EntryShell({
           }}
           onOpenSearch={() => setProjectSearchOpen(true)}
           open={railOpen}
-          topRightSlot={topRightCampaignAudience || canRenderProductionCampaignBadge(amrLoggedIn === true, amrAccountId) ? (
+          topRightSlot={topRightCampaignAudience || amrLoggedIn === true ? (
             <>
               {topRightCampaignAudience ? (
                 <WorkbenchCampaignBadge
@@ -1710,6 +1711,12 @@ export function EntryShell({
                 />
               ) : null}
               {canRenderProductionCampaignBadge(amrLoggedIn === true, amrAccountId) ? <ProductionCampaignBadge authenticated sessionSubject={amrAccountId} /> : null}
+              {/* The requirements-specific hover entry is its own authorized
+                  touchpoint, beside—not renamed from—the account badge. */}
+              <ProductionCampaignHover
+                authenticated={amrLoggedIn === true}
+                sessionSubject={amrAccountId}
+              />
             </>
           ) : null}
           context={railWorkspaceContext}

--- a/apps/web/src/components/HoverTouchpointOverlay.module.css
+++ b/apps/web/src/components/HoverTouchpointOverlay.module.css
@@ -1,5 +1,5 @@
 .root { display: contents; }
-.entry { position: fixed; right: 16px; bottom: 88px; z-index: 101; display: block; min-width: 24px; min-height: 24px; }
+.entry { position: relative; z-index: 101; display: block; min-width: 24px; min-height: 24px; }
 .overlayRoot { position: fixed; inset: 0; z-index: 100; pointer-events: none; }
 .layer { position: fixed; display: block; overflow: auto; pointer-events: auto; }
 .entry[hidden], .layer[hidden] { display: none; }

--- a/apps/web/src/components/HoverTouchpointOverlay.tsx
+++ b/apps/web/src/components/HoverTouchpointOverlay.tsx
@@ -76,6 +76,32 @@ export function placeHoverOverlay(
 	});
 }
 
+/**
+ * Returns the physical gap shared by vertically adjacent entry and layer
+ * rectangles. The overlap requirement prevents an unrelated side exit from
+ * becoming a permissive hover region.
+ */
+export function hoverBridgeRect(anchor: Rect, layer: Rect): Rect | undefined {
+	const left = Math.max(anchor.left, layer.left);
+	const right = Math.min(anchor.right, layer.right);
+	if (right <= left) return undefined;
+	if (anchor.bottom <= layer.top) {
+		return { left, right, top: anchor.bottom, bottom: layer.top, width: right - left, height: layer.top - anchor.bottom };
+	}
+	if (layer.bottom <= anchor.top) {
+		return { left, right, top: layer.bottom, bottom: anchor.top, width: right - left, height: anchor.top - layer.bottom };
+	}
+	return undefined;
+}
+
+function pointIsInRect(point: Pick<PointerEvent, "clientX" | "clientY">, rect: Rect | undefined) {
+	return Boolean(
+		rect &&
+			point.clientX >= rect.left && point.clientX <= rect.right &&
+			point.clientY >= rect.top && point.clientY <= rect.bottom,
+	);
+}
+
 function viewportRect(): Rect {
 	const visual = window.visualViewport;
 	const left = visual?.offsetLeft ?? 0;
@@ -129,6 +155,7 @@ export function HoverTouchpointOverlay({
 	const layerRef = useRef<HTMLElement>(null);
 	const restoreFocusRef = useRef<HTMLElement | null>(null);
 	const restoringFocusRef = useRef(false);
+	const pointerIsInBridgeRef = useRef(false);
 	const [position, setPosition] = useState<HoverOverlayPosition>();
 	const [elementReady, setElementReady] = useState(() =>
 		typeof customElements !== "undefined" && customElements.get("opend-touchpoint") !== undefined,
@@ -139,6 +166,7 @@ export function HoverTouchpointOverlay({
 	}, []);
 
 	const close = useCallback((restoreFocus = false) => {
+		pointerIsInBridgeRef.current = false;
 		setOpen(false);
 		if (restoreFocus) {
 			restoringFocusRef.current = true;
@@ -146,6 +174,26 @@ export function HoverTouchpointOverlay({
 			restoringFocusRef.current = false;
 		}
 	}, []);
+	const openHover = useCallback(() => {
+		pointerIsInBridgeRef.current = false;
+		setOpen(true);
+	}, []);
+	const pointerIsInBridge = useCallback((event: Pick<PointerEvent, "clientX" | "clientY">) => {
+		const anchor = entryRef.current?.getBoundingClientRect();
+		const layer = layerRef.current?.getBoundingClientRect();
+		return Boolean(anchor && layer && pointIsInRect(event, hoverBridgeRect(anchor, layer)));
+	}, []);
+	const schedulePointerClose = useCallback((event: React.PointerEvent) => {
+		pointerIsInBridgeRef.current = pointerIsInBridge(event.nativeEvent);
+		if (!pointerIsInBridgeRef.current) close();
+	}, [close, pointerIsInBridge]);
+	useEffect(() => {
+		const closeWhenLeavingBridge = (event: PointerEvent) => {
+			if (pointerIsInBridgeRef.current && !pointerIsInBridge(event)) close();
+		};
+		document.addEventListener("pointermove", closeWhenLeavingBridge);
+		return () => document.removeEventListener("pointermove", closeWhenLeavingBridge);
+	}, [close, pointerIsInBridge]);
 	const refreshPosition = useCallback(() => {
 		const anchor = entryRef.current?.getBoundingClientRect();
 		const overlay = layerRef.current?.getBoundingClientRect();
@@ -294,6 +342,8 @@ export function HoverTouchpointOverlay({
 		return () => window.removeEventListener("keydown", keydown);
 	}, [open, close]);
 
+	const relatedTargetIsInUnion = (relatedTarget: EventTarget | null) =>
+		relatedTarget instanceof Node && rootRef.current?.contains(relatedTarget);
 	const closeIfOutsideUnion = () =>
 		queueMicrotask(() => {
 			const active = document.activeElement;
@@ -317,19 +367,19 @@ export function HoverTouchpointOverlay({
 			tabIndex: 0,
 			"aria-expanded": open,
 			"aria-haspopup": "dialog",
-			onPointerEnter: () => setOpen(true),
+			onPointerEnter: openHover,
 			onPointerLeave: (event: React.PointerEvent) => {
-				if (!rootRef.current?.contains(event.relatedTarget as Node | null))
-					close();
+				if (!relatedTargetIsInUnion(event.relatedTarget))
+					schedulePointerClose(event);
 			},
 			onFocus: () => {
 				restoreFocusRef.current = entryRef.current;
-				if (!restoringFocusRef.current) setOpen(true);
+				if (!restoringFocusRef.current) openHover();
 			},
 			onBlur: closeIfOutsideUnion,
 			// Hover and focus may already have opened the layer before a click.
 			// Activation always opens; Escape/outside focus remain the close paths.
-			onClick: () => setOpen(true),
+			onClick: openHover,
 		}),
 		createElement(
 			"div",
@@ -352,12 +402,12 @@ export function HoverTouchpointOverlay({
 							maxHeight: position.maxHeight,
 						}
 					: undefined,
-				onPointerEnter: () => setOpen(true),
+				onPointerEnter: openHover,
 				onPointerLeave: (event: React.PointerEvent) => {
-					if (!rootRef.current?.contains(event.relatedTarget as Node | null))
-						close();
+					if (!relatedTargetIsInUnion(event.relatedTarget))
+						schedulePointerClose(event);
 				},
-				onFocus: () => setOpen(true),
+				onFocus: openHover,
 				onBlur: closeIfOutsideUnion,
 			}),
 		),

--- a/apps/web/src/components/ProductionCampaignModal.tsx
+++ b/apps/web/src/components/ProductionCampaignModal.tsx
@@ -16,10 +16,14 @@ import {
 	trapWebTouchpointModalFocus,
 	verifyWebTouchpoint,
 	webTouchpointContext,
+	hasWebTouchpointCloseControl,
 	type OpenDesignTouchpointElement,
 	type WebTouchpointContent,
 } from "./touchpoint-component";
-import { emitProductionTouchpointLoadDiagnostic, loadProductionTouchpointDecision } from "./production-touchpoint-loader";
+import {
+	emitProductionTouchpointLoadDiagnostic,
+	loadProductionTouchpointDecision,
+} from "./production-touchpoint-loader";
 import {
 	TestTouchpointMount,
 	recordVisibleTestTouchpoint,
@@ -29,6 +33,7 @@ import type { TestCampaignPlacement, TestDecision } from "./TestCampaignModal";
 import styles from "./TestCampaignModal.module.css";
 const PLACEMENT = "opend.home.campaign-modal";
 const MAX_LEASE_MS = 5 * 60_000;
+export const PRODUCTION_ACTION_TELEMETRY_TIMEOUT_MS = 3_000;
 const supportedCapabilities = new Set(["close", "static-action"]);
 
 type Decision = {
@@ -93,10 +98,17 @@ export async function dispatchProductionCampaignAction(
 		});
 		return false;
 	}
+	let response: Response | undefined;
+	const telemetryController = new AbortController();
+	const telemetryTimeout = setTimeout(
+		() => telemetryController.abort(),
+		PRODUCTION_ACTION_TELEMETRY_TIMEOUT_MS,
+	);
 	try {
-		const response = await fetch("/api/touchpoints/production-runtime/events", {
+		response = await fetch("/api/touchpoints/production-runtime/events", {
 			method: "POST",
 			headers: { "content-type": "application/json" },
+			signal: telemetryController.signal,
 			body: JSON.stringify({
 				touchpointDecisionId: decision.touchpointDecisionId,
 				activityId: decision.activityId,
@@ -105,21 +117,39 @@ export async function dispatchProductionCampaignAction(
 				kind: "click",
 			}),
 		});
-		if (
-			!response.ok ||
-			generation !== currentGeneration() ||
-			expiresAt <= Date.now()
-		) {
-			emitWebTouchpointDiagnostic({
-				code: "touchpoint_action_denied",
-				detail: actionId,
-			});
-			return false;
-		}
+	} catch {
+		emitWebTouchpointDiagnostic({
+			code: "touchpoint_action_telemetry_failed",
+			detail: "network",
+		});
+	} finally {
+		clearTimeout(telemetryTimeout);
+	}
+	if (response && !response.ok && response.status < 500) {
+		emitWebTouchpointDiagnostic({
+			code: "touchpoint_action_denied",
+			detail: actionId,
+		});
+		return false;
+	}
+	if (response && !response.ok && response.status >= 500) {
+		emitWebTouchpointDiagnostic({
+			code: "touchpoint_action_telemetry_failed",
+			detail: `http_${response.status}`,
+		});
+	}
+	if (generation !== currentGeneration() || expiresAt <= Date.now()) {
+		emitWebTouchpointDiagnostic({
+			code: "touchpoint_action_denied",
+			detail: actionId,
+		});
+		return false;
+	}
+	try {
 		if (action.target.kind === "https")
 			await openExternalUrl(action.target.url);
 		else if (internalTarget) window.location.assign(internalTarget.href);
-	else return false;
+		else return false;
 		return true;
 	} catch {
 		emitWebTouchpointDiagnostic({
@@ -145,8 +175,14 @@ export function ProductionCampaignModal({
 	const testRuntime = useTestRuntime();
 	const testDecision = testRuntime?.decisions.get(PLACEMENT);
 	const [testClosed, setTestClosed] = useState(false);
+	const [testCloseControlAvailable, setTestCloseControlAvailable] = useState<
+		boolean | null
+	>(null);
 	const decisionRef = useRef<AuthorizedDecision | null>(null);
 	const [closed, setClosed] = useState(false);
+	const [closeControlAvailable, setCloseControlAvailable] = useState<
+		boolean | null
+	>(null);
 	const elementRef = useRef<HTMLDivElement | null>(null);
 	const modalRef = useRef<HTMLDivElement | null>(null);
 	const expiry = useRef(0);
@@ -194,15 +230,29 @@ export function ProductionCampaignModal({
 			const nextRequestGeneration = ++requestGeneration.current;
 			try {
 				const loaded = await loadProductionTouchpointDecision(
-					PLACEMENT, locale, controller.signal, decisionRef.current?.touchpointDecisionId,
+					PLACEMENT,
+					locale,
+					controller.signal,
+					decisionRef.current?.touchpointDecisionId,
 				);
 				if (!current(nextRequestGeneration)) return;
 				if (loaded.kind === "revoked") {
 					const active = decisionRef.current;
-					if (active && loaded.receipt.touchpointDecisionId === active.touchpointDecisionId && loaded.receipt.deploymentId === active.deploymentId && loaded.receipt.activityId === active.activityId && loaded.receipt.contentVersionId === active.content.id) clear();
+					if (
+						active &&
+						loaded.receipt.touchpointDecisionId ===
+							active.touchpointDecisionId &&
+						loaded.receipt.deploymentId === active.deploymentId &&
+						loaded.receipt.activityId === active.activityId &&
+						loaded.receipt.contentVersionId === active.content.id
+					)
+						clear();
 					return;
 				}
-				if (loaded.kind === "no-decision") { if (!decisionRef.current) clear(); return; }
+				if (loaded.kind === "no-decision") {
+					if (!decisionRef.current) clear();
+					return;
+				}
 				const next = loaded.value as Decision;
 				if (!current(nextRequestGeneration)) return;
 				const deadline = Math.min(
@@ -262,7 +312,11 @@ export function ProductionCampaignModal({
 					Math.max(0, deadline - Date.now()),
 				);
 			} catch (error) {
-				if (!current(nextRequestGeneration) || (error instanceof DOMException && error.name === "AbortError")) return;
+				if (
+					!current(nextRequestGeneration) ||
+					(error instanceof DOMException && error.name === "AbortError")
+				)
+					return;
 				const diagnostic = emitProductionTouchpointLoadDiagnostic(error);
 				if (diagnostic) emitWebTouchpointDiagnostic(diagnostic);
 				clear();
@@ -303,6 +357,8 @@ export function ProductionCampaignModal({
 		const element = document.createElement(
 			"opend-touchpoint",
 		) as OpenDesignTouchpointElement;
+		setCloseControlAvailable(null);
+		let closeControlObserver: MutationObserver | undefined;
 		let elementDisposed = false;
 		let verifiedDisposed = false;
 		const disposeElement = () => {
@@ -355,6 +411,7 @@ export function ProductionCampaignModal({
 				);
 				if (!current() || !context) {
 					dispose();
+					if (current() && !context) setCloseControlAvailable(false);
 					if (current() && !context)
 						emitWebTouchpointDiagnostic({
 							code: "touchpoint_locale_unsupported",
@@ -381,20 +438,59 @@ export function ProductionCampaignModal({
 						onDiagnostic: emitWebTouchpointDiagnostic,
 					},
 				);
-				if (!current()) dispose();
+				if (!current()) {
+					dispose();
+					return;
+				}
+				setCloseControlAvailable(hasWebTouchpointCloseControl(element));
+				closeControlObserver = new MutationObserver(() => {
+					if (!current()) return;
+					setCloseControlAvailable(hasWebTouchpointCloseControl(element));
+				});
+				const closeControlObserverOptions: MutationObserverInit = {
+					attributes: true,
+					attributeFilter: [
+						"aria-label",
+						"aria-disabled",
+						"aria-hidden",
+						"class",
+						"disabled",
+						"hidden",
+						"style",
+						"title",
+					],
+					childList: true,
+					characterData: true,
+					subtree: true,
+				};
+				if (element.shadowRoot)
+					closeControlObserver.observe(
+						element.shadowRoot,
+						closeControlObserverOptions,
+					);
+				const dialog = element.closest('[role="dialog"]');
+				if (dialog)
+					closeControlObserver.observe(dialog, closeControlObserverOptions);
 			} catch (error) {
+				if (!current()) {
+					dispose();
+					return;
+				}
+				setCloseControlAvailable(false);
 				if (current()) {
 					emitWebTouchpointDiagnostic({
 						code:
 							error instanceof Error ? error.message : "touchpoint_load_failed",
 					});
-					clear();
+					setCloseControlAvailable(false);
 				}
 				dispose();
 			}
 		})();
 		return () => {
 			cancelled = true;
+			closeControlObserver?.disconnect();
+			setCloseControlAvailable(null);
 			++authorizationGeneration.current;
 			dispose();
 			container.replaceChildren();
@@ -413,7 +509,10 @@ export function ProductionCampaignModal({
 		};
 		document.addEventListener("keydown", key);
 		queueMicrotask(() =>
-			modalRef.current?.querySelector<HTMLElement>("button")?.focus(),
+			(
+				modalRef.current?.querySelector<HTMLElement>("button") ??
+				modalRef.current
+			)?.focus(),
 		);
 		return () => {
 			document.removeEventListener("keydown", key);
@@ -429,14 +528,22 @@ export function ProductionCampaignModal({
 	}, [closed, decision, sessionSubject]);
 	useEffect(() => {
 		if (!testDecision || testClosed || !authenticated) return;
-		const previous = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+		const previous =
+			document.activeElement instanceof HTMLElement
+				? document.activeElement
+				: null;
 		const releaseScrollLock = lockWebTouchpointModalScroll();
 		const onKeyDown = (event: KeyboardEvent) => {
 			if (event.key === "Escape") setTestClosed(true);
 			else trapWebTouchpointModalFocus(event, modalRef.current);
 		};
 		document.addEventListener("keydown", onKeyDown);
-		queueMicrotask(() => modalRef.current?.querySelector<HTMLElement>("button")?.focus());
+		queueMicrotask(() =>
+			(
+				modalRef.current?.querySelector<HTMLElement>("button") ??
+				modalRef.current
+			)?.focus(),
+		);
 		return () => {
 			document.removeEventListener("keydown", onKeyDown);
 			releaseScrollLock();
@@ -449,21 +556,32 @@ export function ProductionCampaignModal({
 	const closeTestModal = useCallback(() => setTestClosed(true), []);
 	const onTestVisible = useCallback(
 		(next: TestDecision, placementKey: TestCampaignPlacement) => {
-			if (testRuntime) recordVisibleTestTouchpoint(testRuntime, next, placementKey);
+			if (testRuntime)
+				recordVisibleTestTouchpoint(testRuntime, next, placementKey);
 		},
 		[testRuntime],
 	);
 	if (authenticated && testRuntime && testDecision && !testClosed) {
 		return (
-			<div className={styles.backdrop} role="dialog" aria-label="Test campaign" aria-modal="true">
+			<div
+				className={styles.backdrop}
+				role="dialog"
+				aria-label="Test campaign"
+				aria-modal="true"
+			>
 				<div className={styles.modal} ref={modalRef} tabIndex={-1}>
-					<Button type="button" onClick={() => setTestClosed(true)}>Close</Button>
+					{testCloseControlAvailable === false ? (
+						<Button type="button" onClick={() => setTestClosed(true)}>
+							Close
+						</Button>
+					) : null}
 					<TestTouchpointMount
 						decision={testDecision}
 						placementKey={PLACEMENT}
 						testId="campaign-custom-element"
 						onVisible={onTestVisible}
 						requestClose={closeTestModal}
+						onCloseControlChange={setTestCloseControlAvailable}
 					/>
 				</div>
 			</div>
@@ -477,9 +595,11 @@ export function ProductionCampaignModal({
 			aria-modal="true"
 		>
 			<div className={styles.modal} ref={modalRef} tabIndex={-1}>
-				<Button type="button" onClick={() => setClosed(true)}>
-					Close
-				</Button>
+				{closeControlAvailable === false ? (
+					<Button type="button" onClick={() => setClosed(true)}>
+						Close
+					</Button>
+				) : null}
 				<div ref={elementRef} data-testid="campaign-custom-element" />
 			</div>
 		</div>

--- a/apps/web/src/components/ProductionCampaignModal.tsx
+++ b/apps/web/src/components/ProductionCampaignModal.tsx
@@ -46,6 +46,25 @@ type Decision = {
 const closedKey = (subject: string, activity: string) =>
 	`touchpoint-closed:${subject}:${activity}`;
 
+/**
+ * Parses an internal action at execution time. Browser URL normalization treats
+ * backslashes as hierarchy separators, so manifest validation alone cannot be
+ * the origin boundary.
+ */
+export function internalActionNavigationUrl(
+	path: unknown,
+	href = window.location.href,
+): URL | null {
+	if (typeof path !== "string") return null;
+	try {
+		const origin = new URL(href).origin;
+		const target = new URL(path, href);
+		return target.origin === origin ? target : null;
+	} catch {
+		return null;
+	}
+}
+
 /** Performs a server-validated click before the host consumes a static target. */
 export async function dispatchProductionCampaignAction(
 	decision: Decision,
@@ -57,8 +76,13 @@ export async function dispatchProductionCampaignAction(
 	const action = decision.staticActions.find(
 		(candidate) => candidate.id === actionId,
 	);
+	const internalTarget =
+		action?.target.kind === "internal"
+			? internalActionNavigationUrl(action.target.path)
+			: undefined;
 	if (
 		!action ||
+		(action.target.kind === "internal" && !internalTarget) ||
 		generation !== currentGeneration() ||
 		expiresAt <= Date.now() ||
 		!navigator.userActivation?.isActive
@@ -94,7 +118,8 @@ export async function dispatchProductionCampaignAction(
 		}
 		if (action.target.kind === "https")
 			await openExternalUrl(action.target.url);
-		else window.location.assign(action.target.path);
+		else if (internalTarget) window.location.assign(internalTarget.href);
+	else return false;
 		return true;
 	} catch {
 		emitWebTouchpointDiagnostic({

--- a/apps/web/src/components/TestCampaignModal.module.css
+++ b/apps/web/src/components/TestCampaignModal.module.css
@@ -3,4 +3,5 @@
 .control select { min-width: 148px; }
 .control output { display: block; margin-top: 8px; padding: 8px 10px; border-radius: 8px; background: var(--surface, #fff); font: 12px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; }
 .backdrop { position: fixed; inset: 0; display: grid; place-items: center; background: rgb(0 0 0 / 45%); z-index: 1000; }
-.modal { width: min(640px, calc(100vw - 32px)); max-height: calc(100vh - 32px); overflow: auto; padding: 16px; background: var(--surface, #fff); }
+.modal { max-width: calc(100vw - 32px); max-height: calc(100vh - 32px); overflow: auto; background: var(--surface, #fff); }
+.modal > * { display: block; max-width: 100%; }

--- a/apps/web/src/components/TestCampaignModal.tsx
+++ b/apps/web/src/components/TestCampaignModal.tsx
@@ -1,6 +1,16 @@
-import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import {
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+	useSyncExternalStore,
+} from "react";
 import { getOpenDesignHost, OPEN_DESIGN_HOST_VERSION } from "@open-design/host";
-import { TOUCHPOINT_COMPONENT_V2_RUNTIME_API_VERSION, TOUCHPOINT_COMPONENT_V2_WRAPPER_VERSION, TOUCHPOINT_COMPONENT_V2_SDK_VERSION } from "@open-design/contracts";
+import {
+	TOUCHPOINT_COMPONENT_V2_RUNTIME_API_VERSION,
+	TOUCHPOINT_COMPONENT_V2_WRAPPER_VERSION,
+	TOUCHPOINT_COMPONENT_V2_SDK_VERSION,
+} from "@open-design/contracts";
 import {
 	emitWebTouchpointDiagnostic,
 	ensureWebTouchpointElement,
@@ -8,14 +18,22 @@ import {
 	supportsWebTouchpointCapabilities,
 	verifyWebTouchpoint,
 	webTouchpointContext,
+	hasWebTouchpointCloseControl,
 	type OpenDesignTouchpointElement,
 	type WebTouchpointContent,
 } from "./touchpoint-component";
-import { touchpointStaticActionsMatch, type TouchpointStaticAction } from "./touchpoint-static-actions";
+import {
+	touchpointStaticActionsMatch,
+	type TouchpointStaticAction,
+} from "./touchpoint-static-actions";
 import styles from "./TestCampaignModal.module.css";
 
-export const TEST_CAMPAIGN_MODAL_PLACEMENT = "opend.home.campaign-modal" as const;
-export const TEST_CAMPAIGN_MODAL_CAPABILITIES = ["close", "static-action"] as const;
+export const TEST_CAMPAIGN_MODAL_PLACEMENT =
+	"opend.home.campaign-modal" as const;
+export const TEST_CAMPAIGN_MODAL_CAPABILITIES = [
+	"close",
+	"static-action",
+] as const;
 export const TEST_CAMPAIGN_PLACEMENTS = [
 	"opend.home.account-badge",
 	"opend.home.campaign-modal",
@@ -83,9 +101,15 @@ function getTestRuntimeSnapshot(): TestRuntimeSession | null {
 	return currentTestSession;
 }
 export function useTestRuntime(): TestRuntimeSession | null {
-	return useSyncExternalStore(subscribeTestRuntime, getTestRuntimeSnapshot, getTestRuntimeSnapshot);
+	return useSyncExternalStore(
+		subscribeTestRuntime,
+		getTestRuntimeSnapshot,
+		getTestRuntimeSnapshot,
+	);
 }
-export function setTestRuntimeSession(session: TestRuntimeSession | null): void {
+export function setTestRuntimeSession(
+	session: TestRuntimeSession | null,
+): void {
 	currentTestSession = session;
 	acceptanceState.clear();
 	for (const listener of testRuntimeListeners) listener();
@@ -103,13 +127,15 @@ export function isSelectedTestCampaignDecision(
 	context: TestContext,
 	placementKey: string = TEST_CAMPAIGN_MODAL_PLACEMENT,
 ): boolean {
-	return next.deploymentId === context.deploymentId &&
+	return (
+		next.deploymentId === context.deploymentId &&
 		next.placementKey === placementKey &&
 		next.content?.placementKey === placementKey &&
 		next.testContext?.deploymentId === context.deploymentId &&
 		next.testContext?.scenario === context.scenario &&
 		next.testContext?.simulatedAt === context.simulatedAt &&
-		next.testContext?.updatedAt === context.updatedAt;
+		next.testContext?.updatedAt === context.updatedAt
+	);
 }
 
 /** Test has no server event contract, so static targets remain default-deny. */
@@ -144,7 +170,11 @@ function supportsHost(authenticated: boolean): boolean {
 }
 
 export function readCampaignHostLocale(): string {
-	return document.documentElement.lang.trim() || getOpenDesignHost()?.client.osLocale?.trim() || "en-US";
+	return (
+		document.documentElement.lang.trim() ||
+		getOpenDesignHost()?.client.osLocale?.trim() ||
+		"en-US"
+	);
 }
 
 function hostTheme(): "light" | "dark" {
@@ -165,10 +195,14 @@ function expectedSnapshotMatches(
 	// Missing identities are not a compatible snapshot and must never authorize
 	// a mount. Fixtures follow the same complete payload as the real API.
 	return (
-		Boolean(deployment.snapshotHash) && decision.snapshotHash === deployment.snapshotHash &&
-		Boolean(snapshot.contentVersionId) && decision.content?.id === snapshot.contentVersionId &&
-		Boolean(snapshot.manifestHash) && decision.manifestHash === snapshot.manifestHash &&
-		Boolean(snapshot.artifactHash) && decision.artifactHash === snapshot.artifactHash
+		Boolean(deployment.snapshotHash) &&
+		decision.snapshotHash === deployment.snapshotHash &&
+		Boolean(snapshot.contentVersionId) &&
+		decision.content?.id === snapshot.contentVersionId &&
+		Boolean(snapshot.manifestHash) &&
+		decision.manifestHash === snapshot.manifestHash &&
+		Boolean(snapshot.artifactHash) &&
+		decision.artifactHash === snapshot.artifactHash
 	);
 }
 
@@ -182,9 +216,16 @@ function decisionMatchesSelection(
 		isSelectedTestCampaignDecision(decision, context, placementKey) &&
 		decision.activityId === deployment.activityId &&
 		decision.testContext.testerMemberId === context.testerMemberId &&
-		["before", "active", "ended"].includes(decision.testContext.scheduleState) &&
+		["before", "active", "ended"].includes(
+			decision.testContext.scheduleState,
+		) &&
 		expectedSnapshotMatches(decision, deployment) &&
-		touchpointStaticActionsMatch(decision.staticActions, decision.content.manifest.placements.find((placement) => placement.key === placementKey)?.staticActions ?? []) &&
+		touchpointStaticActionsMatch(
+			decision.staticActions,
+			decision.content.manifest.placements.find(
+				(placement) => placement.key === placementKey,
+			)?.staticActions ?? [],
+		) &&
 		decision.content.id.length > 0
 	);
 }
@@ -197,7 +238,9 @@ function acceptanceEvidence(
 		locale: string;
 		scenario: string;
 	}>,
-	href = typeof window === "undefined" ? "http://127.0.0.1/" : window.location.href,
+	href = typeof window === "undefined"
+		? "http://127.0.0.1/"
+		: window.location.href,
 ): string {
 	let url: URL;
 	try {
@@ -222,14 +265,16 @@ function acceptanceEvidence(
  * The URL is an evidence pointer to the current local host and identity; it is
  * never presented as a screenshot or written as a success receipt by the client.
  */
-export async function recordTestAcceptance(input: Readonly<{
-	deploymentId: string;
-	snapshotHash: string;
-	placementKey: TestCampaignPlacement;
-	locale: string;
-	scenario: Scenario;
-	hostVersion?: string;
-}>): Promise<unknown> {
+export async function recordTestAcceptance(
+	input: Readonly<{
+		deploymentId: string;
+		snapshotHash: string;
+		placementKey: TestCampaignPlacement;
+		locale: string;
+		scenario: Scenario;
+		hostVersion?: string;
+	}>,
+): Promise<unknown> {
 	const response = await fetch(
 		`/api/touchpoints/test-runtime/test-deployments/${encodeURIComponent(input.deploymentId)}/acceptances`,
 		{
@@ -241,28 +286,32 @@ export async function recordTestAcceptance(input: Readonly<{
 				locale: input.locale,
 				scenario: input.scenario,
 				evidence: acceptanceEvidence(input),
-				hostCompatibility: process.env.NEXT_PUBLIC_CMS_HOST_RELEASE ? {
-					version: 1,
-					snapshotHash: input.snapshotHash,
-					hostFamily: "open-design-desktop",
-					platform: "desktop",
-					hostRelease: process.env.NEXT_PUBLIC_CMS_HOST_RELEASE,
-					runtime: {
-						kind: "web-component",
-						apiVersion: TOUCHPOINT_COMPONENT_V2_RUNTIME_API_VERSION,
-						wrapperVersion: TOUCHPOINT_COMPONENT_V2_WRAPPER_VERSION,
-						sdkVersion: TOUCHPOINT_COMPONENT_V2_SDK_VERSION,
-					},
-					capabilities: input.placementKey === TEST_CAMPAIGN_MODAL_PLACEMENT
-						? [...TEST_CAMPAIGN_MODAL_CAPABILITIES]
-						: input.placementKey === "opend.home.account-badge"
-							? ["static-action"]
-							: [...placementCapabilities],
-				} : undefined,
+				hostCompatibility: process.env.NEXT_PUBLIC_CMS_HOST_RELEASE
+					? {
+							version: 1,
+							snapshotHash: input.snapshotHash,
+							hostFamily: "open-design-desktop",
+							platform: "desktop",
+							hostRelease: process.env.NEXT_PUBLIC_CMS_HOST_RELEASE,
+							runtime: {
+								kind: "web-component",
+								apiVersion: TOUCHPOINT_COMPONENT_V2_RUNTIME_API_VERSION,
+								wrapperVersion: TOUCHPOINT_COMPONENT_V2_WRAPPER_VERSION,
+								sdkVersion: TOUCHPOINT_COMPONENT_V2_SDK_VERSION,
+							},
+							capabilities:
+								input.placementKey === TEST_CAMPAIGN_MODAL_PLACEMENT
+									? [...TEST_CAMPAIGN_MODAL_CAPABILITIES]
+									: input.placementKey === "opend.home.account-badge"
+										? ["static-action"]
+										: [...placementCapabilities],
+						}
+					: undefined,
 			}),
 		},
 	);
-	if (!response.ok) throw new Error(`touchpoint_test_acceptance_http_${response.status}`);
+	if (!response.ok)
+		throw new Error(`touchpoint_test_acceptance_http_${response.status}`);
 	return response.json().catch(() => undefined);
 }
 
@@ -272,13 +321,15 @@ export function recordVisibleTestTouchpoint(
 	decision: TestDecision,
 	placementKey: TestCampaignPlacement,
 ): void {
-	if (currentTestSession !== session || session.context.scenario !== "active") return;
+	if (currentTestSession !== session || session.context.scenario !== "active")
+		return;
 	const key = `${session.selectionKey}:${placementKey}`;
 	if (acceptanceState.has(key)) return;
 	acceptanceState.set(key, "in-flight");
 	void recordTestAcceptance({
 		deploymentId: session.deployment.id,
-		snapshotHash: session.deployment.snapshotHash ?? decision.snapshotHash ?? "",
+		snapshotHash:
+			session.deployment.snapshotHash ?? decision.snapshotHash ?? "",
 		placementKey,
 		locale: decision.content.locale,
 		scenario: session.context.scenario,
@@ -311,8 +362,12 @@ export type TestTouchpointMountProps = Readonly<{
 	placementKey: TestCampaignPlacement;
 	testId: string;
 	className?: string;
-	onVisible: (decision: TestDecision, placementKey: TestCampaignPlacement) => void;
+	onVisible: (
+		decision: TestDecision,
+		placementKey: TestCampaignPlacement,
+	) => void;
 	requestClose?: () => void;
+	onCloseControlChange?: (available: boolean | null) => void;
 }>;
 
 /** Mounts one immutable v2 placement in the real OpenDesign Shadow DOM host. */
@@ -323,6 +378,7 @@ export function TestTouchpointMount({
 	className,
 	onVisible,
 	requestClose,
+	onCloseControlChange,
 }: TestTouchpointMountProps) {
 	const containerRef = useRef<HTMLDivElement | null>(null);
 	const [ready, setReady] = useState(false);
@@ -331,7 +387,11 @@ export function TestTouchpointMount({
 		if (!container) return;
 		let cancelled = false;
 		let verified: Awaited<ReturnType<typeof verifyWebTouchpoint>> | undefined;
-		const element = document.createElement("opend-touchpoint") as OpenDesignTouchpointElement;
+		let closeControlObserver: MutationObserver | undefined;
+		const element = document.createElement(
+			"opend-touchpoint",
+		) as OpenDesignTouchpointElement;
+		onCloseControlChange?.(null);
 		container.replaceChildren(element);
 		const mount = async () => {
 			try {
@@ -342,8 +402,11 @@ export function TestTouchpointMount({
 				);
 				if (cancelled || !context) {
 					verified.dispose();
+					onCloseControlChange?.(false);
 					if (!cancelled)
-						emitWebTouchpointDiagnostic({ code: "touchpoint_locale_unsupported" });
+						emitWebTouchpointDiagnostic({
+							code: "touchpoint_locale_unsupported",
+						});
 					return;
 				}
 				await element.mount(
@@ -361,34 +424,83 @@ export function TestTouchpointMount({
 					},
 				);
 				if (cancelled) return;
+				onCloseControlChange?.(hasWebTouchpointCloseControl(element));
+				closeControlObserver = new MutationObserver(() => {
+					if (cancelled) return;
+					onCloseControlChange?.(hasWebTouchpointCloseControl(element));
+				});
+				const closeControlObserverOptions: MutationObserverInit = {
+					attributes: true,
+					attributeFilter: [
+						"aria-label",
+						"aria-disabled",
+						"aria-hidden",
+						"class",
+						"disabled",
+						"hidden",
+						"style",
+						"title",
+					],
+					childList: true,
+					characterData: true,
+					subtree: true,
+				};
+				if (element.shadowRoot)
+					closeControlObserver.observe(
+						element.shadowRoot,
+						closeControlObserverOptions,
+					);
+				const dialog = element.closest('[role="dialog"]');
+				if (dialog)
+					closeControlObserver.observe(dialog, closeControlObserverOptions);
 				setReady(true);
 				await afterPaint();
-				if (!cancelled && actuallyVisible(element)) onVisible(decision, placementKey);
+				if (!cancelled && actuallyVisible(element))
+					onVisible(decision, placementKey);
 			} catch (error) {
-				if (!cancelled)
-					emitWebTouchpointDiagnostic({
-						code: error instanceof Error ? error.message : "touchpoint_load_failed",
-					});
+				if (cancelled) return;
+				onCloseControlChange?.(false);
+				emitWebTouchpointDiagnostic({
+					code:
+						error instanceof Error ? error.message : "touchpoint_load_failed",
+				});
 			}
 		};
 		void mount();
 		return () => {
 			cancelled = true;
+			closeControlObserver?.disconnect();
+			onCloseControlChange?.(null);
 			void element.dispose(verified?.resourceUrls).catch(() => undefined);
 			verified?.dispose();
 			container.replaceChildren();
 		};
-	}, [decision, onVisible, placementKey, requestClose]);
-	return <div ref={containerRef} className={className} data-testid={testId} hidden={!ready} />;
+	}, [decision, onCloseControlChange, onVisible, placementKey, requestClose]);
+	return (
+		<div
+			ref={containerRef}
+			className={className}
+			data-testid={testId}
+			hidden={!ready}
+		/>
+	);
 }
 
 /** Real Electron Test harness for all enabled OpenDesign placements. */
-export function TestCampaignModal({ authenticated, sessionSubject }: { authenticated: boolean; sessionSubject?: string | null }) {
+export function TestCampaignModal({
+	authenticated,
+	sessionSubject,
+}: {
+	authenticated: boolean;
+	sessionSubject?: string | null;
+}) {
 	const compatible = supportsHost(authenticated);
 	const [deployments, setDeployments] = useState<TestDeployment[]>([]);
 	const [deployment, setDeployment] = useState<TestDeployment | null>(null);
 	const [context, setContext] = useState<TestContext | null>(null);
-	const [decisions, setDecisions] = useState<Map<TestCampaignPlacement, TestDecision>>(new Map());
+	const [decisions, setDecisions] = useState<
+		Map<TestCampaignPlacement, TestDecision>
+	>(new Map());
 	const testSessionRef = useRef<TestRuntimeSession | null>(null);
 	const selectionGeneration = useRef(0);
 	const selectionKeyRef = useRef("");
@@ -409,10 +521,13 @@ export function TestCampaignModal({ authenticated, sessionSubject }: { authentic
 	useEffect(() => {
 		ensureWebTouchpointElement();
 	}, []);
-	useEffect(() => () => {
-		testSessionRef.current = null;
-		clearTestRuntimeSession();
-	}, []);
+	useEffect(
+		() => () => {
+			testSessionRef.current = null;
+			clearTestRuntimeSession();
+		},
+		[],
+	);
 	useEffect(() => {
 		if (!compatible) {
 			setDeployments([]);
@@ -420,7 +535,9 @@ export function TestCampaignModal({ authenticated, sessionSubject }: { authentic
 			return;
 		}
 		let cancelled = false;
-		void fetch("/api/touchpoints/test-runtime/deployments", { cache: "no-store" })
+		void fetch("/api/touchpoints/test-runtime/deployments", {
+			cache: "no-store",
+		})
 			.then((response) =>
 				response.ok
 					? (response.json() as Promise<{ deployments?: TestDeployment[] }>)
@@ -446,16 +563,26 @@ export function TestCampaignModal({ authenticated, sessionSubject }: { authentic
 
 	const select = useCallback(
 		async (deploymentId: string, scenario: Scenario) => {
-			const selected = deployments.find((candidate) => candidate.id === deploymentId);
+			const selected = deployments.find(
+				(candidate) => candidate.id === deploymentId,
+			);
 			const generation = ++selectionGeneration.current;
 			setDeployment(null);
 			setDecisions(new Map());
 			setContext(null);
-			if (!selected) { clear(); return; }
+			if (!selected) {
+				clear();
+				return;
+			}
 			setDeployment(selected);
 			const previousContext = testSessionRef.current?.context;
 			const pendingSession: TestRuntimeSession = Object.freeze({
-				selectionKey: [selected.id, selected.snapshotHash ?? "", "pending", String(generation)].join(":"),
+				selectionKey: [
+					selected.id,
+					selected.snapshotHash ?? "",
+					"pending",
+					String(generation),
+				].join(":"),
 				deployment: selected,
 				context: previousContext ?? {
 					deploymentId,
@@ -475,7 +602,9 @@ export function TestCampaignModal({ authenticated, sessionSubject }: { authentic
 				});
 				if (generation !== selectionGeneration.current) return;
 				if (!response.ok) {
-					emitWebTouchpointDiagnostic({ code: `touchpoint_test_context_http_${response.status}` });
+					emitWebTouchpointDiagnostic({
+						code: `touchpoint_test_context_http_${response.status}`,
+					});
 					return;
 				}
 				const nextContext = (await response.json()) as TestContext;
@@ -526,7 +655,11 @@ export function TestCampaignModal({ authenticated, sessionSubject }: { authentic
 						selected,
 						item.placementKey,
 					);
-					if (identityMatches && item.decision.testContext.scheduleState !== "active") continue;
+					if (
+						identityMatches &&
+						item.decision.testContext.scheduleState !== "active"
+					)
+						continue;
 					const capabilitiesMatch = supportsWebTouchpointCapabilities(
 						item.decision.content,
 						item.decision.requiredCapabilities,
@@ -544,7 +677,9 @@ export function TestCampaignModal({ authenticated, sessionSubject }: { authentic
 								: undefined,
 						});
 					} else {
-						emitWebTouchpointDiagnostic({ code: "touchpoint_decision_mismatch" });
+						emitWebTouchpointDiagnostic({
+							code: "touchpoint_decision_mismatch",
+						});
 					}
 				}
 				if (nextDecisions.size !== available.length) {
@@ -567,7 +702,10 @@ export function TestCampaignModal({ authenticated, sessionSubject }: { authentic
 			} catch (error) {
 				if (generation !== selectionGeneration.current) return;
 				emitWebTouchpointDiagnostic({
-					code: error instanceof Error ? error.message : "touchpoint_test_load_failed",
+					code:
+						error instanceof Error
+							? error.message
+							: "touchpoint_test_load_failed",
 				});
 			}
 		},
@@ -616,7 +754,8 @@ export function TestCampaignModal({ authenticated, sessionSubject }: { authentic
 			</label>
 			{context ? (
 				<output data-testid="touchpoint-test-clock">
-					Test clock: {context.scenario} / {active ? "active" : ""} / {context.simulatedAt}
+					Test clock: {context.scenario} / {active ? "active" : ""} /{" "}
+					{context.simulatedAt}
 				</output>
 			) : null}
 		</div>

--- a/apps/web/src/components/touchpoint-component.ts
+++ b/apps/web/src/components/touchpoint-component.ts
@@ -38,6 +38,63 @@ export type TouchpointLifecycleOptions = Readonly<{
 	requestClose?: () => void;
 	onDiagnostic?: (diagnostic: TouchpointDiagnostic) => void;
 }>;
+
+/**
+ * Close is a runtime UI capability. Manifest metadata only grants the SDK
+ * callback, so the host fallback stays available unless the mounted component
+ * exposes an explicit close control marker.
+ */
+const TOUCHPOINT_CLOSE_CONTROL_SELECTOR =
+	'[data-touchpoint-close], [data-close], button[aria-label*="close" i], [role="button"][aria-label*="close" i]';
+
+function isVisibleAndEnabled(element: Element): boolean {
+	for (let current: Element | null = element; current; current = current.parentElement) {
+		if (
+			current.hasAttribute("hidden") ||
+			current.getAttribute("aria-hidden") === "true" ||
+			current.getAttribute("aria-disabled") === "true"
+		)
+			return false;
+		if (
+			current instanceof HTMLButtonElement ||
+			current instanceof HTMLInputElement ||
+			current instanceof HTMLSelectElement ||
+			current instanceof HTMLTextAreaElement ||
+			current instanceof HTMLOptGroupElement ||
+			current instanceof HTMLOptionElement
+		) {
+			if (current.disabled) return false;
+		}
+		const style = getComputedStyle(current);
+		if (style.display === "none" || style.visibility === "hidden" || style.visibility === "collapse")
+			return false;
+	}
+	return true;
+}
+
+export function hasWebTouchpointCloseControl(
+	element: OpenDesignTouchpointElement,
+): boolean {
+	const root = element.shadowRoot;
+	if (!root || !isVisibleAndEnabled(element)) return false;
+	const controls = [
+		...root.querySelectorAll(TOUCHPOINT_CLOSE_CONTROL_SELECTOR),
+		...root.querySelectorAll("button, [role='button']"),
+	];
+	return controls.some(
+		(control) =>
+			isVisibleAndEnabled(control) &&
+			(control.matches(TOUCHPOINT_CLOSE_CONTROL_SELECTOR) ||
+				/^close(?:\b|\s)/iu.test(
+					(
+						control.getAttribute("aria-label") ??
+						control.getAttribute("title") ??
+						control.textContent ??
+						""
+					).trim(),
+				)),
+	);
+}
 const ELEMENT_NAME = "opend-touchpoint";
 
 type ComponentModule = TouchpointComponentModule<

--- a/apps/web/tests/campaigns/deepseek-v4-flash-ui-contract.test.ts
+++ b/apps/web/tests/campaigns/deepseek-v4-flash-ui-contract.test.ts
@@ -60,13 +60,16 @@ describe('DeepSeek V4 Flash workbench campaign entry', () => {
 
   it('keeps the top-right campaign entry visible across entry tabs and project detail', () => {
     expect(entryShellSource).toMatch(
-      /topRightSlot=\{\s*topRightCampaignAudience\s*\|\|\s*canRenderProductionCampaignBadge\(amrLoggedIn === true, amrAccountId\)\s*\?\s*\(/,
+      /topRightSlot=\{\s*topRightCampaignAudience\s*\|\|\s*amrLoggedIn === true\s*\?\s*\(/,
     );
     expect(entryShellSource).toMatch(
       /topRightSlot=\{[\s\S]*?\{\s*topRightCampaignAudience\s*\?\s*\([\s\S]*?<WorkbenchCampaignBadge[\s\S]*?audience=\{topRightCampaignAudience\}[\s\S]*?page="home"/,
     );
     expect(entryShellSource).toMatch(
       /canRenderProductionCampaignBadge\(amrLoggedIn === true, amrAccountId\)\s*\?\s*<ProductionCampaignBadge authenticated sessionSubject=\{amrAccountId\}/,
+    );
+    expect(entryShellSource).toMatch(
+      /<ProductionCampaignHover\s+authenticated=\{amrLoggedIn === true\}\s+sessionSubject=\{amrAccountId\}/,
     );
     expect(entryShellSource).not.toMatch(
       /topRightSlot=\{\s*view === 'home'/,

--- a/apps/web/tests/components/HoverTouchpointOverlay.test.ts
+++ b/apps/web/tests/components/HoverTouchpointOverlay.test.ts
@@ -41,7 +41,7 @@ vi.mock("../../src/components/touchpoint-component", async () => ({
 	})),
 }));
 
-const { HoverTouchpointOverlay } = await import(
+const { HoverTouchpointOverlay, hoverBridgeRect, placeHoverOverlay } = await import(
 	"../../src/components/HoverTouchpointOverlay"
 );
 const content = (placementKey: string): WebTouchpointContent => ({
@@ -165,6 +165,66 @@ describe("HoverTouchpointOverlay interaction boundary", () => {
 		expect(layer!.parentElement).toHaveAttribute("hidden");
 		unmount();
 		await waitFor(() => expect(disposes).toHaveBeenCalledTimes(2));
+	});
+
+	it("keeps the union open across the measured 8px bridge over multiple frames three times so a layer action can be clicked", async () => {
+		const { container } = render(
+			createElement(HoverTouchpointOverlay, {
+				entry: content("opend.home.hover-entry"),
+				layer: content("opend.home.hover-layer"),
+			}),
+		);
+		const [entry, layer] = Array.from(container.querySelectorAll("opend-touchpoint")) as [HTMLElement, HTMLElement];
+		const entryRect = { left: 40, top: 20, right: 64, bottom: 44, width: 24, height: 24 };
+		const layerRect = { left: 40, top: 52, right: 160, bottom: 112, width: 120, height: 60 };
+		vi.spyOn(entry, "getBoundingClientRect").mockReturnValue(entryRect as unknown as DOMRect);
+		vi.spyOn(layer, "getBoundingClientRect").mockReturnValue(layerRect as unknown as DOMRect);
+		await waitFor(() => expect(entry).not.toHaveAttribute("hidden"));
+		expect(hoverBridgeRect(entryRect, layerRect)).toMatchObject({ top: 44, bottom: 52, left: 40, right: 64 });
+		for (let crossing = 0; crossing < 3; crossing += 1) {
+			fireEvent.pointerEnter(entry);
+			fireEvent.pointerLeave(entry, { clientX: 52, clientY: 46 });
+			// Slow diagonal movement can spend several paints in the physical gap.
+			await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+			fireEvent.pointerMove(document, { clientX: 54, clientY: 50 });
+			fireEvent.pointerEnter(layer, { clientX: 56, clientY: 54 });
+			expect(layer.parentElement).not.toHaveAttribute("hidden");
+		}
+		// The same measured corridor must work when returning from the layer.
+		fireEvent.pointerLeave(layer, { clientX: 52, clientY: 50 });
+		await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+		fireEvent.pointerMove(document, { clientX: 52, clientY: 46 });
+		fireEvent.pointerEnter(entry, { clientX: 52, clientY: 42 });
+		expect(layer.parentElement).not.toHaveAttribute("hidden");
+		const action = document.createElement("button");
+		const click = vi.fn();
+		action.addEventListener("click", click);
+		layer.appendChild(action);
+		fireEvent.click(action);
+		expect(click).toHaveBeenCalledOnce();
+		expect(layer.parentElement).not.toHaveAttribute("hidden");
+		fireEvent.pointerLeave(layer, { clientX: 200, clientY: 130 });
+		expect(layer.parentElement).toHaveAttribute("hidden");
+	});
+
+	it("flips above and clamps to a narrow viewport without changing keyboard dismissal", async () => {
+		const position = placeHoverOverlay(
+			{ left: 70, top: 80, right: 94, bottom: 104, width: 24, height: 24 },
+			{ width: 120, height: 60 },
+			{ left: 0, top: 0, right: 100, bottom: 110, width: 100, height: 110 },
+		);
+		expect(position).toMatchObject({ placement: "above", left: 8, maxWidth: 84 });
+		const { container } = render(createElement(HoverTouchpointOverlay, {
+			entry: content("opend.home.hover-entry"),
+			layer: content("opend.home.hover-layer"),
+		}));
+		const [entry, layer] = Array.from(container.querySelectorAll("opend-touchpoint")) as [HTMLElement, HTMLElement];
+		await waitFor(() => expect(entry).not.toHaveAttribute("hidden"));
+		act(() => entry.focus());
+		expect(layer.parentElement).not.toHaveAttribute("hidden");
+		fireEvent.keyDown(window, { key: "Escape" });
+		expect(layer.parentElement).toHaveAttribute("hidden");
+		expect(document.activeElement).toBe(entry);
 	});
 
 	it("disposes a resource acquired after unmount during first verification", async () => {

--- a/apps/web/tests/components/HoverTouchpointOverlay.top-right-host.test.ts
+++ b/apps/web/tests/components/HoverTouchpointOverlay.top-right-host.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const entryShellSource = readFileSync(
+  resolve(process.cwd(), 'src/components/EntryShell.tsx'),
+  'utf8',
+);
+const appSource = readFileSync(resolve(process.cwd(), 'src/App.tsx'), 'utf8');
+const overlayStyles = readFileSync(
+  resolve(process.cwd(), 'src/components/HoverTouchpointOverlay.module.css'),
+  'utf8',
+);
+
+describe('HoverTouchpointOverlay top-right host', () => {
+  it('mounts the authorized hover entry in the top-right campaign slot, not the shell root', () => {
+    const topRightSlot = entryShellSource.indexOf('topRightSlot=');
+    const hoverHost = entryShellSource.indexOf('<ProductionCampaignHover');
+    expect(topRightSlot).toBeGreaterThanOrEqual(0);
+    expect(hoverHost).toBeGreaterThan(topRightSlot);
+    expect(entryShellSource.slice(hoverHost, hoverHost + 200)).toContain(
+      'authenticated={amrLoggedIn === true}',
+    );
+    expect(entryShellSource.slice(hoverHost, hoverHost + 200)).toContain(
+      'sessionSubject={amrAccountId}',
+    );
+    expect(appSource).not.toContain('<ProductionCampaignHover');
+  });
+
+  it('keeps the hover entry distinct from the account badge and removes its bottom-right positioning', () => {
+    expect(entryShellSource).toContain('<ProductionCampaignBadge');
+    expect(entryShellSource).toContain('not renamed from—the account badge');
+    const entryRuleStart = overlayStyles.indexOf('.entry {');
+    const entryRuleEnd = overlayStyles.indexOf('}', entryRuleStart);
+    const entryRule = overlayStyles.slice(entryRuleStart, entryRuleEnd);
+    expect(entryRule).toContain('position: relative');
+    expect(entryRule).not.toContain('bottom:');
+    expect(entryRule).not.toContain('right:');
+    expect(entryRule).not.toContain('position: fixed');
+  });
+});

--- a/apps/web/tests/components/ProductionCampaignModal.test.tsx
+++ b/apps/web/tests/components/ProductionCampaignModal.test.tsx
@@ -14,12 +14,17 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const openExternalUrlMock = vi.hoisted(() => vi.fn(async () => true));
-type CampaignHostGlobal = typeof globalThis & { __openDesignCampaignTestHost?: unknown };
+type CampaignHostGlobal = typeof globalThis & {
+	__openDesignCampaignTestHost?: unknown;
+};
 vi.mock("@open-design/host", () => ({
 	OPEN_DESIGN_HOST_VERSION: 2,
-	getOpenDesignHost: () => (globalThis as CampaignHostGlobal).__openDesignCampaignTestHost,
+	getOpenDesignHost: () =>
+		(globalThis as CampaignHostGlobal).__openDesignCampaignTestHost,
 }));
-vi.mock("../../src/providers/registry", () => ({ openExternalUrl: openExternalUrlMock }));
+vi.mock("../../src/providers/registry", () => ({
+	openExternalUrl: openExternalUrlMock,
+}));
 
 import {
 	ProductionCampaignModal,
@@ -28,15 +33,89 @@ import {
 import * as touchpointComponent from "../../src/components/touchpoint-component";
 import { OpenDesignTouchpointElement } from "../../src/components/touchpoint-component";
 
-const digest = (value: string) => `sha256:${createHash("sha256").update(value).digest("hex")}`;
-const entryModule = "export function mount(root) { root.textContent = 'Verified campaign'; return root; }";
-const manifest = { formatVersion: 2 as const, runtimeKind: "web-component" as const, runtimeApiVersion: 1 as const, platformWrapperVersion: "vela-touchpoint-wrapper-v1" as const, sdkVersion: "vela-touchpoint-sdk-v1" as const, contentLine: "production", placements: [{ key: "opend.home.campaign-modal" as const, entry: "component.js", resources: [], locales: ["en-US"], requiredCapabilities: ["close", "static-action"], staticActions: [{ id: "learn", target: { kind: "https" as const, url: "https://example.com" } }] }], resources: ["component.js"], images: [] };
-const content = { id: "version-1", placementKey: "opend.home.campaign-modal", locale: "en-US", manifestHash: digest(JSON.stringify(manifest)), entryPath: "component.js", entryDigest: digest(entryModule), entryModule, resources: [{ path: "component.js", digest: digest(entryModule), bytes: btoa(entryModule) }], runtime: { kind: "web-component" as const, apiVersion: 1 as const, wrapperVersion: "vela-touchpoint-wrapper-v1" as const, sdkVersion: "vela-touchpoint-sdk-v1" as const }, buildIdentity: { fingerprint: "fixed" }, manifest };
+const digest = (value: string) =>
+	`sha256:${createHash("sha256").update(value).digest("hex")}`;
+const entryModule =
+	"export function mount(root) { root.textContent = 'Verified campaign'; return root; }";
+const manifest = {
+	formatVersion: 2 as const,
+	runtimeKind: "web-component" as const,
+	runtimeApiVersion: 1 as const,
+	platformWrapperVersion: "vela-touchpoint-wrapper-v1" as const,
+	sdkVersion: "vela-touchpoint-sdk-v1" as const,
+	contentLine: "production",
+	placements: [
+		{
+			key: "opend.home.campaign-modal" as const,
+			entry: "component.js",
+			resources: [],
+			locales: ["en-US"],
+			requiredCapabilities: ["close", "static-action"],
+			staticActions: [
+				{
+					id: "learn",
+					target: { kind: "https" as const, url: "https://example.com" },
+				},
+			],
+		},
+	],
+	resources: ["component.js"],
+	images: [],
+};
+const content = {
+	id: "version-1",
+	placementKey: "opend.home.campaign-modal",
+	locale: "en-US",
+	manifestHash: digest(JSON.stringify(manifest)),
+	entryPath: "component.js",
+	entryDigest: digest(entryModule),
+	entryModule,
+	resources: [
+		{
+			path: "component.js",
+			digest: digest(entryModule),
+			bytes: btoa(entryModule),
+		},
+	],
+	runtime: {
+		kind: "web-component" as const,
+		apiVersion: 1 as const,
+		wrapperVersion: "vela-touchpoint-wrapper-v1" as const,
+		sdkVersion: "vela-touchpoint-sdk-v1" as const,
+	},
+	buildIdentity: { fingerprint: "fixed" },
+	manifest,
+};
 function decision(overrides: Partial<Record<string, unknown>> = {}) {
- const serverTime = new Date(); return { activityId: "campaign-1", authorizationExpiresAt: new Date(serverTime.getTime() + 60_000).toISOString(), content, deploymentId: "deployment-1", endsAt: new Date(serverTime.getTime() + 5 * 60_000).toISOString(), placementKey: "opend.home.campaign-modal", requiredCapabilities: ["close", "static-action"], touchpointDecisionId: "decision-1", serverTime: serverTime.toISOString(), staticActions: [{ id: "learn", target: { kind: "https", url: "https://example.com" } }], ...overrides };
+	const serverTime = new Date();
+	return {
+		activityId: "campaign-1",
+		authorizationExpiresAt: new Date(
+			serverTime.getTime() + 60_000,
+		).toISOString(),
+		content,
+		deploymentId: "deployment-1",
+		endsAt: new Date(serverTime.getTime() + 5 * 60_000).toISOString(),
+		placementKey: "opend.home.campaign-modal",
+		requiredCapabilities: ["close", "static-action"],
+		touchpointDecisionId: "decision-1",
+		serverTime: serverTime.toISOString(),
+		staticActions: [
+			{ id: "learn", target: { kind: "https", url: "https://example.com" } },
+		],
+		...overrides,
+	};
 }
 
-beforeEach(() => { vi.spyOn(OpenDesignTouchpointElement.prototype, "mount").mockImplementation(async function (this: OpenDesignTouchpointElement) { this.shadowRoot?.replaceChildren(document.createTextNode("Verified campaign")); }); });
+beforeEach(() => {
+	vi.spyOn(OpenDesignTouchpointElement.prototype, "mount").mockImplementation(
+		async function (this: OpenDesignTouchpointElement) {
+			this.shadowRoot?.replaceChildren(
+				document.createTextNode("Verified campaign"),
+			);
+		},
+	);
+});
 
 afterEach(() => {
 	cleanup();
@@ -60,14 +139,22 @@ describe("ProductionCampaignModal", () => {
 		expect(modalRule).not.toMatch(/(?:^|[;{]\s*)width:/);
 		expect(modalRule).not.toMatch(/(?:^|[;{]\s*)padding:/);
 	});
-	it("does not restart the production loader on an unchanged parent render",async()=>{
-		(globalThis as CampaignHostGlobal).__openDesignCampaignTestHost={client:{osLocale:"en-US",type:"desktop"}};
-		const fetchMock=vi.fn(async()=>new Response(JSON.stringify(decision()),{status:200}));
-		vi.stubGlobal("fetch",fetchMock);
-		const {rerender}=render(<ProductionCampaignModal authenticated sessionSubject="stable-user" />);
+	it("does not restart the production loader on an unchanged parent render", async () => {
+		(globalThis as CampaignHostGlobal).__openDesignCampaignTestHost = {
+			client: { osLocale: "en-US", type: "desktop" },
+		};
+		const fetchMock = vi.fn(
+			async () => new Response(JSON.stringify(decision()), { status: 200 }),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const { rerender } = render(
+			<ProductionCampaignModal authenticated sessionSubject="stable-user" />,
+		);
 		await screen.findByRole("dialog");
-		rerender(<ProductionCampaignModal authenticated sessionSubject="stable-user" />);
-		await act(async()=>{});
+		rerender(
+			<ProductionCampaignModal authenticated sessionSubject="stable-user" />,
+		);
+		await act(async () => {});
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 	it("suppresses a closed campaign for the same subject while leaving a normal update in the current bounded lease", async () => {
@@ -101,11 +188,15 @@ describe("ProductionCampaignModal", () => {
 		await screen.findByRole("dialog");
 		fireEvent.focus(window);
 		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
-		expect(screen.getByTestId("campaign-custom-element").querySelector("opend-touchpoint")).not.toBeNull();
+		expect(
+			screen
+				.getByTestId("campaign-custom-element")
+				.querySelector("opend-touchpoint"),
+		).not.toBeNull();
 		expect(document.body.style.overflow).toBe("hidden");
 		expect(document.querySelector("iframe,webview")).toBeNull();
-		// The frozen `close` capability only grants an SDK callback; this fixture
-		// deliberately renders no close affordance, so the host fallback must remain.
+		// The fixture declares the SDK capability but exposes no actual close
+		// control, so the host fallback remains available.
 		expect(screen.getByRole("button", { name: "Close" })).toBeTruthy();
 		fireEvent.keyDown(document, { key: "Escape" });
 		expect(document.body.style.overflow).toBe("");
@@ -120,55 +211,135 @@ describe("ProductionCampaignModal", () => {
 		await screen.findByRole("dialog");
 	});
 
- it.each([
-  ["matching receipt clears the mounted lease", "matching", true, false],
-  ["valid mismatched receipt retains the mounted lease", "mismatched", false, false],
-  ["malformed 410 diagnoses and clears the mounted lease", "malformed", true, true],
- ] as const)("%s", async (_name, kind, clears, diagnoses) => {
-  (globalThis as CampaignHostGlobal).__openDesignCampaignTestHost = { client: { osLocale: "en-US", type: "desktop" } };
-  const active = decision();
-  const receipt = { touchpointDecisionId: active.touchpointDecisionId, deploymentId: active.deploymentId, activityId: active.activityId, contentVersionId: active.content.id };
-  const response = kind === "malformed"
-   ? new Response(JSON.stringify({ error: "production_runtime_revoked", receipt: { touchpointDecisionId: receipt.touchpointDecisionId } }), { status: 410 })
-   : new Response(JSON.stringify({ error: "production_runtime_revoked", receipt: kind === "matching" ? receipt : { ...receipt, deploymentId: "other-deployment" } }), { status: 410 });
-  const fetchMock = vi.fn()
-   .mockResolvedValueOnce(new Response(JSON.stringify(active), { status: 200 }))
-   .mockResolvedValueOnce(response);
-  const diagnostic = vi.spyOn(touchpointComponent, "emitWebTouchpointDiagnostic");
-  vi.stubGlobal("fetch", fetchMock);
-  render(<ProductionCampaignModal authenticated sessionSubject="user-a" />);
-  await screen.findByTestId("campaign-custom-element");
-  window.dispatchEvent(new Event("focus"));
-  await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
-  expect(fetchMock.mock.calls[1]?.[0]).toContain(`activeDecisionId=${active.touchpointDecisionId}`);
-  if (clears) await waitFor(() => expect(screen.queryByTestId("campaign-custom-element")).toBeNull());
-  else expect(screen.getByRole("dialog")).toBeTruthy();
-  if (diagnoses) expect(diagnostic).toHaveBeenCalledWith({ code: "touchpoint_load_failed", detail: "http_410" });
-  else expect(diagnostic).not.toHaveBeenCalledWith(expect.objectContaining({ detail: "http_410" }));
- });
-
+	it.each([
+		["matching receipt clears the mounted lease", "matching", true, false],
+		[
+			"valid mismatched receipt retains the mounted lease",
+			"mismatched",
+			false,
+			false,
+		],
+		[
+			"malformed 410 diagnoses and clears the mounted lease",
+			"malformed",
+			true,
+			true,
+		],
+	] as const)("%s", async (_name, kind, clears, diagnoses) => {
+		(globalThis as CampaignHostGlobal).__openDesignCampaignTestHost = {
+			client: { osLocale: "en-US", type: "desktop" },
+		};
+		const active = decision();
+		const receipt = {
+			touchpointDecisionId: active.touchpointDecisionId,
+			deploymentId: active.deploymentId,
+			activityId: active.activityId,
+			contentVersionId: active.content.id,
+		};
+		const response =
+			kind === "malformed"
+				? new Response(
+						JSON.stringify({
+							error: "production_runtime_revoked",
+							receipt: { touchpointDecisionId: receipt.touchpointDecisionId },
+						}),
+						{ status: 410 },
+					)
+				: new Response(
+						JSON.stringify({
+							error: "production_runtime_revoked",
+							receipt:
+								kind === "matching"
+									? receipt
+									: { ...receipt, deploymentId: "other-deployment" },
+						}),
+						{ status: 410 },
+					);
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(
+				new Response(JSON.stringify(active), { status: 200 }),
+			)
+			.mockResolvedValueOnce(response);
+		const diagnostic = vi.spyOn(
+			touchpointComponent,
+			"emitWebTouchpointDiagnostic",
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		render(<ProductionCampaignModal authenticated sessionSubject="user-a" />);
+		await screen.findByTestId("campaign-custom-element");
+		window.dispatchEvent(new Event("focus"));
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+		expect(fetchMock.mock.calls[1]?.[0]).toContain(
+			`activeDecisionId=${active.touchpointDecisionId}`,
+		);
+		if (clears)
+			await waitFor(() =>
+				expect(screen.queryByTestId("campaign-custom-element")).toBeNull(),
+			);
+		else expect(screen.getByRole("dialog")).toBeTruthy();
+		if (diagnoses)
+			expect(diagnostic).toHaveBeenCalledWith({
+				code: "touchpoint_load_failed",
+				detail: "http_410",
+			});
+		else
+			expect(diagnostic).not.toHaveBeenCalledWith(
+				expect.objectContaining({ detail: "http_410" }),
+			);
+	});
 });
 
 it("denies synchronously when authentication is revoked and ignores a deferred A response body", async () => {
- (globalThis as CampaignHostGlobal).__openDesignCampaignTestHost = { client: { osLocale: "en-US", type: "desktop" } };
- let resolveBody: ((value: ReturnType<typeof decision>) => void) | undefined;
- const body = new Promise<ReturnType<typeof decision>>((resolve) => { resolveBody = resolve; });
- vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: () => body }));
- const view = render(<ProductionCampaignModal authenticated sessionSubject="user-a" />);
- await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
- view.rerender(<ProductionCampaignModal authenticated={false} sessionSubject="user-a" />);
- expect(screen.queryByRole("dialog")).toBeNull();
- resolveBody?.(decision());
- await Promise.resolve();
- expect(screen.queryByRole("dialog")).toBeNull();
+	(globalThis as CampaignHostGlobal).__openDesignCampaignTestHost = {
+		client: { osLocale: "en-US", type: "desktop" },
+	};
+	let resolveBody: ((value: ReturnType<typeof decision>) => void) | undefined;
+	const body = new Promise<ReturnType<typeof decision>>((resolve) => {
+		resolveBody = resolve;
+	});
+	vi.stubGlobal(
+		"fetch",
+		vi.fn().mockResolvedValue({ ok: true, json: () => body }),
+	);
+	const view = render(
+		<ProductionCampaignModal authenticated sessionSubject="user-a" />,
+	);
+	await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+	view.rerender(
+		<ProductionCampaignModal authenticated={false} sessionSubject="user-a" />,
+	);
+	expect(screen.queryByRole("dialog")).toBeNull();
+	resolveBody?.(decision());
+	await Promise.resolve();
+	expect(screen.queryByRole("dialog")).toBeNull();
 });
 
 it("rejects static actions substituted from the verified modal placement", async () => {
- (globalThis as CampaignHostGlobal).__openDesignCampaignTestHost = { client: { osLocale: "en-US", type: "desktop" } };
- vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify(decision({ staticActions: [{ id: "substituted", target: { kind: "internal", path: "/other" } }] })), { status: 200 })));
- render(<ProductionCampaignModal authenticated sessionSubject="user-a" />);
- await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
- await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+	(globalThis as CampaignHostGlobal).__openDesignCampaignTestHost = {
+		client: { osLocale: "en-US", type: "desktop" },
+	};
+	vi.stubGlobal(
+		"fetch",
+		vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify(
+					decision({
+						staticActions: [
+							{
+								id: "substituted",
+								target: { kind: "internal", path: "/other" },
+							},
+						],
+					}),
+				),
+				{ status: 200 },
+			),
+		),
+	);
+	render(<ProductionCampaignModal authenticated sessionSubject="user-a" />);
+	await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+	await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
 });
 
 it("rejects a decision unless both decision and content target the campaign modal placement", async () => {
@@ -179,9 +350,14 @@ it("rejects a decision unless both decision and content target the campaign moda
 			removeContent: vi.fn(async () => ({ ok: true })),
 		},
 	};
-	const mismatchedContent = { ...content, placementKey: "opend.home.account-badge" };
+	const mismatchedContent = {
+		...content,
+		placementKey: "opend.home.account-badge",
+	};
 	const fetchMock = vi.fn().mockResolvedValue(
-		new Response(JSON.stringify(decision({ content: mismatchedContent })), { status: 200 }),
+		new Response(JSON.stringify(decision({ content: mismatchedContent })), {
+			status: 200,
+		}),
 	);
 	vi.stubGlobal("fetch", fetchMock);
 	render(<ProductionCampaignModal authenticated sessionSubject="user-a" />);
@@ -191,154 +367,610 @@ it("rejects a decision unless both decision and content target the campaign moda
 });
 
 describe("Production campaign action guard", () => {
- it("rejects normalized cross-origin internal targets before reporting an event", async () => {
-  Object.defineProperty(navigator, "userActivation", { configurable: true, value: { isActive: true } });
-  const fetchMock = vi.fn(); vi.stubGlobal("fetch", fetchMock);
-  const accepted = await (await import("../../src/components/ProductionCampaignModal")).dispatchProductionCampaignAction(
-   decision({ staticActions: [{ id: "escape", target: { kind: "internal", path: "/\\evil.example" } }] }) as any,
-   "escape", 1, () => 1, Date.now() + 10_000,
-  );
-  expect(accepted).toBe(false);
-  expect(fetchMock).not.toHaveBeenCalled();
- });
+	it.each([500, 502, 503])(
+		"consumes an authorized action when telemetry returns %s",
+		async (status) => {
+			const { dispatchProductionCampaignAction } = await import(
+				"../../src/components/ProductionCampaignModal"
+			);
+			Object.defineProperty(navigator, "userActivation", {
+				configurable: true,
+				value: { isActive: true },
+			});
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(async () => new Response("telemetry unavailable", { status })),
+			);
+			const accepted = await dispatchProductionCampaignAction(
+				decision() as any,
+				"learn",
+				1,
+				() => 1,
+				Date.now() + 10_000,
+			);
+			expect(accepted).toBe(true);
+			expect(openExternalUrlMock).toHaveBeenCalledWith("https://example.com");
+		},
+	);
 
- it("keeps valid internal navigation on the current origin", () => {
-  expect(internalActionNavigationUrl("/projects?view=active#recent", "https://app.example/home")?.href).toBe(
-   "https://app.example/projects?view=active#recent",
-  );
-  for (const path of [
-   String.raw`/\evil.example`,
-   `/${"\t"}/evil.example`,
-   `/${"\n"}/evil.example`,
-  ]) expect(internalActionNavigationUrl(path, "https://app.example/home")).toBeNull();
- });
+	it("consumes an authorized action when telemetry is unreachable", async () => {
+		const { dispatchProductionCampaignAction } = await import(
+			"../../src/components/ProductionCampaignModal"
+		);
+		Object.defineProperty(navigator, "userActivation", {
+			configurable: true,
+			value: { isActive: true },
+		});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				throw new TypeError("Failed to fetch");
+			}),
+		);
+		const accepted = await dispatchProductionCampaignAction(
+			decision() as any,
+			"learn",
+			1,
+			() => 1,
+			Date.now() + 10_000,
+		);
+		expect(accepted).toBe(true);
+		expect(openExternalUrlMock).toHaveBeenCalledWith("https://example.com");
+	});
 
- it("rejects stale callbacks before they can report or consume a static action", async () => {
-  const { dispatchProductionCampaignAction } = await import("../../src/components/ProductionCampaignModal");
-  const fetchMock = vi.fn(); vi.stubGlobal("fetch", fetchMock);
-  const accepted = await dispatchProductionCampaignAction(
-   decision({ staticActions: [{ id: "learn", target: { kind: "https", url: "https://example.com" } }] }) as any,
-   "learn", 1, () => 2, Date.now() + 10_000,
-  );
-  expect(accepted).toBe(false);
-  expect(fetchMock).not.toHaveBeenCalled();
- });
+	it("bounds a hanging telemetry request and still consumes the live action", async () => {
+		const {
+			dispatchProductionCampaignAction,
+			PRODUCTION_ACTION_TELEMETRY_TIMEOUT_MS,
+		} = await import("../../src/components/ProductionCampaignModal");
+		vi.useFakeTimers();
+		Object.defineProperty(navigator, "userActivation", {
+			configurable: true,
+			value: { isActive: true },
+		});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				(_input: RequestInfo | URL, init?: RequestInit) =>
+					new Promise<Response>((_resolve, reject) => {
+						init?.signal?.addEventListener("abort", () =>
+							reject(new DOMException("aborted", "AbortError")),
+						);
+					}),
+			),
+		);
+		const pending = dispatchProductionCampaignAction(
+			decision() as any,
+			"learn",
+			1,
+			() => 1,
+			Date.now() + 10_000,
+		);
+		await vi.advanceTimersByTimeAsync(PRODUCTION_ACTION_TELEMETRY_TIMEOUT_MS);
+		expect(await pending).toBe(true);
+		expect(openExternalUrlMock).toHaveBeenCalledWith("https://example.com");
+		vi.useRealTimers();
+	});
+
+	it.each([401, 403, 409, 422])(
+		"denies an action when telemetry returns authorization/conflict status %s",
+		async (status) => {
+			const { dispatchProductionCampaignAction } = await import(
+				"../../src/components/ProductionCampaignModal"
+			);
+			Object.defineProperty(navigator, "userActivation", {
+				configurable: true,
+				value: { isActive: true },
+			});
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(async () => new Response("denied", { status })),
+			);
+			const accepted = await dispatchProductionCampaignAction(
+				decision() as any,
+				"learn",
+				1,
+				() => 1,
+				Date.now() + 10_000,
+			);
+			expect(accepted).toBe(false);
+			expect(openExternalUrlMock).not.toHaveBeenCalled();
+		},
+	);
+
+	it("rejects normalized cross-origin internal targets before reporting an event", async () => {
+		Object.defineProperty(navigator, "userActivation", {
+			configurable: true,
+			value: { isActive: true },
+		});
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+		const accepted = await (
+			await import("../../src/components/ProductionCampaignModal")
+		).dispatchProductionCampaignAction(
+			decision({
+				staticActions: [
+					{
+						id: "escape",
+						target: { kind: "internal", path: "/\\evil.example" },
+					},
+				],
+			}) as any,
+			"escape",
+			1,
+			() => 1,
+			Date.now() + 10_000,
+		);
+		expect(accepted).toBe(false);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("keeps valid internal navigation on the current origin", () => {
+		expect(
+			internalActionNavigationUrl(
+				"/projects?view=active#recent",
+				"https://app.example/home",
+			)?.href,
+		).toBe("https://app.example/projects?view=active#recent");
+		for (const path of [
+			String.raw`/\evil.example`,
+			`/${"\t"}/evil.example`,
+			`/${"\n"}/evil.example`,
+		])
+			expect(
+				internalActionNavigationUrl(path, "https://app.example/home"),
+			).toBeNull();
+	});
+
+	it("rejects stale callbacks before they can report or consume a static action", async () => {
+		const { dispatchProductionCampaignAction } = await import(
+			"../../src/components/ProductionCampaignModal"
+		);
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+		const accepted = await dispatchProductionCampaignAction(
+			decision({
+				staticActions: [
+					{
+						id: "learn",
+						target: { kind: "https", url: "https://example.com" },
+					},
+				],
+			}) as any,
+			"learn",
+			1,
+			() => 2,
+			Date.now() + 10_000,
+		);
+		expect(accepted).toBe(false);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
 });
 
-
- it("reports the trusted production click before consuming its static target", async () => {
-  const { dispatchProductionCampaignAction } = await import("../../src/components/ProductionCampaignModal");
-  Object.defineProperty(navigator, "userActivation", { configurable: true, value: { isActive: true } });
-  const fetchMock = vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 })); vi.stubGlobal("fetch", fetchMock);
-  const accepted = await dispatchProductionCampaignAction(decision({ staticActions: [{ id: "learn", target: { kind: "https", url: "https://example.com" } }] }) as any, "learn", 1, () => 1, Date.now() + 10_000);
-  expect(accepted).toBe(true); expect(fetchMock).toHaveBeenCalledWith("/api/touchpoints/production-runtime/events", expect.objectContaining({ method: "POST" }));
-  expect(openExternalUrlMock).toHaveBeenCalledWith("https://example.com");
- });
-
+it("reports the trusted production click before consuming its static target", async () => {
+	const { dispatchProductionCampaignAction } = await import(
+		"../../src/components/ProductionCampaignModal"
+	);
+	Object.defineProperty(navigator, "userActivation", {
+		configurable: true,
+		value: { isActive: true },
+	});
+	const fetchMock = vi.fn(
+		async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+	);
+	vi.stubGlobal("fetch", fetchMock);
+	const accepted = await dispatchProductionCampaignAction(
+		decision({
+			staticActions: [
+				{ id: "learn", target: { kind: "https", url: "https://example.com" } },
+			],
+		}) as any,
+		"learn",
+		1,
+		() => 1,
+		Date.now() + 10_000,
+	);
+	expect(accepted).toBe(true);
+	expect(fetchMock).toHaveBeenCalledWith(
+		"/api/touchpoints/production-runtime/events",
+		expect.objectContaining({ method: "POST" }),
+	);
+	expect(openExternalUrlMock).toHaveBeenCalledWith("https://example.com");
+});
 
 describe("ProductionCampaignModal mount lifetime", () => {
- it("keeps the mounted modal action authorized across focus and online refreshes", async () => {
-  (globalThis as CampaignHostGlobal).__openDesignCampaignTestHost = { client: { osLocale: "en-US", type: "desktop" } };
-  let dispatchAction: ((actionId: string) => Promise<void>) | undefined;
-  vi.spyOn(OpenDesignTouchpointElement.prototype, "mount").mockImplementation(async function (this: OpenDesignTouchpointElement, _entry, _digest, _context, _urls, _actions, options) { dispatchAction = options?.dispatchAction; this.shadowRoot?.replaceChildren(document.createTextNode("Verified campaign")); });
-  const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => Promise.resolve(
-   init?.method === "POST"
-    ? new Response(JSON.stringify({ ok: true }), { status: 200 })
-    : new Response(JSON.stringify(decision()), { status: 200 }),
-  )); vi.stubGlobal("fetch", fetchMock);
-  Object.defineProperty(navigator, "userActivation", { configurable: true, value: { isActive: true } });
-  render(<ProductionCampaignModal authenticated sessionSubject="user-a" />);
-  await waitFor(() => expect(dispatchAction).toBeTypeOf("function"));
-  window.dispatchEvent(new Event("focus")); window.dispatchEvent(new Event("online"));
-  await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
-  await dispatchAction?.("learn");
-  expect(fetchMock).toHaveBeenCalledWith("/api/touchpoints/production-runtime/events", expect.objectContaining({ method: "POST" }));
-  expect(openExternalUrlMock).toHaveBeenCalledWith("https://example.com");
- });
+	it("uses an actual shadow close control and closes on pointer activation", async () => {
+		(globalThis as CampaignHostGlobal).__openDesignCampaignTestHost = {
+			client: { osLocale: "en-US", type: "desktop" },
+		};
+		vi.spyOn(OpenDesignTouchpointElement.prototype, "mount").mockImplementation(
+			async function (
+				this: OpenDesignTouchpointElement,
+				_entry,
+				_digest,
+				_context,
+				_urls,
+				_actions,
+				options,
+			) {
+				const close = document.createElement("button");
+				close.type = "button";
+				close.dataset.touchpointClose = "true";
+				close.textContent = "Close campaign";
+				close.addEventListener("click", () => options?.requestClose?.());
+				this.shadowRoot?.replaceChildren(close);
+			},
+		);
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockResolvedValue(
+					new Response(JSON.stringify(decision()), { status: 200 }),
+				),
+		);
+		render(<ProductionCampaignModal authenticated sessionSubject="user-a" />);
+		const host = await screen.findByTestId("campaign-custom-element");
+		const close = await waitFor(() => {
+			const control = host
+				.querySelector("opend-touchpoint")
+				?.shadowRoot?.querySelector("[data-touchpoint-close]");
+			expect(control).toBeTruthy();
+			return control as HTMLElement;
+		});
+		expect(screen.queryByRole("button", { name: "Close" })).toBeNull();
+		fireEvent.pointerUp(close);
+		fireEvent.click(close);
+		await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+		expect(document.body.style.overflow).toBe("");
+	});
 
- it("mounts valid modal content when a refresh starts while verification is deferred", async () => {
-  (globalThis as CampaignHostGlobal).__openDesignCampaignTestHost = { client: { osLocale: "en-US", type: "desktop" } };
-  let resolveVerified: ((value: any) => void) | undefined;
-  const verified = new Promise<any>((resolve) => { resolveVerified = resolve; });
-  const verify = vi.spyOn(touchpointComponent, "verifyWebTouchpoint").mockReturnValue(verified);
-  const fetchMock = vi.fn(() => Promise.resolve(new Response(JSON.stringify(decision()), { status: 200 }))); vi.stubGlobal("fetch", fetchMock);
-  render(<ProductionCampaignModal authenticated sessionSubject="user-a" />);
-  await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
-  window.dispatchEvent(new Event("focus")); await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
-  resolveVerified?.({ entryUrl: "blob:modal", resourceUrls: new Map(), dispose: vi.fn() });
-  const host = await screen.findByTestId("campaign-custom-element");
-  await waitFor(() => expect(host.querySelector("opend-touchpoint")?.shadowRoot?.textContent).toContain("Verified campaign"));
- });
+	it("keeps a host fallback when the component mount fails", async () => {
+		(globalThis as CampaignHostGlobal).__openDesignCampaignTestHost = {
+			client: { osLocale: "en-US", type: "desktop" },
+		};
+		vi.spyOn(OpenDesignTouchpointElement.prototype, "mount").mockRejectedValue(
+			new Error("mount failed"),
+		);
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockResolvedValue(
+					new Response(JSON.stringify(decision()), { status: 200 }),
+				),
+		);
+		render(<ProductionCampaignModal authenticated sessionSubject="user-a" />);
+		await waitFor(() =>
+			expect(screen.getByRole("button", { name: "Close" })).toBeTruthy(),
+		);
+		expect(screen.getByRole("dialog")).toBeTruthy();
+	});
 
- it("cancels and fences an expired modal timer after accepting a replacement", async () => {
-  (globalThis as CampaignHostGlobal).__openDesignCampaignTestHost = { client: { osLocale: "en-US", type: "desktop" } };
-  const start = Date.now();
-  const now = vi.spyOn(Date, "now").mockReturnValue(start);
-  const scheduledTimers: Array<{ callback: () => void; delay: number; handle: number }> = [];
-  const actualSetTimeout = globalThis.setTimeout;
-  vi.spyOn(globalThis, "setTimeout").mockImplementation(((callback: TimerHandler, delay?: number, ...args: any[]) => {
-   const handle = actualSetTimeout(callback, delay, ...args);
-   if (typeof callback === "function") scheduledTimers.push({ callback: () => callback(...args), delay: Number(delay), handle });
-   return handle;
-  }) as typeof setTimeout);
-  const clearTimeoutMock = vi.spyOn(globalThis, "clearTimeout");
-  const callbacks: Array<(actionId: string) => Promise<void>> = [];
-  vi.spyOn(OpenDesignTouchpointElement.prototype, "mount").mockImplementation(async function (this: OpenDesignTouchpointElement, _entry, _digest, _context, _urls, _actions, options) { if (options?.dispatchAction) callbacks.push(options.dispatchAction); this.shadowRoot?.replaceChildren(document.createTextNode("Verified campaign")); });
-  let resolveReplacement: ((value: ReturnType<typeof decision>) => void) | undefined;
-  const replacementBody = new Promise<ReturnType<typeof decision>>((resolve) => { resolveReplacement = resolve; });
-  const oldDecision = decision({ authorizationExpiresAt: new Date(start + 7_000).toISOString() });
-  const replacementDecision = decision({ authorizationExpiresAt: new Date(start + 15_000).toISOString(), touchpointDecisionId: "replacement-modal" });
-  const replacementResponse = new Response(JSON.stringify(replacementDecision), { status: 200 });
-  vi.spyOn(replacementResponse, "json").mockReturnValue(replacementBody);
-  const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
-   if (init?.method === "POST") return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
-   if (fetchMock.mock.calls.length === 2) return Promise.resolve(replacementResponse);
-   return Promise.resolve(new Response(JSON.stringify(oldDecision), { status: 200 }));
-  });
-  vi.stubGlobal("fetch", fetchMock);
-  Object.defineProperty(navigator, "userActivation", { configurable: true, value: { isActive: true } });
-  render(<ProductionCampaignModal authenticated sessionSubject="user-a" />);
-  await waitFor(() => expect(callbacks).toHaveLength(1));
-  const oldCallback = callbacks[0]!;
-  const oldTimer = scheduledTimers.find((timer) => timer.delay === 7_000);
-  expect(oldTimer).toBeDefined();
-  now.mockReturnValue(start + 7_001); // The old lease is expired, but its timer callback is delayed.
-  window.dispatchEvent(new Event("focus"));
-  await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
-  resolveReplacement?.(replacementDecision);
-  await Promise.resolve(); // Replacement acceptance must cancel and fence the old timer before React cleanup.
-  expect(clearTimeoutMock).toHaveBeenCalled(); // The queued old timer below proves cancellation/fencing behavior without Node Timeout identity.
-  await oldCallback("learn");
-  expect(fetchMock).toHaveBeenCalledTimes(2);
-  expect(openExternalUrlMock).not.toHaveBeenCalled();
-  await waitFor(() => expect(callbacks).toHaveLength(2));
-  await act(async () => { oldTimer?.callback(); }); // A queued stale callback must not clear the replacement.
-  expect(screen.getByTestId("campaign-custom-element").querySelector("opend-touchpoint")?.shadowRoot?.textContent).toContain("Verified campaign");
-  await callbacks[1]!("learn");
-  expect(fetchMock).toHaveBeenCalledWith("/api/touchpoints/production-runtime/events", expect.objectContaining({ method: "POST" }));
-  expect(openExternalUrlMock).toHaveBeenCalledWith("https://example.com");
-  const replacementTimer = scheduledTimers.find((timer) => timer.delay === 7_999);
-  expect(replacementTimer).toBeDefined();
-  now.mockReturnValue(start + 15_001);
-  await act(async () => { replacementTimer?.callback(); });
-  expect(screen.queryByTestId("campaign-custom-element")).toBeNull();
-  await callbacks[1]!("learn");
-  expect(fetchMock).toHaveBeenCalledTimes(3);
- });
+	it("removes the host fallback when a shadow close control becomes enabled", async () => {
+		(globalThis as CampaignHostGlobal).__openDesignCampaignTestHost = {
+			client: { osLocale: "en-US", type: "desktop" },
+		};
+		let closeControl!: HTMLButtonElement;
+		vi.spyOn(OpenDesignTouchpointElement.prototype, "mount").mockImplementation(
+			async function (this: OpenDesignTouchpointElement) {
+				closeControl = document.createElement("button");
+				closeControl.dataset.touchpointClose = "true";
+				closeControl.disabled = true;
+				this.shadowRoot?.replaceChildren(closeControl);
+			},
+		);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response(JSON.stringify(decision()), { status: 200 }),
+			),
+		);
+		render(<ProductionCampaignModal authenticated sessionSubject="user-a" />);
+		await waitFor(() =>
+			expect(screen.getByRole("button", { name: "Close" })).toBeTruthy(),
+		);
+		closeControl.disabled = false;
+		await waitFor(() =>
+			expect(screen.queryByRole("button", { name: "Close" })).toBeNull(),
+		);
+	});
 
- it("releases a late verified modal resource once without mounting after unmount", async () => {
-  (globalThis as CampaignHostGlobal).__openDesignCampaignTestHost = { client: { osLocale: "en-US", type: "desktop" } };
-  let resolveVerified: ((value: any) => void) | undefined;
-  const verified = new Promise<any>((resolve) => { resolveVerified = resolve; });
-  const verify = vi.spyOn(touchpointComponent, "verifyWebTouchpoint").mockReturnValue(verified);
-  const mount = vi.spyOn(OpenDesignTouchpointElement.prototype, "mount"); mount.mockClear();
-  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify(decision()), { status: 200 })));
-  const view = render(<ProductionCampaignModal authenticated sessionSubject="user-a" />);
-  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
-  await waitFor(() => expect(verify).toHaveBeenCalledTimes(1));
-  view.unmount();
-  const release = vi.fn(); resolveVerified?.({ entryUrl: "blob:modal", resourceUrls: new Map(), dispose: release });
-  await waitFor(() => expect(release).toHaveBeenCalledTimes(1));
-  expect(mount).not.toHaveBeenCalled();
- });
+	it("keeps the mounted modal action authorized across focus and online refreshes", async () => {
+		(globalThis as CampaignHostGlobal).__openDesignCampaignTestHost = {
+			client: { osLocale: "en-US", type: "desktop" },
+		};
+		let dispatchAction: ((actionId: string) => Promise<void>) | undefined;
+		vi.spyOn(OpenDesignTouchpointElement.prototype, "mount").mockImplementation(
+			async function (
+				this: OpenDesignTouchpointElement,
+				_entry,
+				_digest,
+				_context,
+				_urls,
+				_actions,
+				options,
+			) {
+				dispatchAction = options?.dispatchAction;
+				this.shadowRoot?.replaceChildren(
+					document.createTextNode("Verified campaign"),
+				);
+			},
+		);
+		const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) =>
+			Promise.resolve(
+				init?.method === "POST"
+					? new Response(JSON.stringify({ ok: true }), { status: 200 })
+					: new Response(JSON.stringify(decision()), { status: 200 }),
+			),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		Object.defineProperty(navigator, "userActivation", {
+			configurable: true,
+			value: { isActive: true },
+		});
+		render(<ProductionCampaignModal authenticated sessionSubject="user-a" />);
+		await waitFor(() => expect(dispatchAction).toBeTypeOf("function"));
+		window.dispatchEvent(new Event("focus"));
+		window.dispatchEvent(new Event("online"));
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+		await dispatchAction?.("learn");
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/touchpoints/production-runtime/events",
+			expect.objectContaining({ method: "POST" }),
+		);
+		expect(openExternalUrlMock).toHaveBeenCalledWith("https://example.com");
+	});
+
+	it("mounts valid modal content when a refresh starts while verification is deferred", async () => {
+		(globalThis as CampaignHostGlobal).__openDesignCampaignTestHost = {
+			client: { osLocale: "en-US", type: "desktop" },
+		};
+		let resolveVerified: ((value: any) => void) | undefined;
+		const verified = new Promise<any>((resolve) => {
+			resolveVerified = resolve;
+		});
+		const verify = vi
+			.spyOn(touchpointComponent, "verifyWebTouchpoint")
+			.mockReturnValue(verified);
+		const fetchMock = vi.fn(() =>
+			Promise.resolve(
+				new Response(JSON.stringify(decision()), { status: 200 }),
+			),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		render(<ProductionCampaignModal authenticated sessionSubject="user-a" />);
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+		window.dispatchEvent(new Event("focus"));
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+		resolveVerified?.({
+			entryUrl: "blob:modal",
+			resourceUrls: new Map(),
+			dispose: vi.fn(),
+		});
+		const host = await screen.findByTestId("campaign-custom-element");
+		await waitFor(() =>
+			expect(
+				host.querySelector("opend-touchpoint")?.shadowRoot?.textContent,
+			).toContain("Verified campaign"),
+		);
+	});
+
+	it("does not let a rejected stale mount restore the fallback over a replacement close control", async () => {
+		(globalThis as CampaignHostGlobal).__openDesignCampaignTestHost = {
+			client: { osLocale: "en-US", type: "desktop" },
+		};
+		const start = Date.now();
+		const now = vi.spyOn(Date, "now").mockReturnValue(start);
+		const oldDecision = decision({
+			touchpointDecisionId: "old-modal",
+			authorizationExpiresAt: new Date(start + 1_000).toISOString(),
+		});
+		const replacementDecision = decision({
+			touchpointDecisionId: "replacement-modal",
+			authorizationExpiresAt: new Date(start + 5_000).toISOString(),
+		});
+		let rejectOldMount!: (reason?: unknown) => void;
+		let mountCount = 0;
+		vi.spyOn(OpenDesignTouchpointElement.prototype, "mount").mockImplementation(
+			async function (this: OpenDesignTouchpointElement) {
+				mountCount += 1;
+				if (mountCount === 1) {
+					await new Promise<never>((_, reject) => {
+						rejectOldMount = reject;
+					});
+					return;
+				}
+				const close = document.createElement("button");
+				close.dataset.touchpointClose = "true";
+				close.textContent = "Close campaign";
+				this.shadowRoot?.replaceChildren(close);
+			},
+		);
+		let fetchCount = 0;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				const value = fetchCount++ === 0 ? oldDecision : replacementDecision;
+				return new Response(JSON.stringify(value), { status: 200 });
+			}),
+		);
+		render(<ProductionCampaignModal authenticated sessionSubject="user-a" />);
+		await waitFor(() => expect(mountCount).toBe(1));
+		now.mockReturnValue(start + 1_001);
+		window.dispatchEvent(new Event("focus"));
+		await waitFor(() => expect(fetchCount).toBe(2));
+		await waitFor(() => expect(mountCount).toBe(2));
+		await waitFor(() =>
+			expect(
+				screen
+					.getByTestId("campaign-custom-element")
+					.querySelector("opend-touchpoint")
+					?.shadowRoot?.querySelector("[data-touchpoint-close]"),
+			).toBeTruthy(),
+		);
+		rejectOldMount(new Error("stale mount failed"));
+		await waitFor(() =>
+			expect(screen.queryByRole("button", { name: "Close" })).toBeNull(),
+		);
+	});
+
+	it("cancels and fences an expired modal timer after accepting a replacement", async () => {
+		(globalThis as CampaignHostGlobal).__openDesignCampaignTestHost = {
+			client: { osLocale: "en-US", type: "desktop" },
+		};
+		const start = Date.now();
+		const now = vi.spyOn(Date, "now").mockReturnValue(start);
+		const scheduledTimers: Array<{
+			callback: () => void;
+			delay: number;
+			handle: number;
+		}> = [];
+		const actualSetTimeout = globalThis.setTimeout;
+		vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+			callback: TimerHandler,
+			delay?: number,
+			...args: any[]
+		) => {
+			const handle = actualSetTimeout(callback, delay, ...args);
+			if (typeof callback === "function")
+				scheduledTimers.push({
+					callback: () => callback(...args),
+					delay: Number(delay),
+					handle,
+				});
+			return handle;
+		}) as typeof setTimeout);
+		const clearTimeoutMock = vi.spyOn(globalThis, "clearTimeout");
+		const callbacks: Array<(actionId: string) => Promise<void>> = [];
+		vi.spyOn(OpenDesignTouchpointElement.prototype, "mount").mockImplementation(
+			async function (
+				this: OpenDesignTouchpointElement,
+				_entry,
+				_digest,
+				_context,
+				_urls,
+				_actions,
+				options,
+			) {
+				if (options?.dispatchAction) callbacks.push(options.dispatchAction);
+				this.shadowRoot?.replaceChildren(
+					document.createTextNode("Verified campaign"),
+				);
+			},
+		);
+		let resolveReplacement:
+			| ((value: ReturnType<typeof decision>) => void)
+			| undefined;
+		const replacementBody = new Promise<ReturnType<typeof decision>>(
+			(resolve) => {
+				resolveReplacement = resolve;
+			},
+		);
+		const oldDecision = decision({
+			authorizationExpiresAt: new Date(start + 7_000).toISOString(),
+		});
+		const replacementDecision = decision({
+			authorizationExpiresAt: new Date(start + 15_000).toISOString(),
+			touchpointDecisionId: "replacement-modal",
+		});
+		const replacementResponse = new Response(
+			JSON.stringify(replacementDecision),
+			{ status: 200 },
+		);
+		vi.spyOn(replacementResponse, "json").mockReturnValue(replacementBody);
+		const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+			if (init?.method === "POST")
+				return Promise.resolve(
+					new Response(JSON.stringify({ ok: true }), { status: 200 }),
+				);
+			if (fetchMock.mock.calls.length === 2)
+				return Promise.resolve(replacementResponse);
+			return Promise.resolve(
+				new Response(JSON.stringify(oldDecision), { status: 200 }),
+			);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+		Object.defineProperty(navigator, "userActivation", {
+			configurable: true,
+			value: { isActive: true },
+		});
+		render(<ProductionCampaignModal authenticated sessionSubject="user-a" />);
+		await waitFor(() => expect(callbacks).toHaveLength(1));
+		const oldCallback = callbacks[0]!;
+		const oldTimer = scheduledTimers.find((timer) => timer.delay === 7_000);
+		expect(oldTimer).toBeDefined();
+		now.mockReturnValue(start + 7_001); // The old lease is expired, but its timer callback is delayed.
+		window.dispatchEvent(new Event("focus"));
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+		resolveReplacement?.(replacementDecision);
+		await Promise.resolve(); // Replacement acceptance must cancel and fence the old timer before React cleanup.
+		expect(clearTimeoutMock).toHaveBeenCalled(); // The queued old timer below proves cancellation/fencing behavior without Node Timeout identity.
+		await oldCallback("learn");
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(openExternalUrlMock).not.toHaveBeenCalled();
+		await waitFor(() => expect(callbacks).toHaveLength(2));
+		await act(async () => {
+			oldTimer?.callback();
+		}); // A queued stale callback must not clear the replacement.
+		expect(
+			screen
+				.getByTestId("campaign-custom-element")
+				.querySelector("opend-touchpoint")?.shadowRoot?.textContent,
+		).toContain("Verified campaign");
+		await callbacks[1]!("learn");
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/touchpoints/production-runtime/events",
+			expect.objectContaining({ method: "POST" }),
+		);
+		expect(openExternalUrlMock).toHaveBeenCalledWith("https://example.com");
+		const replacementTimer = scheduledTimers.find(
+			(timer) => timer.delay === 7_999,
+		);
+		expect(replacementTimer).toBeDefined();
+		now.mockReturnValue(start + 15_001);
+		await act(async () => {
+			replacementTimer?.callback();
+		});
+		expect(screen.queryByTestId("campaign-custom-element")).toBeNull();
+		await callbacks[1]!("learn");
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+	});
+
+	it("releases a late verified modal resource once without mounting after unmount", async () => {
+		(globalThis as CampaignHostGlobal).__openDesignCampaignTestHost = {
+			client: { osLocale: "en-US", type: "desktop" },
+		};
+		let resolveVerified: ((value: any) => void) | undefined;
+		const verified = new Promise<any>((resolve) => {
+			resolveVerified = resolve;
+		});
+		const verify = vi
+			.spyOn(touchpointComponent, "verifyWebTouchpoint")
+			.mockReturnValue(verified);
+		const mount = vi.spyOn(OpenDesignTouchpointElement.prototype, "mount");
+		mount.mockClear();
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockResolvedValue(
+					new Response(JSON.stringify(decision()), { status: 200 }),
+				),
+		);
+		const view = render(
+			<ProductionCampaignModal authenticated sessionSubject="user-a" />,
+		);
+		await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+		await waitFor(() => expect(verify).toHaveBeenCalledTimes(1));
+		view.unmount();
+		const release = vi.fn();
+		resolveVerified?.({
+			entryUrl: "blob:modal",
+			resourceUrls: new Map(),
+			dispose: release,
+		});
+		await waitFor(() => expect(release).toHaveBeenCalledTimes(1));
+		expect(mount).not.toHaveBeenCalled();
+	});
 });

--- a/apps/web/tests/components/ProductionCampaignModal.test.tsx
+++ b/apps/web/tests/components/ProductionCampaignModal.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 
 import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import {
 	act,
 	cleanup,
@@ -19,7 +21,10 @@ vi.mock("@open-design/host", () => ({
 }));
 vi.mock("../../src/providers/registry", () => ({ openExternalUrl: openExternalUrlMock }));
 
-import { ProductionCampaignModal } from "../../src/components/ProductionCampaignModal";
+import {
+	ProductionCampaignModal,
+	internalActionNavigationUrl,
+} from "../../src/components/ProductionCampaignModal";
 import * as touchpointComponent from "../../src/components/touchpoint-component";
 import { OpenDesignTouchpointElement } from "../../src/components/touchpoint-component";
 
@@ -43,7 +48,18 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
+const modalHostStyles = readFileSync(
+	resolve(process.cwd(), "src/components/TestCampaignModal.module.css"),
+	"utf8",
+);
+
 describe("ProductionCampaignModal", () => {
+	it("keeps generic modal chrome content-sized without asymmetric host padding", () => {
+		const modalRule = modalHostStyles.match(/\.modal\s*\{[^}]*\}/)?.[0];
+		expect(modalRule).toContain("max-width: calc(100vw - 32px)");
+		expect(modalRule).not.toMatch(/(?:^|[;{]\s*)width:/);
+		expect(modalRule).not.toMatch(/(?:^|[;{]\s*)padding:/);
+	});
 	it("does not restart the production loader on an unchanged parent render",async()=>{
 		(globalThis as CampaignHostGlobal).__openDesignCampaignTestHost={client:{osLocale:"en-US",type:"desktop"}};
 		const fetchMock=vi.fn(async()=>new Response(JSON.stringify(decision()),{status:200}));
@@ -88,7 +104,10 @@ describe("ProductionCampaignModal", () => {
 		expect(screen.getByTestId("campaign-custom-element").querySelector("opend-touchpoint")).not.toBeNull();
 		expect(document.body.style.overflow).toBe("hidden");
 		expect(document.querySelector("iframe,webview")).toBeNull();
-		fireEvent.click(screen.getByRole("button", { name: "Close" }));
+		// The frozen `close` capability only grants an SDK callback; this fixture
+		// deliberately renders no close affordance, so the host fallback must remain.
+		expect(screen.getByRole("button", { name: "Close" })).toBeTruthy();
+		fireEvent.keyDown(document, { key: "Escape" });
 		expect(document.body.style.overflow).toBe("");
 		expect(screen.queryByRole("dialog")).toBeNull();
 		first.unmount();
@@ -172,6 +191,28 @@ it("rejects a decision unless both decision and content target the campaign moda
 });
 
 describe("Production campaign action guard", () => {
+ it("rejects normalized cross-origin internal targets before reporting an event", async () => {
+  Object.defineProperty(navigator, "userActivation", { configurable: true, value: { isActive: true } });
+  const fetchMock = vi.fn(); vi.stubGlobal("fetch", fetchMock);
+  const accepted = await (await import("../../src/components/ProductionCampaignModal")).dispatchProductionCampaignAction(
+   decision({ staticActions: [{ id: "escape", target: { kind: "internal", path: "/\\evil.example" } }] }) as any,
+   "escape", 1, () => 1, Date.now() + 10_000,
+  );
+  expect(accepted).toBe(false);
+  expect(fetchMock).not.toHaveBeenCalled();
+ });
+
+ it("keeps valid internal navigation on the current origin", () => {
+  expect(internalActionNavigationUrl("/projects?view=active#recent", "https://app.example/home")?.href).toBe(
+   "https://app.example/projects?view=active#recent",
+  );
+  for (const path of [
+   String.raw`/\evil.example`,
+   `/${"\t"}/evil.example`,
+   `/${"\n"}/evil.example`,
+  ]) expect(internalActionNavigationUrl(path, "https://app.example/home")).toBeNull();
+ });
+
  it("rejects stale callbacks before they can report or consume a static action", async () => {
   const { dispatchProductionCampaignAction } = await import("../../src/components/ProductionCampaignModal");
   const fetchMock = vi.fn(); vi.stubGlobal("fetch", fetchMock);

--- a/apps/web/tests/components/TestCampaignModal.test.tsx
+++ b/apps/web/tests/components/TestCampaignModal.test.tsx
@@ -17,7 +17,12 @@ vi.mock("@open-design/host", () => ({
 	getOpenDesignHost: () =>
 		(globalThis as CampaignHostGlobal).__openDesignCampaignTestHost,
 }));
-import { TestCampaignModal, useTestRuntime } from "../../src/components/TestCampaignModal";
+import {
+	TestCampaignModal,
+	TestTouchpointMount,
+	useTestRuntime,
+} from "../../src/components/TestCampaignModal";
+import type { TestDecision } from "../../src/components/TestCampaignModal";
 import { ProductionCampaignModal } from "../../src/components/ProductionCampaignModal";
 import * as touchpointComponent from "../../src/components/touchpoint-component";
 import { OpenDesignTouchpointElement } from "../../src/components/touchpoint-component";
@@ -103,12 +108,17 @@ function fetches(response: Record<string, unknown> = runtime()) {
 										id: "deployment-1",
 										activityId: "activity-1",
 										snapshotHash: "sha256:test-snapshot",
-										snapshot: { contentVersionId:content.id, manifestHash:content.manifestHash, artifactHash:"sha256:test-artifact", placementKeys: ["opend.home.campaign-modal"] },
+										snapshot: {
+											contentVersionId: content.id,
+											manifestHash: content.manifestHash,
+											artifactHash: "sha256:test-artifact",
+											placementKeys: ["opend.home.campaign-modal"],
+										},
 									},
 								],
 							}
-							: url.includes("context")
-								? response.context
+						: url.includes("context")
+							? response.context
 							: response,
 				),
 				{ status: 200 },
@@ -145,9 +155,12 @@ const allTestManifest = {
 	resources: allTestPlacements.map((key) => `${key.split(".").at(-1)}.js`),
 	images: [],
 };
-function fourPlacementContent(placementKey: (typeof allTestPlacements)[number]) {
+function fourPlacementContent(
+	placementKey: (typeof allTestPlacements)[number],
+) {
 	const entryPath = `${placementKey.split(".").at(-1)}.js`;
-	const module = "export function mount(root) { root.textContent = 'Verified campaign'; return root; }";
+	const module =
+		"export function mount(root) { root.textContent = 'Verified campaign'; return root; }";
 	return {
 		...content,
 		id: "version-four-placement",
@@ -158,12 +171,21 @@ function fourPlacementContent(placementKey: (typeof allTestPlacements)[number]) 
 		entryPath,
 		entryDigest: digest(module),
 		entryModule: module,
-		resources: [{ path: entryPath, digest: digest(module), bytes: btoa(module) }],
+		resources: [
+			{ path: entryPath, digest: digest(module), bytes: btoa(module) },
+		],
 	};
 }
 function TestRuntimeProbe() {
 	const runtime = useTestRuntime();
-	return <output data-testid="test-runtime-decision-count" data-selected={runtime?.deployment.id ?? ""}>{runtime?.decisions.size ?? 0}</output>;
+	return (
+		<output
+			data-testid="test-runtime-decision-count"
+			data-selected={runtime?.deployment.id ?? ""}
+		>
+			{runtime?.decisions.size ?? 0}
+		</output>
+	);
 }
 function TestCampaignHarness({
 	authenticated,
@@ -174,7 +196,10 @@ function TestCampaignHarness({
 }) {
 	return (
 		<>
-			<TestCampaignModal authenticated={authenticated} sessionSubject={sessionSubject} />
+			<TestCampaignModal
+				authenticated={authenticated}
+				sessionSubject={sessionSubject}
+			/>
 			<ProductionCampaignModal
 				authenticated={authenticated}
 				sessionSubject={sessionSubject ?? null}
@@ -290,6 +315,95 @@ describe("CMS modal host cleanup", () => {
 });
 
 describe("TestCampaignModal host guards", () => {
+	it("refreshes close-control availability when a shadow control becomes enabled", async () => {
+		let closeControl!: HTMLButtonElement;
+		vi.spyOn(touchpointComponent, "verifyWebTouchpoint").mockResolvedValue({
+			entryUrl: "blob:test-campaign",
+			resourceUrls: new Map(),
+			dispose: vi.fn(),
+		} as never);
+		vi.spyOn(OpenDesignTouchpointElement.prototype, "mount").mockImplementation(
+			async function (this: OpenDesignTouchpointElement) {
+				closeControl = document.createElement("button");
+				closeControl.dataset.touchpointClose = "true";
+				closeControl.disabled = true;
+				this.shadowRoot?.replaceChildren(closeControl);
+			},
+		);
+		const onCloseControlChange = vi.fn();
+		render(
+			<TestTouchpointMount
+				decision={runtime() as TestDecision}
+				placementKey="opend.home.campaign-modal"
+				testId="test-touchpoint-mount"
+				onVisible={vi.fn()}
+				onCloseControlChange={onCloseControlChange}
+			/>,
+		);
+		await waitFor(() => expect(onCloseControlChange).toHaveBeenCalledWith(false));
+		closeControl.disabled = false;
+		await waitFor(() => expect(onCloseControlChange).toHaveBeenCalledWith(true));
+	});
+
+	it("does not let a rejected stale Test mount overwrite a replacement close control", async () => {
+		let rejectOldMount!: (reason?: unknown) => void;
+		let mountCount = 0;
+		vi.spyOn(touchpointComponent, "verifyWebTouchpoint").mockResolvedValue({
+			entryUrl: "blob:test-campaign",
+			resourceUrls: new Map(),
+			dispose: vi.fn(),
+		} as never);
+		vi.spyOn(OpenDesignTouchpointElement.prototype, "mount").mockImplementation(
+			async function (this: OpenDesignTouchpointElement) {
+				mountCount += 1;
+				if (mountCount === 1) {
+					await new Promise<never>((_, reject) => {
+						rejectOldMount = reject;
+					});
+					return;
+				}
+				const close = document.createElement("button");
+				close.dataset.touchpointClose = "true";
+				this.shadowRoot?.replaceChildren(close);
+			},
+		);
+		const onCloseControlChange = vi.fn();
+		touchpointComponent.ensureWebTouchpointElement();
+		const firstDecision = runtime() as TestDecision;
+		const replacementDecision = {
+			...firstDecision,
+			content: { ...firstDecision.content, id: "replacement-version" },
+		} as TestDecision;
+		const { rerender } = render(
+			<div role="dialog">
+				<TestTouchpointMount
+					decision={firstDecision}
+					placementKey="opend.home.campaign-modal"
+					testId="test-touchpoint-mount"
+					onVisible={vi.fn()}
+					onCloseControlChange={onCloseControlChange}
+				/>
+			</div>,
+		);
+		await waitFor(() => expect(mountCount).toBe(1));
+		rerender(
+			<div role="dialog">
+				<TestTouchpointMount
+					decision={replacementDecision}
+					placementKey="opend.home.campaign-modal"
+					testId="test-touchpoint-mount"
+					onVisible={vi.fn()}
+					onCloseControlChange={onCloseControlChange}
+				/>
+			</div>,
+		);
+		await waitFor(() => expect(mountCount).toBe(2));
+		await waitFor(() => expect(onCloseControlChange).toHaveBeenLastCalledWith(true));
+		rejectOldMount(new Error("stale Test mount failed"));
+		await Promise.resolve();
+		expect(onCloseControlChange).toHaveBeenLastCalledWith(true);
+	});
+
 	it("skips a decision whose required capabilities drift from its immutable manifest and emits a diagnostic", async () => {
 		const diagnostics: string[] = [];
 		document.addEventListener(
@@ -356,77 +470,150 @@ describe("Test campaign decision and lifecycle guards", () => {
 		expect(screen.queryByRole("dialog")).toBeNull();
 	});
 	it("refuses a selected deployment whose immutable snapshot identity is missing", async () => {
-		const base=fetches();
-		vi.stubGlobal("fetch",async(url:string)=>{
-			const response=await base(url);
-			if(!url.endsWith("/deployments"))return response;
-			const body=await response.json();
+		const base = fetches();
+		vi.stubGlobal("fetch", async (url: string) => {
+			const response = await base(url);
+			if (!url.endsWith("/deployments")) return response;
+			const body = await response.json();
 			delete body.deployments[0].snapshotHash;
 			return new Response(JSON.stringify(body));
 		});
-		const diagnostics:string[]=[];
-		document.addEventListener("touchpointdiagnostic",event=>diagnostics.push((event as CustomEvent).detail.code),{once:true});
-		render(<><TestCampaignHarness authenticated /><TestRuntimeProbe /></>);
+		const diagnostics: string[] = [];
+		document.addEventListener(
+			"touchpointdiagnostic",
+			(event) => diagnostics.push((event as CustomEvent).detail.code),
+			{ once: true },
+		);
+		render(
+			<>
+				<TestCampaignHarness authenticated />
+				<TestRuntimeProbe />
+			</>,
+		);
 		await screen.findByTestId("touchpoint-test-selector");
-		fireEvent.change(screen.getByLabelText("Test activity"),{target:{value:"deployment-1"}});
-		await waitFor(()=>expect(diagnostics).toContain("touchpoint_decision_mismatch"));
+		fireEvent.change(screen.getByLabelText("Test activity"), {
+			target: { value: "deployment-1" },
+		});
+		await waitFor(() =>
+			expect(diagnostics).toContain("touchpoint_decision_mismatch"),
+		);
 		expect(screen.queryByRole("dialog")).toBeNull();
-		expect(screen.getByTestId("test-runtime-decision-count")).toHaveAttribute("data-selected","deployment-1");
+		expect(screen.getByTestId("test-runtime-decision-count")).toHaveAttribute(
+			"data-selected",
+			"deployment-1",
+		);
 	});
-	it.each(["activity", "tester", "actions"])("rejects mismatched %s identity before mounting",async(kind)=>{
-		const value=runtime();
-		const response={...value,
-			...(kind==="activity"?{activityId:"other-activity"}:{}),
-			...(kind==="tester"?{testContext:{...value.testContext,testerMemberId:"other-tester"}}:{}),
-			...(kind==="actions"?{staticActions:[{id:"forged",target:{kind:"https",url:"https://example.com"}}]}:{}),
-		};
-		const diagnostics:string[]=[];
-		document.addEventListener("touchpointdiagnostic",event=>diagnostics.push((event as CustomEvent).detail.code),{once:true});
-		vi.stubGlobal("fetch",fetches(response));
-		render(<TestCampaignHarness authenticated />);
+	it.each(["activity", "tester", "actions"])(
+		"rejects mismatched %s identity before mounting",
+		async (kind) => {
+			const value = runtime();
+			const response = {
+				...value,
+				...(kind === "activity" ? { activityId: "other-activity" } : {}),
+				...(kind === "tester"
+					? {
+							testContext: {
+								...value.testContext,
+								testerMemberId: "other-tester",
+							},
+						}
+					: {}),
+				...(kind === "actions"
+					? {
+							staticActions: [
+								{
+									id: "forged",
+									target: { kind: "https", url: "https://example.com" },
+								},
+							],
+						}
+					: {}),
+			};
+			const diagnostics: string[] = [];
+			document.addEventListener(
+				"touchpointdiagnostic",
+				(event) => diagnostics.push((event as CustomEvent).detail.code),
+				{ once: true },
+			);
+			vi.stubGlobal("fetch", fetches(response));
+			render(<TestCampaignHarness authenticated />);
+			await screen.findByTestId("touchpoint-test-selector");
+			fireEvent.change(screen.getByLabelText("Test activity"), {
+				target: { value: "deployment-1" },
+			});
+			await waitFor(() =>
+				expect(diagnostics).toContain("touchpoint_decision_mismatch"),
+			);
+			expect(screen.queryByRole("dialog")).toBeNull();
+		},
+	);
+	it("clears selected Test content when the authenticated account changes", async () => {
+		vi.stubGlobal("fetch", fetches());
+		const { rerender } = render(
+			<TestCampaignHarness authenticated sessionSubject="account-a" />,
+		);
 		await screen.findByTestId("touchpoint-test-selector");
-		fireEvent.change(screen.getByLabelText("Test activity"),{target:{value:"deployment-1"}});
-		await waitFor(()=>expect(diagnostics).toContain("touchpoint_decision_mismatch"));
-		expect(screen.queryByRole("dialog")).toBeNull();
-	});
-	it("clears selected Test content when the authenticated account changes",async()=>{
-		vi.stubGlobal("fetch",fetches());
-		const {rerender}=render(<TestCampaignHarness authenticated sessionSubject="account-a" />);
-		await screen.findByTestId("touchpoint-test-selector");
-		fireEvent.change(screen.getByLabelText("Test activity"),{target:{value:"deployment-1"}});
+		fireEvent.change(screen.getByLabelText("Test activity"), {
+			target: { value: "deployment-1" },
+		});
 		await screen.findByRole("dialog");
 		rerender(<TestCampaignHarness authenticated sessionSubject="account-b" />);
-		await waitFor(()=>expect(screen.queryByRole("dialog")).toBeNull());
+		await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
 		expect(screen.getByLabelText("Test activity")).toHaveValue("");
 	});
-	it("does not let a late failed context request clear a newer selection",async()=>{
-		let failFirst!: (value:Response)=>void;
-		const firstContext=new Promise<Response>(resolve=>{failFirst=resolve;});
-		const base=fetches();
-		vi.stubGlobal("fetch",async(url:string,init?:RequestInit)=>{
-			if(url.endsWith("/deployments")){
-				const body=await (await base(url)).json();
-				body.deployments.push({...body.deployments[0],id:"deployment-2",activityId:"activity-2"});
+	it("does not let a late failed context request clear a newer selection", async () => {
+		let failFirst!: (value: Response) => void;
+		const firstContext = new Promise<Response>((resolve) => {
+			failFirst = resolve;
+		});
+		const base = fetches();
+		vi.stubGlobal("fetch", async (url: string, init?: RequestInit) => {
+			if (url.endsWith("/deployments")) {
+				const body = await (await base(url)).json();
+				body.deployments.push({
+					...body.deployments[0],
+					id: "deployment-2",
+					activityId: "activity-2",
+				});
 				return new Response(JSON.stringify(body));
 			}
-			if(url.endsWith("/context")){
-				const selected=JSON.parse(String(init?.body)).deploymentId;
-				if(selected==="deployment-1")return firstContext;
-				return new Response(JSON.stringify({...runtime().context,deploymentId:selected}));
+			if (url.endsWith("/context")) {
+				const selected = JSON.parse(String(init?.body)).deploymentId;
+				if (selected === "deployment-1") return firstContext;
+				return new Response(
+					JSON.stringify({ ...runtime().context, deploymentId: selected }),
+				);
 			}
-			const value=runtime();
-			return new Response(JSON.stringify({...value,activityId:"activity-2",deploymentId:"deployment-2",testContext:{...value.testContext,deploymentId:"deployment-2"}}));
+			const value = runtime();
+			return new Response(
+				JSON.stringify({
+					...value,
+					activityId: "activity-2",
+					deploymentId: "deployment-2",
+					testContext: { ...value.testContext, deploymentId: "deployment-2" },
+				}),
+			);
 		});
 		render(<TestCampaignHarness authenticated />);
 		await screen.findByTestId("touchpoint-test-selector");
-		fireEvent.change(screen.getByLabelText("Test activity"),{target:{value:"deployment-1"}});
-		fireEvent.change(screen.getByLabelText("Test activity"),{target:{value:"deployment-2"}});
+		fireEvent.change(screen.getByLabelText("Test activity"), {
+			target: { value: "deployment-1" },
+		});
+		fireEvent.change(screen.getByLabelText("Test activity"), {
+			target: { value: "deployment-2" },
+		});
 		await screen.findByRole("dialog");
-		await act(async()=>{
-			failFirst(new Response(JSON.stringify({error:"failed"}),{status:500}));
+		await act(async () => {
+			failFirst(
+				new Response(JSON.stringify({ error: "failed" }), { status: 500 }),
+			);
 			await firstContext;
 		});
-		await waitFor(()=>expect(screen.getByLabelText("Test activity")).toHaveValue("deployment-2"));
+		await waitFor(() =>
+			expect(screen.getByLabelText("Test activity")).toHaveValue(
+				"deployment-2",
+			),
+		);
 		expect(screen.getByRole("dialog")).toBeInTheDocument();
 	});
 	it("diagnoses immutable byte integrity failure and revokes every created Blob URL", async () => {
@@ -509,7 +696,7 @@ describe("Test campaign decision and lifecycle guards", () => {
 	});
 });
 
-	describe("Test campaign four-placement contract", () => {
+describe("Test campaign four-placement contract", () => {
 	it("loads the real context shape, mounts every enabled placement, and records one server acceptance per visible host", async () => {
 		const context = {
 			deploymentId: "deployment-four",
@@ -540,48 +727,96 @@ describe("Test campaign decision and lifecycle guards", () => {
 					artifactHash: deployment.snapshot.artifactHash,
 					manifestHash: deployment.snapshot.manifestHash,
 					requiredCapabilities:
-					placementKey === "opend.home.campaign-modal"
-						? ["close", "static-action"]
-						: placementKey === "opend.home.account-badge"
-							? ["static-action"]
-							: ["hover", "static-action"],
+						placementKey === "opend.home.campaign-modal"
+							? ["close", "static-action"]
+							: placementKey === "opend.home.account-badge"
+								? ["static-action"]
+								: ["hover", "static-action"],
 					activityId: deployment.activityId,
 					testContext: { ...context, scheduleState: "active" as const },
 				},
 			]),
 		);
-		((globalThis as CampaignHostGlobal).__openDesignCampaignTestHost as { client: { osLocale: string } }).client.osLocale = "zh-CN";
+		(
+			(globalThis as CampaignHostGlobal).__openDesignCampaignTestHost as {
+				client: { osLocale: string };
+			}
+		).client.osLocale = "zh-CN";
 		const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
 			if (init?.method === "POST" && url.includes("acceptances"))
-				return new Response(JSON.stringify({ id: "acceptance" }), { status: 201 });
+				return new Response(JSON.stringify({ id: "acceptance" }), {
+					status: 201,
+				});
 			if (init?.method === "POST")
 				return new Response(JSON.stringify(context), { status: 201 });
 			if (url.includes("/deployments"))
-				return new Response(JSON.stringify({ deployments: [deployment] }), { status: 200 });
-			const placementKey = new URL(url, "http://127.0.0.1").searchParams.get("placementKey");
-			return new Response(JSON.stringify(responses.get(placementKey as (typeof allTestPlacements)[number])), { status: 200 });
+				return new Response(JSON.stringify({ deployments: [deployment] }), {
+					status: 200,
+				});
+			const placementKey = new URL(url, "http://127.0.0.1").searchParams.get(
+				"placementKey",
+			);
+			return new Response(
+				JSON.stringify(
+					responses.get(placementKey as (typeof allTestPlacements)[number]),
+				),
+				{ status: 200 },
+			);
 		});
 		vi.stubGlobal("fetch", fetchMock);
-		const mount = vi.spyOn(OpenDesignTouchpointElement.prototype, "mount").mockImplementation(async function (this: OpenDesignTouchpointElement) {
-			this.shadowRoot?.replaceChildren(document.createTextNode("Verified campaign"));
-		});
+		const mount = vi
+			.spyOn(OpenDesignTouchpointElement.prototype, "mount")
+			.mockImplementation(async function (this: OpenDesignTouchpointElement) {
+				this.shadowRoot?.replaceChildren(
+					document.createTextNode("Verified campaign"),
+				);
+			});
 		vi.spyOn(touchpointComponent, "verifyWebTouchpoint").mockResolvedValue({
 			entryUrl: "blob:test-four-placement",
 			resourceUrls: new Map(),
 			dispose: vi.fn(),
 		} as never);
-		vi.spyOn(HTMLElement.prototype, "getClientRects").mockReturnValue({ length: 1, item: () => null } as unknown as DOMRectList);
-		render(<><TestRuntimeProbe /><TestCampaignHarness authenticated /></>);
+		vi.spyOn(HTMLElement.prototype, "getClientRects").mockReturnValue({
+			length: 1,
+			item: () => null,
+		} as unknown as DOMRectList);
+		render(
+			<>
+				<TestRuntimeProbe />
+				<TestCampaignHarness authenticated />
+			</>,
+		);
 		await screen.findByTestId("touchpoint-test-selector");
-		fireEvent.change(screen.getByLabelText("Test activity"), { target: { value: deployment.id } });
+		fireEvent.change(screen.getByLabelText("Test activity"), {
+			target: { value: deployment.id },
+		});
 		await screen.findByRole("dialog");
-		await waitFor(() => expect(screen.getByTestId("test-runtime-decision-count")).toHaveTextContent("4"));
+		await waitFor(() =>
+			expect(
+				screen.getByTestId("test-runtime-decision-count"),
+			).toHaveTextContent("4"),
+		);
 		await waitFor(() => expect(mount).toHaveBeenCalledTimes(1));
-		const acceptanceCalls = () => fetchMock.mock.calls.filter(([url, init]) => init?.method === "POST" && url.includes("acceptances"));
+		const acceptanceCalls = () =>
+			fetchMock.mock.calls.filter(
+				([url, init]) => init?.method === "POST" && url.includes("acceptances"),
+			);
 		await waitFor(() => expect(acceptanceCalls()).toHaveLength(1));
-		expect(acceptanceCalls().map(([, init]) => JSON.parse(String(init?.body)).placementKey)).toEqual(["opend.home.campaign-modal"]);
+		expect(
+			acceptanceCalls().map(
+				([, init]) => JSON.parse(String(init?.body)).placementKey,
+			),
+		).toEqual(["opend.home.campaign-modal"]);
 		for (const placementKey of allTestPlacements) {
-			expect(fetchMock.mock.calls.some(([url, init]) => init?.method !== "POST" && new URL(url, "http://127.0.0.1").searchParams.get("placementKey") === placementKey)).toBe(true);
+			expect(
+				fetchMock.mock.calls.some(
+					([url, init]) =>
+						init?.method !== "POST" &&
+						new URL(url, "http://127.0.0.1").searchParams.get(
+							"placementKey",
+						) === placementKey,
+				),
+			).toBe(true);
 		}
 	});
 });

--- a/apps/web/tests/components/touchpoint-component.test.ts
+++ b/apps/web/tests/components/touchpoint-component.test.ts
@@ -3,6 +3,8 @@ import { createHash } from "node:crypto";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+	hasWebTouchpointCloseControl,
+	OpenDesignTouchpointElement,
 	verifyWebTouchpoint,
 	type WebTouchpointContent,
 } from "../../src/components/touchpoint-component";
@@ -100,6 +102,27 @@ function content(
 }
 
 afterEach(() => vi.restoreAllMocks());
+
+describe("hasWebTouchpointCloseControl", () => {
+	it("ignores disabled or hidden marker controls and accepts a usable control", () => {
+		const element = document.createElement(
+			"opend-touchpoint",
+		) as OpenDesignTouchpointElement;
+		const root = element.attachShadow({ mode: "open" });
+		const hidden = document.createElement("button");
+		hidden.dataset.touchpointClose = "true";
+		hidden.disabled = true;
+		root.append(hidden);
+		expect(hasWebTouchpointCloseControl(element)).toBe(false);
+		hidden.disabled = false;
+		hidden.hidden = true;
+		expect(hasWebTouchpointCloseControl(element)).toBe(false);
+		hidden.hidden = false;
+		expect(hasWebTouchpointCloseControl(element)).toBe(true);
+		element.hidden = true;
+		expect(hasWebTouchpointCloseControl(element)).toBe(false);
+	});
+});
 
 describe("verifyWebTouchpoint multi-placement resource closure", () => {
 	it("loads only OD resources from a mixed package containing a Vela subscription action", async () => {

--- a/apps/web/tests/runtime/cms-host-release-fingerprint.test.ts
+++ b/apps/web/tests/runtime/cms-host-release-fingerprint.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  CMS_HOST_RELEASE_INPUTS,
+  cmsHostReleaseFingerprint,
+} from '../../next.config';
+
+const workspaceRoot = resolve(process.cwd(), '../..');
+const readCmsHostReleaseInput = (
+  file: (typeof CMS_HOST_RELEASE_INPUTS)[number],
+) => readFileSync(resolve(workspaceRoot, file));
+
+describe('CMS host release fingerprint', () => {
+  it('is stable for identical host sources', () => {
+    expect(cmsHostReleaseFingerprint(readCmsHostReleaseInput)).toBe(
+      cmsHostReleaseFingerprint(readCmsHostReleaseInput),
+    );
+  });
+
+  it.each([
+    'apps/web/src/components/HoverTouchpointOverlay.tsx',
+    'apps/web/src/components/HoverTouchpointOverlay.module.css',
+  ] as const)('changes when real hover overlay input %s changes', (changedFile) => {
+    expect(CMS_HOST_RELEASE_INPUTS).toContain(changedFile);
+
+    const baseline = cmsHostReleaseFingerprint(readCmsHostReleaseInput);
+    const changedOverlay = cmsHostReleaseFingerprint((file) =>
+      file === changedFile
+        ? Buffer.concat([readCmsHostReleaseInput(file), Buffer.from('\n/* changed */')])
+        : readCmsHostReleaseInput(file),
+    );
+
+    expect(changedOverlay).not.toBe(baseline);
+  });
+});

--- a/apps/web/tests/runtime/cms-host-release-fingerprint.test.ts
+++ b/apps/web/tests/runtime/cms-host-release-fingerprint.test.ts
@@ -1,36 +1,37 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
 import {
-  CMS_HOST_RELEASE_INPUTS,
-  cmsHostReleaseFingerprint,
-} from '../../next.config';
+	CMS_HOST_RELEASE_INPUTS,
+	cmsHostReleaseFingerprint,
+} from "../../next.config";
 
-const workspaceRoot = resolve(process.cwd(), '../..');
+const workspaceRoot = resolve(process.cwd(), "../..");
 const readCmsHostReleaseInput = (
-  file: (typeof CMS_HOST_RELEASE_INPUTS)[number],
+	file: (typeof CMS_HOST_RELEASE_INPUTS)[number],
 ) => readFileSync(resolve(workspaceRoot, file));
 
-describe('CMS host release fingerprint', () => {
-  it('is stable for identical host sources', () => {
-    expect(cmsHostReleaseFingerprint(readCmsHostReleaseInput)).toBe(
-      cmsHostReleaseFingerprint(readCmsHostReleaseInput),
-    );
-  });
+describe("CMS host release fingerprint", () => {
+	it("is stable for identical host sources", () => {
+		expect(cmsHostReleaseFingerprint(readCmsHostReleaseInput)).toBe(
+			cmsHostReleaseFingerprint(readCmsHostReleaseInput),
+		);
+	});
 
-  it.each([
-    'apps/web/src/components/HoverTouchpointOverlay.tsx',
-    'apps/web/src/components/HoverTouchpointOverlay.module.css',
-  ] as const)('changes when real hover overlay input %s changes', (changedFile) => {
-    expect(CMS_HOST_RELEASE_INPUTS).toContain(changedFile);
+	it.each(CMS_HOST_RELEASE_INPUTS)(
+		"changes when host input %s changes",
+		(changedFile) => {
+			const baseline = cmsHostReleaseFingerprint(readCmsHostReleaseInput);
+			const changedHost = cmsHostReleaseFingerprint((file) =>
+				file === changedFile
+					? Buffer.concat([
+							readCmsHostReleaseInput(file),
+							Buffer.from("\n/* changed */"),
+						])
+					: readCmsHostReleaseInput(file),
+			);
 
-    const baseline = cmsHostReleaseFingerprint(readCmsHostReleaseInput);
-    const changedOverlay = cmsHostReleaseFingerprint((file) =>
-      file === changedFile
-        ? Buffer.concat([readCmsHostReleaseInput(file), Buffer.from('\n/* changed */')])
-        : readCmsHostReleaseInput(file),
-    );
-
-    expect(changedOverlay).not.toBe(baseline);
-  });
+			expect(changedHost).not.toBe(baseline);
+		},
+	);
 });

--- a/docs/qa/cms-codex-handoff-20260910.md
+++ b/docs/qa/cms-codex-handoff-20260910.md
@@ -1,0 +1,53 @@
+# CMS Codex 验收交接（2026-09-10）
+
+## 目的与边界
+
+本交接覆盖本 PR 的已完成代码、可复跑验收和剩余阻断项；它**不**授权合并、部署、生产操作、Plane 更新或自动关闭任何工单。认证、部署状态、远端 CI、合并和已部署版本均为 **UNKNOWN**，除非接手者以自己的安全登录态重新读取并记录。不得读取凭据、不得静默改指向生产、不得接管其他运行时。
+
+依赖顺序：既有 Vela #1963 的分支 `codex/cms-content-selection` → 本 Vela 后续 PR；既有 Open Design #7986 的分支 `codex/fix-cms-shared-manifest`（其原有 base `codex/cms-admin-hosts-e2e` 保持不变）→ 本 OD 后续 PR。两仓库不可合为一个 PR。
+
+## 状态矩阵
+
+| 验收 ID | 状态 | 本 PR 实现/本地测试 | 当前浏览器/集成 | 结论 |
+|---|---|---|---|---|
+| AC-2998 | 已实现，局部验证 | 四位年份上限、blur/save；Admin 定向测试与 lint 通过 | Admin 真浏览器和持久化读回 UNKNOWN | 不可声称已部署 |
+| AC-3020 | 已实现，局部验证 | API/BFF/Admin 字段错误、create/edit 保留及 update failure-seam 测试通过 | 真 Admin/API UNKNOWN | 不可声称已部署 |
+| AC-3000 | 已实现，局部验证 | 反斜杠/控制字符/哨兵源拒绝，query/hash 允许；contracts 通过 | 受控 Chromium helper 通过；所有 placement/Test 默认拒绝 UNKNOWN | 非端到端 |
+| AC-3001 | 已实现，局部验证 | host fingerprint 纳入 overlay；定向测试通过 | 编译运行时 fingerprint UNKNOWN | 开发者指纹测试，不是通用 UI 断言 |
+| AC-3009 | 部分实现 | 内容尺寸/视口 CSS 与测试通过；保留无条件 host Close 兼容 fallback | 精确编译包、500px/窄/短滚动 UNKNOWN | 重复 Close **未修复** |
+| AC-3010 | 既有 base 行为 | 无本 PR 独立修复 | UNKNOWN | 不归功于本 PR |
+| AC-3013 | 已实现，局部验证 | top-right host/相对定位及结构测试通过 | 最终 EntryShell/账号角标集成 UNKNOWN | 不可声称完整布局验收 |
+| AC-3014 | 部分浏览器验证 | hover 几何与组件测试通过 | 受控 Chromium：三次慢速正反跨 8px、可信 Shadow SDK action、Escape 焦点、窄屏翻转通过；非真实 dispatcher/native linked runtime | 受控证据，不是全链路 |
+| AC-3002 | **FOLLOW-UP / FAIL** | 当前 `ProductionCampaignModal` 仍 await telemetry；500/network 拒绝已授权 action | 不把早期 Vela click harness 当 OD 重现 | 必须单独修复后复测 |
+
+历史恢复/既有事项 2999、3005、3007、2982、3021 不是本 PR 的自有变更；恶意 SVG 与五个 pending receipt 仍为历史未闭环发现。源 ZIP 中缺少 `girl.webp` 并不代表包损坏：源 `girl-source.jpg` 会编译为 `girl.webp`。
+
+## 可观察验收（测试人员）
+
+- **AC-2998**：新建与编辑各输入六位年份，blur 后保存应拒绝；输入有效四位年份，日历值保存后保持。
+- **AC-3020**：分别验证 past-start、end<=start、missing、not-ready、unsupported placements 的单字段错误；新建/编辑中返回 4xx 与拒绝的 5xx 都保留名称、Ready 内容版本、placements、开始、结束、时区六字段。Ready selector 可能阻止无效版本，需使用受控后端错误 fixture，不要伪造 UI 输入。
+- **AC-3000**：`/projects?view=active#recent` 可用；反斜杠、`/\\evil.example`、slash+tab/newline 必拒绝；混合 manifest 只允许本 host action；Test 默认拒绝。
+- **AC-3013/3014**：右上入口与账号角标同时存在且没有底部重复；慢速正向/反向各跨 8px 缝隙三次后可点真实 action；再验外部离开、窄屏翻转、Escape 与焦点返回。
+- **AC-3009**：500px、窄屏、短屏滚动与 fallback Close；记录“重复 Close 未修复”，不得把 fallback 当单一 Close 证明。
+- **AC-3002（修复后强制复测）**：先保持 auth 拒绝，再独立验证 telemetry 500/network 不撤销已经授权的 action；冻结策略后再分类 401/403/409。
+- **AC-3001**：比较开发者提供的编译包 fingerprint，不以普通 UI 画面替代。
+
+## 安全运行手册
+
+1. 以两个隔离 checkout 加载候选；先确认显示的 source/build runtime 属于候选 SHA，绝不复用或重启用户拥有的 `17686/17687`、`agent-cms-operator-da21`。
+2. Open Design 仅按 scoped docs 启动：`OD_DATA_DIR=<candidate>/.tmp/joint-validation-browser/data corepack pnpm@10.33.2 tools-dev run web --namespace cms-joint-validation-browser --daemon-port 19786 --web-port 19787`。端口 `19786/19787` 及 fixture `19788` 为本次 owned 约定；如占用，停止并记录，不接管。
+3. Vela 仅用其 scoped docs 的 `pnpm dev` / `with-env` 隔离命令和自己的 sandbox；不自行编造认证、fixture 或环境变量。需要登录时请测试者通过安全用户登录完成，不读 secret。
+4. 固定源归档：`/Users/alche/Downloads/deepseek-v4.1-flash-五点位测试组件.zip`，SHA-256 `690d897450e4a53af269ffcd40cb4ab393652f58b5856cfd8abf9f6185028ad6`。每次还要记录**新编译包**的身份/fingerprint；历史活动 `wobpnxd7ptplgjjzevqx9xyd` 与 deployment `gbaa211ukd9duci6c66prrgy` 不是当前已验证身份。
+5. 每条证据使用：`ID / 步骤 / 期望 / 实际 / PASS|FAIL|UNKNOWN / build SHA / 环境 / 包 SHA / 时间 / 截图或网络或 receipt / 回归影响`。Codex 返回报告与 defect；不得宣称获得 merge/deploy 授权。
+
+## 最终无回归门（所有修复、所有最终 commit 之后）
+
+对每个 bug 用相同 client/environment/package 重复原始复现；只隔离比较 baseline，绝不回退用户运行时。随后跑：五个 placement、upload→build→Ready→Test→retract→edit→new Test、stale-context deny、receipt 在 Admin 持久可见、modal/badge/hover 共存、locale、calendar、schedule/expiry/revocation、可恢复网络失败。生产共存只允许隔离 test fixture，不做生产操作。任一复测失败：修复→复测→重跑受影响回归；最终 SHA 改变即使旧证明失效。完整验收要求无 P0/P1；部分 PR 是否合并必须显式人工决定，绝不自动。
+
+回滚仅通过已评审的 follow-up revert PR；禁止盲 revert 或生产回滚。签收：**PENDING**。
+
+## 开发者附录
+
+- Vela 协议源 `packages/shared/src/touchpoints.ts` 的最终 SHA-256：`be26f9c4e5cfe6e0a0eedee3d31dc70df8f1c8ee61704e765d4f5c89879fc2f0`；OD `TOUCHPOINT_COMPONENT_V2_UPSTREAM_PROVENANCE.sourceSha256.touchpoints` 必须与其一致。
+- 已记录本地：Vela root `pnpm lint` PASS；Edit 定向 `42 passed`；OD contracts `6`、combined `30`、typecheck/guard PASS。此前 OD #3001 production build 只可称“单独验证”，不可称 combined build。
+- #3002 源缺陷位置：`apps/web/src/components/ProductionCampaignModal.tsx:96-128`。#3009 仅为 sizing patch，unconditional host Close 保留。

--- a/e2e/ui/cms-hover.test.ts
+++ b/e2e/ui/cms-hover.test.ts
@@ -1,0 +1,431 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { expect, test } from "@/playwright/suite";
+import {
+	mockAmrPersonalWorkspace,
+	mockAmrWalletSnapshot,
+} from "@/playwright/amr";
+import { applyStandardMocks } from "@/playwright/mock-factory";
+import { T } from "@/timeouts";
+import type { Page, Route } from "@playwright/test";
+
+const { cmsHostReleaseFingerprint } = (await import(
+	`${process.cwd()}/../apps/web/next.config.ts`,
+)) as {
+	cmsHostReleaseFingerprint: (
+		readFile: (file: string) => string | Buffer,
+	) => string;
+};
+
+const WORKSPACE_ROOT = resolve(process.cwd(), "..");
+const digest = (value: string | Buffer) =>
+	`sha256:${createHash("sha256").update(value).digest("hex")}`;
+const hostReleaseFingerprint = cmsHostReleaseFingerprint((file) =>
+	readFileSync(resolve(WORKSPACE_ROOT, file)),
+);
+
+const ENTRY_PLACEMENT = "opend.home.hover-entry";
+const LAYER_PLACEMENT = "opend.home.hover-layer";
+const BADGE_PLACEMENT = "opend.home.account-badge";
+const ACTION_ID = "learn";
+
+const entryModule = `
+  export function mount(root) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = 'Open campaign';
+    button.style.cssText = 'width: 128px; height: 32px;';
+    root.append(button);
+    return button;
+  }
+`;
+const layerModule = `
+  export function mount(root, context, sdk) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = 'Learn more';
+    button.style.cssText = 'width: 180px; height: 72px;';
+    button.addEventListener('click', () => void sdk.dispatchAction('${ACTION_ID}'));
+    root.append(button);
+    return button;
+  }
+`;
+const badgeModule = `
+  export function mount(root) {
+    const badge = document.createElement('span');
+    badge.textContent = 'Campaign badge';
+    badge.style.cssText = 'display: inline-block; width: 116px; height: 24px;';
+    root.append(badge);
+    return badge;
+  }
+`;
+
+const manifest = {
+	formatVersion: 2 as const,
+	runtimeKind: "web-component" as const,
+	runtimeApiVersion: 1 as const,
+	platformWrapperVersion: "vela-touchpoint-wrapper-v1" as const,
+	sdkVersion: "vela-touchpoint-sdk-v1" as const,
+	contentLine: "cms-hover-browser-fixture",
+	placements: [
+		{
+			key: ENTRY_PLACEMENT,
+			entry: "hover-entry.js",
+			resources: [],
+			locales: ["en-US"],
+			requiredCapabilities: ["hover", "static-action"],
+			staticActions: [
+				{
+					id: ACTION_ID,
+					target: {
+						kind: "https" as const,
+						url: "https://example.com/campaign",
+					},
+				},
+			],
+		},
+		{
+			key: LAYER_PLACEMENT,
+			entry: "hover-layer.js",
+			resources: [],
+			locales: ["en-US"],
+			requiredCapabilities: ["hover", "static-action"],
+			staticActions: [
+				{
+					id: ACTION_ID,
+					target: {
+						kind: "https" as const,
+						url: "https://example.com/campaign",
+					},
+				},
+			],
+		},
+		{
+			key: BADGE_PLACEMENT,
+			entry: "badge.js",
+			resources: [],
+			locales: ["en-US"],
+			requiredCapabilities: ["static-action"],
+			staticActions: [
+				{
+					id: ACTION_ID,
+					target: {
+						kind: "https" as const,
+						url: "https://example.com/campaign",
+					},
+				},
+			],
+		},
+	],
+	resources: ["hover-entry.js", "hover-layer.js", "badge.js"],
+	images: [],
+};
+
+const moduleByPlacement = new Map([
+	[ENTRY_PLACEMENT, ["hover-entry.js", entryModule]],
+	[LAYER_PLACEMENT, ["hover-layer.js", layerModule]],
+	[BADGE_PLACEMENT, ["badge.js", badgeModule]],
+] as const);
+
+function contentFor(placementKey: string) {
+	const [entryPath, entry] =
+		moduleByPlacement.get(placementKey as typeof ENTRY_PLACEMENT) ?? [];
+	if (!entryPath || !entry)
+		throw new Error(`missing fixture module for ${placementKey}`);
+	return {
+		id: "cms-hover-browser-version",
+		placementKey,
+		locale: "en-US",
+		manifest,
+		manifestHash: digest(JSON.stringify(manifest)),
+		entryPath,
+		entryDigest: digest(entry),
+		entryModule: entry,
+		resources: [
+			{
+				path: entryPath,
+				digest: digest(entry),
+				bytes: Buffer.from(entry).toString("base64"),
+			},
+		],
+		runtime: {
+			kind: "web-component" as const,
+			apiVersion: 1 as const,
+			wrapperVersion: "vela-touchpoint-wrapper-v1" as const,
+			sdkVersion: "vela-touchpoint-sdk-v1" as const,
+		},
+		buildIdentity: { fingerprint: hostReleaseFingerprint },
+	};
+}
+
+function decisionFor(placementKey: string) {
+	const now = Date.now();
+	return {
+		activityId: "cms-hover-browser-activity",
+		touchpointDecisionId: `cms-hover-${placementKey}`,
+		deploymentId: "cms-hover-browser-deployment",
+		authorizationExpiresAt: new Date(now + 60_000).toISOString(),
+		endsAt: new Date(now + 300_000).toISOString(),
+		serverTime: new Date(now).toISOString(),
+		placementKey,
+		requiredCapabilities:
+			placementKey === BADGE_PLACEMENT
+				? ["static-action"]
+				: ["hover", "static-action"],
+		staticActions: [
+			{
+				id: ACTION_ID,
+				target: { kind: "https" as const, url: "https://example.com/campaign" },
+			},
+		],
+		content: contentFor(placementKey),
+	};
+}
+
+async function installDesktopHost(page: Page) {
+	await page.addInitScript(() => {
+		(window as Window & { __od__?: unknown }).__od__ = {
+			version: 2,
+			client: { type: "desktop", platform: "test", osLocale: "en-US" },
+			shell: {
+				openExternal: async () => ({ ok: true }),
+				openPath: async () => ({ ok: true }),
+			},
+			browser: { clearData: async () => ({ ok: true }) },
+			capture: {
+				page: async () => ({
+					ok: true,
+					dataUrl: "data:image/png;base64,",
+					h: 1,
+					w: 1,
+				}),
+			},
+			project: {
+				pickAndImport: async () => ({
+					ok: true,
+					projectId: "fixture",
+					conversationId: "fixture",
+					entryFile: "index.html",
+				}),
+				pickAndReplaceWorkingDir: async () => ({
+					ok: true,
+					baseDir: "/tmp/fixture",
+					entryFile: null,
+				}),
+			},
+			pdf: { print: async () => ({ ok: true }) },
+			pet: { setVisible: () => undefined },
+			updater: {
+				status: async () => ({
+					arch: "arm64",
+					capabilities: {},
+					channel: "beta",
+					currentVersion: "fixture",
+					enabled: true,
+					mode: "test",
+					platform: "test",
+					state: "idle",
+					supported: true,
+				}),
+				check: async () => ({ ok: true }),
+				"clear-cache": async () => ({ ok: true }),
+				download: async () => ({ ok: true }),
+				install: async () => ({ ok: true }),
+				quit: async () => ({ ok: true }),
+				setMenuLabels: async () => ({ ok: true }),
+				subscribe: () => () => undefined,
+				subscribeOpenDialog: () => () => undefined,
+			},
+		};
+	});
+}
+
+async function installCmsFixture(page: Page) {
+	const responses: Array<{ placementKey: string; fingerprint: string }> = [];
+	const events: Array<Record<string, unknown>> = [];
+	await page.route("**/api/integrations/vela/status", async (route) => {
+		await route.fulfill({
+			json: {
+				loggedIn: true,
+				profile: "local",
+				user: {
+					id: "cms-hover-user",
+					email: "cms-hover@example.com",
+					plan: "free",
+				},
+			},
+		});
+	});
+	await mockAmrPersonalWorkspace(page, undefined, { accountPlan: "free" });
+	await mockAmrWalletSnapshot(page, {
+		email: "cms-hover@example.com",
+		plan: "free",
+	});
+	await page.route(
+		"**/api/touchpoints/production-runtime**",
+		async (route: Route) => {
+			const request = route.request();
+			if (request.method() === "POST") {
+				events.push(request.postDataJSON() as Record<string, unknown>);
+				await route.fulfill({ json: { ok: true } });
+				return;
+			}
+			const placementKey = new URL(request.url()).searchParams.get(
+				"placementKey",
+			);
+			if (!placementKey || placementKey === "opend.home.campaign-modal") {
+				await route.fulfill({ status: 404, json: { error: "no_decision" } });
+				return;
+			}
+			const decision = decisionFor(placementKey);
+			responses.push({
+				placementKey,
+				fingerprint: decision.content.buildIdentity.fingerprint,
+			});
+			await route.fulfill({ json: decision });
+		},
+	);
+	return { responses, events };
+}
+
+async function gotoCmsHome(page: Page) {
+	await page.goto("/", { waitUntil: "domcontentloaded" });
+	await expect(page.getByText("Loading OpenDesign…")).toHaveCount(0, {
+		timeout: T.long,
+	});
+	await expect(page.getByTestId("home-hero")).toBeVisible({ timeout: T.long });
+}
+
+test.describe.configure({ timeout: T.xlong });
+
+test.beforeEach(async ({ page }) => {
+	await applyStandardMocks(page);
+	await installDesktopHost(page);
+});
+
+test("[P1] controlled CMS fixture mounts the top-right badge and hover pair in the real browser", async ({
+	page,
+}) => {
+	const fixture = await installCmsFixture(page);
+	await gotoCmsHome(page);
+
+	const cluster = page.locator(".entry-top-right-cluster");
+	await expect(cluster).toBeVisible();
+	const badge = cluster.getByTestId("production-campaign-badge");
+	await expect(badge).toBeVisible({ timeout: T.medium });
+	const hoverRoot = cluster.getByTestId("cms-hover-overlay-root");
+	const entry = hoverRoot.locator("opend-touchpoint").first();
+	await expect(entry).toBeVisible();
+	await expect.poll(() => fixture.responses.length).toBeGreaterThanOrEqual(3);
+	expect(
+		fixture.responses.every(
+			(response) => response.fingerprint === hostReleaseFingerprint,
+		),
+	).toBe(true);
+	expect(
+		await page
+			.locator(
+				'.entry-top-right-cluster [data-testid="cms-hover-overlay-root"]',
+			)
+			.count(),
+	).toBe(1);
+	expect(
+		await page
+			.locator('[style*="bottom"] [data-testid="cms-hover-overlay-root"]')
+			.count(),
+	).toBe(0);
+});
+
+test("[P1] controlled CMS fixture keeps the real hover layer open across three slow 8px crossings each way", async ({
+	page,
+}) => {
+	const fixture = await installCmsFixture(page);
+	await gotoCmsHome(page);
+	const hoverRoot = page.getByTestId("cms-hover-overlay-root");
+	const entry = hoverRoot.locator("opend-touchpoint").first();
+	const layer = hoverRoot.locator("opend-touchpoint").nth(1);
+	await expect(entry).toBeVisible({ timeout: T.medium });
+	await entry.hover();
+	await expect(layer).toBeVisible({ timeout: T.medium });
+
+	const entryBox = await entry.boundingBox();
+	const layerBox = await layer.boundingBox();
+	expect(entryBox).not.toBeNull();
+	expect(layerBox).not.toBeNull();
+	const entryPoint = {
+		x: entryBox!.x + entryBox!.width / 2,
+		y: entryBox!.y + entryBox!.height / 2,
+	};
+	const layerPoint = {
+		x: layerBox!.x + layerBox!.width / 2,
+		y: layerBox!.y + layerBox!.height / 2,
+	};
+	const layerIsBelow = layerBox!.y >= entryBox!.y + entryBox!.height;
+	const gap = layerIsBelow
+		? layerBox!.y - (entryBox!.y + entryBox!.height)
+		: entryBox!.y - (layerBox!.y + layerBox!.height);
+	expect(gap).toBe(8);
+	const bridgePoint = {
+		x: 0,
+		y: layerIsBelow
+			? entryBox!.y + entryBox!.height + gap / 2
+			: layerBox!.y + layerBox!.height + gap / 2,
+	};
+	bridgePoint.x =
+		Math.max(entryBox!.x, layerBox!.x) +
+		(Math.min(entryBox!.x + entryBox!.width, layerBox!.x + layerBox!.width) -
+			Math.max(entryBox!.x, layerBox!.x)) /
+			2;
+	const cross = async (from: typeof entryPoint, to: typeof layerPoint) => {
+		await page.mouse.move(from.x, from.y);
+		await page.mouse.move(bridgePoint.x, bridgePoint.y, { steps: 8 });
+		await page.mouse.move(to.x, to.y, { steps: 6 });
+	};
+	for (let index = 0; index < 3; index += 1) {
+		await cross(entryPoint, layerPoint);
+		await expect(layer).toBeVisible();
+		await cross(layerPoint, entryPoint);
+		await expect(layer).toBeVisible();
+	}
+
+	const action = layer.locator("button", { hasText: "Learn more" });
+	await expect(action).toBeVisible();
+	await action.click();
+	await expect.poll(() => fixture.events.length).toBeGreaterThanOrEqual(1);
+	expect(fixture.events.at(-1)).toMatchObject({
+		activityId: "cms-hover-browser-activity",
+		placementKey: LAYER_PLACEMENT,
+		touchpointDecisionId: `cms-hover-${LAYER_PLACEMENT}`,
+		kind: "click",
+	});
+});
+
+test("[P1] controlled CMS fixture stays within a narrow viewport and restores focus on Escape", async ({
+	page,
+}) => {
+	const fixture = await installCmsFixture(page);
+	await gotoCmsHome(page);
+	await page.setViewportSize({ width: 360, height: 160 });
+	const hoverRoot = page.getByTestId("cms-hover-overlay-root");
+	const entry = hoverRoot.locator("opend-touchpoint").first();
+	const layer = hoverRoot.locator("opend-touchpoint").nth(1);
+	await expect(entry).toBeVisible({ timeout: T.medium });
+	await entry.focus();
+	await expect(layer).toBeVisible({ timeout: T.medium });
+	const box = await layer.boundingBox();
+	expect(box).not.toBeNull();
+	expect(box!.x).toBeGreaterThanOrEqual(0);
+	expect(box!.y).toBeGreaterThanOrEqual(0);
+	expect(box!.x + box!.width).toBeLessThanOrEqual(360);
+	expect(box!.y + box!.height).toBeLessThanOrEqual(160);
+	await page.keyboard.press("Escape");
+	await expect(layer).toBeHidden();
+	await expect(entry).toBeFocused();
+	expect(
+		fixture.responses.some(
+			(response) => response.placementKey === ENTRY_PLACEMENT,
+		),
+	).toBe(true);
+});

--- a/e2e/ui/cms-hover.test.ts
+++ b/e2e/ui/cms-hover.test.ts
@@ -1,18 +1,17 @@
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-
-import { expect, test } from "@/playwright/suite";
+import type { Page, Route } from "@playwright/test";
 import {
 	mockAmrPersonalWorkspace,
 	mockAmrWalletSnapshot,
 } from "@/playwright/amr";
 import { applyStandardMocks } from "@/playwright/mock-factory";
+import { expect, test } from "@/playwright/suite";
 import { T } from "@/timeouts";
-import type { Page, Route } from "@playwright/test";
 
 const { cmsHostReleaseFingerprint } = (await import(
-	`${process.cwd()}/../apps/web/next.config.ts`,
+	`${process.cwd()}/../apps/web/next.config.ts`
 )) as {
 	cmsHostReleaseFingerprint: (
 		readFile: (file: string) => string | Buffer,
@@ -428,4 +427,62 @@ test("[P1] controlled CMS fixture stays within a narrow viewport and restores fo
 			(response) => response.placementKey === ENTRY_PLACEMENT,
 		),
 	).toBe(true);
+});
+
+test("[P1] controlled CMS fixture closes the hover layer after the pointer leaves the entry-layer union", async ({
+	page,
+}) => {
+	await installCmsFixture(page);
+	await gotoCmsHome(page);
+	const hoverRoot = page.getByTestId("cms-hover-overlay-root");
+	const entry = hoverRoot.locator("opend-touchpoint").first();
+	const layer = hoverRoot.locator("opend-touchpoint").nth(1);
+	await expect(entry).toBeVisible({ timeout: T.medium });
+	await entry.hover();
+	await expect(layer).toBeVisible({ timeout: T.medium });
+
+	const entryBox = await entry.boundingBox();
+	const layerBox = await layer.boundingBox();
+	if (!entryBox || !layerBox)
+		throw new Error("hover fixture did not expose measurable rectangles");
+	const outside = { x: 8, y: 8 };
+	const contains = (box: typeof entryBox, point: typeof outside) =>
+		point.x >= box.x &&
+		point.x <= box.x + box.width &&
+		point.y >= box.y &&
+		point.y <= box.y + box.height;
+	expect(contains(entryBox, outside)).toBe(false);
+	expect(contains(layerBox, outside)).toBe(false);
+	await page.mouse.move(outside.x, outside.y);
+	await expect(layer).toBeHidden();
+	await expect(entry).toHaveAttribute("aria-expanded", "false");
+});
+
+test("[P1] controlled CMS fixture flips the hover layer above an anchor near the viewport bottom", async ({
+	page,
+}) => {
+	await installCmsFixture(page);
+	await gotoCmsHome(page);
+	await page.setViewportSize({ width: 640, height: 240 });
+	const hoverRoot = page.getByTestId("cms-hover-overlay-root");
+	const entry = hoverRoot.locator("opend-touchpoint").first();
+	const layer = hoverRoot.locator("opend-touchpoint").nth(1);
+	await expect(entry).toBeVisible({ timeout: T.medium });
+	const initialEntryBox = await entry.boundingBox();
+	if (!initialEntryBox)
+		throw new Error("hover entry did not expose a measurable rectangle");
+	const targetTop = 240 - initialEntryBox.height - 16;
+	await entry.evaluate((element, translateY) => {
+		element.style.transform = `translateY(${translateY}px)`;
+	}, targetTop - initialEntryBox.y);
+
+	await entry.hover();
+	await expect(layer).toBeVisible({ timeout: T.medium });
+	const entryBox = await entry.boundingBox();
+	const layerBox = await layer.boundingBox();
+	if (!entryBox || !layerBox)
+		throw new Error("hover fixture did not expose measurable rectangles");
+	expect(layerBox.y + layerBox.height).toBe(entryBox.y - 8);
+	expect(layerBox.y).toBeGreaterThanOrEqual(8);
+	expect(layerBox.y + layerBox.height).toBeLessThanOrEqual(240 - 8);
 });

--- a/e2e/ui/cms-modal.test.ts
+++ b/e2e/ui/cms-modal.test.ts
@@ -1,0 +1,366 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { expect, test } from "@/playwright/suite";
+import {
+	mockAmrPersonalWorkspace,
+	mockAmrWalletSnapshot,
+} from "@/playwright/amr";
+import { applyStandardMocks } from "@/playwright/mock-factory";
+import { T } from "@/timeouts";
+import type { Page, Route } from "@playwright/test";
+
+const { cmsHostReleaseFingerprint } = (await import(
+	`${process.cwd()}/../apps/web/next.config.ts`
+)) as {
+	cmsHostReleaseFingerprint: (
+		readFile: (file: string) => string | Buffer,
+	) => string;
+};
+const workspaceRoot = resolve(process.cwd(), "..");
+const digest = (value: string | Buffer) =>
+	`sha256:${createHash("sha256").update(value).digest("hex")}`;
+const hostFingerprint = cmsHostReleaseFingerprint((file) =>
+	readFileSync(resolve(workspaceRoot, file)),
+);
+
+const PLACEMENT = "opend.home.campaign-modal";
+const ACTION_ID = "use";
+type CloseMode = "sdk" | "failed" | "hidden" | "disabled" | "none";
+
+const moduleFor = (mode: CloseMode, tall = false) => `
+  export function mount(root, context, sdk) {
+    ${mode === "failed" ? "throw new Error('fixture_mount_failed');" : ""}
+    ${tall ? "const filler = document.createElement('div'); filler.style.cssText = 'height: 900px; width: 420px;'; root.append(filler);" : ""}
+    const title = document.createElement('h1');
+    title.textContent = 'CMS campaign fixture';
+    root.append(title);
+    ${mode === "sdk" ? "const close = document.createElement('button'); close.type = 'button'; close.setAttribute('aria-label', 'Close campaign'); close.textContent = 'Close'; close.addEventListener('click', () => sdk.requestClose()); root.append(close);" : ""}
+    ${mode === "hidden" ? "const close = document.createElement('button'); close.type = 'button'; close.setAttribute('aria-label', 'Close campaign'); close.hidden = true; close.textContent = 'Close'; root.append(close);" : ""}
+    ${mode === "disabled" ? "const close = document.createElement('button'); close.type = 'button'; close.setAttribute('aria-label', 'Close campaign'); close.disabled = true; close.textContent = 'Close'; root.append(close);" : ""}
+    const action = document.createElement('button');
+    action.type = 'button';
+    action.textContent = 'Use campaign';
+    action.addEventListener('click', () => void sdk.dispatchAction('${ACTION_ID}'));
+    root.append(action);
+    return root;
+  }
+`;
+
+function contentFor(mode: CloseMode, tall = false) {
+	const entryModule = moduleFor(mode, tall);
+	const manifest = {
+		formatVersion: 2 as const,
+		runtimeKind: "web-component" as const,
+		runtimeApiVersion: 1 as const,
+		platformWrapperVersion: "vela-touchpoint-wrapper-v1" as const,
+		sdkVersion: "vela-touchpoint-sdk-v1" as const,
+		contentLine: "cms-modal-browser-fixture",
+		placements: [
+			{
+				key: PLACEMENT,
+				entry: "campaign-modal.js",
+				resources: [],
+				locales: ["en-US"],
+				requiredCapabilities: ["close", "static-action"],
+				staticActions: [
+					{
+						id: ACTION_ID,
+						target: {
+							kind: "https" as const,
+							url: "https://example.com/campaign",
+						},
+					},
+				],
+			},
+		],
+		resources: ["campaign-modal.js"],
+		images: [],
+	};
+	return {
+		id: `cms-modal-${mode}-${tall ? "tall" : "normal"}`,
+		placementKey: PLACEMENT,
+		locale: "en-US",
+		manifest,
+		manifestHash: digest(JSON.stringify(manifest)),
+		entryPath: "campaign-modal.js",
+		entryDigest: digest(entryModule),
+		entryModule,
+		resources: [
+			{
+				path: "campaign-modal.js",
+				digest: digest(entryModule),
+				bytes: Buffer.from(entryModule).toString("base64"),
+			},
+		],
+		runtime: {
+			kind: "web-component" as const,
+			apiVersion: 1 as const,
+			wrapperVersion: "vela-touchpoint-wrapper-v1" as const,
+			sdkVersion: "vela-touchpoint-sdk-v1" as const,
+		},
+		buildIdentity: { fingerprint: hostFingerprint },
+	};
+}
+
+function decisionFor(mode: CloseMode, tall = false) {
+	const now = Date.now();
+	return {
+		activityId: `cms-modal-${mode}-activity`,
+		touchpointDecisionId: `cms-modal-${mode}-decision`,
+		deploymentId: "cms-modal-browser-deployment",
+		authorizationExpiresAt: new Date(now + 60_000).toISOString(),
+		endsAt: new Date(now + 300_000).toISOString(),
+		serverTime: new Date(now).toISOString(),
+		placementKey: PLACEMENT,
+		requiredCapabilities: ["close", "static-action"],
+		staticActions: [
+			{
+				id: ACTION_ID,
+				target: {
+					kind: "https" as const,
+					url: "https://example.com/campaign",
+				},
+			},
+		],
+		content: contentFor(mode, tall),
+	};
+}
+
+async function installDesktopHost(page: Page) {
+	await page.addInitScript(() => {
+		const scope = window as Window & {
+			__od__?: unknown;
+			__cmsExternalOpens?: string[];
+		};
+		scope.__cmsExternalOpens = [];
+		scope.__od__ = {
+			version: 2,
+			client: { type: "desktop", platform: "test", osLocale: "en-US" },
+			shell: {
+				openExternal: async (url: string) => {
+					scope.__cmsExternalOpens?.push(url);
+					return { ok: true };
+				},
+				openPath: async () => ({ ok: true }),
+			},
+			browser: { clearData: async () => ({ ok: true }) },
+			capture: {
+				page: async () => ({
+					ok: true,
+					dataUrl: "data:image/png;base64,",
+					h: 1,
+					w: 1,
+				}),
+			},
+			project: {
+				pickAndImport: async () => ({
+					ok: true,
+					projectId: "fixture",
+					conversationId: "fixture",
+					entryFile: "index.html",
+				}),
+				pickAndReplaceWorkingDir: async () => ({
+					ok: true,
+					baseDir: "/tmp/fixture",
+					entryFile: null,
+				}),
+			},
+			pdf: { print: async () => ({ ok: true }) },
+			pet: { setVisible: () => undefined },
+			updater: {
+				status: async () => ({
+					arch: "arm64",
+					capabilities: {},
+					channel: "beta",
+					currentVersion: "fixture",
+					enabled: true,
+					mode: "test",
+					platform: "test",
+					state: "idle",
+					supported: true,
+				}),
+				check: async () => ({ ok: true }),
+				"clear-cache": async () => ({ ok: true }),
+				download: async () => ({ ok: true }),
+				install: async () => ({ ok: true }),
+				quit: async () => ({ ok: true }),
+				setMenuLabels: async () => ({ ok: true }),
+				subscribe: () => () => undefined,
+				subscribeOpenDialog: () => () => undefined,
+			},
+		};
+	});
+}
+
+async function installProductionFixture(
+	page: Page,
+	options: {
+		mode?: CloseMode;
+		tall?: boolean;
+		eventStatus?: number;
+		eventNetworkFailure?: boolean;
+	} = {},
+) {
+	const mode = options.mode ?? "none";
+	const events: Array<Record<string, unknown>> = [];
+	await page.route("**/api/integrations/vela/status", async (route) => {
+		await route.fulfill({
+			json: {
+				loggedIn: true,
+				profile: "local",
+				user: {
+					id: "cms-modal-user",
+					email: "cms-modal@example.com",
+					plan: "free",
+				},
+			},
+		});
+	});
+	await mockAmrPersonalWorkspace(page, undefined, { accountPlan: "free" });
+	await mockAmrWalletSnapshot(page, {
+		email: "cms-modal@example.com",
+		plan: "free",
+	});
+	await page.route(
+		"**/api/touchpoints/production-runtime**",
+		async (route: Route) => {
+			const request = route.request();
+			if (request.method() === "POST") {
+				if (options.eventNetworkFailure) {
+					await route.abort();
+					return;
+				}
+				events.push(request.postDataJSON() as Record<string, unknown>);
+				await route.fulfill({
+					status: options.eventStatus ?? 200,
+					json: {
+						ok: options.eventStatus == null || options.eventStatus < 400,
+					},
+				});
+				return;
+			}
+			await route.fulfill({ json: decisionFor(mode, options.tall) });
+		},
+	);
+	return { events };
+}
+
+async function gotoModal(page: Page) {
+	await page.goto("/", { waitUntil: "domcontentloaded" });
+	await expect(page.getByText("Loading OpenDesign…")).toHaveCount(0, {
+		timeout: T.long,
+	});
+	await expect(page.getByRole("dialog", { name: "Campaign" })).toBeVisible({
+		timeout: T.long,
+	});
+}
+
+test.describe.configure({ timeout: T.xlong });
+
+test.beforeEach(async ({ page }) => {
+	await applyStandardMocks(page);
+	await installDesktopHost(page);
+});
+
+test("[P1] production modal closes through its mounted SDK control without a host fallback", async ({
+	page,
+}) => {
+	await installProductionFixture(page, { mode: "sdk" });
+	await gotoModal(page);
+	const modal = page.getByRole("dialog", { name: "Campaign" });
+	await expect(
+		modal.getByRole("button", { name: "Close campaign" }),
+	).toBeVisible({
+		timeout: T.medium,
+	});
+	await expect(
+		modal.getByRole("button", { name: "Close", exact: true }),
+	).toHaveCount(0);
+	await modal.getByRole("button", { name: "Close campaign" }).click();
+	await expect(modal).toBeHidden();
+});
+
+for (const mode of ["failed", "hidden", "disabled"] as const) {
+	test(`[P1] production modal uses one host Close fallback when the mounted control is ${mode}`, async ({
+		page,
+	}) => {
+		await installProductionFixture(page, { mode });
+		await gotoModal(page);
+		const modal = page.getByRole("dialog", { name: "Campaign" });
+		const fallback = modal.getByRole("button", { name: "Close", exact: true });
+		await expect(fallback).toHaveCount(1, { timeout: T.medium });
+		await fallback.click();
+		await expect(modal).toBeHidden();
+	});
+}
+
+test("[P1] production modal stays within short and narrow viewports and closes on Escape", async ({
+	page,
+}) => {
+	await page.setViewportSize({ width: 500, height: 240 });
+	await installProductionFixture(page, { mode: "sdk", tall: true });
+	await gotoModal(page);
+	const modal = page.getByRole("dialog", { name: "Campaign" });
+	const surface = modal;
+	await expect(surface).toBeVisible();
+	const box = await surface.boundingBox();
+	expect(box).not.toBeNull();
+	expect(box!.width).toBeLessThanOrEqual(500);
+	expect(box!.height).toBeLessThanOrEqual(240);
+	await page.setViewportSize({ width: 320, height: 180 });
+	const narrowBox = await modal.boundingBox();
+	expect(narrowBox).not.toBeNull();
+	expect(narrowBox!.width).toBeLessThanOrEqual(320);
+	expect(narrowBox!.height).toBeLessThanOrEqual(180);
+	await page.keyboard.press("Escape");
+	await expect(modal).toBeHidden();
+	await expect(page.locator("body")).toHaveCSS("overflow", "visible");
+});
+
+for (const outcome of [
+	{ label: "401", eventStatus: 401, navigates: false },
+	{ label: "403", eventStatus: 403, navigates: false },
+	{ label: "409", eventStatus: 409, navigates: false },
+	{ label: "500", eventStatus: 500, navigates: true },
+	{ label: "network failure", eventNetworkFailure: true, navigates: true },
+] as const) {
+	test(`[P1] production action telemetry ${outcome.label} ${outcome.navigates ? "still navigates" : "denies navigation"}`, async ({
+		page,
+	}) => {
+		const fixture = await installProductionFixture(page, outcome);
+		await gotoModal(page);
+		const modal = page.getByRole("dialog", { name: "Campaign" });
+		await modal.getByRole("button", { name: "Use campaign" }).click();
+		await expect
+			.poll(() => fixture.events.length)
+			.toBeGreaterThanOrEqual(outcome.eventNetworkFailure ? 0 : 1);
+		await expect
+			.poll(async () =>
+				page.evaluate(
+					() =>
+						(window as Window & { __cmsExternalOpens?: string[] })
+							.__cmsExternalOpens?.length ?? 0,
+				),
+			)
+			.toBe(outcome.navigates ? 1 : 0);
+		if (outcome.navigates) {
+			expect(
+				await page.evaluate(
+					() =>
+						(window as Window & { __cmsExternalOpens?: string[] })
+							.__cmsExternalOpens,
+				),
+			).toEqual(["https://example.com/campaign"]);
+		} else {
+			expect(
+				await page.evaluate(
+					() =>
+						(window as Window & { __cmsExternalOpens?: string[] })
+							.__cmsExternalOpens,
+				),
+			).toEqual([]);
+		}
+	});
+}

--- a/packages/contracts/src/touchpoint-component-v2.ts
+++ b/packages/contracts/src/touchpoint-component-v2.ts
@@ -16,7 +16,7 @@ export const TOUCHPOINT_COMPONENT_V2_UPSTREAM_PROVENANCE = Object.freeze({
 	]),
 	sourceSha256: Object.freeze({
 		touchpoints:
-			"1b5f6fb5e52d8cc522649c723b829240b729727e04806fc237732163c5ebb58e",
+			"be26f9c4e5cfe6e0a0eedee3d31dc70df8f1c8ee61704e765d4f5c89879fc2f0",
 		fixture: "278a40cd787dc74544aa785f85d218d8a51820d2d0e14c7b8d7c6eced10b4c92",
 	}),
 });
@@ -27,6 +27,24 @@ export const TOUCHPOINT_COMPONENT_V2_WRAPPER_VERSION =
 	"vela-touchpoint-wrapper-v1" as const;
 export const TOUCHPOINT_COMPONENT_V2_SDK_VERSION =
 	"vela-touchpoint-sdk-v1" as const;
+
+const INTERNAL_ACTION_SENTINEL_ORIGIN = "https://vela.invalid";
+
+/**
+ * Mirrors browser URL normalization without depending on the current host. The
+ * raw path restrictions remain separate so shared manifests reject both
+ * ambiguous spellings and normalized origin escapes.
+ */
+function hasSentinelInternalOrigin(path: string): boolean {
+	try {
+		return (
+			new URL(path, INTERNAL_ACTION_SENTINEL_ORIGIN).origin ===
+			INTERNAL_ACTION_SENTINEL_ORIGIN
+		);
+	} catch {
+		return false;
+	}
+}
 
 const placementKeySchema = z.enum([
 	"opend.home.campaign-modal",
@@ -80,8 +98,16 @@ const staticActionSchema = z.object({
 				.max(1024)
 				.regex(/^\/(?!\/).*$/u)
 				.refine(
+					(value) => !value.includes("\\"),
+					"internal action path must not contain backslashes",
+				)
+				.refine(
 					(value) => !value.split("/").includes(".."),
 					"internal action path must not traverse",
+				)
+				.refine(
+					hasSentinelInternalOrigin,
+					"internal action path must resolve on the sentinel origin",
 				),
 		}),
 	]),

--- a/packages/contracts/tests/touchpoint-component-v2.test.ts
+++ b/packages/contracts/tests/touchpoint-component-v2.test.ts
@@ -49,6 +49,36 @@ describe("touchpoint component v2 controlled mirror", () => {
 		).toBe(false);
 	});
 
+	it("rejects ambiguous internal paths after browser URL normalization", () => {
+		const withInternalPath = (path: string) => ({
+			...structuredClone(touchpointComponentV2Fixture.manifest),
+			placements: [
+				{
+					...touchpointComponentV2Fixture.manifest.placements[0],
+					staticActions: [{ id: "action", target: { kind: "internal", path } }],
+				},
+			],
+		});
+
+		const rejectedPaths = [
+			String.raw`/\evil.example`,
+			String.raw`/foo\bar`,
+			`/${"\t"}/evil.example`,
+			`/${"\n"}/evil.example`,
+		];
+		for (const path of rejectedPaths)
+			expect(
+				TouchpointComponentV2ManifestSchema.safeParse(withInternalPath(path))
+					.success,
+			).toBe(false);
+
+		expect(
+			TouchpointComponentV2ManifestSchema.safeParse(
+				withInternalPath("/projects?view=active#recent"),
+			).success,
+		).toBe(true);
+	});
+
 	it("imports and parses the frozen Vela v2 fixture through the public contract package", () => {
 		expect(TOUCHPOINT_COMPONENT_V2_PROTOCOL).toBe(
 			"vela-touchpoint-component/v2",
@@ -70,7 +100,7 @@ describe("touchpoint component v2 controlled mirror", () => {
 			],
 			sourceSha256: {
 				touchpoints:
-					"1b5f6fb5e52d8cc522649c723b829240b729727e04806fc237732163c5ebb58e",
+					"be26f9c4e5cfe6e0a0eedee3d31dc70df8f1c8ee61704e765d4f5c89879fc2f0",
 				fixture:
 					"278a40cd787dc74544aa785f85d218d8a51820d2d0e14c7b8d7c6eced10b4c92",
 			},


### PR DESCRIPTION
## Problem and behavior

已授权 CMS 动作不再因点击统计接口 500、网络错误或超时而被取消；401/403/409 等明确拒绝仍阻断执行。弹窗依据实际挂载且可用的组件关闭控件决定是否提供宿主兜底，避免重复 Close，同时保留失败、隐藏或禁用控件的恢复路径。

此 PR 还包含安全的站内 URL 解析、完整宿主指纹输入、右上角 badge/hover 共存、8px 间隙跨越及窄屏交互；Test 动作默认拒绝，混合 OD/Vela 包只允许当前宿主资源和动作。

## Scope and dependencies

- 目标分支：`codex/fix-cms-shared-manifest`，叠加在 #7986 上。
- 配套 API/Admin：[Vela #1965](https://github.com/powerformer/vela/pull/1965)，目标为 #1963 的源分支。
- 最新联合回归记录：[cms-joint-regression-20260911.md](https://github.com/powerformer/vela/blob/fix/cms-reviewed-followups-20260910/docs/qa/cms-joint-regression-20260911.md)。

## Validation

- Web 完整套件：1100 文件，11367 项通过，1 项预期失败、11 项跳过；production Web build、workspace typecheck、root guard 和 E2E typecheck 通过。
- Chromium 弹窗/悬浮层回归覆盖单一有效 Close、安全兜底、尺寸/滚动、授权拒绝、统计 500/网络恢复、真实指针跨越及窄屏焦点。
- 最新动作边界两文件 32 项通过：合法 Test 动作默认拒绝；OD 点位上的 Vela 专属动作在 Blob 资源创建前拒绝；混合包只加载选定 OD 资源。
- 最终源码的编译 Web fingerprint 与静态输出一致。真实源代码启动的 Electron 加 Vela Web，在同一本地 CMS 环境完成两轮独立 5/5 Test 回执。
- 原生弹窗实测 500 CSS px、一个有效 Close；Test CTA 不导航；badge/hover 共存。撤回、编辑后新 Test、旧 context 拒绝、前后排期及中英文 Web 视图已验证。

- 新增 Chromium 外部移出关闭、底部入口向上翻转两项通过。原三项已有通过证据；一次整组尝试中，原三项在测试服务 warmup 阶段失败、未进入测试体，未将该次整组记为通过。

## Delivery boundaries

保留 Draft。推送后的 CI 单独核验；未合并、未部署。原生验收不是安装包发布证明。生产发布/下架/恢复仅有受控数据库生命周期证据，真实恢复启动门禁仍禁用。OPEND-3011 视觉优化按原交接不属于本期。
