### PR TITLE
fix(web): make max-tokens upper bound model-aware

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -108,8 +108,8 @@ export {
   providerModelsCacheKey,
 } from './providerModelsCache';
 import {
-  MAX_MAX_TOKENS,
   MIN_MAX_TOKENS,
+  maxTokensUpperBound,
   modelMaxTokensDefault,
 } from '../state/maxTokens';
 import type {
@@ -2329,13 +2329,16 @@ export function SettingsDialog({
       return;
     }
     const value = Number(trimmed);
-    const nextMaxTokens =
-      Number.isInteger(value) &&
-      value >= MIN_MAX_TOKENS &&
-      value <= MAX_MAX_TOKENS
-        ? value
-        : undefined;
-    setCfg((c) => ({ ...c, maxTokens: nextMaxTokens }));
+    // The upper bound is model-aware, so read the model from current state
+    // rather than a closure: the same rule has to hold for whichever model is
+    // selected when the edit lands.
+    setCfg((c) => ({
+      ...c,
+      maxTokens:
+        Number.isInteger(value) && value >= MIN_MAX_TOKENS && value <= maxTokensUpperBound(c.model)
+          ? value
+          : undefined,
+    }));
   };
   const markAgentInstallIntent = () => {
     pendingAgentInstallRescanRef.current = true;
@@ -5659,7 +5662,7 @@ export function SettingsDialog({
                 <input
                   type="number"
                   min={MIN_MAX_TOKENS}
-                  max={MAX_MAX_TOKENS}
+                  max={maxTokensUpperBound(cfg.model)}
                   step={1}
                   placeholder={String(modelMaxTokensDefault(cfg.model))}
                   value={maxTokensInput}

--- a/apps/web/src/state/maxTokens.ts
+++ b/apps/web/src/state/maxTokens.ts
@@ -16,6 +16,11 @@ export const FALLBACK_MAX_TOKENS = 8192;
 // for both the UI input attributes and runtime validation in
 // `effectiveMaxTokens`, so a stale or hand-edited localStorage value
 // can't sneak past the UI's promise.
+//
+// MAX_MAX_TOKENS is the floor of that ceiling, not the ceiling itself: a few
+// models ship a default above it, and a bound that rejected their own default
+// left it usable but not re-enterable once the field had been edited (#8048).
+// `maxTokensUpperBound` is what both call sites must use.
 export const MIN_MAX_TOKENS = 1024;
 export const MAX_MAX_TOKENS = 200000;
 
@@ -84,12 +89,18 @@ export function modelMaxTokensDefault(model: string): number {
   return OVERRIDES[model] ?? LITELLM_MODELS[model] ?? FALLBACK_MAX_TOKENS;
 }
 
-function isValidOverride(value: number | undefined): value is number {
+// The highest override this model accepts: never below MAX_MAX_TOKENS, and
+// raised to the model's own default when that default is higher.
+export function maxTokensUpperBound(model: string): number {
+  return Math.max(MAX_MAX_TOKENS, modelMaxTokensDefault(model));
+}
+
+function isValidOverride(value: number | undefined, model: string): value is number {
   return (
     typeof value === 'number' &&
     Number.isInteger(value) &&
     value >= MIN_MAX_TOKENS &&
-    value <= MAX_MAX_TOKENS
+    value <= maxTokensUpperBound(model)
   );
 }
 
@@ -97,6 +108,6 @@ export function effectiveMaxTokens(cfg: Pick<AppConfig, 'maxTokens' | 'model'>):
   // Out-of-range or non-integer overrides (stale localStorage, hand-edited
   // config, future schema drift) fall back to the model default rather
   // than silently shipping an invalid `max_tokens` upstream.
-  if (isValidOverride(cfg.maxTokens)) return cfg.maxTokens;
+  if (isValidOverride(cfg.maxTokens, cfg.model)) return cfg.maxTokens;
   return modelMaxTokensDefault(cfg.model);
 }

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -887,6 +887,34 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     });
   });
 
