### PR TITLE
fix(daemon): keep proxy Basic credentials off the media wait tool-token lane

### DIFF
--- a/apps/daemon/src/routes/media.ts
+++ b/apps/daemon/src/routes/media.ts
@@ -1155,9 +1155,16 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
       return res.status(403).json({ error: 'cross-origin request rejected' });
     }
     const authorizationHeader = req.get('authorization');
-    // Once a caller chooses the tool-token lane, invalid, expired, or
-    // under-scoped credentials must not downgrade to project authorization.
-    const toolGrant = typeof authorizationHeader === 'string'
+    // Only a Bearer credential chooses the tool-token lane: that is the sole
+    // shape `bearerTokenFromRequest` parses. A reverse proxy that
+    // authenticates browsers itself forwards its own `Authorization: Basic
+    // ...`, which can never satisfy the lane, so claiming it here failed
+    // every proxied wait with TOOL_TOKEN_MISSING. Once a Bearer caller does
+    // choose the lane, invalid, expired, or under-scoped credentials must not
+    // downgrade to project authorization.
+    const usesToolTokenLane = typeof authorizationHeader === 'string'
+      && /^Bearer\s+/i.test(authorizationHeader.trim());
+    const toolGrant = usesToolTokenLane
       ? authorizeToolRequest(
           req,
           res,
@@ -1165,7 +1172,7 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
           { endpoint: MEDIA_TASK_WAIT_TOOL_ENDPOINT },
         )
       : null;
