### PR TITLE
fix(ci): scope trusted canonical-repo jobs so repository mirrors skip them

### DIFF
--- a/.github/workflows/bake-plugin-previews.yml
+++ b/.github/workflows/bake-plugin-previews.yml
@@ -36,6 +36,10 @@ concurrency:
 jobs:
   bake:
     name: Bake plugin previews
+    # R2 uploads and rolling manifest PRs are trusted canonical-repository
+    # writes. Mirrors do not inherit those credentials and should not attempt
+    # this publisher on push or on the copied nightly schedule.
+    if: github.repository == 'nexu-io/open-design'
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     steps:

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1323,6 +1323,11 @@ process.stdin.on("end", () => {
     // regressing any of them fails here instead of silently breaking auto-merge.
     const workflow = await readFile(bakePreviewsWorkflowPath, "utf8");
 
+    // This publisher needs canonical-repository R2 and release-bot credentials. Mirrors do not
+    // inherit those secrets, so their push/nightly runs must skip the trusted publisher instead
+    // of reaching the AWS CLI with empty bucket/endpoint arguments.
+    expect(workflow).toContain("if: github.repository == 'nexu-io/open-design'");
+
     // 1. The rolling PR is pushed with the release-bot App token, not GITHUB_TOKEN — a
     //    GITHUB_TOKEN-authored push triggers no CI, so the PR could never clear main's required
     //    `Validate workspace` check or the merge queue.


### PR DESCRIPTION
## Why

Repository mirrors copy every workflow verbatim - including push triggers and cron schedules - but inherit none of the credentials or infrastructure those jobs assume. Today that means, on every mirror:

- **bake-plugin-previews / bake-plugin-previews-gc**: publish to canonical R2 and open rolling manifest PRs with the release-bot App token - mirrors reach the AWS CLI with empty bucket/endpoint arguments
- **critique-conformance**: feeds the canonical 14-day ratchet history a mirror does not own - nightly cron is pure failure noise
- **visual-baseline**: runs on the private Blacksmith pool and publishes to R2 - the mirror's push-to-main run queues on a runner label that does not exist until GitHub cancels the job at 24h
- **ci.yml `runners` job**: resolves the private `nexu-runners-small` ARC label; a same-repository mirror PR is *not* a fork PR, so without a guard it never gets a runner, GitHub cancels the bootstrap at 24h, and every `needs: [runners]` job is skipped - the PR strands at UNSTABLE forever

## What

Explicit `github.repository` gates, one per trusted surface:

- `bake-plugin-previews.yml`, `bake-plugin-previews-gc.yml`, `critique-conformance.yml`, `visual-baseline.yml`: job-level `if: github.repository == 'nexu-io/open-design'` (before `runs-on`, so the job is skipped rather than burning runner minutes on checkout)
- `ci.yml`: hosted bootstrap `runs-on` *and* the `OD_CI_RUNNER_MODE` resolution both treat a non-canonical repository like a fork PR (`github.repository != 'nexu-io/open-design' || ...`) - both halves are required, otherwise downstream jobs still resolve private pool classes from `runners.json`

## Validation

`e2e/tests/packaged-smoke-workflow.test.ts` asserts every gate stays in place - job-level, before `runs-on` - so a refactor cannot silently drop one again.

## Scope

Single objective: mirror-safe CI. Split out of #7572 per @PerishCode's review (the adapter PR is now adapter-only). Supersedes the mis-scoped, closed #8034. This is the complete policy as originally authored - not just the preview publisher.