### PR TITLE
fix(web): report a degraded archive export instead of substituting silently

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -7590,6 +7590,17 @@ function HtmlViewer({
               if (toastFormats.has(format)) setExportToast(null);
               return;
             }
+            // A 'degraded' export handed the browser a fallback artifact
+            // instead of the one that was requested. The download succeeded,
+            // so it must not be reported as a plain success: the request
+            // failed, and the user has to be told which artifact they got.
+            if (result === 'degraded') {
+              void finish('failed', 'degraded_fallback_artifact');
+              if (toastFormats.has(format)) {
+                setExportToast({ message: t('fileViewer.exportDegradedFallback'), tone: 'error' });
+              }
+              return;
+            }
             void finish('success');
             if (toastFormats.has(format)) setExportToast({ message: t('fileViewer.exportDone'), tone: 'success' });
           },
@@ -7603,6 +7614,13 @@ function HtmlViewer({
         if (out === 'cancelled') {
           void finish('cancelled');
           if (toastFormats.has(format)) setExportToast(null);
+          return;
+        }
+        if (out === 'degraded') {
+          void finish('failed', 'degraded_fallback_artifact');
+          if (toastFormats.has(format)) {
+            setExportToast({ message: t('fileViewer.exportDegradedFallback'), tone: 'error' });
+          }
           return;
         }
         void finish('success');

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -3261,6 +3261,7 @@ export const ar: Dict = {
   'fileViewer.exportSlideEta': 'الشريحة {current}/{total} · يتبقى ~{seconds}ث',
   'fileViewer.exportFailed': 'فشل التصدير. يرجى المحاولة مرة أخرى.',
   'fileViewer.exportDone': 'اكتمل التصدير',
+  'fileViewer.exportDegradedFallback': 'تعذّر الوصول إلى ملفات المشروع — يحتوي ملف ZIP هذا على الصفحة المعروضة فقط.',
   'fileViewer.exportImageFailed': 'فشل التقاط الصورة. يرجى المحاولة مرة أخرى أو استخدام أداة لقطة الشاشة في المتصفح.',
   'fileViewer.exportImageModalSubtitle': 'اختر تنسيقًا، ثم نزّل المعاينة الحالية كصورة.',
   'fileViewer.exportImageFormatLabel': 'التنسيق',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -3261,6 +3261,7 @@ export const de: Dict = {
   'fileViewer.exportSlideEta': 'Folie {current}/{total} · noch ca. {seconds}s',
   'fileViewer.exportFailed': 'Export fehlgeschlagen. Bitte erneut versuchen.',
   'fileViewer.exportDone': 'Export abgeschlossen',
+  'fileViewer.exportDegradedFallback': 'Projektdateien konnten nicht abgerufen werden – dieses ZIP enthält nur die gerenderte Seite.',
   'fileViewer.exportImageFailed': 'Bildaufnahme fehlgeschlagen. Bitte versuchen Sie es erneut oder verwenden Sie das Screenshot-Tool Ihres Browsers.',
   'fileViewer.exportImageModalSubtitle': 'Wählen Sie ein Format und laden Sie dann die aktuelle Vorschau als Bild herunter.',
   'fileViewer.exportImageFormatLabel': 'Format',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -3275,6 +3275,7 @@ export const en: Dict = {
   'fileViewer.exportSlideEta': 'Exporting slide {current}/{total} · ~{seconds}s left',
   'fileViewer.exportFailed': 'Export failed. Please try again.',
   'fileViewer.exportDone': 'Export complete',
+  'fileViewer.exportDegradedFallback': 'Couldn\'t reach the project files — this ZIP contains only the rendered page.',
   'fileViewer.exportImageFailed': 'Image capture failed. Please try again or use your browser\'s screenshot tool.',
   'fileViewer.exportImageModalSubtitle': 'Choose a format, then download the current preview as an image.',
   'fileViewer.exportImageFormatLabel': 'Format',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -3261,6 +3261,7 @@ export const esES: Dict = {
   'fileViewer.exportSlideEta': 'Diapositiva {current}/{total} · quedan ~{seconds}s',
   'fileViewer.exportFailed': 'La exportación falló. Inténtalo de nuevo.',
   'fileViewer.exportDone': 'Exportación completada',
+  'fileViewer.exportDegradedFallback': 'No se pudo acceder a los archivos del proyecto: este ZIP solo contiene la página renderizada.',
   'fileViewer.exportImageFailed': 'Error al capturar la imagen. Inténtalo de nuevo o usa la herramienta de captura de pantalla de tu navegador.',
   'fileViewer.exportImageModalSubtitle': 'Elige un formato y descarga la vista previa actual como imagen.',
   'fileViewer.exportImageFormatLabel': 'Formato',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -3261,6 +3261,7 @@ export const fa: Dict = {
   'fileViewer.exportSlideEta': 'اسلاید {current}/{total} · ~{seconds}ثانیه مانده',
   'fileViewer.exportFailed': 'خروجی‌گرفتن ناموفق بود. لطفاً دوباره تلاش کنید.',
   'fileViewer.exportDone': 'خروجی کامل شد',
+  'fileViewer.exportDegradedFallback': 'دسترسی به فایل‌های پروژه ممکن نشد — این ZIP فقط شامل صفحهٔ رندرشده است.',
   'fileViewer.exportImageFailed': 'گرفتن تصویر ناموفق بود. لطفاً دوباره تلاش کنید یا از ابزار اسکرین‌شات مرورگرتان استفاده کنید.',
   'fileViewer.exportImageModalSubtitle': 'یک قالب انتخاب کنید، سپس پیش‌نمایش فعلی را به‌صورت تصویر دانلود کنید.',
   'fileViewer.exportImageFormatLabel': 'قالب',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -3261,6 +3261,7 @@ export const fr: Dict = {
   'fileViewer.exportSlideEta': 'Diapositive {current}/{total} · ~{seconds}s restantes',
   'fileViewer.exportFailed': 'Échec de l’exportation. Veuillez réessayer.',
   'fileViewer.exportDone': 'Exportation terminée',
+  'fileViewer.exportDegradedFallback': 'Impossible d\'accéder aux fichiers du projet – cette archive ZIP ne contient que la page rendue.',
   'fileViewer.exportImageFailed': 'La capture d\'image a échoué. Veuillez réessayer ou utiliser l\'outil de capture d\'écran de votre navigateur.',
   'fileViewer.exportImageModalSubtitle': 'Choisissez un format, puis téléchargez l’aperçu actuel en image.',
   'fileViewer.exportImageFormatLabel': 'Format',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -3261,6 +3261,7 @@ export const hu: Dict = {
   'fileViewer.exportSlideEta': '{current}/{total}. dia · ~{seconds}mp van hátra',
   'fileViewer.exportFailed': 'Az exportálás nem sikerült. Próbáld újra.',
   'fileViewer.exportDone': 'Exportálás kész',
+  'fileViewer.exportDegradedFallback': 'A projektfájlok nem érhetők el – ez a ZIP csak a megjelenített oldalt tartalmazza.',
   'fileViewer.exportImageFailed': 'A képrögzítés sikertelen. Kérjük, próbálja újra, vagy használja a böngészője képernyőkép eszközét.',
   'fileViewer.exportImageModalSubtitle': 'Válasszon formátumot, majd töltse le az aktuális előnézetet képként.',
   'fileViewer.exportImageFormatLabel': 'Formátum',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -3261,6 +3261,7 @@ export const id: Dict = {
   'fileViewer.exportSlideEta': 'Slide {current}/{total} · ~{seconds}d lagi',
   'fileViewer.exportFailed': 'Ekspor gagal. Silakan coba lagi.',
   'fileViewer.exportDone': 'Ekspor selesai',
+  'fileViewer.exportDegradedFallback': 'Tidak dapat mengakses berkas proyek — ZIP ini hanya berisi halaman yang dirender.',
   'fileViewer.exportImageFailed': 'Gagal menangkap gambar. Silakan coba lagi atau gunakan alat tangkapan layar browser Anda.',
   'fileViewer.exportImageModalSubtitle': 'Pilih format, lalu unduh pratinjau saat ini sebagai gambar.',
   'fileViewer.exportImageFormatLabel': 'Format',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -3261,6 +3261,7 @@ export const it: Dict = {
   'fileViewer.exportSlideEta': 'Diapositiva {current}/{total} · ~{seconds}s rimanenti',
   'fileViewer.exportFailed': 'Esportazione non riuscita. Riprova.',
   'fileViewer.exportDone': 'Esportazione completata',
+  'fileViewer.exportDegradedFallback': 'Impossibile raggiungere i file del progetto: questo ZIP contiene solo la pagina renderizzata.',
   'fileViewer.exportImageFailed': 'Acquisizione immagine non riuscita. Riprova o usa lo strumento screenshot del browser.',
   'fileViewer.exportImageModalSubtitle': 'Scegli un formato, poi scarica l\'anteprima corrente come immagine.',
   'fileViewer.exportImageFormatLabel': 'Formato',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -3261,6 +3261,7 @@ export const ja: Dict = {
   'fileViewer.exportSlideEta': 'スライド {current}/{total} を書き出し中 · 残り約 {seconds}秒',
   'fileViewer.exportFailed': '書き出しに失敗しました。もう一度お試しください。',
   'fileViewer.exportDone': '書き出しが完了しました',
+  'fileViewer.exportDegradedFallback': 'プロジェクトファイルを取得できませんでした。この ZIP にはレンダリング済みのページのみが含まれます。',
   'fileViewer.exportImageFailed': '画像のキャプチャに失敗しました。再試行するか、ブラウザのスクリーンショット機能をご利用ください。',
   'fileViewer.exportImageModalSubtitle': '形式を選択して、現在のプレビューを画像としてダウンロードします。',
   'fileViewer.exportImageFormatLabel': '形式',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -3261,6 +3261,7 @@ export const ko: Dict = {
   'fileViewer.exportSlideEta': '슬라이드 {current}/{total} 내보내는 중 · 약 {seconds}초 남음',
   'fileViewer.exportFailed': '내보내기에 실패했습니다. 다시 시도해 주세요.',
   'fileViewer.exportDone': '내보내기 완료',
+  'fileViewer.exportDegradedFallback': '프로젝트 파일에 접근하지 못했습니다. 이 ZIP에는 렌더링된 페이지만 포함되어 있습니다.',
   'fileViewer.exportImageFailed': '이미지 캡처에 실패했습니다. 다시 시도하거나 브라우저의 스크린샷 도구를 사용하세요.',
   'fileViewer.exportImageModalSubtitle': '형식을 선택한 다음 현재 미리보기를 이미지로 다운로드합니다.',
   'fileViewer.exportImageFormatLabel': '형식',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -3261,6 +3261,7 @@ export const pl: Dict = {
   'fileViewer.exportSlideEta': 'Slajd {current}/{total} · pozostało ~{seconds}s',
   'fileViewer.exportFailed': 'Eksport nie powiódł się. Spróbuj ponownie.',
   'fileViewer.exportDone': 'Eksport zakończony',
+  'fileViewer.exportDegradedFallback': 'Nie udało się pobrać plików projektu — to archiwum ZIP zawiera tylko wyrenderowaną stronę.',
   'fileViewer.exportImageFailed': 'Przechwytywanie obrazu nie powiodło się. Spróbuj ponownie lub użyj narzędzia do zrzutów ekranu w przeglądarce.',
   'fileViewer.exportImageModalSubtitle': 'Wybierz format, a następnie pobierz bieżący podgląd jako obraz.',
   'fileViewer.exportImageFormatLabel': 'Format',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -3261,6 +3261,7 @@ export const ptBR: Dict = {
   'fileViewer.exportSlideEta': 'Slide {current}/{total} · ~{seconds}s restantes',
   'fileViewer.exportFailed': 'Falha na exportação. Tente novamente.',
   'fileViewer.exportDone': 'Exportação concluída',
+  'fileViewer.exportDegradedFallback': 'Não foi possível acessar os arquivos do projeto — este ZIP contém apenas a página renderizada.',
   'fileViewer.exportImageFailed': 'Falha ao capturar a imagem. Tente novamente ou use a ferramenta de captura de tela do seu navegador.',
   'fileViewer.exportImageModalSubtitle': 'Escolha um formato e baixe a prévia atual como imagem.',
   'fileViewer.exportImageFormatLabel': 'Formato',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -3261,6 +3261,7 @@ export const ru: Dict = {
   'fileViewer.exportSlideEta': 'Слайд {current}/{total} · осталось ~{seconds}с',
   'fileViewer.exportFailed': 'Не удалось экспортировать. Повторите попытку.',
   'fileViewer.exportDone': 'Экспорт завершён',
+  'fileViewer.exportDegradedFallback': 'Не удалось получить файлы проекта — этот ZIP содержит только отрисованную страницу.',
   'fileViewer.exportImageFailed': 'Не удалось сделать снимок. Попробуйте ещё раз или воспользуйтесь инструментом скриншотов вашего браузера.',
   'fileViewer.exportImageModalSubtitle': 'Выберите формат, затем скачайте текущий предпросмотр как изображение.',
   'fileViewer.exportImageFormatLabel': 'Формат',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -3261,6 +3261,7 @@ export const th: Dict = {
   'fileViewer.exportSlideEta': 'สไลด์ {current}/{total} · เหลือ ~{seconds} วินาที',
   'fileViewer.exportFailed': 'การส่งออกล้มเหลว โปรดลองอีกครั้ง',
   'fileViewer.exportDone': 'ส่งออกเสร็จสิ้น',
+  'fileViewer.exportDegradedFallback': 'ไม่สามารถเข้าถึงไฟล์โปรเจกต์ ไฟล์ ZIP นี้มีเฉพาะหน้าที่เรนเดอร์แล้วเท่านั้น',
   'fileViewer.exportImageFailed': 'การจับภาพล้มเหลว กรุณาลองอีกครั้งหรือใช้เครื่องมือจับภาพหน้าจอของเบราว์เซอร์',
   'fileViewer.exportImageModalSubtitle': 'เลือกรูปแบบ แล้วดาวน์โหลดตัวอย่างปัจจุบันเป็นรูปภาพ',
   'fileViewer.exportImageFormatLabel': 'รูปแบบ',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -3261,6 +3261,7 @@ export const tr: Dict = {
   'fileViewer.exportSlideEta': '{current}/{total} slayt · ~{seconds}sn kaldı',
   'fileViewer.exportFailed': 'Dışa aktarma başarısız. Lütfen tekrar deneyin.',
   'fileViewer.exportDone': 'Dışa aktarma tamamlandı',
+  'fileViewer.exportDegradedFallback': 'Proje dosyalarına erişilemedi — bu ZIP yalnızca işlenmiş sayfayı içeriyor.',
   'fileViewer.exportImageFailed': 'Görsel yakalama başarısız oldu. Lütfen tekrar deneyin veya tarayıcınızın ekran görüntüsü aracını kullanın.',
   'fileViewer.exportImageModalSubtitle': 'Bir biçim seçin, ardından geçerli önizlemeyi resim olarak indirin.',
   'fileViewer.exportImageFormatLabel': 'Biçim',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -3261,6 +3261,7 @@ export const uk: Dict = {
   'fileViewer.exportSlideEta': 'Слайд {current}/{total} · залишилось ~{seconds}с',
   'fileViewer.exportFailed': 'Не вдалося експортувати. Спробуйте ще раз.',
   'fileViewer.exportDone': 'Експорт завершено',
+  'fileViewer.exportDegradedFallback': 'Не вдалося отримати файли проєкту — цей ZIP містить лише відрендерену сторінку.',
   'fileViewer.exportImageFailed': 'Не вдалося захопити зображення. Спробуйте ще раз або скористайтеся інструментом знімків екрана вашого браузера.',
   'fileViewer.exportImageModalSubtitle': 'Виберіть формат, а потім завантажте поточний попередній перегляд як зображення.',
   'fileViewer.exportImageFormatLabel': 'Формат',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -3435,6 +3435,7 @@ export const zhCN: Dict = {
     "正在导出第 {current}/{total} 页 · 约剩 {seconds} 秒",
   "fileViewer.exportFailed": "导出失败，请重试。",
   "fileViewer.exportDone": "导出完成",
+  "fileViewer.exportDegradedFallback": "无法获取项目文件，此 ZIP 仅包含渲染后的页面。",
   "fileViewer.exportImageFailed":
     "图片捕获失败，请重试或使用浏览器的截图工具。",
   "fileViewer.exportImageModalSubtitle":

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -3444,6 +3444,7 @@ export const zhTW: Dict = {
     "正在匯出第 {current}/{total} 張 · 約剩 {seconds} 秒",
   "fileViewer.exportFailed": "匯出失敗，請重試。",
   "fileViewer.exportDone": "匯出完成",
+  "fileViewer.exportDegradedFallback": "無法取得專案檔案，此 ZIP 僅包含算繪後的頁面。",
   "fileViewer.exportImageFailed":
     "圖片擷取失敗，請重試或使用瀏覽器的截圖工具。",
   "fileViewer.exportImageModalSubtitle":

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -4177,6 +4177,7 @@ export interface Dict {
   'fileViewer.exportSlideEta': string;
   'fileViewer.exportFailed': string;
   'fileViewer.exportDone': string;
+  'fileViewer.exportDegradedFallback': string;
   'fileViewer.exportImageFailed': string;
   'fileViewer.exportImageModalSubtitle': string;
   'fileViewer.exportImageFormatLabel': string;

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -934,9 +934,12 @@ export async function exportProjectAsZip(opts: {
       exportAsZip(await resp.text(), opts.fallbackTitle);
       return;
     } catch (err) {
-      // Same silent-substitution problem as the archive path below: the
-      // fallback ships the *current* content under the name of the version
-      // the user asked for, so the caller must be able to say so.
+      // Same silent-substitution problem as the archive path below, though
+      // milder: callers pass the selected version's own cached content as
+      // `fallbackHtml` (`HtmlVersionExportContext.content` is required), so
+      // the user gets the right version — but as a client-rendered snapshot
+      // instead of the server-rendered export they asked for. Still a
+      // different artifact than the one requested, so say so.
       console.warn('[exportProjectAsZip] falling back to single-file ZIP:', err);
       exportAsZip(opts.fallbackHtml, opts.fallbackTitle);
       return 'degraded';

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -872,6 +872,21 @@ export function exportReactComponentAsZip(
 // daemon for the whole project. Falls back to the in-memory single-file
 // ZIP on any failure so the action never silently no-ops.
 /**
+ * True when the blob begins with the ZIP signature `PK` (`PK\x03\x04` for a
+ * normal archive, `PK\x05\x06` for an empty one).
+ *
+ * A 2xx is not proof the body is an archive: an authenticating proxy can
+ * answer with its own HTML interstitial at 200, and a truncated or empty
+ * transfer arrives as a 0-byte body. Without this check both are handed to
+ * the user as a .zip and reported as a successful export.
+ */
+async function looksLikeZip(blob: Blob): Promise<boolean> {
+  if (blob.size < 2) return false;
+  const magic = new Uint8Array(await blob.slice(0, 2).arrayBuffer());
+  return magic[0] === 0x50 && magic[1] === 0x4b;
+}
+
+/**
  * Downloads the project's on-disk tree as a ZIP.
  *
  * When the archive request fails the browser still receives a ZIP, but it is
@@ -927,6 +942,9 @@ export async function exportProjectAsZip(opts: {
       : await fetch(url);
     if (!resp.ok) throw new Error(`archive request failed (${resp.status})`);
     const blob = await resp.blob();
+    if (!await looksLikeZip(blob)) {
+      throw new Error(`archive response was not a ZIP (${blob.size} bytes)`);
+    }
     triggerDownload(blob, archiveFilenameFrom(resp, opts.fallbackTitle, root));
   } catch (err) {
     console.warn('[exportProjectAsZip] falling back to single-file ZIP:', err);
@@ -1260,6 +1278,9 @@ export async function downloadDesignSystemArchive(opts: {
       : await fetch(url);
     if (!resp.ok) throw new Error(`archive request failed (${resp.status})`);
     const blob = await resp.blob();
+    if (!await looksLikeZip(blob)) {
+      throw new Error(`archive response was not a ZIP (${blob.size} bytes)`);
+    }
     triggerDownload(blob, archiveFilenameFrom(resp, opts.fallbackTitle, ''));
     return true;
   } catch (err) {
@@ -1286,6 +1307,9 @@ export async function downloadProjectArchive(opts: {
       : await fetch(url);
     if (!resp.ok) throw new Error(`archive request failed (${resp.status})`);
     const blob = await resp.blob();
+    if (!await looksLikeZip(blob)) {
+      throw new Error(`archive response was not a ZIP (${blob.size} bytes)`);
+    }
     triggerDownload(blob, archiveFilenameFrom(resp, opts.fallbackTitle, root));
     return true;
   } catch (err) {

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -871,9 +871,21 @@ export function exportReactComponentAsZip(
 // directory we scope the archive to that directory, otherwise we ask the
 // daemon for the whole project. Falls back to the in-memory single-file
 // ZIP on any failure so the action never silently no-ops.
+/** Local file header — every non-empty ZIP starts here. */
+const ZIP_SIGNATURE_LOCAL_FILE = [0x50, 0x4b, 0x03, 0x04] as const;
+/** End of central directory — the whole body of an empty ZIP. */
+const ZIP_SIGNATURE_EMPTY_ARCHIVE = [0x50, 0x4b, 0x05, 0x06] as const;
+const ZIP_SIGNATURES = [ZIP_SIGNATURE_LOCAL_FILE, ZIP_SIGNATURE_EMPTY_ARCHIVE] as const;
+const ZIP_SIGNATURE_BYTES = 4;
+
 /**
- * True when the blob begins with the ZIP signature `PK` (`PK\x03\x04` for a
- * normal archive, `PK\x05\x06` for an empty one).
+ * True when the blob begins with a full four-byte ZIP signature — `PK\x03\x04`
+ * for a normal archive, `PK\x05\x06` for an empty one. Both bytes after `PK`
+ * are checked, so a short or corrupt body that merely starts with `PK` is
+ * rejected rather than passed off as an archive.
+ *
+ * This is a signature check, not archive-integrity validation: it tells us the
+ * response is shaped like a ZIP, not that the ZIP is complete or readable.
  *
  * A 2xx is not proof the body is an archive: an authenticating proxy can
  * answer with its own HTML interstitial at 200, and a truncated or empty
@@ -881,9 +893,9 @@ export function exportReactComponentAsZip(
  * the user as a .zip and reported as a successful export.
  */
 async function looksLikeZip(blob: Blob): Promise<boolean> {
-  if (blob.size < 2) return false;
-  const magic = new Uint8Array(await blob.slice(0, 2).arrayBuffer());
-  return magic[0] === 0x50 && magic[1] === 0x4b;
+  if (blob.size < ZIP_SIGNATURE_BYTES) return false;
+  const magic = new Uint8Array(await blob.slice(0, ZIP_SIGNATURE_BYTES).arrayBuffer());
+  return ZIP_SIGNATURES.some((signature) => signature.every((byte, i) => magic[i] === byte));
 }
 
 /**

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -871,31 +871,117 @@ export function exportReactComponentAsZip(
 // directory we scope the archive to that directory, otherwise we ask the
 // daemon for the whole project. Falls back to the in-memory single-file
 // ZIP on any failure so the action never silently no-ops.
-/** Local file header — every non-empty ZIP starts here. */
-const ZIP_SIGNATURE_LOCAL_FILE = [0x50, 0x4b, 0x03, 0x04] as const;
-/** End of central directory — the whole body of an empty ZIP. */
-const ZIP_SIGNATURE_EMPTY_ARCHIVE = [0x50, 0x4b, 0x05, 0x06] as const;
-const ZIP_SIGNATURES = [ZIP_SIGNATURE_LOCAL_FILE, ZIP_SIGNATURE_EMPTY_ARCHIVE] as const;
-const ZIP_SIGNATURE_BYTES = 4;
+/** Local file header — every non-empty ZIP starts with one. */
+const ZIP_LOCAL_FILE_SIGNATURE = [0x50, 0x4b, 0x03, 0x04] as const;
+/** End of central directory record: 22 bytes, plus an optional comment. */
+const ZIP_EOCD_SIGNATURE = [0x50, 0x4b, 0x05, 0x06] as const;
+const ZIP_EOCD_SIZE = 22;
+/** The EOCD comment length field is a uint16, so the record starts at most this far from the end. */
+const ZIP_MAX_COMMENT = 0xffff;
+/** Central directory file header — one per entry, 46 bytes plus name/extra/comment. */
+const ZIP_CENTRAL_HEADER_SIGNATURE = [0x50, 0x4b, 0x01, 0x02] as const;
+const ZIP_CENTRAL_HEADER_SIZE = 46;
 
 /**
- * True when the blob begins with a full four-byte ZIP signature — `PK\x03\x04`
- * for a normal archive, `PK\x05\x06` for an empty one. Both bytes after `PK`
- * are checked, so a short or corrupt body that merely starts with `PK` is
- * rejected rather than passed off as an archive.
+ * Walks the central directory the EOCD points at and confirms it holds
+ * exactly the number of well-formed records the EOCD declares, consuming the
+ * declared size exactly.
  *
- * This is a signature check, not archive-integrity validation: it tells us the
- * response is shaped like a ZIP, not that the ZIP is complete or readable.
+ * Checking only that the directory's byte range fits inside the file is not
+ * enough: a stream damaged in that region keeps a plausible range while the
+ * records themselves are gone, and a reader then fails with something like
+ * "expected 1 records in central dir, got 0".
+ */
+async function centralDirectoryIsIntact(
+  blob: Blob,
+  offset: number,
+  size: number,
+  declaredEntries: number,
+): Promise<boolean> {
+  // An empty archive has no directory at all.
+  if (size === 0) return declaredEntries === 0;
+  if (size < ZIP_CENTRAL_HEADER_SIZE) return false;
+
+  // The EOCD entry count is a uint16, so it is only ever the low 16 bits of
+  // the real total. Writers that predate Zip64 — including JSZip, which the
+  // daemon uses to build project archives, and this app's own `buildZip` —
+  // truncate rather than emitting the Zip64 sentinel, so 65,536 entries are
+  // written as 0 and 65,537 as 1. Comparing modulo 65,536 accepts those
+  // readable archives while still catching a directory that genuinely
+  // disagrees with its own count. 0xffff is the Zip64 sentinel proper, where
+  // the real count lives in the Zip64 record and no comparison is possible.
+  const countIsComparable = declaredEntries !== 0xffff;
+
+  const bytes = new Uint8Array(await blob.slice(offset, offset + size).arrayBuffer());
+  if (bytes.length !== size) return false;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+
+  let cursor = 0;
+  let found = 0;
+  while (cursor < bytes.length) {
+    if (cursor + ZIP_CENTRAL_HEADER_SIZE > bytes.length) return false;
+    if (!ZIP_CENTRAL_HEADER_SIGNATURE.every((b, k) => bytes[cursor + k] === b)) return false;
+    const nameLength = view.getUint16(cursor + 28, true);
+    const extraLength = view.getUint16(cursor + 30, true);
+    const commentLength = view.getUint16(cursor + 32, true);
+    cursor += ZIP_CENTRAL_HEADER_SIZE + nameLength + extraLength + commentLength;
+    found += 1;
+  }
+  // The records must consume the declared directory size exactly, and — when
+  // the EOCD count is trustworthy — match it.
+  if (cursor !== bytes.length) return false;
+  return countIsComparable ? found % 0x10000 === declaredEntries : found > 0;
+}
+
+/**
+ * True when the blob is a structurally complete ZIP.
  *
  * A 2xx is not proof the body is an archive: an authenticating proxy can
- * answer with its own HTML interstitial at 200, and a truncated or empty
- * transfer arrives as a 0-byte body. Without this check both are handed to
- * the user as a .zip and reported as a successful export.
+ * answer with its own HTML interstitial at 200, and an empty or truncated
+ * transfer arrives short. Without this check each is handed to the user as a
+ * .zip and reported as a successful export.
+ *
+ * A signature prefix alone is not enough either. `PK\x05\x06` is only the
+ * first four bytes of the 22-byte end-of-central-directory record, and
+ * `PK\x03\x04…` is a local header with no central directory behind it —
+ * both are unreadable archives, and a truncated stream produces exactly the
+ * latter. So the EOCD is located and validated:
+ *
+ *   1. scan back from the end for the EOCD signature (bounded by the maximum
+ *      comment length, so the window is at most 64 KiB + 22 bytes),
+ *   2. require the declared comment length to account for every remaining
+ *      byte, so nothing is missing after the record,
+ *   3. walk the central directory it points at and require exactly the
+ *      declared number of well-formed records, consuming its declared size.
+ *
+ * This establishes that the archive's index is present and self-consistent.
+ * It is not a full parse: entry contents and CRCs are not verified.
  */
 async function looksLikeZip(blob: Blob): Promise<boolean> {
-  if (blob.size < ZIP_SIGNATURE_BYTES) return false;
-  const magic = new Uint8Array(await blob.slice(0, ZIP_SIGNATURE_BYTES).arrayBuffer());
-  return ZIP_SIGNATURES.some((signature) => signature.every((byte, i) => magic[i] === byte));
+  if (blob.size < ZIP_EOCD_SIZE) return false;
+
+  const head = new Uint8Array(await blob.slice(0, 4).arrayBuffer());
+  const startsWith = (sig: readonly number[]): boolean => sig.every((b, i) => head[i] === b);
+  if (!startsWith(ZIP_LOCAL_FILE_SIGNATURE) && !startsWith(ZIP_EOCD_SIGNATURE)) return false;
+
+  const windowSize = Math.min(blob.size, ZIP_EOCD_SIZE + ZIP_MAX_COMMENT);
+  const tail = new Uint8Array(await blob.slice(blob.size - windowSize).arrayBuffer());
+  const view = new DataView(tail.buffer, tail.byteOffset, tail.byteLength);
+
+  for (let i = tail.length - ZIP_EOCD_SIZE; i >= 0; i -= 1) {
+    if (!ZIP_EOCD_SIGNATURE.every((b, k) => tail[i + k] === b)) continue;
+    // Every byte after the record must be accounted for by its comment.
+    if (ZIP_EOCD_SIZE + view.getUint16(i + 20, true) !== tail.length - i) continue;
+    const declaredEntries = view.getUint16(i + 10, true);
+    const centralDirSize = view.getUint32(i + 12, true);
+    const centralDirOffset = view.getUint32(i + 16, true);
+    const eocdAt = blob.size - (tail.length - i);
+    if (centralDirOffset + centralDirSize > eocdAt) continue;
+    if (await centralDirectoryIsIntact(blob, centralDirOffset, centralDirSize, declaredEntries)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -871,6 +871,16 @@ export function exportReactComponentAsZip(
 // directory we scope the archive to that directory, otherwise we ask the
 // daemon for the whole project. Falls back to the in-memory single-file
 // ZIP on any failure so the action never silently no-ops.
+/**
+ * Downloads the project's on-disk tree as a ZIP.
+ *
+ * When the archive request fails the browser still receives a ZIP, but it is
+ * a client-rendered single-file snapshot rather than the project files. That
+ * substitution used to be silent, so a failed export was indistinguishable
+ * from a successful one. Returning 'degraded' — mirroring the 'cancelled'
+ * sentinel other exporters use — lets the caller tell the user which artifact
+ * they actually got.
+ */
 export async function exportProjectAsZip(opts: {
   projectId: string;
   filePath: string;
@@ -878,7 +888,7 @@ export async function exportProjectAsZip(opts: {
   fallbackTitle: string;
   versionId?: string;
   workspaceContext?: WorkspaceCollabContext | null;
-}): Promise<void> {
+}): Promise<void | 'degraded'> {
   if (opts.versionId) {
     const segments = opts.filePath
       .split('/')
@@ -897,9 +907,12 @@ export async function exportProjectAsZip(opts: {
       exportAsZip(await resp.text(), opts.fallbackTitle);
       return;
     } catch (err) {
+      // Same silent-substitution problem as the archive path below: the
+      // fallback ships the *current* content under the name of the version
+      // the user asked for, so the caller must be able to say so.
       console.warn('[exportProjectAsZip] falling back to single-file ZIP:', err);
       exportAsZip(opts.fallbackHtml, opts.fallbackTitle);
-      return;
+      return 'degraded';
     }
   }
   const root = archiveRootFromFilePath(opts.filePath);
@@ -918,6 +931,7 @@ export async function exportProjectAsZip(opts: {
   } catch (err) {
     console.warn('[exportProjectAsZip] falling back to single-file ZIP:', err);
     exportAsZip(opts.fallbackHtml, opts.fallbackTitle);
+    return 'degraded';
   }
 }
 

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -949,6 +949,8 @@ async function centralDirectoryIsIntact(
  *
  *   1. scan back from the end for the EOCD signature (bounded by the maximum
  *      comment length, so the window is at most 64 KiB + 22 bytes),
+ *   1a. require the single-volume form: both disk fields zero, and the
+ *      per-disk entry count equal to the total,
  *   2. require the declared comment length to account for every remaining
  *      byte, so nothing is missing after the record,
  *   3. walk the central directory it points at and require exactly the
@@ -972,7 +974,22 @@ async function looksLikeZip(blob: Blob): Promise<boolean> {
     if (!ZIP_EOCD_SIGNATURE.every((b, k) => tail[i + k] === b)) continue;
     // Every byte after the record must be accounted for by its comment.
     if (ZIP_EOCD_SIZE + view.getUint16(i + 20, true) !== tail.length - i) continue;
+    // Only the single-volume form is supported, so require the disk
+    // identifiers to say so. A record advertising a multi-volume archive
+    // passes every other check unchanged while the response carries one
+    // volume, and this guard has no multi-volume handling to fall back on.
+    //
+    // Note this is a metadata-consistency check, not a readability one:
+    // JSZip 3.10.1 and Python's zipfile both still open an archive whose
+    // disk number has been flipped. Nothing in the real path produces one —
+    // the daemon builds these with JSZip, which always writes zero — so
+    // rejecting an unsupported shape costs nothing and beats guessing.
+    const thisDisk = view.getUint16(i + 4, true);
+    const centralDirStartDisk = view.getUint16(i + 6, true);
+    const entriesOnThisDisk = view.getUint16(i + 8, true);
     const declaredEntries = view.getUint16(i + 10, true);
+    if (thisDisk !== 0 || centralDirStartDisk !== 0) continue;
+    if (entriesOnThisDisk !== declaredEntries) continue;
     const centralDirSize = view.getUint32(i + 12, true);
     const centralDirOffset = view.getUint32(i + 16, true);
     const eocdAt = blob.size - (tail.length - i);

--- a/apps/web/tests/components/FileWorkspace.design-system.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.design-system.test.tsx
@@ -11,6 +11,7 @@ import {
   type WorkspaceCollabContext,
 } from '@open-design/contracts';
 
+import { buildZip } from '../../src/runtime/zip';
 import { FileWorkspace } from '../../src/components/FileWorkspace';
 import {
   CollabProvider,
@@ -749,11 +750,12 @@ describe('FileWorkspace design-system project surface', () => {
           headers: { 'Content-Type': 'application/json' },
         });
       }
-      // Real ZIP signature: the archive download verifies it now. Note the
-      // body is passed as a string — `new Response(new Blob([...]))` is
-      // stringified to "[object Blob]" in this environment, so the previous
-      // fixture never carried the bytes it appeared to.
-      return new Response('PK\x03\x04zip', {
+      // A genuine archive from the app's own writer: the download now
+      // validates ZIP structure (central directory + EOCD), so a signature
+      // prefix is rejected. Passed as an ArrayBuffer because
+      // `new Response(new Blob([...]))` stringifies to "[object Blob]" here,
+      // which is what the original fixture was silently serving.
+      return new Response(await buildZip([{ path: 'acme.html', content: 'zip' }]).arrayBuffer(), {
         status: 200,
         headers: { 'Content-Disposition': 'attachment; filename="acme.zip"' },
       });

--- a/apps/web/tests/components/FileWorkspace.design-system.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.design-system.test.tsx
@@ -749,7 +749,11 @@ describe('FileWorkspace design-system project surface', () => {
           headers: { 'Content-Type': 'application/json' },
         });
       }
-      return new Response(new Blob(['zip']), {
+      // Real ZIP signature: the archive download verifies it now. Note the
+      // body is passed as a string — `new Response(new Blob([...]))` is
+      // stringified to "[object Blob]" in this environment, so the previous
+      // fixture never carried the bytes it appeared to.
+      return new Response('PK\x03\x04zip', {
         status: 200,
         headers: { 'Content-Disposition': 'attachment; filename="acme.zip"' },
       });

--- a/apps/web/tests/runtime/exports.test.ts
+++ b/apps/web/tests/runtime/exports.test.ts
@@ -791,7 +791,7 @@ describe('binary project/design-system downloads', () => {
       if (url.endsWith('/export/html')) {
         return new Response('<!doctype html><p>exported</p>', { status: 200 });
       }
-      return new Response('archive-or-rendered-bytes', {
+      return new Response(`PK\x03\x04archive-or-rendered-bytes`, {
         status: 200,
         headers: {
           'content-type': 'application/octet-stream',
@@ -1011,7 +1011,7 @@ describe('binary project/design-system downloads', () => {
   });
 
   it('downloads the backing project archive with the daemon filename', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => new Response('project-zip', {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(`PK\x03\x04project-zip`, {
       status: 200,
       headers: {
         'content-type': 'application/zip',
@@ -1031,7 +1031,7 @@ describe('binary project/design-system downloads', () => {
   });
 
   it('passes an optional root when downloading a project subfolder archive', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => new Response('folder-zip', {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(`PK\x03\x04folder-zip`, {
       status: 200,
       headers: {
         'content-type': 'application/zip',
@@ -1784,9 +1784,35 @@ describe('exportProjectAsZip degraded-archive reporting (#8005)', () => {
     expect(capturedFilename).toBeTruthy();
   });
 
+  it.each([
+    ['an empty 200 body', '', 200, { 'content-type': 'application/zip', 'content-disposition': 'attachment; filename="p.zip"' }],
+    ['a 200 HTML interstitial from a proxy', '<html><body>Gateway error</body></html>', 200, { 'content-type': 'text/html' }],
+    ['a 204 with no content', '', 204, {}],
+  ] as const)('treats %s as degraded rather than a successful archive', async (_label, body, status, headers) => {
+    // Given: the archive request "succeeds" but the body is not an archive.
+    // A 2xx alone is not proof: an authenticating proxy can answer with its
+    // own error page at 200, and a truncated transfer arrives as 0 bytes.
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(
+      status === 204 ? null : body,
+      { status, headers: headers as Record<string, string> },
+    )));
+
+    // When: the user picks "Download as .zip".
+    const result = await exportProjectAsZip({
+      projectId: 'project-a',
+      filePath: 'index.html',
+      fallbackHtml: '<main>rendered page</main>',
+      fallbackTitle: 'Not A Zip',
+    });
+
+    // Then: it is reported as degraded instead of handing over a .zip that
+    // holds an HTML error page or nothing at all.
+    expect(result).toBe('degraded');
+  });
+
   it('resolves without a degraded marker when the archive succeeds', async () => {
     // Given: the archive route returns the project tree.
-    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response('archive-bytes', {
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(`PK\x03\x04archive-bytes`, {
       status: 200,
       headers: {
         'content-type': 'application/zip',
@@ -1805,7 +1831,7 @@ describe('exportProjectAsZip degraded-archive reporting (#8005)', () => {
     // Then: the success path is unchanged — no marker, real bytes downloaded.
     expect(result).toBeUndefined();
     expect(capturedFilename).toBe('project.zip');
-    expect(await capturedBlob?.text()).toBe('archive-bytes');
+    expect(await capturedBlob?.text()).toBe('PK\x03\x04archive-bytes');
   });
 
   it('reports a failed version export as degraded rather than passing off current content', async () => {

--- a/apps/web/tests/runtime/exports.test.ts
+++ b/apps/web/tests/runtime/exports.test.ts
@@ -1722,3 +1722,108 @@ describe('exportAsImage', () => {
     expect(target?.filename).toBe('My-Design.png');
   });
 });
+
+describe('exportProjectAsZip degraded-archive reporting (#8005)', () => {
+  let capturedBlob: Blob | undefined;
+  let capturedFilename: string | undefined;
+
+  beforeEach(() => {
+    capturedBlob = undefined;
+    capturedFilename = undefined;
+    vi.stubGlobal('URL', {
+      createObjectURL: (blob: Blob) => {
+        capturedBlob = blob;
+        return 'blob:test';
+      },
+      revokeObjectURL: () => {},
+    });
+    vi.stubGlobal('document', {
+      createElement: () => {
+        const anchor = { href: '', click: () => {} } as { href: string; download?: string; click: () => void };
+        Object.defineProperty(anchor, 'download', {
+          set(value: string) {
+            capturedFilename = value;
+          },
+          get() {
+            return capturedFilename ?? '';
+          },
+        });
+        return anchor;
+      },
+      body: { appendChild: () => {}, removeChild: () => {} },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('reports a rejected archive response as degraded instead of resolving silently', async () => {
+    // Given: the archive route fails, exactly as it does behind a reverse
+    // proxy that forwards its own Basic credentials (#7819) — but equally for
+    // a 500, a missing project directory, or a transport error.
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => Response.json(
+      { error: { code: 'TOOL_TOKEN_MISSING', message: 'tool token is required' } },
+      { status: 401 },
+    )));
+
+    // When: the user picks "Download as .zip".
+    const result = await exportProjectAsZip({
+      projectId: 'project-a',
+      filePath: 'index.html',
+      fallbackHtml: '<main>rendered page</main>',
+      fallbackTitle: 'Degraded ZIP',
+    });
+
+    // Then: a ZIP is still delivered, but the caller is told it is the
+    // fallback artifact rather than the project tree, so the export is not
+    // reported to the user as a plain success.
+    expect(result).toBe('degraded');
+    expect(capturedBlob).toBeInstanceOf(Blob);
+    expect(capturedFilename).toBeTruthy();
+  });
+
+  it('resolves without a degraded marker when the archive succeeds', async () => {
+    // Given: the archive route returns the project tree.
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response('archive-bytes', {
+      status: 200,
+      headers: {
+        'content-type': 'application/zip',
+        'content-disposition': 'attachment; filename="project.zip"',
+      },
+    })));
+
+    // When: the same export runs.
+    const result = await exportProjectAsZip({
+      projectId: 'project-a',
+      filePath: 'index.html',
+      fallbackHtml: '<main>rendered page</main>',
+      fallbackTitle: 'Real ZIP',
+    });
+
+    // Then: the success path is unchanged — no marker, real bytes downloaded.
+    expect(result).toBeUndefined();
+    expect(capturedFilename).toBe('project.zip');
+    expect(await capturedBlob?.text()).toBe('archive-bytes');
+  });
+
+  it('reports a failed version export as degraded rather than passing off current content', async () => {
+    // Given: a version-scoped export whose fetch fails. The fallback ships the
+    // *current* content under the requested version's name.
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response('nope', { status: 500 })));
+
+    // When: the user exports a specific version as a ZIP.
+    const result = await exportProjectAsZip({
+      projectId: 'project-a',
+      filePath: 'index.html',
+      fallbackHtml: '<main>current content</main>',
+      fallbackTitle: 'Versioned ZIP',
+      versionId: 'version-7',
+    });
+
+    // Then: the substitution is reported instead of silently standing in.
+    expect(result).toBe('degraded');
+    expect(capturedBlob).toBeInstanceOf(Blob);
+  });
+});

--- a/apps/web/tests/runtime/exports.test.ts
+++ b/apps/web/tests/runtime/exports.test.ts
@@ -26,7 +26,18 @@ import {
   sourceLooksLikeExportableDeck,
   sourceLooksLikeNavigableDeck,
 } from '../../src/runtime/exports';
+import { buildZip } from '../../src/runtime/zip';
 import { workspaceContextFixture } from '../helpers/workspace-context';
+
+/**
+ * A genuine ZIP built by the app's own writer, so archive fixtures carry a
+ * real central directory and EOCD rather than a hand-written signature
+ * prefix. `exportProjectAsZip` validates archive structure, and a prefix
+ * alone is an unreadable archive.
+ */
+async function realZipBytes(name = 'index.html', content = 'archive-bytes'): Promise<ArrayBuffer> {
+  return buildZip([{ path: name, content }]).arrayBuffer();
+}
 
 describe('planDeckImageCapture (#4604 current-slide capture for runtime decks)', () => {
   it('whole-deck capture renders off-screen with no index (stitch all)', () => {
@@ -791,7 +802,7 @@ describe('binary project/design-system downloads', () => {
       if (url.endsWith('/export/html')) {
         return new Response('<!doctype html><p>exported</p>', { status: 200 });
       }
-      return new Response(`PK\x03\x04archive-or-rendered-bytes`, {
+      return new Response(await realZipBytes('mixed.html', 'archive-or-rendered-bytes'), {
         status: 200,
         headers: {
           'content-type': 'application/octet-stream',
@@ -978,7 +989,7 @@ describe('binary project/design-system downloads', () => {
   });
 
   it('fetches the design-system archive endpoint and downloads the daemon-named zip', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => new Response('PKzip-bytes', {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(await realZipBytes('ds.html', 'zip-bytes'), {
       status: 200,
       headers: {
         'content-type': 'application/zip',
@@ -1011,7 +1022,7 @@ describe('binary project/design-system downloads', () => {
   });
 
   it('downloads the backing project archive with the daemon filename', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => new Response(`PK\x03\x04project-zip`, {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(await realZipBytes('project.html', 'project-zip'), {
       status: 200,
       headers: {
         'content-type': 'application/zip',
@@ -1031,7 +1042,7 @@ describe('binary project/design-system downloads', () => {
   });
 
   it('passes an optional root when downloading a project subfolder archive', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => new Response(`PK\x03\x04folder-zip`, {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(await realZipBytes('folder.html', 'folder-zip'), {
       status: 200,
       headers: {
         'content-type': 'application/zip',
@@ -1815,6 +1826,9 @@ describe('exportProjectAsZip degraded-archive reporting (#8005)', () => {
     ['a three-byte truncated signature', 'PK\x03'],
     ['PK followed by the wrong signature bytes', 'PK\x01\x02rest'],
     ['a text body that merely begins with PK', 'PKzip-bytes'],
+    ['a bare four-byte EOCD prefix', 'PK\x05\x06'],
+    ['a truncated local header with no central directory', 'PK\x03\x04payload'],
+    ['an archive truncated mid-central-directory', 'PK\x03\x04payloadPK\x01\x02truncated'],
   ] as const)('rejects %s', async (_label, body) => {
     // Given: a 200 whose body starts with PK but is not a ZIP. Checking only
     // the first two bytes would let each of these through as an archive.
@@ -1836,9 +1850,10 @@ describe('exportProjectAsZip degraded-archive reporting (#8005)', () => {
   });
 
   it.each([
-    ['a normal archive (PK\\x03\\x04)', 'PK\x03\x04payload'],
-    ['an empty archive (PK\\x05\\x06)', 'PK\x05\x06'],
-  ] as const)('accepts %s', async (_label, body) => {
+    ['a single-entry archive', async () => realZipBytes('a.html', 'payload')],
+    ['an empty archive (bare 22-byte EOCD)', async () => new Uint8Array(22).fill(0).map((_v, i) => [0x50, 0x4b, 0x05, 0x06][i] ?? 0).buffer],
+  ] as const)('accepts %s', async (_label, makeBody) => {
+    const body = await makeBody();
     // Given: a body carrying a real ZIP signature — both forms the daemon can
     // produce, including the end-of-central-directory-only empty archive.
     vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(body, {
@@ -1855,9 +1870,117 @@ describe('exportProjectAsZip degraded-archive reporting (#8005)', () => {
     })).resolves.toBeUndefined();
   });
 
+  it.each([
+    ['its central-directory signature is damaged', (bytes: Uint8Array) => {
+      // Zero the PK\x01\x02 record signature, as a stream damaged in that
+      // region would. The EOCD still declares a plausible range, so a
+      // range-only check passes while a reader reports
+      // "expected 1 records in central dir, got 0".
+      for (let i = 0; i + 3 < bytes.length; i += 1) {
+        if (bytes[i] === 0x50 && bytes[i + 1] === 0x4b && bytes[i + 2] === 0x01 && bytes[i + 3] === 0x02) {
+          bytes[i] = 0; bytes[i + 1] = 0; bytes[i + 2] = 0; bytes[i + 3] = 0;
+          return;
+        }
+      }
+      throw new Error('fixture has no central-directory record to damage');
+    }],
+    ['the EOCD over-declares its entry count', (bytes: Uint8Array) => {
+      // Claim two records where the directory holds one.
+      const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+      for (let i = bytes.length - 22; i >= 0; i -= 1) {
+        if (bytes[i] === 0x50 && bytes[i + 1] === 0x4b && bytes[i + 2] === 0x05 && bytes[i + 3] === 0x06) {
+          view.setUint16(i + 8, 2, true);
+          view.setUint16(i + 10, 2, true);
+          return;
+        }
+      }
+      throw new Error('fixture has no EOCD to edit');
+    }],
+  ] as const)('treats an archive as degraded when %s', async (_label, damage) => {
+    // Given: a genuine archive from the app's own writer, then damaged.
+    const bytes = new Uint8Array(await realZipBytes('a.html', 'payload'));
+    damage(bytes);
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(bytes.slice(0), {
+      status: 200,
+      headers: { 'content-type': 'application/zip', 'content-disposition': 'attachment; filename="p.zip"' },
+    })));
+
+    // When: the export runs.
+    const result = await exportProjectAsZip({
+      projectId: 'project-a',
+      filePath: 'index.html',
+      fallbackHtml: '<main>rendered page</main>',
+      fallbackTitle: 'Damaged Directory',
+    });
+
+    // Then: an unreadable archive is not reported as a successful export.
+    expect(result).toBe('degraded');
+  });
+
+  it.each([
+    ['65,536 entries (count wraps to 0)', 65_536],
+    ['65,537 entries (count wraps to 1)', 65_537],
+  ] as const)('accepts a genuine archive of %s', async (_label, entryCount) => {
+    // Given: an archive large enough that the uint16 EOCD count wraps. JSZip —
+    // which the daemon uses to build project archives — and this app's own
+    // buildZip both truncate rather than emitting the Zip64 sentinel, so the
+    // declared count is the real total modulo 65,536. These archives are
+    // readable, so they must not be reported as degraded.
+    const entries = Array.from({ length: entryCount }, (_v, i) => ({ path: `f${i}`, content: '' }));
+    const archive = await buildZip(entries).arrayBuffer();
+
+    const tail = new Uint8Array(archive.slice(archive.byteLength - 22));
+    const declared = new DataView(tail.buffer).getUint16(10, true);
+    expect(declared).toBe(entryCount % 0x10000);
+    expect(declared).not.toBe(entryCount);
+
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(archive.slice(0), {
+      status: 200,
+      headers: { 'content-type': 'application/zip', 'content-disposition': 'attachment; filename="p.zip"' },
+    })));
+
+    // When / Then: the wrapped count is reconciled modulo 65,536.
+    await expect(exportProjectAsZip({
+      projectId: 'project-a',
+      filePath: 'index.html',
+      fallbackHtml: '<main>rendered page</main>',
+      fallbackTitle: 'Wrapped Count',
+    })).resolves.toBeUndefined();
+  }, 60_000);
+
+  it('still accepts a well-formed archive declaring the Zip64 sentinel count', async () => {
+    // Given: 0xffff means the real count lives in the Zip64 record, so no
+    // comparison is possible and structure alone decides.
+    const bytes = new Uint8Array(await realZipBytes('a.html', 'payload'));
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    for (let i = bytes.length - 22; i >= 0; i -= 1) {
+      if (bytes[i] === 0x50 && bytes[i + 1] === 0x4b && bytes[i + 2] === 0x05 && bytes[i + 3] === 0x06) {
+        view.setUint16(i + 8, 0xffff, true);
+        view.setUint16(i + 10, 0xffff, true);
+        break;
+      }
+    }
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(bytes.slice(0), {
+      status: 200,
+      headers: { 'content-type': 'application/zip', 'content-disposition': 'attachment; filename="p.zip"' },
+    })));
+
+    await expect(exportProjectAsZip({
+      projectId: 'project-a',
+      filePath: 'index.html',
+      fallbackHtml: '<main>rendered page</main>',
+      fallbackTitle: 'Zip64 Sentinel',
+    })).resolves.toBeUndefined();
+  });
+
   it('resolves without a degraded marker when the archive succeeds', async () => {
-    // Given: the archive route returns the project tree.
-    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(`PK\x03\x04archive-bytes`, {
+    // Given: the archive route returns the project tree. Build the archive
+    // ONCE and reuse those bytes for both the response and the assertion:
+    // buildZip() stamps a DOS timestamp with two-second resolution, so
+    // generating a second archive to compare against would fail whenever the
+    // two calls straddle a boundary.
+    const archive = await realZipBytes();
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(archive.slice(0), {
       status: 200,
       headers: {
         'content-type': 'application/zip',
@@ -1876,7 +1999,7 @@ describe('exportProjectAsZip degraded-archive reporting (#8005)', () => {
     // Then: the success path is unchanged — no marker, real bytes downloaded.
     expect(result).toBeUndefined();
     expect(capturedFilename).toBe('project.zip');
-    expect(await capturedBlob?.text()).toBe('PK\x03\x04archive-bytes');
+    expect(await capturedBlob?.arrayBuffer()).toEqual(archive);
   });
 
   it('reports a failed version export as degraded rather than passing off a client snapshot', async () => {

--- a/apps/web/tests/runtime/exports.test.ts
+++ b/apps/web/tests/runtime/exports.test.ts
@@ -1879,9 +1879,11 @@ describe('exportProjectAsZip degraded-archive reporting (#8005)', () => {
     expect(await capturedBlob?.text()).toBe('PK\x03\x04archive-bytes');
   });
 
-  it('reports a failed version export as degraded rather than passing off current content', async () => {
-    // Given: a version-scoped export whose fetch fails. The fallback ships the
-    // *current* content under the requested version's name.
+  it('reports a failed version export as degraded rather than passing off a client snapshot', async () => {
+    // Given: a version-scoped export whose fetch fails. Callers pass the
+    // selected version's own cached content as fallbackHtml, so the user gets
+    // the right version — but as a client-rendered snapshot rather than the
+    // server-rendered export that was requested.
     vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response('nope', { status: 500 })));
 
     // When: the user exports a specific version as a ZIP.

--- a/apps/web/tests/runtime/exports.test.ts
+++ b/apps/web/tests/runtime/exports.test.ts
@@ -33,7 +33,7 @@ import { workspaceContextFixture } from '../helpers/workspace-context';
  * A genuine ZIP built by the app's own writer, so archive fixtures carry a
  * real central directory and EOCD rather than a hand-written signature
  * prefix. `exportProjectAsZip` validates archive structure, and a prefix
- * alone is an unreadable archive.
+ * alone is not a valid archive.
  */
 async function realZipBytes(name = 'index.html', content = 'archive-bytes'): Promise<ArrayBuffer> {
   return buildZip([{ path: name, content }]).arrayBuffer();
@@ -1884,6 +1884,42 @@ describe('exportProjectAsZip degraded-archive reporting (#8005)', () => {
       }
       throw new Error('fixture has no central-directory record to damage');
     }],
+    ['the EOCD advertises a multi-volume archive', (bytes: Uint8Array) => {
+      // Flip "number of this disk" to 1. Every other field — entry count,
+      // directory range, each central header — is untouched, so only a disk
+      // check catches it. The archive stays readable in practice (JSZip and
+      // Python's zipfile both open it); the point is that the metadata
+      // declares a form this guard does not support, and no real producer
+      // emits it.
+      const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+      for (let i = bytes.length - 22; i >= 0; i -= 1) {
+        if (bytes[i] === 0x50 && bytes[i + 1] === 0x4b && bytes[i + 2] === 0x05 && bytes[i + 3] === 0x06) {
+          view.setUint16(i + 4, 1, true);
+          return;
+        }
+      }
+      throw new Error('fixture has no EOCD to edit');
+    }],
+    ['the EOCD central directory starts on another disk', (bytes: Uint8Array) => {
+      const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+      for (let i = bytes.length - 22; i >= 0; i -= 1) {
+        if (bytes[i] === 0x50 && bytes[i + 1] === 0x4b && bytes[i + 2] === 0x05 && bytes[i + 3] === 0x06) {
+          view.setUint16(i + 6, 1, true);
+          return;
+        }
+      }
+      throw new Error('fixture has no EOCD to edit');
+    }],
+    ['the per-disk entry count disagrees with the total', (bytes: Uint8Array) => {
+      const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+      for (let i = bytes.length - 22; i >= 0; i -= 1) {
+        if (bytes[i] === 0x50 && bytes[i + 1] === 0x4b && bytes[i + 2] === 0x05 && bytes[i + 3] === 0x06) {
+          view.setUint16(i + 8, 2, true);
+          return;
+        }
+      }
+      throw new Error('fixture has no EOCD to edit');
+    }],
     ['the EOCD over-declares its entry count', (bytes: Uint8Array) => {
       // Claim two records where the directory holds one.
       const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
@@ -1913,7 +1949,7 @@ describe('exportProjectAsZip degraded-archive reporting (#8005)', () => {
       fallbackTitle: 'Damaged Directory',
     });
 
-    // Then: an unreadable archive is not reported as a successful export.
+    // Then: an invalid or unsupported archive is not reported as a successful export.
     expect(result).toBe('degraded');
   });
 

--- a/apps/web/tests/runtime/exports.test.ts
+++ b/apps/web/tests/runtime/exports.test.ts
@@ -1810,6 +1810,51 @@ describe('exportProjectAsZip degraded-archive reporting (#8005)', () => {
     expect(result).toBe('degraded');
   });
 
+  it.each([
+    ['a two-byte body that is only the PK prefix', 'PK'],
+    ['a three-byte truncated signature', 'PK\x03'],
+    ['PK followed by the wrong signature bytes', 'PK\x01\x02rest'],
+    ['a text body that merely begins with PK', 'PKzip-bytes'],
+  ] as const)('rejects %s', async (_label, body) => {
+    // Given: a 200 whose body starts with PK but is not a ZIP. Checking only
+    // the first two bytes would let each of these through as an archive.
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(body, {
+      status: 200,
+      headers: { 'content-type': 'application/zip', 'content-disposition': 'attachment; filename="p.zip"' },
+    })));
+
+    // When: the export runs.
+    const result = await exportProjectAsZip({
+      projectId: 'project-a',
+      filePath: 'index.html',
+      fallbackHtml: '<main>rendered page</main>',
+      fallbackTitle: 'Partial Signature',
+    });
+
+    // Then: the full four-byte signature is required, so it is degraded.
+    expect(result).toBe('degraded');
+  });
+
+  it.each([
+    ['a normal archive (PK\\x03\\x04)', 'PK\x03\x04payload'],
+    ['an empty archive (PK\\x05\\x06)', 'PK\x05\x06'],
+  ] as const)('accepts %s', async (_label, body) => {
+    // Given: a body carrying a real ZIP signature — both forms the daemon can
+    // produce, including the end-of-central-directory-only empty archive.
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(body, {
+      status: 200,
+      headers: { 'content-type': 'application/zip', 'content-disposition': 'attachment; filename="p.zip"' },
+    })));
+
+    // When / Then: the success path is untouched.
+    await expect(exportProjectAsZip({
+      projectId: 'project-a',
+      filePath: 'index.html',
+      fallbackHtml: '<main>rendered page</main>',
+      fallbackTitle: 'Real Zip',
+    })).resolves.toBeUndefined();
+  });
+
   it('resolves without a degraded marker when the archive succeeds', async () => {
     // Given: the archive route returns the project tree.
     vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(`PK\x03\x04archive-bytes`, {


### PR DESCRIPTION
Fixes #8005
Refs #1236

## Why

Found while reproducing #7819 against real reverse proxies. `exportProjectAsZip` caught a failed archive request, generated a client-rendered single-file ZIP from the fallback HTML, and resolved normally. The download succeeded, so `FileViewer` recorded the export as a success and showed the normal completion state — the user was handed a snapshot of the rendered page instead of their project files, with nothing to indicate it.

The archive route exists specifically to avoid that artifact. Its own comment (`apps/daemon/src/import-export-routes.ts:1300`) says it streams the project tree "so the 'Download as .zip' share menu can hand the user the actual files they uploaded — e.g. the imported `ui-design/` folder — **instead of a one-file snapshot of the rendered HTML**". The fallback silently produced exactly that.

The `catch` does not discriminate, so this covered every archive failure: HTTP 500, a missing project directory, a permission denial, a dropped connection, as well as the proxy-auth 401 of #7819 that surfaced it. Fixing #7819 removes today's most common trigger but not the masking.

Per maintainer guidance on #8005: the fallback is preserved, and now reports an explicit degraded-artifact outcome.

## What users will see

When a ZIP download cannot reach the project files, the export now reports a warning instead of "Export complete":

> Couldn't reach the project files — this ZIP contains only the rendered page.

The fallback ZIP is still delivered, so nobody loses the escape hatch — they are simply told what they received. A successful archive export is unchanged.

## Surface area

- [x] **UI** — new warning message on the existing export toast surface in `FileViewer`; no new component, dialog or menu item
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var** — **not applicable.** This fixes how the browser reports a fallback that is generated client-side in `apps/web`. The `od` CLI has its own archive path and never calls `exportProjectAsZip`; no subcommand, flag or `OD_*` variable is added or changed.
- [ ] **API / contract** — no endpoint or contract change. `TrackingExportResult` in `packages/contracts` is deliberately left as `'success' | 'failed' | 'cancelled'`; a degraded export reports the existing `failed` rather than adding a value.
- [ ] **Extension point**
- [x] **i18n keys** — `fileViewer.exportDegradedFallback` added to all 19 locales; `i18n/types.ts` makes a missing locale a typecheck error
- [ ] **New top-level dependency**
- [x] **Default behavior change** — an export that silently reported success now reports a warning and records `failed` in analytics. That is the point of the fix, but it does change what existing users see, and it stops degraded exports inflating export-success metrics.

Two scope notes for the reviewer, both deliberate and easy to drop if unwanted:

1. **The `versionId` branch** had the same silent fallback, though the degradation is milder than I first described: callers pass the selected version's own cached content as `fallbackHtml` (`HtmlVersionExportContext.content` is required), so the user gets the right version — but as a client-rendered snapshot instead of the server-rendered export they requested. Still a different artifact than the one asked for, so it is reported the same way.
2. **The archive validation is wider than #8005's brief.** The issue asks for a visible outcome on the archive *failure* path; a `200` carrying a proxy error page is not a failure by that definition, but produces the same harm — a `.zip` the user cannot open, reported as a success. It is included because it is the same defect reached by a different route, and is straightforward to drop into a follow-up if you would rather this PR stay narrow.
3. **`downloadProjectArchive` and `downloadDesignSystemArchive`** share the ZIP-validation gap below. They already report failure through their boolean return, so only detection changes there. Guarding one archive path and not the others seemed arbitrary.

## Screenshots

Captured against a real `od` daemon behind real nginx with HTTP Basic auth — the deployment shape from #7819 — with pristine `main` and this branch served from the same daemon and the same project.
**The outcome.** Same project, same daemon, same `401` on the archive request — the toast is the only difference. The old build reports the failed export as a success:

| Before (`main`) | After (this branch) |
|---|---|
| <img alt="before: green Export complete toast" src="https://github.com/user-attachments/assets/2af0b00c-da52-4d68-8ee1-c33d681f39c5" /> | <img alt="after: red warning that the ZIP contains only the rendered page" src="https://github.com/user-attachments/assets/a0cbee95-3e74-465a-b1f1-31c2218bd1ef" /> |
| green — **"Export complete"** | red — **"Couldn't reach the project files — this ZIP contains only the rendered page."** |

<sub>The toast sits at the top of the viewport and is small relative to the page; open the images full size to compare.</sub>

**The entry point** — the Export menu where a user meets this, unchanged by this PR:

| Before (`main`) | After (this branch) |
|---|---|
| <img alt="before: Export menu with Download as .zip" src="https://github.com/user-attachments/assets/bbc5de24-d70d-4c11-af7f-b7a9b0bbbbbb" /> | <img alt="after: Export menu with Download as .zip" src="https://github.com/user-attachments/assets/bf63659a-a248-4af5-a1eb-1da04e3a99c4" /> |


| | Before (`main`) | After (this branch) |
|---|---|---|
| Archive request | `401` | `401` |
| Download | succeeds | succeeds |
| Toast | green "Export complete" | red "Couldn't reach the project files — this ZIP contains only the rendered page." |
| ZIP contents | `index.html` 32,550 b + handoff + manifest | identical |

Both downloads are the same 44,827-byte ZIP with the same three entries. The artifact does not change — only whether the UI tells the truth about it.

The entry-point screenshots show the **Export** menu with "Download as .zip", which is where a user meets this.

## Bug fix verification

Every case below was run against unmodified source first and observed failing, then against this branch and observed passing.

**1. The silent substitution** — `apps/web/tests/runtime/exports.test.ts` → `reports a rejected archive response as degraded instead of resolving silently`

```
AssertionError: expected undefined to be 'degraded'
```

**2. Responses that are `ok` but not an archive.** Measured before the guard, all three reported as a successful export:

| Response | Delivered before | Now |
|---|---|---|
| `200` + empty body | 0-byte `.zip` | `degraded` |
| `200` + HTML proxy interstitial | `.zip` containing `<html>Gateway error</html>` | `degraded` |
| `204 No Content` | 0-byte `.zip` | `degraded` |

**3. Structural validation.** A signature prefix is not enough — `PK\x05\x06` is only the first four bytes of the 22-byte end-of-central-directory record, and `PK\x03\x04…` is a local header with no directory behind it, which is exactly the shape a truncated transfer produces. `looksLikeZip` therefore locates the EOCD in the trailing window, requires its declared comment length to account for every remaining byte, and walks the central directory it points at, requiring well-formed records that consume the declared size.

Each of these was verified failing under the weaker check it replaced:

| Rejected | Passed under |
|---|---|
| `PK`, `PK\x03`, `PK\x01\x02rest`, `PKzip-bytes` | a two-byte prefix check |
| bare `PK\x05\x06`; `PK\x03\x04payload`; truncated mid-directory | a four-byte prefix check |
| central-directory signature zeroed; EOCD over-declaring its count | a range-only check |
| EOCD declaring a multi-volume archive (either disk field non-zero, or a per-disk count that disagrees with the total) | a check that ignored the disk fields |

**4. Not rejecting readable archives.** The EOCD entry count is a uint16, so it is only the low 16 bits of the real total. JSZip — which the daemon uses to build project archives (`apps/daemon/src/projects.ts:391`) — and this app's own `buildZip` both truncate rather than emitting the Zip64 sentinel. Comparing modulo 65,536 keeps those readable:

| Entries | EOCD declares | Result |
|---|---|---|
| 65,536 | `0` | accepted |
| 65,537 | `1` | accepted |
| 0xffff (Zip64 sentinel) | — | count skipped, structure decides |

Those cases use genuine archives built by the app's writer, and each asserts the count actually wrapped, so the fixture cannot silently stop testing it. Both were verified failing under the earlier strict-count version.

As an independent check, eight archive variants were classified by this guard and by Python's `zipfile`. They agree on all but one: an EOCD that over-declares its count is rejected here and read leniently by Python. That divergence is deliberate — the record is malformed per spec and JSZip rejects the same class.

**4. End-to-end in a browser** — the before/after above. Same daemon, same project, same 401; the only difference is which message the user sees.

Guard tests are included for behaviour that must *not* change: a successful archive still resolves with no marker, and a complete empty archive (a bare 22-byte EOCD) is accepted. Those pass with and without the source change by design.

## Validation

- `pnpm guard` — pass (exit 0)
- `pnpm --filter @open-design/web typecheck` — pass (exit 0)
- `pnpm i18n:check` — pass (exit 0), all 19 locales
- `apps/web/tests/runtime/exports.test.ts` — **105 passed**
- `pnpm --filter @open-design/web test` (full package suite) — **11,515 passed, 0 failed, 20 skipped** (11,536 tests / 1,119 files)

On the full web suite: an earlier run on this branch reported **11,492 passed** with 3 failures, in `tests/components/chat/audio-wave-pulse.test.tsx` and `tests/components/chat/plan-step-weight.test.tsx`. Those are unrelated to this change and reproduce on a pristine `main` checkout containing none of it. Every failure is `Error: Test timed out in 5000ms`, not a failed assertion: the helper `readExpandedIndexCss()` inlines the `@import` chain into **1.7 MB of CSS across 11,569 rules**, injected per test, and jsdom's cascade over that exceeds the default 5 s `testTimeout` on this machine. The count varies with load (3, 6 and 8 observed), which is consistent with a timeout threshold rather than a defect. There is no upstream issue for it; happy to file one separately if useful.

The suite is fully green on this head. Two chat tests (`audio-wave-pulse`, `plan-step-weight`) time out intermittently on slower machines — they inject 1.7 MB of CSS across 11,569 rules per test against a 5 s `testTimeout`, and have failed 3, 2, 1 and 0 times across runs of identical code. They are unrelated to this change and reproduce on a pristine `main` checkout.

**A note on the multi-volume check.** It was added at review request, but the stated rationale — that readers such as JSZip reject such an archive — does not hold. Tested against JSZip 3.10.1 (the library the daemon uses to build these archives) and Python's `zipfile`: both open all three mutations and read the entry back. The checks are still worth keeping for a different reason, and the comments say so: this is metadata consistency, not readability. No real producer emits a non-zero disk field, and a genuinely split archive is already rejected because its central directory is not present at the declared offset.

One regression was caught by this suite run and fixed before it could reach CI. `FileWorkspace` chains `downloadProjectArchive(...) || downloadDesignSystemArchive(...)`, so once the guard rejected the project archive the component fell through to the design-system archive and `FileWorkspace.design-system.test.tsx` saw an extra request. The cause was the fixture, not the guard: it used `new Response(new Blob(['zip']))`, and `Response` stringifies a Blob body in this environment, so the archive download had always been handed the literal text `[object Blob]`. Nothing inspected the payload before, so the fixture asserted a successful archive download while serving something that was never an archive. It now carries a genuine archive from the app's own writer; no source change was needed.




