### PR TITLE
fix(web): restore system-font fallback for missing brand fonts

### DIFF
--- a/apps/web/src/components/DesignSystemFlow.tsx
+++ b/apps/web/src/components/DesignSystemFlow.tsx
@@ -83,6 +83,7 @@ import { DesignSystemAssetDropzone } from './DesignSystemAssetDropzone';
 import { BrandPickerModal } from './BrandPickerModal';
 import { DesignSystemCreateHero } from './DesignSystemCreateHero';
 import { DesignSystemPicker } from './DesignSystemPicker';
+import { MissingBrandFontsBanner } from './MissingBrandFontsBanner';
 import { LibraryPicker } from './LibraryPicker';
 import { notifyConnectorsChanged } from './connectors-events';
 import { connectorAuthSnapshotChanged } from './connectors-state';
@@ -2964,17 +2965,9 @@ export function DesignSystemDetailView({
               onRebuildTokenContract={() => void startTokenContractRebuild(false)}
               onForceRebuildTokenContract={() => void startTokenContractRebuild(true)}
             />
-            <div className="ds-warning-card">
-              <Icon name="help-circle" />
-              <span>
-                <strong>{t('dsFlow.brandFontsMissingTitle')}</strong>
-                {t('dsFlow.brandFontsMissingBody')}
-              </span>
-              <Button variant="ghost" className="compact">
-                <Icon name="upload" />
-                {t('dsFlow.addBrandFonts')}
-              </Button>
-            </div>
+            {editable && workspaceProjectId ? (
+              <MissingBrandFontsBanner projectId={workspaceProjectId} />
+            ) : null}
             {statusLine ? <div className="ds-status-line">{statusLine}</div> : null}
             <WorkspaceActivityCard message={workspaceActivityMessage} active={chatStreaming} />
             {pendingRevision ? (

--- a/apps/web/src/components/MissingBrandFontsBanner.tsx
+++ b/apps/web/src/components/MissingBrandFontsBanner.tsx
@@ -49,7 +49,7 @@ export function MissingBrandFontsBanner({
   }, [projectId]);
   if (dismissed) return null;
 
-  function keepSubstitutes(): void {
+  function useSystemFonts(): void {
     if (projectId && typeof window !== 'undefined') {
       try {
         window.localStorage.setItem(fontBannerDismissKey(projectId), '1');
@@ -75,8 +75,8 @@ export function MissingBrandFontsBanner({
             Add brand font files
           </Button>
         ) : null}
-        <Button variant="ghost" className="compact" onClick={keepSubstitutes}>
-          Keep substitutes
+        <Button variant="ghost" className="compact" onClick={useSystemFonts}>
+          Use system fonts
         </Button>
       </div>
     </div>

--- a/apps/web/tests/components/DesignSystemFlow.test.tsx
+++ b/apps/web/tests/components/DesignSystemFlow.test.tsx
@@ -2614,6 +2614,50 @@ describe('DesignSystemCreationFlow', () => {
 });
 
 describe('DesignSystemDetailView', () => {
+  it('offers a per-project Use system fonts dismissal on the detail banner', async () => {
+    const system: DesignSystemDetail = {
+      id: 'user:font-banner-audit',
+      title: 'Font Banner Audit',
+      category: 'Custom',
+      summary: 'Audit fixture',
+      swatches: [],
+      surface: 'web',
+      body: '# Font Banner Audit',
+      source: 'user',
+      status: 'draft',
+      isEditable: true,
+      projectId: 'font-banner-audit-project',
+    };
+    const project: Project = {
+      id: system.projectId!,
+      name: system.title,
+      skillId: null,
+      designSystemId: system.id,
+      createdAt: 1,
+      updatedAt: 1,
+      metadata: { kind: 'other', importedFrom: 'design-system' },
+    };
+    mocks.fetchDesignSystem.mockResolvedValue(system);
+    mocks.ensureDesignSystemWorkspace.mockResolvedValue({ project, files: [] });
+    mocks.getProject.mockResolvedValue(project);
+
+    render(
+      <I18nProvider locale="en">
+        <DesignSystemDetailView
+          id={system.id}
+          selectedId={system.id}
+          config={{ mode: 'daemon', agentId: 'agent-1' } as AppConfig}
+          agents={[]}
+          onBack={() => {}}
+          onSetDefault={() => {}}
+        />
+      </I18nProvider>,
+    );
+
+    expect(await screen.findByText(/missing brand fonts/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /use system fonts/i })).toBeTruthy();
+  });
+
   it('keeps a fresh R2 file snapshot when an older R1 resolves afterward', async () => {
     const system: DesignSystemDetail = {
       id: 'user:refresh-race-design-system',

--- a/apps/web/tests/components/DesignSystemFlow.test.tsx
+++ b/apps/web/tests/components/DesignSystemFlow.test.tsx
@@ -2654,7 +2654,7 @@ describe('DesignSystemDetailView', () => {
       </I18nProvider>,
     );
 
-    expect(await screen.findByText(/missing brand fonts/i)).toBeTruthy();
+    expect(await screen.findByText(/brand font files missing/i)).toBeTruthy();
     expect(screen.getByRole('button', { name: /use system fonts/i })).toBeTruthy();
   });
 


### PR DESCRIPTION
## Why
OPEND-2814: the design-system review showed a missing-brand-font warning, but the existing action did not provide the product-approved system-font fallback/dismissal path.

## What users will see
The existing warning now uses the shared per-project banner and exposes the existing `Use system fonts` action. Choosing it dismisses the warning for that project.

## Validation
- Red test on origin/main: the expected `Use system fonts` action was absent.
- Green on this branch: 44 passed, 6 skipped.
- Withdrawal: 43 passed, 6 skipped; the `Use system fonts` assertion failed.
- Focused command: `pnpm exec vitest run -c vitest.config.ts tests/components/DesignSystemFlow.test.tsx --maxWorkers=1`

Plane: OPEND-2814
