### PR TITLE
fix(od-next): keep the Run input access root writable for sandbox teardown

### DIFF
--- a/apps/daemon/src/strategies/od-next/task-input-snapshot.ts
+++ b/apps/daemon/src/strategies/od-next/task-input-snapshot.ts
@@ -1040,7 +1040,17 @@ export function createOdNextRunInputProjection(input: {
     }
     fs.chmodSync(attachmentsDir, 0o555);
     fs.chmodSync(projectionDir, 0o555);
-    fs.chmodSync(taskProjectionRoot, 0o555);
+    // The access root is handed to adapters as a writable root, and codex's
+    // Linux sandbox materialises synthetic bubblewrap mount targets (`.codex`,
+    // `.agents`, `.git`) directly inside every writable root. Creating them
+    // succeeds because bwrap runs in a user namespace, but the teardown that
+    // unlinks them runs as the real user and needs write permission on the
+    // PARENT. Freezing the root to 0o555 therefore made codex abort with
+    // `failed to remove synthetic bubblewrap mount target ... Permission
+    // denied`, and made our own cleanup below leave the root behind forever.
+    // Immutability lives on the projection directory and its 0o444 files, one
+    // level down; the root only needs to be traversable and owner-writable.
+    fs.chmodSync(taskProjectionRoot, 0o700);
     const projectedPaths = loaded.files.map((file) => (
       path.join(projectionDir, file.relativePath)
     ));
@@ -1060,7 +1070,7 @@ export function createOdNextRunInputProjection(input: {
     if (projectionPathVerified) {
       removeRunProjectionTree(projectionDir);
       if (fs.existsSync(taskProjectionRoot)) {
-        try { fs.chmodSync(taskProjectionRoot, 0o555); } catch { /* best effort */ }
+        try { fs.chmodSync(taskProjectionRoot, 0o700); } catch { /* best effort */ }
       }
     }
     throw error;
@@ -1096,10 +1106,26 @@ export function removeOdNextRunInputProjection(
   }
   fs.chmodSync(projectionAccessRoot, 0o700);
   removeRunProjectionTree(projectionDir);
+  // Sandboxes that treat the access root as a writable root leave their own
+  // synthetic mount targets behind: empty directories such as `.codex`,
+  // `.agents` and `.git`. They are not ours to interpret, but an EMPTY
+  // directory carries no caller data, so removing it is safe and keeps the
+  // per-Run root from accumulating forever. Anything else — a file, a symlink,
+  // a directory with content — is left untouched and reported by the root
+  // surviving this call.
+  for (const entry of fs.readdirSync(projectionAccessRoot)) {
+    const candidate = path.join(projectionAccessRoot, entry);
+    try {
+      const stat = fs.lstatSync(candidate);
+      if (stat.isSymbolicLink() || !stat.isDirectory()) continue;
+      if (fs.readdirSync(candidate).length !== 0) continue;
+      fs.rmdirSync(candidate);
+    } catch { /* best effort: leave the entry and the root behind */ }
+  }
   if (fs.readdirSync(projectionAccessRoot).length === 0) {
     fs.rmdirSync(projectionAccessRoot);
   } else {
-    fs.chmodSync(projectionAccessRoot, 0o555);
+    fs.chmodSync(projectionAccessRoot, 0o700);
   }
 }
 

--- a/apps/daemon/tests/strategies/od-next-task-input-snapshot.test.ts
+++ b/apps/daemon/tests/strategies/od-next-task-input-snapshot.test.ts
@@ -458,6 +458,70 @@ describe('OD Next task-scoped input snapshots', () => {
     expect(readFileSync(canonical.attachmentPaths[1]!, 'utf8')).toBe('canonical text');
   });
 
+  it('leaves the access root writable and clears sandbox mount targets on teardown', () => {
+    const f = fixture();
+    writeFileSync(path.join(f.projectRoot, 'brief.txt'), 'canonical text');
+    const descriptor = createOdNextTaskInputSnapshot({
+      ...f,
+      taskExecutionId: 'odnext_teardown',
+      projectAttachments: ['brief.txt'],
+    });
+    const projectionsRoot = path.join(f.root, 'data', 'run-inputs');
+    const projection = createOdNextRunInputProjection({
+      descriptor,
+      snapshotsRoot: f.snapshotsRoot,
+      projectionsRoot,
+      runId: 'run-teardown',
+    });
+
+    // The projected inputs stay immutable one level down...
+    expect(statSync(projection.projectionDir).mode & 0o777).toBe(
+      process.platform === 'win32' ? statSync(projection.projectionDir).mode & 0o777 : 0o555,
+    );
+    // ...while the access root itself must stay owner-writable, because codex's
+    // Linux sandbox creates and then unlinks synthetic mount targets inside
+    // every writable root it is given. A read-only root made that teardown
+    // abort with `failed to remove synthetic bubblewrap mount target`.
+    if (process.platform !== 'win32') {
+      expect(statSync(projection.projectionAccessRoot).mode & 0o200).toBe(0o200);
+    }
+
+    // Simulate what the sandbox leaves behind next to the projection.
+    for (const target of ['.codex', '.agents', '.git']) {
+      mkdirSync(path.join(projection.projectionAccessRoot, target), { mode: 0o755 });
+    }
+
+    removeOdNextRunInputProjection(projection);
+    expect(existsSync(projection.projectionDir)).toBe(false);
+    expect(existsSync(projection.projectionAccessRoot)).toBe(false);
+  });
+
+  it('keeps the access root when a leftover entry still carries data', () => {
+    const f = fixture();
+    writeFileSync(path.join(f.projectRoot, 'brief.txt'), 'canonical text');
+    const descriptor = createOdNextTaskInputSnapshot({
+      ...f,
+      taskExecutionId: 'odnext_teardown_data',
+      projectAttachments: ['brief.txt'],
+    });
+    const projectionsRoot = path.join(f.root, 'data', 'run-inputs');
+    const projection = createOdNextRunInputProjection({
+      descriptor,
+      snapshotsRoot: f.snapshotsRoot,
+      projectionsRoot,
+      runId: 'run-teardown-data',
+    });
+
+    const survivor = path.join(projection.projectionAccessRoot, 'unexpected');
+    mkdirSync(survivor, { mode: 0o700 });
+    writeFileSync(path.join(survivor, 'keep.txt'), 'not ours to delete');
+
+    removeOdNextRunInputProjection(projection);
+    expect(existsSync(projection.projectionDir)).toBe(false);
+    expect(existsSync(projection.projectionAccessRoot)).toBe(true);
+    expect(readFileSync(path.join(survivor, 'keep.txt'), 'utf8')).toBe('not ours to delete');
+  });
+
   it('rejects an intermediate attachments-directory symlink even with identical bytes', () => {
     const f = fixture();
     writeFileSync(path.join(f.projectRoot, 'brief.txt'), 'identical frozen bytes');


### PR DESCRIPTION
## Problem

On Linux, an OD Next run that hands its input projection to codex aborts during
sandbox teardown:

```
thread 'main' panicked at linux-sandbox/src/linux_run_main.rs:1273:25:
failed to remove synthetic bubblewrap mount target
.../od-next-run-inputs/odnext_<id>/.codex: Permission denied (os error 13)
```

## Why

`createOdNextRunInputProjection` freezes the per-Run access root to `0o555` and
hands that same path to adapters as a **writable** root
(`projectionAccessRoot` → `extraAllowedDirs` → `--add-dir` /
`sandbox_workspace_write.writable_roots`).

codex's Linux sandbox materialises synthetic bubblewrap mount targets
(`.codex`, `.agents`, `.git`) inside every writable root. Creating them
succeeds because bwrap runs in a user namespace; the teardown that unlinks
them runs as the real user and needs write permission on the **parent**. The
parent is the `0o555` root, so the unlink fails and the run dies.

Note the failing mode is the *parent's*, not the target's: the mount targets
themselves are `0o755`. Removing a directory entry is governed by write
permission on the directory that contains it.

The same cause had a second, quieter effect:
`removeOdNextRunInputProjection` chmods the root to `0o700`, removes
`projectionDir`, and then takes its non-empty branch because the sandbox's
leftovers are still there. It re-froze the root to `0o555` and left it on disk
permanently, so `od-next-run-inputs/` accumulated one dead root per run. Four
had piled up on the machine where this was found.

## Fix

Immutability belongs to `projectionDir` and its `0o444` files, one level down,
and is unchanged: projected inputs still cannot be modified. The access root
itself only needs to be traversable and owner-writable, so it now stays
`0o700`.

Teardown additionally clears leftover mount targets, but only when they are
**empty directories**. A file, a symlink, or a directory with content is left
untouched and the root survives the call, so nothing that carries caller data
is ever removed by this path.

## Tests

Two regression tests in
`apps/daemon/tests/strategies/od-next-task-input-snapshot.test.ts`:

- the access root stays owner-writable, and teardown clears simulated
  `.codex` / `.agents` / `.git` mount targets and removes the root;
- a leftover entry that carries data is preserved, and the root survives.

Both fail on `main` and pass with this change. The full `apps/daemon` suite
was run before and after: same result either way, with the only failures being
pre-existing environment-dependent ones in `cli-startup`,
`update-lifecycle-observations` and `runtimes/executables`.

Context: part of getting the packaged Linux app healthy, alongside #7979 and
issue #3759.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194Hms4LU5cR3fJ2Pa4Mirx
