### PR TITLE
fix(chat): preserve uploaded attachment sizes

### DIFF
--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -289,7 +289,20 @@ function withSeededSlideIndex(
  * path strings; persisted messages store `{ path, name, kind, order }` so the
  * UI can reload chips and annotation context after a headless omit-pin seed.
  */
-function seededUserMessageAttachmentFields(meta: JsonRecord): {
+function seededAttachmentSize(projectRoot: string | null | undefined, attachmentPath: string): number | undefined {
+  if (!projectRoot) return undefined;
+  try {
+    const absolute = path.resolve(projectRoot, attachmentPath);
+    const relative = path.relative(path.resolve(projectRoot), absolute);
+    if (relative.startsWith('..') || path.isAbsolute(relative)) return undefined;
+    const stat = fs.statSync(absolute);
+    return stat.isFile() ? stat.size : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function seededUserMessageAttachmentFields(meta: JsonRecord, projectRoot?: string | null): {
   attachments?: Array<{ path: string; name: string; kind: 'image' | 'file'; order: number }>;
   commentAttachments?: SeededCommentAttachment[];
 } {
@@ -299,10 +312,12 @@ function seededUserMessageAttachmentFields(meta: JsonRecord): {
         .map((attachmentPath, index) => {
           const name = path.basename(attachmentPath) || attachmentPath;
           const ext = path.extname(name).toLowerCase();
+          const size = seededAttachmentSize(projectRoot, attachmentPath);
           return {
             path: attachmentPath,
             name,
             kind: SEEDED_USER_IMAGE_EXTS.has(ext) ? ('image' as const) : ('file' as const),
+            ...(size === undefined ? {} : { size }),
             order: index,
           };
         })
@@ -2518,7 +2533,10 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       // message is still seedable when attachment metadata is present so
       // chips/annotations survive reload for omit-pin clients that leave
       // currentPrompt unset.
-      const seededAttachments = seededUserMessageAttachmentFields(meta);
+      const projectRoot = runProject && meta.projectId
+        ? resolveProjectDir(PROJECTS_DIR, meta.projectId, runProject.metadata)
+        : null;
+      const seededAttachments = seededUserMessageAttachmentFields(meta, projectRoot);
       const hasSeedableAttachmentMetadata =
         (seededAttachments.attachments?.length ?? 0) > 0 ||
         (seededAttachments.commentAttachments?.length ?? 0) > 0;

--- a/apps/daemon/tests/headless-runs.test.ts
+++ b/apps/daemon/tests/headless-runs.test.ts
@@ -299,6 +299,22 @@ describe('POST /api/runs headless fallbacks', () => {
     const prompt = `omit-pin with attachments ${randomUUID()}`;
     const attachmentPath = 'assets/hero.png';
     const bmpAttachmentPath = 'assets/scan.bmp';
+    const fileContents = 'hero fixture bytes';
+    const bmpContents = 'scan fixture bytes';
+    for (const [name, content] of [
+      [attachmentPath, fileContents],
+      [bmpAttachmentPath, bmpContents],
+    ] as const) {
+      const fileResponse = await fetch(
+        `${started.url}/api/projects/${encodeURIComponent(projectId)}/files`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name, content }),
+        },
+      );
+      expect(fileResponse.status).toBe(200);
+    }
     const commentAttachment = {
       id: `comment-${randomUUID()}`,
       order: 1,
@@ -336,7 +352,13 @@ describe('POST /api/runs headless fallbacks', () => {
       messages: Array<{
         role: string;
         content: string;
-        attachments?: Array<{ path: string; name: string; kind: string; order?: number }>;
+        attachments?: Array<{
+          path: string;
+          name: string;
+          kind: string;
+          size?: number;
+          order?: number;
+        }>;
         commentAttachments?: Array<{
           id: string;
           filePath: string;
@@ -356,12 +378,14 @@ describe('POST /api/runs headless fallbacks', () => {
         path: attachmentPath,
         name: 'hero.png',
         kind: 'image',
+        size: Buffer.byteLength(fileContents),
         order: 0,
       },
       {
         path: bmpAttachmentPath,
         name: 'scan.bmp',
         kind: 'image',
+        size: Buffer.byteLength(bmpContents),
         order: 1,
       },
     ]);

--- a/apps/daemon/tests/headless-runs.test.ts
+++ b/apps/daemon/tests/headless-runs.test.ts
@@ -290,6 +290,81 @@ describe('POST /api/runs headless fallbacks', () => {
     expect(userMessages.some((m) => m.content === transcript)).toBe(false);
   });
 
+  // OPEND-2980: normal web requests carry both pins, while the optimistic
+  // PUT and daemon user seed can arrive in either order. Exercise the actual
+  // multipart upload response and reload the same user row after each write.
+  for (const clientWrite of ['before-seed', 'after-seed'] as const) {
+    for (const prompt of ['Inspect this diagnostic archive', '']) {
+      it(`retains uploaded ZIP size with UI pins, ${clientWrite}, ${prompt ? 'text' : 'attachments-only'}`, async () => {
+        started = await startTestServer();
+        const { projectId, conversationId } = await createProject(started.url, 'UI upload size');
+        const bytes = Buffer.from('UEsDBBQAAAAAAJOuK13X0oKVGAAAABgAAAAOAAAAZGlhZ25vc3RpYy50eHRhdHRhY2htZW50IHNpemUgZml4dHVyZQpQSwECFAMUAAAAAACTritd19KClRgAAAAYAAAADgAAAAAAAAAAAAAAgAEAAAAAZGlhZ25vc3RpYy50eHRQSwUGAAAAAAEAAQA8AAAARAAAAAAA', 'base64');
+        const upload = new FormData();
+        upload.append('files', new File([bytes], 'diagnostics.zip', { type: 'application/zip' }));
+        const uploadResponse = await fetch(`${started.url}/api/projects/${encodeURIComponent(projectId)}/upload`, {
+          method: 'POST',
+          body: upload,
+        });
+        expect(uploadResponse.status).toBe(200);
+        const uploaded = await uploadResponse.json() as {
+          files: Array<{ path: string; name: string; originalName: string; size: number }>;
+        };
+        expect(uploaded.files).toHaveLength(1);
+        expect(uploaded.files[0]).toMatchObject({
+          path: 'diagnostics.zip', originalName: 'diagnostics.zip', size: bytes.length,
+        });
+        const attachment = {
+          path: uploaded.files[0]!.path,
+          name: uploaded.files[0]!.originalName,
+          kind: 'file' as const,
+          size: uploaded.files[0]!.size,
+        };
+        const userMessageId = randomUUID();
+        const assistantMessageId = randomUUID();
+        const messagesUrl = `${started.url}/api/projects/${encodeURIComponent(projectId)}/conversations/${encodeURIComponent(conversationId)}/messages`;
+        const assertReload = async () => {
+          const response = await fetch(messagesUrl);
+          expect(response.status).toBe(200);
+          const body = await response.json() as {
+            messages: Array<{ id: string; role: string; content: string; attachments?: Array<{ path: string; size?: number }> }>;
+          };
+          const rows = body.messages.filter((message) => message.id === userMessageId);
+          expect(rows).toHaveLength(1);
+          expect(rows[0]).toMatchObject({ role: 'user', content: prompt, attachments: [attachment] });
+        };
+        const saveClientMessage = async () => {
+          const response = await fetch(`${messagesUrl}/${encodeURIComponent(userMessageId)}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              id: userMessageId, role: 'user', content: prompt, attachments: [attachment],
+            }),
+          });
+          expect(response.status).toBe(200);
+          await assertReload();
+        };
+        if (clientWrite === 'before-seed') await saveClientMessage();
+        const runResponse = await fetch(`${started.url}/api/runs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            // No provider budget: missing runtime fails after the real run
+            // admission/pinning path. This is metadata persistence coverage,
+            // not a successful agent or browser end-to-end claim.
+            agentId: `missing-agent-${randomUUID()}`,
+            projectId, conversationId, userMessageId, assistantMessageId,
+            message: prompt, currentPrompt: prompt,
+            attachments: [attachment.path],
+          }),
+        });
+        expect(runResponse.status).toBe(202);
+        // Check seed before a later client PUT can mask a lost size.
+        await assertReload();
+        if (clientWrite === 'after-seed') await saveClientMessage();
+      });
+    }
+  }
+
   it('preserves attachments and commentAttachments on omit-pin seeded user turns', async () => {
     started = await startTestServer();
     const { projectId, conversationId } = await createProject(


### PR DESCRIPTION
Fixes #2980

## Why

The ChatPanel already renders an attachment's size when it is present, but omit-pin run seeding rebuilt uploaded attachments from paths and discarded their filesystem metadata. After reload, persisted user file cards could therefore lose the size line even though the staged upload card showed it.

## What users will see

Uploaded file cards retain their size after the conversation reloads, including attachments-only turns.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change**
- [ ] **None**

## Screenshots

Not applicable: this restores existing metadata in the existing attachment card.

## Bug fix verification

- Test path: `apps/daemon/tests/headless-runs.test.ts`
- The test went red on `origin/main` and after temporarily withdrawing the implementation: 16 tests, 1 failed because both persisted attachments omitted `size`.
- With the fix restored, the same complete file passes 16/16.

## Validation

- `pnpm --filter @open-design/daemon test tests/headless-runs.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `git diff --check`
