### PR TITLE
Raise MAX_MAX_TOKENS to 400000 so shipped defaults are reachable through Settings

### DIFF
--- a/apps/web/src/state/maxTokens.ts
+++ b/apps/web/src/state/maxTokens.ts
@@ -16,8 +16,12 @@ export const FALLBACK_MAX_TOKENS = 8192;
 // for both the UI input attributes and runtime validation in
 // `effectiveMaxTokens`, so a stale or hand-edited localStorage value
 // can't sneak past the UI's promise.
+//
+// MAX_MAX_TOKENS must be >= the highest shipped per-model default so that
+// a user who edits the override can restore the placeholder value through
+// the same control.
 export const MIN_MAX_TOKENS = 1024;
-export const MAX_MAX_TOKENS = 200000;
+export const MAX_MAX_TOKENS = 400000;
 
 const LITELLM_MODELS = litellmData.models as Record<string, number>;
 


### PR DESCRIPTION
Three shipped defaults exceed the current MAX_MAX_TOKENS = 200000 bound:

- deepseek-v4-pro: 384000
- deepseek-v4-flash: 384000
- qwen3-coder:480b: 262144

A user on these models who edits the max-tokens override cannot restore the placeholder value through the Settings field — it is rejected by isValidOverride. Clearing the field does restore the default (via effectiveMaxTokens falling through to modelMaxTokensDefault), but this is not discoverable.

This raises MAX_MAX_TOKENS to 400000, which covers all three defaults with room to spare, restoring bidirectionality between the UI control and the shipped defaults.

Also adds a comment documenting the invariant: MAX_MAX_TOKENS >= highest per-model default.

Closes #8048