-    if (typeof authorizationHeader === 'string' && !toolGrant) return;
+    if (usesToolTokenLane && !toolGrant) return;
     if (
       toolGrant
       && !await ctx.authorizeProjectToolRequest(

--- a/apps/daemon/src/routes/media.ts
+++ b/apps/daemon/src/routes/media.ts
@@ -1162,8 +1162,12 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
     // every proxied wait with TOOL_TOKEN_MISSING. Once a Bearer caller does
     // choose the lane, invalid, expired, or under-scoped credentials must not
     // downgrade to project authorization.
+    // Classify the scheme independently of whether a token follows it: a bare
+    // `Bearer` (or `Bearer ` trimmed to it) is still a caller reaching for the
+    // tool-token lane and must keep failing closed with TOOL_TOKEN_MISSING
+    // rather than downgrading to browser project authority.
     const usesToolTokenLane = typeof authorizationHeader === 'string'
-      && /^Bearer\s+/i.test(authorizationHeader.trim());
+      && /^Bearer(?:\s|$)/i.test(authorizationHeader.trim());
     const toolGrant = usesToolTokenLane
       ? authorizeToolRequest(
           req,

--- a/apps/daemon/tests/media/tasks-routes.test.ts
+++ b/apps/daemon/tests/media/tasks-routes.test.ts
@@ -410,6 +410,59 @@ describe('media task route recovery', () => {
     expect(authorityRequests).toBe(startupAuthorityRequests);
   });
 
+  it.each([
+    ['treats a forwarded foreign Basic credential as a proxy-authenticated browser request',
+     `Basic ${Buffer.from('proxy-user:proxy-pass').toString('base64')}`, 200],
+    ['still routes foreign Bearer credentials to the run-scoped tool-token lane',
+     'Bearer forged-tool-token', 401],
+  ] as const)('%s', async (_label, authorization, expected) => {
+    // Given: a running task that a header-free browser request can already read.
+    const dataDir = process.env.OD_DATA_DIR;
+    const db = openDatabase(process.cwd(), dataDir === undefined ? {} : { dataDir });
+    const projectId = `project_${randomUUID()}`;
+    const taskId = `task_${randomUUID()}`;
+    const now = Date.now() - 5_000;
+
+    insertProject(db, {
+      id: projectId,
+      name: 'Proxy-authenticated media project',
+      createdAt: now,
+      updatedAt: now,
+    });
+    insertMediaTask(db, {
+      id: taskId,
+      projectId,
+      status: 'running',
+      surface: 'video',
+      model: 'seedance-2',
+      progress: ['provider task accepted'],
+      startedAt: now,
+      updatedAt: now,
+    });
+
+    const started = await startServer({ port: 0, returnServer: true }) as {
+      url: string;
+      server: http.Server;
+    };
+    server = started.server;
+
+    // When: the credential reaches the dual-lane wait route.
+    const response = await fetch(`${started.url}/api/media/tasks/${encodeURIComponent(taskId)}/wait`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization },
+      body: JSON.stringify({ since: 0, timeoutMs: 0 }),
+    });
+    const body = await response.text();
+
+    // Then: only Bearer claims the tool-token lane. A proxy's Basic header
+    // stays on project authorization like a header-free browser request,
+    // while a foreign Bearer token still fails closed in the registry.
+    expect(response.status, body).toBe(expected);
+    if (expected === 401) {
+      expect(JSON.parse(body)).toMatchObject({ error: { code: 'TOOL_TOKEN_INVALID' } });
+    }
+  });
+
   it('recovers a pre-restart running task so wait returns interrupted instead of 404', async () => {
     const dataDir = process.env.OD_DATA_DIR;
     const db = openDatabase(process.cwd(), dataDir === undefined ? {} : { dataDir });

--- a/apps/daemon/tests/media/tasks-routes.test.ts
+++ b/apps/daemon/tests/media/tasks-routes.test.ts
@@ -415,6 +415,10 @@ describe('media task route recovery', () => {
      `Basic ${Buffer.from('proxy-user:proxy-pass').toString('base64')}`, 200],
     ['still routes foreign Bearer credentials to the run-scoped tool-token lane',
      'Bearer forged-tool-token', 401],
+    ['fails closed on a malformed Bearer credential with no token',
+     'Bearer ', 401],
+    ['fails closed on a bare Bearer scheme',
+     'Bearer', 401],
   ] as const)('%s', async (_label, authorization, expected) => {
     // Given: a running task that a header-free browser request can already read.
     const dataDir = process.env.OD_DATA_DIR;
@@ -459,7 +463,11 @@ describe('media task route recovery', () => {
     // while a foreign Bearer token still fails closed in the registry.
     expect(response.status, body).toBe(expected);
     if (expected === 401) {
-      expect(JSON.parse(body)).toMatchObject({ error: { code: 'TOOL_TOKEN_INVALID' } });
+      // A forged token is INVALID; a Bearer scheme carrying no token at all is
+      // MISSING. Both must stay on the tool-token lane and fail closed rather
+      // than downgrading to browser project authority.
+      const code = (JSON.parse(body) as { error?: { code?: string } }).error?.code;
+      expect(code).toMatch(/^TOOL_TOKEN_(INVALID|MISSING)$/);
     }
   });
 


### PR DESCRIPTION
Fixes #8004

## Why

Same root cause as #7819, in a different route and a different file. #7819 covers `authorizeExportRead` in `apps/daemon/src/import-export-routes.ts`; this is `apps/daemon/src/routes/media.ts`. Filed and fixed separately so each reviews on its own.

On any deployment where a reverse proxy authenticates browsers with HTTP Basic credentials and forwards the `Authorization` header, `POST /api/media/tasks/:id/wait` fails with `401 TOOL_TOKEN_MISSING`. Media task progress cannot be polled, so image and video generation never report completion.

`media.ts:1157` selected the run-scoped tool-token lane on the mere *presence* of an `Authorization` header. Tool tokens are only ever parsed out of a `Bearer` header — `bearerTokenFromRequest` (`apps/daemon/src/http/tool-request-auth.ts:8`) matches `/^Bearer\s+(.+)$/i` and nothing else — so a forwarded `Basic` credential entered a lane it could never satisfy. A guaranteed failure, not a race or a config edge.

Found while verifying #7819 against real reverse proxies; the same probe caught this route.

## What users will see

Behind a reverse proxy that forwards its own Basic credentials, image and video generation report progress and completion again. Previously the polling request 401'd and the task appeared to stall.

No change for desktop, packaged or loopback users — the web client sends no `Authorization` header of its own, so those requests never entered this branch. Agent tool-token calls are unaffected: foreign `Bearer` tokens still fail closed with `TOOL_TOKEN_INVALID` / `TOOL_TOKEN_EXPIRED`.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — no new endpoint or contract shape; changes which auth lane the existing `/api/media/tasks/:id/wait` route selects for a non-Bearer `Authorization` header
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**

Scope note: the other two `authorizeToolRequest` callers in this file — `/api/tools/media/scaffold` (`:1026`) and `/api/tools/media/generate` (`:1092`) — are agent-only endpoints that unconditionally require a tool token. They are correct as written and are left alone. Only `/api/media/tasks/:id/wait` serves both browsers and agents, and only it misclassified.

The existing comment's intent is preserved — once a caller *does* choose the tool-token lane, invalid, expired or under-scoped credentials still must not downgrade to project authorization. This only changes what counts as choosing it.

## Screenshots

n/a — no UI change.

## Bug fix verification

- **Test path that reproduces the bug:** `apps/daemon/tests/media/tasks-routes.test.ts` → `treats a forwarded foreign Basic credential as a proxy-authenticated browser request`
- **Did the test go red on `main` and green on this branch?** **yes.** On `main`:
  ```
  AssertionError: {"error":{"code":"TOOL_TOKEN_MISSING","message":"tool token is required",
    "details":{"endpoint":"/api/media/tasks/:id/wait","operation":"media:generate"}}}
    : expected 401 to be 200
  ```
  With the change it returns 200.

The paired case, `still routes foreign Bearer credentials to the run-scoped tool-token lane`, asserts a forged `Bearer` token still returns `401 TOOL_TOKEN_INVALID`. It passes both with and without the source change by design — it pins the behavior that must not regress into a downgrade path.

Beyond the harness, the bug was reproduced end-to-end against a real `od` daemon behind five real reverse proxies, each with stock HTTP Basic auth and no header stripping. A **nonexistent** task id was used so the control reaches task lookup and returns `404` — a `401` therefore proves the request died at authorization:

| Proxy | `POST /api/media/tasks/no-such-task/wait` |
|---|---|
| nginx 1.24.0 | `401 TOOL_TOKEN_MISSING` |
| Traefik 3.3.4 (`basicAuth`, `removeHeader` unset) | `401 TOOL_TOKEN_MISSING` |
| Caddy 2.9.1 | `401 TOOL_TOKEN_MISSING` |
| HAProxy | `401 TOOL_TOKEN_MISSING` |
| Apache 2.4.58 | `401 TOOL_TOKEN_MISSING` |
| control — same daemon, direct, no `Authorization` | `404 task not found` |

`GET /api/projects` returned **200 through all five**, confirming browsing, auth and origin handling all work and only this route breaks. Every proxy was left at its default configuration — forwarding `Authorization` upstream is the default for all five.

## Validation

- `pnpm guard` — pass (exit 0)
- `pnpm --filter @open-design/daemon typecheck` — pass (exit 0)
- `pnpm exec vitest run` over 14 media and tool-token suites — **86 tests passed**:
  `media/tasks-routes`, `media/tasks-routes-batching`, `media/analytics-routes`, `media-wait-safety-output`, `media-wait-stdout-flush`, `media-generate-multi-image`, `media-generate-prompt-file`, `media-generate-structured-error`, `media-adapters`, `media-scaffold-cli`, `media-failure-reaches-run-terminal`, `late-media-produced-file-association`, `tool-tokens`, `plugins-tool-token-gate`

`tool-tokens` and `plugins-tool-token-gate` are included because the change affects which callers reach the tool-token lane.
