### PR TITLE
fix(daemon): bind uploaded plugin folder/zip to workspace_resources

### DIFF
--- a/apps/daemon/src/routes/plugins/index.ts
+++ b/apps/daemon/src/routes/plugins/index.ts
@@ -233,6 +233,19 @@ export interface RegisterPluginRoutesDeps {
       resourceType: string,
       resourceId: string,
     ) => WorkspaceResourceBindingRow | null | undefined;
+    ensureWorkspaceResource?: (
+      db: SqliteDbLike,
+      resourceType: string,
+      workspaceId: string,
+      resourceId: string,
+      envelope?: {
+        visibility?: 'personal' | 'team';
+        resourceState?: 'active' | 'deleted';
+        createdByWorkspaceMemberId?: string | null;
+        updatedByWorkspaceMemberId?: string | null;
+        syncState?: string;
+      },
+    ) => unknown;
     workspaceTeamPluginBindingAllowsRead?: (
       db: SqliteDbLike,
       workspaceId: string,
@@ -523,6 +536,8 @@ export function registerPluginRoutes(app: Express, deps: RegisterPluginRoutesDep
     helpers.pluginUpload.single('file')(req, res, async (err: unknown) => {
       if (err) return helpers.sendMulterError(res, err);
       try {
+        const authority = await resolveWorkspaceAuthority(req, res);
+        if (authority === undefined) return;
         const file = req.file;
         if (!file?.buffer) {
           return res.status(400).json(pluginUploadFailure('file is required', 'BAD_REQUEST'));
@@ -531,6 +546,21 @@ export function registerPluginRoutes(app: Express, deps: RegisterPluginRoutesDep
           file.buffer,
           `upload:zip:${helpers.decodeMultipartFilename(file.originalname || 'plugin.zip')}`,
         );
+        if (result.ok && result.plugin?.id && authority?.workspaceId) {
+          workspaceResources?.ensureWorkspaceResource?.(
+            db,
+            'plugin',
+            authority.workspaceId,
+            result.plugin.id,
+            {
+              visibility: 'personal',
+              resourceState: 'active',
+              createdByWorkspaceMemberId: authority.workspaceMemberId,
+              updatedByWorkspaceMemberId: authority.workspaceMemberId,
+              syncState: 'local_only',
+            },
+          );
+        }
         return res.status(result.ok ? 200 : 400).json(result);
       } catch (cause) {
         return res.status(400).json(pluginUploadFailure(cause));
@@ -541,6 +571,8 @@ export function registerPluginRoutes(app: Express, deps: RegisterPluginRoutesDep
     helpers.pluginUpload.array('files', 500)(req, res, async (err: unknown) => {
       if (err) return helpers.sendMulterError(res, err);
       try {
+        const authority = await resolveWorkspaceAuthority(req, res);
+        if (authority === undefined) return;
         const files = Array.isArray(req.files)
           ? req.files as Array<{ buffer: Buffer; originalname: string }>
           : [];
@@ -551,6 +583,21 @@ export function registerPluginRoutes(app: Express, deps: RegisterPluginRoutesDep
           files,
           req.body?.paths,
         );
+        if (result.ok && result.plugin?.id && authority?.workspaceId) {
+          workspaceResources?.ensureWorkspaceResource?.(
+            db,
+            'plugin',
+            authority.workspaceId,
+            result.plugin.id,
+            {
+              visibility: 'personal',
+              resourceState: 'active',
+              createdByWorkspaceMemberId: authority.workspaceMemberId,
+              updatedByWorkspaceMemberId: authority.workspaceMemberId,
+              syncState: 'local_only',
+            },
+          );
+        }
         return res.status(result.ok ? 200 : 400).json(result);
       } catch (cause) {
         return res.status(400).json(pluginUploadFailure(cause));

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -9513,6 +9513,7 @@ export async function startServer({
     workspaceResources: {
       getWorkspaceResource,
       getWorkspaceResourceByResourceId,
+      ensureWorkspaceResource,
       workspaceTeamPluginBindingAllowsRead,
       getWorkspaceProjectByProjectId,
     },


### PR DESCRIPTION
### Summary
Fixes #8038

In OpenDesign 0.22, custom plugins are scoped to active workspaces via the `workspace_resources` table (`pluginVisibleFromWorkspace`). However, `POST /api/plugins/upload-folder` and `POST /api/plugins/upload-zip` omitted `resolveWorkspaceAuthority(req, res)` and never invoked `ensureWorkspaceResource`.

Consequently, when a user successfully uploaded a plugin folder/zip through the desktop UI ("新增" -> "上传文件夹"), the upload succeeded, but the plugin was quarantined/filtered out of all scoped workspace queries (`GET /api/plugins` with workspace headers), resulting in an empty "个人的 (Personal)" plugins tab.

### Changes
1. `apps/daemon/src/routes/plugins/index.ts`:
   - Added `ensureWorkspaceResource` to `PluginRouteDeps['workspaceResources']` type interface.
   - Updated `POST /api/plugins/upload-zip` and `POST /api/plugins/upload-folder` to resolve `authority` via `await resolveWorkspaceAuthority(req, res)`.
   - On successful plugin installation (`result.ok && result.plugin?.id && authority?.workspaceId`), invoke `ensureWorkspaceResource` with `visibility: 'personal'`, `resourceState: 'active'`, and creator/updater member IDs.
2. `apps/daemon/src/server.ts`:
   - Exposed `ensureWorkspaceResource` in the `workspaceResources` dependencies passed into `registerPluginRoutes`.

### Verification
Tested by simulating workspace-scoped plugin uploads: the plugin is correctly written to `workspace_resources` upon upload and immediately returned in `GET /api/plugins` queries with active workspace headers.
