### PR TITLE
fix(web): close pending todos when run ends unfinished

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -564,6 +564,7 @@ function AssistantMessageImpl({
       events: displayEvents,
       ...(mediaTasks.length ? { mediaTasks } : {}),
       runStatus: turnRunStatus,
+      ...(message.endedWithUnfinishedWork === true ? { endedWithUnfinishedWork: true } : {}),
       // 只在本轮清单里出现过的条目上取值(`build-turn-blocks` 的 `previous.has`),
       // 所以 agent 不重发时它是纯空转,不会凭空造出任何一行。
       ...(previousTodos?.length ? { previousTodos } : {}),
@@ -593,7 +594,17 @@ function AssistantMessageImpl({
     };
     // `message.endedAt` 从 undefined 变成时刻**就在轮次终止那一刻** —— 不进依赖的话
     // 兜底耗时会停在「还没有终点」的那一版,壳头刚收起时秒数是空的。
-  }, [displayEvents, turnRunStatus, nowMs, previousTodos, message.endedAt, streaming, lastEventAtMs, mediaTasks]);
+  }, [
+    displayEvents,
+    turnRunStatus,
+    nowMs,
+    previousTodos,
+    message.endedAt,
+    message.endedWithUnfinishedWork,
+    streaming,
+    lastEventAtMs,
+    mediaTasks,
+  ]);
   /**
    * 执行记录里**真的有东西**。
    *

--- a/apps/web/src/runtime/chat/build-turn-blocks.ts
+++ b/apps/web/src/runtime/chat/build-turn-blocks.ts
@@ -1574,7 +1574,7 @@ export function buildTurnBlocks(input: BuildTurnInput): TurnBlock[] {
       for (const shell of [top, todoCard]) {
         if (!shell) continue;
         shell.stopped = true;
-        closeRunningSegments(shell);
+        closeRunningSegments(shell, input.endedWithUnfinishedWork === true);
       }
       return;
     }
@@ -1583,7 +1583,7 @@ export function buildTurnBlocks(input: BuildTurnInput): TurnBlock[] {
       if (!shell) continue;
       if (status === 'failed' && shell === (todoCard ?? top)) shell.status = 'failed';
       else if (shell.status === 'running') shell.status = 'done';
-      closeRunningSegments(shell);
+      closeRunningSegments(shell, input.endedWithUnfinishedWork === true);
     }
   }
 
@@ -1709,10 +1709,15 @@ export function buildTurnBlocks(input: BuildTurnInput): TurnBlock[] {
  * 收成 `stopped` 而不是 `completed`:我们只知道它**没跑完就结束了**,不知道它成没成。
  * 标成完成是替 agent 说了它没说过的话;`stopped` 画出来是中性灰,红留给真的错误。
  * 手动停止走的也是这一条 —— 对那条 todo 来说,两种结局是同一件事。
+ *
+ * `pending` 只有在 daemon 明确盖了 `endedWithUnfinishedWork` 时才收停。普通终态、
+ * 历史回放和已交付 done 标记都不能单凭 run 结束推断「尚未开始」已经变成「被截断」。
  */
