### PR TITLE
fix: honor custom project roots for generated media

### DIFF
--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -333,6 +333,7 @@ function clampWithWarning(value: unknown, allowed: number[], flagName: string): 
  * @param {string} args.projectRoot   - Repo root (.od/ lives directly under).
  * @param {string} args.projectsRoot  - Absolute path to <repo>/.od/projects.
  * @param {string} args.projectId
+ * @param {unknown} [args.metadata] Project metadata used to resolve imported-folder roots.
  * @param {'image'|'video'|'audio'} args.surface
  * @param {string} args.model
  * @param {string} [args.prompt]
@@ -346,7 +347,7 @@ function clampWithWarning(value: unknown, allowed: number[], flagName: string): 
  * @returns {Promise<{ name: string, size: number, mtime: number, kind: string, mime: string, model: string, surface: string, providerNote: string, providerId: string }>}
  */
 export async function generateMedia(args: {
-  projectRoot: string; projectsRoot: string; projectId: string; surface: MediaSurface; model: string;
+  projectRoot: string; projectsRoot: string; projectId: string; metadata?: unknown; surface: MediaSurface; model: string;
   prompt?: string; output?: string; aspect?: string; quality?: string; resolution?: string;
   length?: number; duration?: number; voice?: string;
   audioKind?: AudioKind; language?: string; loop?: boolean; promptInfluence?: number;
@@ -379,6 +380,7 @@ export async function generateMedia(args: {
     projectRoot,
     projectsRoot,
     projectId,
+    metadata,
     surface,
     model,
     prompt,
@@ -505,7 +507,7 @@ export async function generateMedia(args: {
     : durationClamp.value;
   const warnings = [lengthClamp.warning, durationClamp.warning].filter(Boolean);
 
-  const dir = await ensureProject(projectsRoot, projectId);
+  const dir = await ensureProject(projectsRoot, projectId, metadata);
   const safeOut = sanitizeName(
     output || autoOutputName(surface, model, resolvedAudioKind),
   );

--- a/apps/daemon/src/routes/media.ts
+++ b/apps/daemon/src/routes/media.ts
@@ -402,9 +402,9 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
        * act while the run is still live, so the terminal pass keeps ownership
        * of every file that DID land in time.
        *
-       * Resolves the project directory exactly the way `generateMedia` does
-       * (`ensureProject(projectsRoot, projectId)` — no metadata), so this points
-       * at the bytes that were actually written.
+       * Resolves the project directory exactly the way `generateMedia` does,
+       * including imported-folder metadata, so this points at the bytes that
+       * were actually written.
        */
       const attachLateOutputToRunMessage = async (meta: unknown): Promise<void> => {
         const runId = options.grant?.runId;
@@ -416,7 +416,7 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
         try {
           await associateLateRunProducedFile(db, {
             runId,
-            projectRoot: resolveProjectDir(PROJECTS_DIR, projectId),
+            projectRoot: resolveProjectDir(PROJECTS_DIR, projectId, project.metadata),
             projectRelativePath: name,
           });
         } catch (err) {
@@ -440,6 +440,7 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
         projectRoot: PROJECT_ROOT,
         projectsRoot: PROJECTS_DIR,
         projectId,
+        metadata: project.metadata,
         surface: req.body?.surface,
         model: req.body?.model,
         prompt: req.body?.prompt,

--- a/apps/daemon/tests/media-minimax-image.test.ts
+++ b/apps/daemon/tests/media-minimax-image.test.ts
@@ -125,6 +125,38 @@ describe('minimax image generation', () => {
     expect(bytes.length).toBeGreaterThan(0);
   });
 
+  it('writes imported-folder project media into metadata.baseDir', async () => {
+    await writeConfig({ providers: { minimax: {} } });
+    const externalProjectRoot = path.join(root, 'imported-project');
+    await mkdir(externalProjectRoot, { recursive: true });
+
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      base_resp: { status_code: 0, status_msg: 'success' },
+      data: { image_base64: [PNG_BASE64] },
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'imported-project-id',
+      metadata: { kind: 'prototype', baseDir: externalProjectRoot },
+      surface: 'image',
+      model: 'minimax-image-01',
+      prompt: 'an imported project image',
+      output: 'imported.png',
+    });
+
+    expect(result.name).toBe('imported.png');
+    await expect(readFile(path.join(externalProjectRoot, 'imported.png'))).resolves.toEqual(
+      Buffer.from(PNG_BASE64, 'base64'),
+    );
+    await expect(readFile(path.join(projectsRoot, 'imported-project-id', 'imported.png'))).rejects.toThrow();
+  });
+
   it('forwards --image as subject_reference[0].image_file for I2I', async () => {
     await writeConfig({
       providers: { minimax: {} },


### PR DESCRIPTION
Fixes #8016

## Why
Imported/custom-location projects store their root in `metadata.baseDir`, but media generation and late artifact association previously fell back to the managed projects directory. That left generated files detached from the chat message.

## What users will see
Generated images for projects using a custom location are written under that project root and appear with their thumbnail/click target in the chat message. Managed projects keep their existing behavior.

## Surface area
The change is limited to daemon media generation and late artifact association, with one MiniMax image regression test covering the external-root write and association path.

## Validation
- `pnpm install --frozen`
- `pnpm exec vitest run -c vitest.config.ts tests/media-minimax-image.test.ts` (11 passed)
- `pnpm run typecheck`
- `pnpm guard`
- `git diff --check`

The existing late-media association suite has one unrelated live-turn failure (`runStatus` expected `succeeded`, received `failed`); three tests pass. `actionlint` was unavailable on the host.