### PR TITLE
fix(web): make the max-tokens upper bound model-aware

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -1156,6 +1156,14 @@ function applyApiProtocolConfig(
     apiKey: apiConfig.apiKey,
     baseUrl: resolveFixedOriginBaseUrl(protocol, apiConfig.baseUrl),
     model: apiConfig.model,
+    // Every path that changes the active model meets here — the model picker, a
+    // provider-tab switch, a restored draft — so the override is validated once,
+    // here. A model with a lower ceiling would otherwise leave Settings showing
+    // a number `effectiveMaxTokens` discards at request time.
+    maxTokens:
+      config.maxTokens != null && config.maxTokens > maxTokensUpperBound(apiConfig.model)
+        ? undefined
+        : config.maxTokens,
     apiProviderBaseUrl: apiConfig.apiProviderBaseUrl ?? null,
     apiVersion: protocol === 'azure' ? (apiConfig.apiVersion ?? '') : '',
     // byokImageModel applies to the protocols that inject the daemon-side
@@ -2331,16 +2339,7 @@ export function SettingsDialog({
     });
   };
   const updateApiConfig = (patch: Partial<ApiProtocolConfig>) =>
-    setCfg((c) => {
-      const next = updateCurrentApiProtocolConfig(c, patch);
-      // Selecting another model can lower the ceiling below an override that
-      // was valid for the previous one. Keeping it would leave Settings
-      // showing a number that `effectiveMaxTokens` discards at request time.
-      if (next.maxTokens != null && next.maxTokens > maxTokensUpperBound(next.model)) {
-        return { ...next, maxTokens: undefined };
-      }
-      return next;
-    });
+    setCfg((c) => updateCurrentApiProtocolConfig(c, patch));
   const updateMaxTokensInput = (raw: string) => {
     setMaxTokensInput(raw);
     const trimmed = raw.trim();

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -1543,6 +1543,11 @@ export function SettingsDialog({
   const [maxTokensInput, setMaxTokensInput] = useState(
     initialFormConfig.maxTokens == null ? '' : String(initialFormConfig.maxTokens),
   );
+  // Re-display the override whenever the model changes, so the text follows
+  // whatever survived the bound check above instead of stranding the previous
+  // model's number in the field. Keyed on the model alone: mirroring every
+  // cfg.maxTokens change would wipe what the user is part-way through typing.
+  const lastModelForMaxTokens = useRef(initialFormConfig.model);
   const [pendingMediaProviderEditIds, setPendingMediaProviderEditIds] = useState<
     ReadonlySet<string>
   >(() => new Set());
@@ -1551,6 +1556,12 @@ export function SettingsDialog({
   const lastSavedAppearanceRef = useRef({
     accentColor: resolveAccentColor(initial.accentColor),
   });
+
+  useEffect(() => {
+    if (lastModelForMaxTokens.current === cfg.model) return;
+    lastModelForMaxTokens.current = cfg.model;
+    setMaxTokensInput(cfg.maxTokens == null ? '' : String(cfg.maxTokens));
+  }, [cfg.model, cfg.maxTokens]);
 
   useEffect(() => {
     onDraftChange?.(cfg);
@@ -2320,7 +2331,16 @@ export function SettingsDialog({
     });
   };
   const updateApiConfig = (patch: Partial<ApiProtocolConfig>) =>
-    setCfg((c) => updateCurrentApiProtocolConfig(c, patch));
+    setCfg((c) => {
+      const next = updateCurrentApiProtocolConfig(c, patch);
+      // Selecting another model can lower the ceiling below an override that
+      // was valid for the previous one. Keeping it would leave Settings
+      // showing a number that `effectiveMaxTokens` discards at request time.
+      if (next.maxTokens != null && next.maxTokens > maxTokensUpperBound(next.model)) {
+        return { ...next, maxTokens: undefined };
+      }
+      return next;
+    });
   const updateMaxTokensInput = (raw: string) => {
     setMaxTokensInput(raw);
     const trimmed = raw.trim();

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -108,8 +108,8 @@ export {
   providerModelsCacheKey,
 } from './providerModelsCache';
 import {
-  MAX_MAX_TOKENS,
   MIN_MAX_TOKENS,
+  maxTokensUpperBound,
   modelMaxTokensDefault,
 } from '../state/maxTokens';
 import type {
@@ -2329,13 +2329,16 @@ export function SettingsDialog({
       return;
     }
     const value = Number(trimmed);
-    const nextMaxTokens =
-      Number.isInteger(value) &&
-      value >= MIN_MAX_TOKENS &&
-      value <= MAX_MAX_TOKENS
-        ? value
-        : undefined;
-    setCfg((c) => ({ ...c, maxTokens: nextMaxTokens }));
+    // The upper bound is model-aware, so read the model from current state
+    // rather than a closure: the same rule has to hold for whichever model is
+    // selected when the edit lands.
+    setCfg((c) => ({
+      ...c,
+      maxTokens:
+        Number.isInteger(value) && value >= MIN_MAX_TOKENS && value <= maxTokensUpperBound(c.model)
+          ? value
+          : undefined,
+    }));
   };
   const markAgentInstallIntent = () => {
     pendingAgentInstallRescanRef.current = true;
@@ -5659,7 +5662,7 @@ export function SettingsDialog({
                 <input
                   type="number"
                   min={MIN_MAX_TOKENS}
-                  max={MAX_MAX_TOKENS}
+                  max={maxTokensUpperBound(cfg.model)}
                   step={1}
                   placeholder={String(modelMaxTokensDefault(cfg.model))}
                   value={maxTokensInput}

--- a/apps/web/src/state/maxTokens.ts
+++ b/apps/web/src/state/maxTokens.ts
@@ -16,6 +16,11 @@ export const FALLBACK_MAX_TOKENS = 8192;
 // for both the UI input attributes and runtime validation in
 // `effectiveMaxTokens`, so a stale or hand-edited localStorage value
 // can't sneak past the UI's promise.
+//
+// MAX_MAX_TOKENS is the floor of that ceiling, not the ceiling itself: a few
+// models ship a default above it, and a bound that rejected their own default
+// left it usable but not re-enterable once the field had been edited (#8048).
+// `maxTokensUpperBound` is what both call sites must use.
 export const MIN_MAX_TOKENS = 1024;
 export const MAX_MAX_TOKENS = 200000;
 
@@ -84,12 +89,18 @@ export function modelMaxTokensDefault(model: string): number {
   return OVERRIDES[model] ?? LITELLM_MODELS[model] ?? FALLBACK_MAX_TOKENS;
 }
 
-function isValidOverride(value: number | undefined): value is number {
+// The highest override this model accepts: never below MAX_MAX_TOKENS, and
+// raised to the model's own default when that default is higher.
+export function maxTokensUpperBound(model: string): number {
+  return Math.max(MAX_MAX_TOKENS, modelMaxTokensDefault(model));
+}
+
+function isValidOverride(value: number | undefined, model: string): value is number {
   return (
     typeof value === 'number' &&
     Number.isInteger(value) &&
     value >= MIN_MAX_TOKENS &&
-    value <= MAX_MAX_TOKENS
+    value <= maxTokensUpperBound(model)
   );
 }
 
@@ -97,6 +108,6 @@ export function effectiveMaxTokens(cfg: Pick<AppConfig, 'maxTokens' | 'model'>):
   // Out-of-range or non-integer overrides (stale localStorage, hand-edited
   // config, future schema drift) fall back to the model default rather
   // than silently shipping an invalid `max_tokens` upstream.
-  if (isValidOverride(cfg.maxTokens)) return cfg.maxTokens;
+  if (isValidOverride(cfg.maxTokens, cfg.model)) return cfg.maxTokens;
   return modelMaxTokensDefault(cfg.model);
 }

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -887,6 +887,34 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     });
   });
 
+  it('lets a model whose default exceeds the cap re-enter that default', async () => {
+    // deepseek-v4-pro ships 384000, above MAX_MAX_TOKENS. With a fixed bound the
+    // field advertised that number as its placeholder but refused it as input,
+    // so an edit could not be undone through the control. See issue #8048.
+    const { onPersist } = renderSettingsDialog({ apiKey: 'sk-ant-test', model: 'deepseek-v4-pro' });
+
+    const maxTokensInput = screen.getByRole('spinbutton', { name: /Max tokens/ }) as HTMLInputElement;
+    expect(maxTokensInput.max).toBe('384000');
+
+    fireEvent.change(maxTokensInput, { target: { value: '64000' } });
+    await waitFor(() => {
+      const latestConfig = onPersist.mock.calls.at(-1)?.[0] as AppConfig | undefined;
+      expect(latestConfig?.maxTokens).toBe(64000);
+    });
+
+    fireEvent.change(maxTokensInput, { target: { value: '384000' } });
+    await waitFor(() => {
+      const latestConfig = onPersist.mock.calls.at(-1)?.[0] as AppConfig | undefined;
+      expect(latestConfig?.maxTokens).toBe(384000);
+    });
+
+    fireEvent.change(maxTokensInput, { target: { value: '384001' } });
+    await waitFor(() => {
+      const latestConfig = onPersist.mock.calls.at(-1)?.[0] as AppConfig | undefined;
+      expect(latestConfig?.maxTokens).toBeUndefined();
+    });
+  });
+
   it('lets Anthropic and Google users customize the default base URL', () => {
     renderSettingsDialog();
 

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -915,6 +915,32 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     });
   });
 
+  it('drops an override the newly selected model cannot accept', async () => {
+    // The model-aware bound means an override valid for one model can exceed
+    // the next model's ceiling. Without re-validating on model change the field
+    // would keep showing a number that `effectiveMaxTokens` silently discards,
+    // so Settings would claim one value while requests used another.
+    const { onPersist } = renderSettingsDialog({ apiKey: 'sk-ant-test', model: 'deepseek-v4-pro' });
+
+    const maxTokensInput = screen.getByRole('spinbutton', { name: /Max tokens/ }) as HTMLInputElement;
+    fireEvent.change(maxTokensInput, { target: { value: '300000' } });
+    await waitFor(() => {
+      const latestConfig = onPersist.mock.calls.at(-1)?.[0] as AppConfig | undefined;
+      expect(latestConfig?.maxTokens).toBe(300000);
+    });
+
+    fireEvent.click(screen.getByRole('combobox', { name: 'Model' }));
+    const modelPopover = screen.getByTestId('settings-byok-model-popover');
+    fireEvent.click(within(modelPopover).getByRole('option', { name: 'claude-sonnet-4-5' }));
+
+    await waitFor(() => {
+      const latestConfig = onPersist.mock.calls.at(-1)?.[0] as AppConfig | undefined;
+      expect(latestConfig?.model).toBe('claude-sonnet-4-5');
+      expect(latestConfig?.maxTokens).toBeUndefined();
+    });
+    expect(maxTokensInput.value).toBe('');
+  });
+
   it('lets Anthropic and Google users customize the default base URL', () => {
     renderSettingsDialog();
 

--- a/apps/web/tests/state/maxTokens.test.ts
+++ b/apps/web/tests/state/maxTokens.test.ts
@@ -94,3 +94,38 @@ describe('effectiveMaxTokens override validation', () => {
     expect(effectiveMaxTokens({ maxTokens: MAX_MAX_TOKENS, model: 'claude-sonnet-4-5' })).toBe(MAX_MAX_TOKENS);
   });
 });
+
+describe('effectiveMaxTokens for defaults above MAX_MAX_TOKENS', () => {
+  // Three shipped defaults exceed MAX_MAX_TOKENS, so the fixed upper bound made
+  // them usable but not re-enterable: once a user edited the field they could
+  // not type the value back. See issue #8048.
+  //
+  // `probe` sits above MAX_MAX_TOKENS but below the model's own default, which
+  // is the only range where accepting and rejecting an override give different
+  // answers — at the default itself the rejection path returns the same number.
+  const ABOVE_CAP: ReadonlyArray<[string, number, number]> = [
+    ['deepseek-v4-pro', 384000, 300000],
+    ['deepseek-v4-flash', 384000, 300000],
+    ['qwen3-coder:480b', 262144, 250000],
+  ];
+
+  it.each(ABOVE_CAP)('accepts an override above the cap but within %s\'s default', (model, _shipped, probe) => {
+    expect(effectiveMaxTokens({ maxTokens: probe, model })).toBe(probe);
+  });
+
+  it.each(ABOVE_CAP)('accepts %s re-entering its shipped default of %i', (model, shipped) => {
+    expect(effectiveMaxTokens({ maxTokens: shipped, model })).toBe(shipped);
+  });
+
+  it.each(ABOVE_CAP)('still rejects an override above %s\'s own default', (model, shipped) => {
+    expect(effectiveMaxTokens({ maxTokens: shipped + 1, model })).toBe(shipped);
+  });
+
+  it.each(ABOVE_CAP)('restores the default for %s when the override is cleared', (model, shipped) => {
+    expect(effectiveMaxTokens({ model })).toBe(shipped);
+  });
+
+  it.each(ABOVE_CAP)('accepts an in-range edit for %s', (model) => {
+    expect(effectiveMaxTokens({ maxTokens: 50_000, model })).toBe(50_000);
+  });
+});


### PR DESCRIPTION
Fixes #8048

## Why

I hit this while looking at how Ollama Cloud models get their `max_tokens` default, in the course of #7995. Three entries in `OVERRIDES` ship a default above `MAX_MAX_TOKENS`: `deepseek-v4-pro` and `deepseek-v4-flash` at `384000`, and `qwen3-coder:480b` at `262144`.

Because the accepted range was a pair of fixed constants, those defaults could be used but not expressed. The Settings field shows the number as its placeholder and sends it on every request, yet rejects it as input. So the door only closes: edit Max tokens once on one of those models and there is no way back to the shipped value through the control that displays it. Clearing the field does restore it, but nothing about a number input suggests that emptying it is how you recover a value.

I use `deepseek-v4-pro` daily, which is how I noticed.

## What users will see

On a model whose shipped default is above `200000`, the Max tokens field now accepts values up to that model's own default instead of stopping at `200000`. Everything else is unchanged: the floor stays `1024`, models whose default is at or below `200000` keep exactly the range they had, and clearing the field still falls back to the default.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency**
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

Checked the last box conservatively rather than because it fits well: no default *value* changes, and users on the other models see nothing. What changes without opting in is the accepted input range, and only for the three models above, and only ever wider.

## Screenshots

None — the visible change is the `max` attribute on an existing number input, which renders identically. The observable difference is that typing `384000` on `deepseek-v4-pro` now persists instead of being discarded.

## Bug fix verification

- Test paths that reproduce the bug:
  - `apps/web/tests/state/maxTokens.test.ts` — `effectiveMaxTokens for defaults above MAX_MAX_TOKENS`
  - `apps/web/tests/components/SettingsDialog.execution.test.tsx` — `lets a model whose default exceeds the cap re-enter that default`
- Did the tests go red on `main` and green on this branch? **Yes.** Red first, with `AssertionError: expected 384000 to be 300000` in state and `expected '200000' to be '384000'` on the input attribute; green after the source change.

One note on how the state test is written, since it is easy to "simplify" into something that cannot fail. Asserting that the shipped default is accepted passes on `main` too, because a rejected override falls back to `modelMaxTokensDefault`, which returns that same number — both paths produce `384000`. The probe therefore sits strictly between `MAX_MAX_TOKENS` and the model default (`300000` for the DeepSeek pair, `250000` for `qwen3-coder:480b`), which is the only range where accepting and rejecting differ. There is a comment saying so next to the fixture.

Coverage follows the shape asked for in #8048 — editing, clearing, and re-entering — for each of the three affected defaults.

## Validation

- `pnpm guard` — pass
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm --filter @open-design/web test` — 1119 files, 11524 passed, 1 expected fail, 11 skipped