+  it('lets a model whose default exceeds the cap re-enter that default', async () => {
+    // deepseek-v4-pro ships 384000, above MAX_MAX_TOKENS. With a fixed bound the
+    // field advertised that number as its placeholder but refused it as input,
+    // so an edit could not be undone through the control. See issue #8048.
+    const { onPersist } = renderSettingsDialog({ apiKey: 'sk-ant-test', model: 'deepseek-v4-pro' });
+
+    const maxTokensInput = screen.getByRole('spinbutton', { name: /Max tokens/ }) as HTMLInputElement;
+    expect(maxTokensInput.max).toBe('384000');
+
+    fireEvent.change(maxTokensInput, { target: { value: '64000' } });
+    await waitFor(() => {
+      const latestConfig = onPersist.mock.calls.at(-1)?.[0] as AppConfig | undefined;
+      expect(latestConfig?.maxTokens).toBe(64000);
+    });
+
+    fireEvent.change(maxTokensInput, { target: { value: '384000' } });
+    await waitFor(() => {
+      const latestConfig = onPersist.mock.calls.at(-1)?.[0] as AppConfig | undefined;
+      expect(latestConfig?.maxTokens).toBe(384000);
+    });
+
+    fireEvent.change(maxTokensInput, { target: { value: '384001' } });
+    await waitFor(() => {
+      const latestConfig = onPersist.mock.calls.at(-1)?.[0] as AppConfig | undefined;
+      expect(latestConfig?.maxTokens).toBeUndefined();
+    });
+  });
+
   it('lets Anthropic and Google users customize the default base URL', () => {
     renderSettingsDialog();
 

--- a/apps/web/tests/state/maxTokens.test.ts
+++ b/apps/web/tests/state/maxTokens.test.ts
@@ -94,3 +94,38 @@ describe('effectiveMaxTokens override validation', () => {
     expect(effectiveMaxTokens({ maxTokens: MAX_MAX_TOKENS, model: 'claude-sonnet-4-5' })).toBe(MAX_MAX_TOKENS);
   });
 });
+
+describe('effectiveMaxTokens for defaults above MAX_MAX_TOKENS', () => {
+  // Three shipped defaults exceed MAX_MAX_TOKENS, so the fixed upper bound made
+  // them usable but not re-enterable: once a user edited the field they could
+  // not type the value back. See issue #8048.
+  //
+  // `probe` sits above MAX_MAX_TOKENS but below the model's own default, which
+  // is the only range where accepting and rejecting an override give different
+  // answers — at the default itself the rejection path returns the same number.
+  const ABOVE_CAP: ReadonlyArray<[string, number, number]> = [
+    ['deepseek-v4-pro', 384000, 300000],
+    ['deepseek-v4-flash', 384000, 300000],
+    ['qwen3-coder:480b', 262144, 250000],
+  ];
+
+  it.each(ABOVE_CAP)('accepts an override above the cap but within %s\'s default', (model, _shipped, probe) => {
+    expect(effectiveMaxTokens({ maxTokens: probe, model })).toBe(probe);
+  });
+
+  it.each(ABOVE_CAP)('accepts %s re-entering its shipped default of %i', (model, shipped) => {
+    expect(effectiveMaxTokens({ maxTokens: shipped, model })).toBe(shipped);
+  });
+
+  it.each(ABOVE_CAP)('still rejects an override above %s\'s own default', (model, shipped) => {
+    expect(effectiveMaxTokens({ maxTokens: shipped + 1, model })).toBe(shipped);
+  });
+
+  it.each(ABOVE_CAP)('restores the default for %s when the override is cleared', (model, shipped) => {
+    expect(effectiveMaxTokens({ model })).toBe(shipped);
+  });
+
+  it.each(ABOVE_CAP)('accepts an in-range edit for %s', (model) => {
+    expect(effectiveMaxTokens({ maxTokens: 50_000, model })).toBe(50_000);
+  });
+});


### PR DESCRIPTION
Fixes #8048

## Why

Three model defaults in `OVERRIDES` exceed `MAX_MAX_TOKENS` (200000): `deepseek-v4-pro` and `deepseek-v4-flash` at 384000, and `qwen3-coder:480b` at 262144. The Settings Max tokens field validates against the fixed 200000 ceiling, but `effectiveMaxTokens` falls back to the higher model default when no override is set. That means the placeholder shows a value the field cannot accept — once a user edits Max tokens on one of these models, they cannot re-enter the shipped default through the control.

## What users will see

On models whose shipped default is above 200000, the Max tokens field now accepts values up to that model's own default. The floor stays 1024; models whose default is at or below 200000 keep the same range. Clearing the field still falls back to the model default.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency**
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

None — the visible change is the `max` attribute on an existing number input. The observable difference is that typing `384000` on `deepseek-v4-pro` now persists instead of being discarded.

## Bug fix verification

- Test paths that reproduce the bug:
  - `apps/web/tests/state/maxTokens.test.ts` — `effectiveMaxTokens for defaults above MAX_MAX_TOKENS`
  - `apps/web/tests/components/SettingsDialog.execution.test.tsx` — `lets a model whose default exceeds the cap re-enter that default`
- Did the tests go red on `main` and green on this branch? Yes. The state test uses probe values strictly between `MAX_MAX_TOKENS` and each model's shipped default (the only range where accepting vs rejecting differs).

## Validation

- `pnpm --filter @open-design/web test tests/state/maxTokens.test.ts` — 29 passed
- `pnpm --filter @open-design/web test tests/components/SettingsDialog.execution.test.tsx` — targeted new and existing max-tokens tests passed