### PR TITLE
fix(amr): reset workspace subscriptions on profile switch

### DIFF
--- a/apps/daemon/src/collab/workspace-billing-runtime.ts
+++ b/apps/daemon/src/collab/workspace-billing-runtime.ts
@@ -354,6 +354,41 @@ export class WorkspaceBillingRuntimeCoordinator {
       .map((key) => ({ ...key }));
   }
 
+  /**
+   * Fence all projections and leases created under a previous AMR profile.
+   * In-flight reads are allowed to settle, but their incremented attempt token
+   * prevents them from publishing into the new environment.
+   */
+  resetIdentity(): void {
+    this.assertUsable();
+    this.clients.clear();
+    this.realtimeHealthyWorkspaces.clear();
+    if (this.refreshQueueTimer) this.scheduler.clearTimeout(this.refreshQueueTimer);
+    this.refreshQueueTimer = null;
+    this.refreshQueue.length = 0;
+    for (const entry of this.entries.values()) {
+      entry.attempt += 1n;
+      entry.inFlight = null;
+      entry.queued = false;
+      entry.queuedReason = null;
+      entry.pending = false;
+      entry.pendingReason = null;
+      if (entry.retryTimer) this.scheduler.clearTimeout(entry.retryTimer);
+      entry.retryTimer = null;
+      entry.retryAt = null;
+      entry.legacyInterestExpiresAt = null;
+      entry.projection = EMPTY_PROJECTION;
+      entry.status = 'loading';
+      entry.errorCode = null;
+      entry.reason = 'workspace-identity-changed';
+      entry.observedAt = null;
+      entry.revision += 1n;
+      this.resolveWaiters(entry);
+    }
+    this.entries.clear();
+    this.publishInterestSet();
+  }
+
   async read(
     keyInput: WorkspaceBillingRuntimeKey,
     options: WorkspaceBillingRuntimeReadOptions = {},

--- a/apps/daemon/src/collab/workspace-hub-subscriptions.ts
+++ b/apps/daemon/src/collab/workspace-hub-subscriptions.ts
@@ -76,6 +76,19 @@ export class WorkspaceHubSubscriptionManager {
     }
   }
 
+  /**
+   * Drop every scope retained under the previous daemon-global AMR profile.
+   * Workspace ids are environment-owned, so neither billing leases nor open
+   * renderer EventSources may carry an id across a profile switch.
+   */
+  resetForEnvironmentChange(): void {
+    this.assertUsable();
+    for (const subscriber of this.subscribers.values()) subscriber.stop();
+    this.subscribers.clear();
+    this.billingWorkspaceIds.clear();
+    this.eventWorkspaceReferences.clear();
+  }
+
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;

