### PR TITLE
fix(web): keep the prerender cache out of the installed app directory

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -169,6 +169,16 @@ const nextConfig: NextConfig = {
     root: WORKSPACE_ROOT,
   },
   ...(DEV_TSCONFIG_PATH ? { typescript: { tsconfigPath: DEV_TSCONFIG_PATH } } : {}),
+  // Packaged desktop builds run Next from inside the installed application
+  // directory, which is root-owned and read-only for the user running the app
+  // (`/opt/...` on Linux, the app bundle on macOS). Next's incremental cache
+  // defaults to flushing prerendered routes to `<distDir>/server/app/...`, so
+  // every render attempted an mkdir there and logged
+  // `EACCES: permission denied` without ever succeeding. Keep that cache in
+  // memory for server output: a local-first desktop app serves one user, the
+  // cache has no value across restarts, and nothing should write into the
+  // installation at runtime.
+  ...(isServerOutput ? { experimental: { isrFlushToDisk: false } } : {}),
   // Static exports keep Next.js's default `out/` output directory so static
   // hosts like Vercel can publish the generated site directly. Server runtimes
   // still keep a predictable traced build directory for sidecar launchers.


### PR DESCRIPTION
## Problem

In a packaged desktop install the web sidecar logs a wall of permission
errors, one per asset, with no successful write ever:

```
Failed to update prerender cache for /assets/<name>.jpg
Error: EACCES: permission denied, mkdir
'/opt/open-design-desktop/appdir/resources/app/node_modules/@open-design/web/.next/server/app/assets'
```

A hundred of them in a single `logs/web/latest.log` on the machine where this
was found.

## Why

Packaged builds run Next from inside the installation directory, which is
root-owned and read-only for the user running the app: `/opt/...` on Linux,
the app bundle on macOS. Next's incremental cache defaults to
`experimental.isrFlushToDisk`, confirmed still `true` in the shipped
`web/.next/required-server-files.json`, so every prerendered route tries to
`mkdir` under `<distDir>/server/app` and fails.

These writes cannot succeed under any circumstance in a packaged install. They
only fail loudly, and they bury real diagnostics in the web log.

## Fix

Server output keeps that cache in memory. A local-first desktop app serves a
single user, the cache has no value across restarts, and nothing should write
into the installation at runtime.

Scoped to `isServerOutput`, so static export and `next dev` are untouched. On
Linux `resolveToolPackWebOutputMode` always returns `server`, so packaged
Linux builds take this path.

`experimental.isrFlushToDisk` is a documented `NextConfig` option and is
present in the bundled Next types.

Context: part of getting the packaged Linux app healthy, alongside #7979 and
issue #3759.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194Hms4LU5cR3fJ2Pa4Mirx
