### PR TITLE
fix(daemon): allow BYOK image input without capability metadata

### DIFF
--- a/apps/daemon/src/runtimes/byok-opencode.ts
+++ b/apps/daemon/src/runtimes/byok-opencode.ts
@@ -79,6 +79,11 @@ export function buildOpenCodeByokProviderConfig(
         models: {
           [rawModel]: {
             name: rawModel,
+            // BYOK capability is unknown, not text-only. Allow OpenCode to
+            // forward images (including later Read tool results) and let the
+            // configured endpoint validate them. This run-scoped transport
+            // policy is not a persisted claim about the model's capabilities.
+            modalities: { input: ['text', 'image'], output: ['text'] },
             limit: {
               context: DEFAULT_CONTEXT_TOKEN_LIMIT,
               output: DEFAULT_OUTPUT_TOKEN_LIMIT,

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -753,6 +753,7 @@ process.stdin.on('end', () => {
         });
         expect(provider?.models?.['deepseek-v4-flash']).toEqual({
           name: 'deepseek-v4-flash',
+          modalities: { input: ['text', 'image'], output: ['text'] },
           limit: {
             context: 128_000,
             output: 16_384,

--- a/apps/daemon/tests/runtimes/byok-opencode.test.ts
+++ b/apps/daemon/tests/runtimes/byok-opencode.test.ts
@@ -37,6 +37,28 @@ describe('byok-opencode runtime config', () => {
     }
   });
 
+  it.each(['openai', 'anthropic', 'google', 'azure', 'ollama', 'senseaudio', 'aihubmix'] as const)(
+    'allows images from attachments and Read tools for unknown %s models',
+    (protocol) => {
+      const out = buildOpenCodeByokProviderConfig(
+        { protocol, apiKey: 'test-key', baseUrl: 'https://provider.example/v1' },
+        'new-custom-model',
+      );
+
+      expect(out?.config).toMatchObject({
+        provider: {
+          [BYOK_OPENCODE_PROVIDER_ID]: {
+            models: {
+              'new-custom-model': {
+                modalities: { input: ['text', 'image'], output: ['text'] },
+              },
+            },
+          },
+        },
+      });
+    },
+  );
+
   it('prefixes raw BYOK models with the run-scoped OpenCode provider id', () => {
     expect(opencodeByokModelId('gpt-4o-mini')).toBe('open-design-byok/gpt-4o-mini');
     expect(opencodeByokModelId('open-design-byok/gpt-4o-mini')).toBe('open-design-byok/gpt-4o-mini');


### PR DESCRIPTION
## Why

A user attached a PNG and asked Open Design to interpret it through BYOK OpenCode. Read returned an image attachment, but OpenCode treated the custom `open-design-byok` model as text-only because its injected configuration omitted input modalities. The model consequently received an unsupported-image placeholder instead of the image.

BYOK model capabilities are unknown. Let the configured endpoint validate image input rather than silently removing it locally, without maintaining a model allowlist or requiring a live model catalogue.

## What users will see

BYOK runs can send images read from project files to their selected endpoint. This allows an image-capable endpoint to answer image questions even when it supplies no capability metadata. It does not guarantee that every endpoint supports images. Existing upstream error handling remains in effect; this change introduces no image-removal retry or persistent capability cache.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — run-scoped BYOK OpenCode configuration permits text and image input.
- [ ] **None**

This shared daemon runtime change applies to existing UI and CLI entry points. No new controls, commands, environment variables, or public contracts are introduced. The allowance is configured at launch because images may first appear in a later Read tool result, after the initial prompt.

## Screenshots

Not applicable: no UI layout or entry point changed. Transport behavior was checked with the installed OpenCode executable and a local HTTP fixture.

## Bug fix verification

- Regression: `apps/daemon/tests/runtimes/byok-opencode.test.ts`, “allows images from attachments and Read tools for unknown %s models”.
- Red on main `933dc96038`: 7 failed / 20 passed, all seven failures caused by absent modalities.
- Green on branch: all 27 configuration tests pass, covering every supported BYOK protocol with an unknown model ID.
- OpenCode 1.18.6 transport smoke: a local OpenAI-compatible fixture requests Read of a real PNG, then inspects the subsequent chat request. Baseline configuration sends no image; patched configuration sends an `image_url` content part. The fixture's initial title-generation request is handled separately. No provider generation request or paid model call was used.
- Live provider recognition and packaged-app acceptance remain unverified. Initial smoke fixture attempts used an invalid tiny PNG that OpenCode omitted during image processing; the final comparison used a valid PNG.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/byok-opencode.test.ts tests/run-retry-policy.test.ts tests/run-failure-classification.test.ts` — 202 passed.
- `corepack pnpm guard` — passed.
- `corepack pnpm typecheck` — passed.
- `git diff --check` — passed.
- Installed OpenCode 1.18.6 + local HTTP fixture: baseline and patched transport comparison passed.

## Adjacent issues

Capability overrides, dynamic model directories, and more specific unsupported-image error presentation are separate follow-ups. No Vela or OpenCode fork changes are needed for this transport fix.
