### PR TITLE
fix: composer plugin list ignores Workspace scope and mis-ranks @-search

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -17,6 +17,7 @@ import { Button } from '@open-design/components';
 import { ThinkingOrb } from './composer/ThinkingOrb';
 import { useI18n } from '../i18n';
 import { localizePluginDescription, localizePluginTitle } from './plugins-home/localization';
+import { pluginMatchesQuery, rankPluginMatches } from './plugins-home/plugin-search';
 import type { Dict, Locale } from '../i18n/types';
 import {
   localizeSkillDescription,
@@ -1145,19 +1146,32 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
     // pre-filtered by enabled/disabled state. We no longer fetch a fresh list
     // here to avoid showing skills the user has disabled via Settings.
 
-    // Lazy-fetch installed plugins once on mount; the tools-menu Plugins
-    // tab and the @-mention picker both consume this list.
+    // Lazy-fetch installed plugins; the tools-menu Plugins tab and the
+    // @-mention picker both consume this list. The Workspace context is
+    // REQUIRED: a plugin bound to the caller's personal Workspace (an
+    // `od plugin install` with --workspace) is filtered out of a headerless
+    // read — the daemon hides any Workspace-claimed resource from a caller
+    // with no identity to check it against. Without the context the composer
+    // silently showed only unbound/bundled plugins, so a freshly installed
+    // personal plugin never appeared in the @ picker. Re-read on
+    // `open-design:plugins-changed` so an install performed while this
+    // project is open shows up without a reload.
     useEffect(() => {
       if (!projectId || !composerEngaged) return;
       let cancelled = false;
-      void listPlugins().then((rows) => {
-        if (cancelled) return;
-        setInstalledPlugins(rows);
-      });
+      const load = () => {
+        void listPlugins({ workspaceContext }).then((rows) => {
+          if (cancelled) return;
+          setInstalledPlugins(rows);
+        });
+      };
+      load();
+      window.addEventListener('open-design:plugins-changed', load);
       return () => {
         cancelled = true;
+        window.removeEventListener('open-design:plugins-changed', load);
       };
-    }, [projectId, composerEngaged]);
+    }, [projectId, composerEngaged, workspaceContext]);
 
     useEffect(() => {
       if (!composerEngaged) return;
@@ -3154,20 +3168,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       [mention, mentionQuery, projectFiles],
     );
     const filteredPlugins = useMemo(
-      () =>
-        mention
-          ? pluginsForComposer
-              .filter((p) => {
-                if (!mentionQuery) return true;
-                return (
-                  p.title.toLowerCase().includes(mentionQuery) ||
-                  p.id.toLowerCase().includes(mentionQuery) ||
-                  (p.manifest?.description ?? '').toLowerCase().includes(mentionQuery) ||
-                  (p.manifest?.tags ?? []).join(' ').toLowerCase().includes(mentionQuery)
-                );
-              })
-              .slice(0, 8)
-          : [],
+      () => (mention ? rankPluginMatches(pluginsForComposer, mentionQuery) : []),
       [mention, mentionQuery, pluginsForComposer],
     );
     const filteredMcpServers = useMemo(
@@ -5644,23 +5645,6 @@ function ToolsSkillsPanel({
     </>
   );
 }
-
-function pluginMatchesQuery(plugin: InstalledPluginRecord, query: string): boolean {
-  const q = query.trim().toLowerCase();
-  if (!q) return true;
-  return [
-    plugin.title,
-    plugin.id,
-    plugin.sourceKind,
-    plugin.source,
-    plugin.manifest?.description ?? '',
-    ...(plugin.manifest?.tags ?? []),
-  ]
-    .join(' ')
-    .toLowerCase()
-    .includes(q);
-}
-
 
 function buildDesignToolboxResources({
   skills,

--- a/apps/web/src/components/plugins-home/plugin-search.ts
+++ b/apps/web/src/components/plugins-home/plugin-search.ts
@@ -1,0 +1,94 @@
+// Plugin catalog search, shared by the composer's two surfaces: the @-mention
+// picker's ranked list and the tools-pane filter.
+//
+// Two behaviors that used to be wrong inline:
+//
+// 1. Localized titles were not indexed. The UI displays
+//    `manifest.title_i18n[locale]` (see ./localization), but the search index
+//    held only the raw English title/id/description/tags — so a plugin could
+//    be found by "prototype" and never by its localized name 原型标注.
+//    Every locale is indexed, not just the active one, so the two directions
+//    both work.
+//
+// 2. Results were filtered and then truncated in catalog order. Hundreds of
+//    example plugins carry generic tags (every web example is tagged
+//    `prototype`), so a query that matches the NAME of a late-alphabet plugin
+//    was crowded out by incidental tag hits. `rankPluginMatches` puts
+//    name hits first.
+
+import type { InstalledPluginRecord } from '@open-design/contracts';
+
+/**
+ * Localized values on a manifest (`title_i18n` / `description_i18n`) as a flat
+ * list. Non-object or non-string entries are ignored rather than throwing —
+ * plugin manifests are user-authored content.
+ */
+export function manifestLocalizedValues(value: unknown): string[] {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return [];
+  return Object.values(value as Record<string, unknown>)
+    .filter((text): text is string => typeof text === 'string');
+}
+
+/** Title-ish search text: raw title + id + every localized title. */
+export function pluginTitleSearchText(plugin: InstalledPluginRecord): string {
+  return [
+    plugin.title,
+    plugin.id,
+    ...manifestLocalizedValues(plugin.manifest?.title_i18n),
+  ].join(' ').toLowerCase();
+}
+
+/** Full search text, including localized descriptions, source, and tags. */
+export function pluginSearchText(plugin: InstalledPluginRecord): string {
+  return [
+    pluginTitleSearchText(plugin),
+    plugin.sourceKind,
+    plugin.source,
+    plugin.manifest?.description ?? '',
+    ...manifestLocalizedValues(plugin.manifest?.description_i18n),
+    ...(plugin.manifest?.tags ?? []),
+  ].join(' ').toLowerCase();
+}
+
+/** Case-insensitive substring match across the full search text. */
+export function pluginMatchesQuery(plugin: InstalledPluginRecord, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return pluginSearchText(plugin).includes(q);
+}
+
+/**
+ * Match strength, lowest first:
+ *   0 — the name (title/id/localized title) starts with the query
+ *   1 — the name contains the query
+ *   2 — description / tags / source contain it (incidental)
+ *  -1 — no match
+ */
+export function pluginMatchTier(plugin: InstalledPluginRecord, query: string): number {
+  const q = query.trim().toLowerCase();
+  if (!q) return 0;
+  const titles = pluginTitleSearchText(plugin);
+  if (titles.includes(q)) return titles.startsWith(q) ? 0 : 1;
+  return pluginSearchText(plugin).includes(q) ? 2 : -1;
+}
+
+/**
+ * The plugin rows the picker should render for `query`: strongest matches
+ * first, catalog order preserved within a tier, capped at `limit`.
+ */
+export function rankPluginMatches(
+  plugins: InstalledPluginRecord[],
+  query: string,
+  limit = 8,
+): InstalledPluginRecord[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return plugins.slice(0, limit);
+  const scored: { record: InstalledPluginRecord; tier: number }[] = [];
+  for (const plugin of plugins) {
+    const tier = pluginMatchTier(plugin, q);
+    if (tier >= 0) scored.push({ record: plugin, tier });
+  }
+  // Array#sort is stable, so catalog order survives within a tier.
+  scored.sort((a, b) => a.tier - b.tier);
+  return scored.slice(0, limit).map((entry) => entry.record);
+}

--- a/apps/web/tests/plugin-search.test.ts
+++ b/apps/web/tests/plugin-search.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import type { InstalledPluginRecord } from '@open-design/contracts';
+
+import {
+  pluginMatchesQuery,
+  pluginMatchTier,
+  rankPluginMatches,
+} from '../src/components/plugins-home/plugin-search';
+
+interface FixtureInput {
+  id: string;
+  title: string;
+  tags?: string[];
+  titleI18n?: Record<string, unknown>;
+  description?: string;
+  descriptionI18n?: Record<string, unknown>;
+}
+
+function plugin(input: FixtureInput): InstalledPluginRecord {
+  return {
+    id: input.id,
+    title: input.title,
+    version: '0.1.0',
+    sourceKind: 'local',
+    source: './plugins/x',
+    trust: 'trusted',
+    capabilitiesGranted: [],
+    manifest: {
+      version: '0.1.0',
+      name: input.id,
+      title: input.title,
+      ...(input.tags ? { tags: input.tags } : {}),
+      ...(input.titleI18n ? { title_i18n: input.titleI18n } : {}),
+      ...(input.description ? { description: input.description } : {}),
+      ...(input.descriptionI18n ? { description_i18n: input.descriptionI18n } : {}),
+    },
+    fsPath: '/tmp/x',
+    installedAt: 0,
+    updatedAt: 0,
+  } as unknown as InstalledPluginRecord;
+}
+
+// Two rows model the real catalog: a late-alphabet plugin whose NAME is what
+// the user types, and an early-alphabet plugin that merely carries the generic
+// `prototype` tag every web example ships with.
+const TAGGED_WEB_EXAMPLE = plugin({
+  id: 'blog-post',
+  title: 'Blog Post',
+  tags: ['example', 'prototype', 'web'],
+});
+
+const ANNOTATION_PLUGIN = plugin({
+  id: 'od-prototype-annotation',
+  title: 'Prototype annotation (AI-generated specs)',
+  tags: ['scenario', 'annotation', 'prototype'],
+  titleI18n: { 'zh-CN': '原型标注（AI 生成规格）', en: 'Prototype annotation' },
+  description: 'AI-generates prototype annotations',
+  descriptionI18n: { 'zh-CN': '让 AI 自动生成原型标注' },
+});
+
+const CATALOG = [TAGGED_WEB_EXAMPLE, ANNOTATION_PLUGIN];
+
+describe('plugin search index', () => {
+  it('indexes every locale of title_i18n, not just the active one', () => {
+    // Before: the index held only raw English fields, so the UI displayed
+    // 原型标注（AI 生成规格） while searching that name returned nothing.
+    expect(pluginMatchesQuery(ANNOTATION_PLUGIN, '原型标注')).toBe(true);
+    expect(pluginMatchesQuery(ANNOTATION_PLUGIN, 'prototype')).toBe(true);
+  });
+
+  it('indexes localized descriptions too', () => {
+    expect(pluginMatchesQuery(ANNOTATION_PLUGIN, '自动生成')).toBe(true);
+  });
+
+  it('does not match unrelated plugins', () => {
+    expect(pluginMatchesQuery(TAGGED_WEB_EXAMPLE, '原型标注')).toBe(false);
+  });
+
+  it('ranks a name hit above an incidental tag hit', () => {
+    expect(pluginMatchTier(ANNOTATION_PLUGIN, 'prototype')).toBeLessThan(
+      pluginMatchTier(TAGGED_WEB_EXAMPLE, 'prototype'),
+    );
+  });
+
+  it('ranks a prefix hit above a mid-string hit', () => {
+    expect(pluginMatchTier(ANNOTATION_PLUGIN, 'proto')).toBe(0);
+  });
+
+  it('surfaces the named plugin even when catalog order works against it', () => {
+    // Before: filter-then-slice in catalog order returned the tag-only hit
+    // first and cut the named plugin off entirely.
+    expect(rankPluginMatches(CATALOG, 'prototype', 1).map((p) => p.id))
+      .toEqual(['od-prototype-annotation']);
+  });
+
+  it('caps results at the limit and keeps catalog order within a tier', () => {
+    const sameTier = [
+      plugin({ id: 'a-prototype-one', title: 'prototype one' }),
+      plugin({ id: 'b-prototype-two', title: 'prototype two' }),
+      plugin({ id: 'c-prototype-three', title: 'prototype three' }),
+    ];
+    expect(rankPluginMatches(sameTier, 'prototype', 2).map((p) => p.id))
+      .toEqual(['a-prototype-one', 'b-prototype-two']);
+  });
+
+  it('returns the leading plugins when the query is empty', () => {
+    expect(rankPluginMatches(CATALOG, '', 1).map((p) => p.id)).toEqual(['blog-post']);
+  });
+
+  it('ignores malformed i18n values instead of throwing', () => {
+    const malformed = plugin({
+      id: 'malformed',
+      title: 'Malformed',
+      titleI18n: { 'zh-CN': 42, en: null },
+    });
+    expect(pluginMatchesQuery(malformed, 'malformed')).toBe(true);
+    expect(pluginMatchesQuery(malformed, '42')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

I hit both of these while installing a plugin into a personal workspace and then trying to select
it from inside a project.

**1. The plugin list was read without the Workspace identity.** The `@`-mention picker and the
tools-menu Plugins tab share one `listPlugins()` call that sent no workspace headers. A headerless
read resolves to the daemon's "no scope" catalogue, where `pluginVisibleFromWorkspace`
(`apps/daemon/src/plugins/registry.ts`) hides every plugin claimed by a workspace — including the
caller's own Personal installs. So the composer showed a smaller plugin list than the Plugins page,
and a freshly installed personal plugin never appeared in `@` at all.

**2. The search index was English-only, and the result cap was catalog-ordered.** The index held raw
`title` / `id` / `description` / `tags`, while the UI displays `manifest.title_i18n[locale]` — so a
plugin could be found by `prototype` but never by its localized name. And the picker filtered the
catalog and then took the first 8 rows **in catalog order**: hundreds of example plugins carry the
generic tag `prototype` (every web example does), so `@prototype` matched hundreds of incidental
tag hits and cut off the plugin actually named "Prototype annotation" — it sorts 284th by title and
never rendered, even though it was in the list data.

## What users will see

- A plugin installed into the user's personal workspace now appears in the composer's `@` picker and
  Plugins tab, matching what the Plugins page already showed.
- Installing a plugin while a project is open shows up without a page reload.
- `@prototype` finds the plugin actually named that, not just tag-matched examples; a localized name
  (e.g. `@原型标注`) finds its plugin too.

## Surface area

- [x] **UI** — the composer's `@` picker and plugin filter behavior changes
- [x] **i18n keys** — none added; existing manifest `title_i18n` / `description_i18n` values are now
      part of the search index
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Pending — I'll attach before/after shots of the `@` picker (typing `@prototype`) from a running
build before marking this ready for review.

## Bug fix verification

- Test path: `apps/web/tests/plugin-search.test.ts`
- **Red against the old algorithm:** 4 of the 9 cases fail — localized title indexing, localized
  description indexing, name-beats-tag ranking, and the named plugin surviving the result cap.
  **Green on this branch:** 9/9.
- The `listPlugins()` half is not unit-testable at the component boundary (it is an HTTP call inside
  a large component — which is also why the search logic moved out of it in this PR). Verified
  against a running daemon instead: `GET /api/plugins` headerless returned 460 rows **without** the
  plugin; the same request carrying the workspace identity headers returned 461 **including** it.
  An end-to-end probe on a real project reproduces the `@` symptom (not found before, found after).

## Validation

- `pnpm guard` — passed
- `pnpm --filter @open-design/web typecheck` for the touched files: no errors in
  `ChatComposer.tsx`, `plugins-home/plugin-search.ts`, or the new test
- `pnpm --filter @open-design/web exec vitest run tests/plugin-search.test.ts` — 9 passed