-function closeRunningSegments(shell: ExecutionShell): void {
+function closeRunningSegments(shell: ExecutionShell, stopPending = false): void {
   for (const seg of shell.segments) {
-    if (seg.status === 'pending' || seg.status === 'in_progress') seg.status = 'stopped';
+    if (seg.status === 'in_progress' || (stopPending && seg.status === 'pending')) {
+      seg.status = 'stopped';
+    }
   }
 }
 

--- a/apps/web/src/runtime/chat/build-turn-blocks.ts
+++ b/apps/web/src/runtime/chat/build-turn-blocks.ts
@@ -1712,7 +1712,7 @@ export function buildTurnBlocks(input: BuildTurnInput): TurnBlock[] {
  */
 function closeRunningSegments(shell: ExecutionShell): void {
   for (const seg of shell.segments) {
-    if (seg.status === 'in_progress') seg.status = 'stopped';
+    if (seg.status === 'pending' || seg.status === 'in_progress') seg.status = 'stopped';
   }
 }
 

--- a/apps/web/src/runtime/chat/contract.ts
+++ b/apps/web/src/runtime/chat/contract.ts
@@ -300,6 +300,8 @@ export interface BuildTurnInput {
   mediaTasks?: ProjectMediaTask[];
   /** run 终止态;终止即收起,不依赖 agent 发 done(D18) */
   runStatus?: 'queued' | 'running' | 'succeeded' | 'failed' | 'canceled';
+  /** daemon 已确认这个终态 run 留下了未完成工作;只在此时收停尚未开始的 todo */
+  endedWithUnfinishedWork?: boolean;
   /** 上一轮的清单,用于召回判定(D17) */
   previousTodos?: Pick<TodoSegment, 'content' | 'status'>[];
   /** 壳头「进行中 · 31s」的当前时刻;不传则运行中不显示秒数 */

--- a/apps/web/src/runtime/todos.ts
+++ b/apps/web/src/runtime/todos.ts
@@ -290,7 +290,8 @@ function stoppedTodoWriteInput(input: unknown): unknown {
     [key]: items.map((todo) => {
       if (!todo || typeof todo !== 'object') return todo;
       const record = todo as Record<string, unknown>;
-      if (record.status !== 'in_progress') return todo;
+      const status = normalizeTodoStatus(record.status);
+      if (status === 'completed' || status === 'stopped') return todo;
       return {
         ...record,
         status: 'stopped',

--- a/apps/web/tests/runtime/chat/build-turn-blocks.test.ts
+++ b/apps/web/tests/runtime/chat/build-turn-blocks.test.ts
@@ -802,10 +802,18 @@ describe('轮次结束后没有东西还在转', () => {
     expect(shell.segments.map((s) => s.status)).not.toContain('in_progress');
   });
 
-  it('没关掉的那条不谎报成功 —— 是「没跑完」不是「做完了」', () => {
+  it('没关掉的那两条都不谎报成功 —— 是「没跑完」不是「做完了」', () => {
     const shell = last(shells(buildTurnBlocks({ events: openList, ...done('succeeded') })));
     expect(nth(shell.segments, 0).status).toBe('stopped');
-    expect(nth(shell.segments, 1).status).toBe('pending');
+    expect(nth(shell.segments, 1).status).toBe('stopped');
+  });
+
+  it('terminal 会保留已完成,只收停未完成的清单项', () => {
+    const shell = last(shells(buildTurnBlocks({
+      events: [...todo('p1', [['已完成', 'completed'], ['未开始', 'pending'], ['进行中', 'in_progress']])],
+      ...done('succeeded'),
+    })));
+    expect(shell.segments.map((s) => s.status)).toEqual(['completed', 'stopped', 'stopped']);
   });
 
   it('还在跑的时候当然照转', () => {

--- a/apps/web/tests/runtime/chat/build-turn-blocks.test.ts
+++ b/apps/web/tests/runtime/chat/build-turn-blocks.test.ts
@@ -802,15 +802,16 @@ describe('轮次结束后没有东西还在转', () => {
     expect(shell.segments.map((s) => s.status)).not.toContain('in_progress');
   });
 
-  it('没关掉的那两条都不谎报成功 —— 是「没跑完」不是「做完了」', () => {
+  it('普通终态只收停进行中的步骤,没有证据时保留尚未开始的步骤', () => {
     const shell = last(shells(buildTurnBlocks({ events: openList, ...done('succeeded') })));
     expect(nth(shell.segments, 0).status).toBe('stopped');
-    expect(nth(shell.segments, 1).status).toBe('stopped');
+    expect(nth(shell.segments, 1).status).toBe('pending');
   });
 
-  it('terminal 会保留已完成,只收停未完成的清单项', () => {
+  it('daemon 确认终态留下未完成工作时,保留已完成并收停所有未完成项', () => {
     const shell = last(shells(buildTurnBlocks({
       events: [...todo('p1', [['已完成', 'completed'], ['未开始', 'pending'], ['进行中', 'in_progress']])],
+      endedWithUnfinishedWork: true,
       ...done('succeeded'),
     })));
     expect(shell.segments.map((s) => s.status)).toEqual(['completed', 'stopped', 'stopped']);

--- a/apps/web/tests/runtime/todos.test.ts
+++ b/apps/web/tests/runtime/todos.test.ts
@@ -220,7 +220,7 @@ describe('todo event helpers', () => {
     expect(unfinishedTodosFromEvents(events)).toEqual([]);
   });
 
-  it('marks the active todo as stopped when a failed run ended without a final TodoWrite', () => {
+  it('marks every unfinished todo as stopped when a failed run ended without a final TodoWrite', () => {
     const input = latestTodoWriteInputForPinnedCard([
       {
         id: 'assistant-1',
@@ -247,11 +247,11 @@ describe('todo event helpers', () => {
     expect(parseTodoWriteInput(input)).toEqual([
       { content: 'Draft layout', status: 'completed', activeForm: undefined },
       { content: 'Build components', status: 'stopped', activeForm: 'Building components' },
-      { content: 'Run QA', status: 'pending', activeForm: undefined },
+      { content: 'Run QA', status: 'stopped', activeForm: undefined },
     ]);
   });
 
-  it('marks the active todo as stopped when a nominally successful run ended with stale progress', () => {
+  it('marks every unfinished todo as stopped when a nominally successful run ended with stale progress', () => {
     const input = latestTodoWriteInputForPinnedCard([
       {
         runStatus: 'succeeded',
@@ -274,7 +274,7 @@ describe('todo event helpers', () => {
 
     expect(parseTodoWriteInput(input)).toEqual([
       { content: 'Generate HTML', status: 'stopped', activeForm: undefined },
-      { content: 'Self-check', status: 'pending', activeForm: undefined },
+      { content: 'Self-check', status: 'stopped', activeForm: undefined },
     ]);
   });
 
@@ -330,7 +330,7 @@ describe('todo event helpers', () => {
     expect(parseTodoWriteInput(input)).toEqual([
       { content: 'Inspect chat rendering', status: 'completed', activeForm: undefined },
       { content: 'Add annotation card', status: 'stopped', activeForm: undefined },
-      { content: 'Run focused tests', status: 'pending', activeForm: undefined },
+      { content: 'Run focused tests', status: 'stopped', activeForm: undefined },
     ]);
   });
 });

--- a/apps/web/tests/runtime/todos.test.ts
+++ b/apps/web/tests/runtime/todos.test.ts
@@ -278,6 +278,33 @@ describe('todo event helpers', () => {
     ]);
   });
 
+  it('marks every unfinished todo as stopped when a terminal run ends with stale progress', () => {
+    const input = latestTodoWriteInputForPinnedCard([
+      {
+        runStatus: 'succeeded',
+        endedAt: 3_000,
+        events: [
+          {
+            kind: 'tool_use',
+            id: 'todo-2989',
+            name: 'TodoWrite',
+            input: {
+              todos: [
+                { content: 'Build single-file HTML deck', status: 'in_progress' },
+                { content: 'Verify exactly one runnable root-level HTML entry', status: 'pending' },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(parseTodoWriteInput(input)).toEqual([
+      { content: 'Build single-file HTML deck', status: 'stopped', activeForm: undefined },
+      { content: 'Verify exactly one runnable root-level HTML entry', status: 'stopped', activeForm: undefined },
+    ]);
+  });
+
   it('marks update_plan items as stopped when a terminal run ends with stale progress', () => {
     const input = latestTodoWriteInputForPinnedCard([
       {

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -1276,6 +1276,9 @@ export interface ChatMessage {
   createdAt?: number;
   runId?: string;
   runStatus?: ChatRunStatus;
+  /** True when this terminal run left declared work unfinished. Mirrors
+   *  ChatRunStatusResponse.endedWithUnfinishedWork. */
+  endedWithUnfinishedWork?: boolean;
   resultDeliveryState?: ResultDeliveryState;
   /** True when this message's failed run can be recovered by resuming the
    *  agent's CLI session (transient upstream drop / inactivity on a


### PR DESCRIPTION
## Why
A run can finish with `endedWithUnfinishedWork` while Todo items remain pending, leaving the ChatPanel in a misleading unfinished state.

## What users will see
When a run ends with unfinished work, every non-completed Todo item is shown as stopped instead of continuing to spin or remain pending.

## Validation
- Red baseline: `apps/web/tests/runtime/todos.test.ts` failed on pending-state closure
- Fixed: 22/22 tests pass
- Withdrawn implementation: 4 related assertions fail, confirming the regression test proves the fix

## Scope
Web runtime Todo terminal projection only; no service startup or full-suite run.