--- a/apps/daemon/src/collab/workspace-hub-subscriptions.ts
+++ b/apps/daemon/src/collab/workspace-hub-subscriptions.ts
@@ -18,6 +18,7 @@ export class WorkspaceHubSubscriptionManager {
   private readonly eventWorkspaceReferences = new Map<string, number>();
   private readonly subscribers = new Map<string, HubEventsSubscriber>();
   private disposed = false;
+  private environmentGeneration = 0;
   private readonly maxSubscribers: number;
 
   constructor(private readonly options: WorkspaceHubSubscriptionManagerOptions) {
@@ -54,9 +55,16 @@ export class WorkspaceHubSubscriptionManager {
       (this.eventWorkspaceReferences.get(workspaceId) ?? 0) + 1,
     );
     this.reconcile();
+    const environmentGeneration = this.environmentGeneration;
     let released = false;
     return () => {
-      if (released || this.disposed) return;
+      if (
+        released ||
+        this.disposed ||
+        environmentGeneration !== this.environmentGeneration
+      ) {
+        return;
+      }
       released = true;
       const remaining = (this.eventWorkspaceReferences.get(workspaceId) ?? 1) - 1;
       if (remaining > 0) {
@@ -83,6 +91,7 @@ export class WorkspaceHubSubscriptionManager {
    */
   resetForEnvironmentChange(): void {
     this.assertUsable();
+    this.environmentGeneration += 1;
     for (const subscriber of this.subscribers.values()) subscriber.stop();
     this.subscribers.clear();
     this.billingWorkspaceIds.clear();

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -4040,20 +4040,35 @@ export async function startServer({
     readVelaControlApiContext,
     configuredAmrEnv(),
   );
+  let workspaceHubAmrProfile = resolveAmrProfile({
+    ...process.env,
+    ...configuredAmrEnv(),
+  });
   const resetWorkspaceIdentityCaches = (): void => {
     workspaceDirectoryAuthority.resetIdentity();
     workspaceExactAuthorityCache.resetIdentity();
     workspaceExactContextCache.resetIdentity();
   };
   const refreshWorkspaceHubAccountIdentity = (): void => {
+    const currentAmrProfile = resolveAmrProfile({
+      ...process.env,
+      ...configuredAmrEnv(),
+    });
     const currentIdentity = velaWorkspaceDirectoryIdentity(
       readVelaControlApiContext,
       configuredAmrEnv(),
     );
     if (currentIdentity === workspaceHubAccountIdentity) return;
+    const environmentChanged = currentAmrProfile !== workspaceHubAmrProfile;
     workspaceHubAccountIdentity = currentIdentity;
+    workspaceHubAmrProfile = currentAmrProfile;
     resetWorkspaceIdentityCaches();
-    workspaceHubSubscriptions?.refreshEndpoints();
+    if (environmentChanged) {
+      workspaceHubSubscriptions?.resetForEnvironmentChange();
+      workspaceBillingRuntime.resetIdentity();
+    } else {
+      workspaceHubSubscriptions?.refreshEndpoints();
+    }
   };
   const fetchWorkspaceDirectoryForAccountSurface = () => {
     refreshWorkspaceHubAccountIdentity();

--- a/apps/daemon/tests/collab/workspace-billing-runtime.test.ts
+++ b/apps/daemon/tests/collab/workspace-billing-runtime.test.ts
@@ -1297,6 +1297,41 @@ describe('WorkspaceBillingRuntimeCoordinator', () => {
     runtime.dispose();
   });
 
+  it('fences old profile projections and clears every retained interest', async () => {
+    const oldRead = deferred<VelaWorkspaceBillingProjection>();
+    const interestSets: string[][] = [];
+    const runtime = createWorkspaceBillingRuntimeCoordinator({
+      fetchProjection: async () => oldRead.promise,
+      onInterestSetChange: (interests) => {
+        interestSets.push(interests.map((interest) => interest.workspaceId));
+      },
+    });
+    runtime.setClientInterests({
+      clientId: 'renderer',
+      clientGeneration: '1',
+      interests: [KEY_A],
+    });
+    const pending = runtime.read(KEY_A, {
+      clientId: 'renderer',
+      clientGeneration: '1',
+    });
+    await vi.waitFor(() => expect(runtime.interestedKeys()).toEqual([KEY_A]));
+
+    runtime.resetIdentity();
+
+    expect(runtime.interestedKeys()).toEqual([]);
+    expect(runtime.peek(KEY_A)).toBeNull();
+    expect(interestSets.at(-1)).toEqual([]);
+    await expect(pending).resolves.toMatchObject({
+      projection: { snapshot: null, workspaceBalance: null },
+      state: { reason: 'workspace-identity-changed' },
+    });
+    oldRead.resolve(projection('workspace-a', 'member-a', '99.00'));
+    await Promise.resolve();
+    expect(runtime.peek(KEY_A)).toBeNull();
+    runtime.dispose();
+  });
+
   it('expires a crashed renderer lease and evicts its inactive snapshot', async () => {
     vi.useFakeTimers();
     const runtime = createWorkspaceBillingRuntimeCoordinator({

--- a/apps/daemon/tests/collab/workspace-hub-subscriptions.test.ts
+++ b/apps/daemon/tests/collab/workspace-hub-subscriptions.test.ts
@@ -61,9 +61,18 @@ describe('WorkspaceHubSubscriptionManager', () => {
 
     expect(stopped.sort()).toEqual(['old-billing', 'old-renderer']);
     expect(manager.activeWorkspaceIds()).toEqual([]);
+    const releaseNewRenderer = manager.retainEventInterest('old-renderer');
     releaseOldRenderer();
+    expect(manager.activeWorkspaceIds()).toEqual(['old-renderer']);
+    releaseNewRenderer();
+    expect(manager.activeWorkspaceIds()).toEqual([]);
     manager.setBillingInterests(['new-billing']);
-    expect(started).toEqual(['old-billing', 'old-renderer', 'new-billing']);
+    expect(started).toEqual([
+      'old-billing',
+      'old-renderer',
+      'old-renderer',
+      'new-billing',
+    ]);
     expect(manager.activeWorkspaceIds()).toEqual(['new-billing']);
   });
 

--- a/apps/daemon/tests/collab/workspace-hub-subscriptions.test.ts
+++ b/apps/daemon/tests/collab/workspace-hub-subscriptions.test.ts
@@ -41,6 +41,32 @@ describe('WorkspaceHubSubscriptionManager', () => {
     expect(refreshEndpoint).toHaveBeenCalledTimes(2);
   });
 
+  it('drops billing and renderer scopes when the AMR environment changes', () => {
+    const started: string[] = [];
+    const stopped: string[] = [];
+    const manager = createWorkspaceHubSubscriptionManager({
+      start: (workspaceId) => {
+        started.push(workspaceId);
+        return {
+          connected: () => true,
+          refreshEndpoint: vi.fn(),
+          stop: () => stopped.push(workspaceId),
+        };
+      },
+    });
+    manager.setBillingInterests(['old-billing']);
+    const releaseOldRenderer = manager.retainEventInterest('old-renderer');
+
+    manager.resetForEnvironmentChange();
+
+    expect(stopped.sort()).toEqual(['old-billing', 'old-renderer']);
+    expect(manager.activeWorkspaceIds()).toEqual([]);
+    releaseOldRenderer();
+    manager.setBillingInterests(['new-billing']);
+    expect(started).toEqual(['old-billing', 'old-renderer', 'new-billing']);
+    expect(manager.activeWorkspaceIds()).toEqual(['new-billing']);
+  });
+
   it('dedupes explicit billing interests into one upstream per workspace', () => {
     const started: string[] = [];
     const stopped: string[] = [];

--- a/apps/daemon/tests/collab/workspace-projects-hub-wiring.test.ts
+++ b/apps/daemon/tests/collab/workspace-projects-hub-wiring.test.ts
@@ -224,10 +224,18 @@ describe('server.ts wiring (source boundary)', () => {
     );
     const body = source.slice(start, end);
     const resetStart = body.indexOf('resetWorkspaceIdentityCaches();');
+    const environmentResetStart = body.indexOf(
+      'workspaceHubSubscriptions?.resetForEnvironmentChange();',
+    );
+    const billingResetStart = body.indexOf(
+      'workspaceBillingRuntime.resetIdentity();',
+    );
     const endpointRefreshStart = body.indexOf(
       'workspaceHubSubscriptions?.refreshEndpoints();',
     );
     expect(resetStart).toBeGreaterThan(-1);
+    expect(environmentResetStart).toBeGreaterThan(resetStart);
+    expect(billingResetStart).toBeGreaterThan(environmentResetStart);
     expect(endpointRefreshStart).toBeGreaterThan(resetStart);
   });
 


### PR DESCRIPTION
## Why

Switching the daemon-global AMR profile kept Workspace billing leases and renderer EventSource interests from the previous environment alive. Their environment-owned Workspace IDs were then reconnected against the newly selected profile, producing duplicate or invalid Hub subscriptions until the old leases expired.

## What users will see

After switching AMR environments, realtime Workspace and billing subscriptions from the previous environment are stopped immediately. The current environment can then establish fresh subscriptions without carrying stale Workspace IDs across profiles. Credential refreshes within the same profile still use the existing endpoint-refresh path.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — added
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — scoped daemon bug fix and regression tests only

## Screenshots

Not applicable; there is no UI change.

## Bug fix verification

- Test paths: `apps/daemon/tests/collab/workspace-hub-subscriptions.test.ts`, `apps/daemon/tests/collab/workspace-billing-runtime.test.ts`, and `apps/daemon/tests/collab/workspace-projects-hub-wiring.test.ts`.
- The regression cases assert that an AMR profile switch stops old Hub subscribers, clears billing and renderer interests, fences in-flight old-profile projections, and wires this reset only to a profile change.
- The production symptom was reproduced from diagnostics as an old-environment Workspace Hub subscription surviving the switch; the new specs were added with the fix rather than executed separately on an unmodified checkout.

## Validation

- `corepack pnpm@10.33.2 --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/collab/workspace-hub-subscriptions.test.ts tests/collab/workspace-billing-runtime.test.ts tests/collab/workspace-projects-hub-wiring.test.ts` — 3 files, 74 tests passed.
- Built `@open-design/contracts` and `@open-design/registry-protocol`, then ran daemon source and test TypeScript checks with `tsc --noEmit`.
- `git diff --check`.