### PR TITLE
fix(chat): remove native tooltips from question options

### DIFF
--- a/apps/web/src/components/QuestionForm.tsx
+++ b/apps/web/src/components/QuestionForm.tsx
@@ -1355,7 +1355,6 @@ function OptionButton({
       type="button"
       role={role}
       aria-checked={on}
-      title={option.description}
       disabled={disabled === true}
       className={`qf-chip${on ? ' qf-chip-on' : ''}${maxed === true ? ' qf-chip-disabled' : ''}`}
       onClick={onPick}

--- a/apps/web/tests/components/QuestionForm.test.tsx
+++ b/apps/web/tests/components/QuestionForm.test.tsx
@@ -219,6 +219,13 @@ const pickedText = (): string | null =>
 describe('QuestionFormView', () => {
   afterEach(() => cleanup());
 
+  it('does not expose option descriptions through the browser native tooltip', () => {
+    render(<QuestionFormView form={richForm} interactive onSubmit={vi.fn()} />);
+
+    const describedOption = screen.getByRole('radio', { name: /Mobile \(iOS\/Android\)/ });
+    expect(describedOption).not.toHaveAttribute('title');
+  });
+
   it('updates locked answers when submitted history arrives after the initial render', () => {
     const onSubmit = vi.fn();
     const { container, rerender } = render(


### PR DESCRIPTION
## Why

Question options already render their descriptions inline, but the option button also sets the same text as the browser's native `title`. Hovering an option therefore opens a duplicate grey tooltip outside the Question card, as shown in OPEND-2796.

## What users will see

Question options keep their inline descriptions and all existing selected/hover states, while the duplicate browser-native tooltip is gone.

## Validation

- Red baseline (with `title` restored): full `QuestionForm.test.tsx` 47 passed, 1 failed.
- Fixed: full `QuestionForm.test.tsx` 48/48 passed.
- `pnpm guard` passed.
- `pnpm --filter @open-design/web typecheck` passed.
- `pnpm --filter @open-design/web build` passed.

Red spec branch: `qa/opend-2796-native-tooltip-red`, commit `57fd7540c0`.

