### PR TITLE
fix(chat): preserve ranges for repeated file reads

### DIFF
--- a/apps/web/src/runtime/file-ops.ts
+++ b/apps/web/src/runtime/file-ops.ts
@@ -16,6 +16,11 @@ import { dedupeToolUsesById, isInFlightToolUse } from './tool-events';
 export type FileOpKind = 'read' | 'write' | 'edit' | 'delete';
 export type FileOpStatus = 'running' | 'done' | 'error';
 
+export interface FileOpReadRange {
+  offset: number;
+  limit: number;
+}
+
 export interface FileOpEntry {
   /**
    * 这一条记录**在项目里的身份** —— 显示用它,右侧工作区也用它开档。
@@ -47,6 +52,8 @@ export interface FileOpEntry {
   total: number;
   /** Worst status across all calls for this file: error > running > done. */
   status: FileOpStatus;
+  /** Read slices requested for this file, in encounter order. */
+  readRanges?: FileOpReadRange[];
 }
 
 const READ_NAMES = new Set(['Read', 'read_file']);
@@ -90,6 +97,13 @@ function mergeStatus(a: FileOpStatus, b: FileOpStatus): FileOpStatus {
   if (a === 'error' || b === 'error') return 'error';
   if (a === 'running' || b === 'running') return 'running';
   return 'done';
+}
+
+function extractReadRange(input: unknown): FileOpReadRange | null {
+  if (!input || typeof input !== 'object') return null;
+  const { offset, limit } = input as { offset?: unknown; limit?: unknown };
+  if (typeof offset !== 'number' || typeof limit !== 'number') return null;
+  return { offset, limit };
 }
 
 /**
@@ -149,7 +163,12 @@ export function deriveFileOps(
   }
 
   const byPath = new Map<string, FileOpEntry>();
-  const add = (fullPath: string, kind: FileOpKind, status: FileOpStatus) => {
+  const add = (
+    fullPath: string,
+    kind: FileOpKind,
+    status: FileOpStatus,
+    readRange?: FileOpReadRange | null,
+  ) => {
     if (!fullPath || fullPath === '(unnamed)') return;
     const existing = byPath.get(fullPath);
     if (existing) {
@@ -157,6 +176,9 @@ export function deriveFileOps(
       existing.opCounts[kind] += 1;
       existing.total += 1;
       existing.status = mergeStatus(existing.status, status);
+      if (kind === 'read' && readRange) {
+        (existing.readRanges ??= []).push(readRange);
+      }
       return;
     }
     const opCounts: Record<FileOpKind, number> = { read: 0, write: 0, edit: 0, delete: 0 };
@@ -168,6 +190,7 @@ export function deriveFileOps(
       opCounts,
       total: 1,
       status,
+      readRanges: kind === 'read' && readRange ? [readRange] : [],
     });
   };
 
@@ -186,7 +209,7 @@ export function deriveFileOps(
     if (!kind) continue;
     const fullPath = extractPath(ev.input);
     if (!fullPath) continue;
-    add(fullPath, kind, status);
+    add(fullPath, kind, status, kind === 'read' ? extractReadRange(ev.input) : null);
   }
 
   return Array.from(byPath.values());

--- a/apps/web/tests/runtime/file-ops.test.ts
+++ b/apps/web/tests/runtime/file-ops.test.ts
@@ -129,6 +129,25 @@ describe('deriveFileOps', () => {
     expect(rows.find((row) => row.path === 'c.ts')?.ops).toEqual(['delete']);
   });
 
+  it('preserves ranges for separate reads of the same file', () => {
+    const events: AgentEvent[] = [
+      use('Read', { file_path: '/repo/example.html', offset: 1, limit: 300 }, 'read-1'),
+      ok('read-1'),
+      use('Read', { file_path: '/repo/example.html', offset: 550, limit: 300 }, 'read-2'),
+      ok('read-2'),
+    ];
+
+    const [row] = deriveFileOps(events);
+    expect(row).toBeDefined();
+    // The ChatPanel must be able to distinguish these two valid reads. The
+    // current implementation merges by path and drops offset/limit entirely.
+    expect((row as unknown as { readRanges: Array<{ offset: number; limit: number }> }).readRanges)
+      .toEqual([
+        { offset: 1, limit: 300 },
+        { offset: 550, limit: 300 },
+      ]);
+  });
+
   it('infers simple Bash rm/unlink targets as delete operations', () => {
     const events: AgentEvent[] = [
       use(


### PR DESCRIPTION
## Why

Repeated reads of the same file can request different `offset`/`limit` ranges, but the ChatPanel file-operation aggregation kept only the path and discarded those ranges. This makes the activity rows unable to distinguish which part of a file was read. This PR addresses OPEND-2791 at the data boundary without choosing a new UI copy or layout.

## What users will see

The aggregated file-operation record retains the ordered read ranges for repeated reads of the same file. Existing operation counts, statuses, and file identity are unchanged; the UI can consume the range metadata without losing it during aggregation.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal data preservation plus regression coverage; no UI choice is made here

## Bug fix verification

- Test path: `apps/web/tests/runtime/file-ops.test.ts`
- On `origin/main` `07170f8d22`: 14 passed, 1 failed (the new repeated-read range assertion).
- With the implementation: 15 passed.
- After withdrawing the implementation again: 14 passed, 1 failed, confirming the business assertion depends on this change.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/runtime/file-ops.test.ts` — 15 passed
- `git diff --check` — passed
