### PR TITLE
perf(packaged): skip retire-existing-sidecar lifecycle on a proven-clean boot (win32)

### DIFF
--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -597,16 +597,17 @@ export async function retireExistingSidecar(
   } = {},
 ): Promise<void> {
   const answered = await probeSidecarEndpointAnswered(stamp, deps);
-  if (answered !== true) {
+  if (answered === false) {
     const findProcesses = deps.findSidecarProcesses ?? findSidecarProcesses;
     const prior = await findProcesses(stamp).catch(() => null);
     if (prior != null && prior.length === 0) {
-      // Nothing is listening on the private endpoint and the precise process
-      // scan finds no stamped generation: the full retire flow could only
-      // return alreadyStopped, so skip it and its repeated enumerations.
-      // Skipping is safe for the child about to spawn: the IPC server unlinks
-      // a stale endpoint before binding (createJsonIpcServer/prepareIpcPath),
-      // so no leftover state can break the new bind.
+      // Confirmed dead endpoint (transport-level ENOENT/ECONNREFUSED) and the
+      // precise process scan finds no stamped generation: the full retire flow
+      // could only return alreadyStopped, so skip it and its repeated
+      // enumerations. Skipping is safe for the child about to spawn: the IPC
+      // server unlinks a stale endpoint before binding
+      // (createJsonIpcServer/prepareIpcPath), so no leftover state can break
+      // the new bind.
       await appendSidecarLifecycleLog(
         logPath,
         `[open-design packaged] no prior ${stamp.app} generation found; skipping retire`,

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -17,6 +17,7 @@ import {
   type WebStatusSnapshot,
 } from "@open-design/sidecar-proto";
 import {
+  findSidecarProcesses,
   getSidecarStatus,
   invokeSidecar,
   spawnSidecar,
@@ -265,6 +266,11 @@ const DAEMON_MIGRATION_STATUS_TIMEOUT_MS = 30 * 60 * 1000;
 // cold start.
 const STATUS_POLL_INITIAL_MS = 150;
 const STATUS_POLL_MAX_MS = 1500;
+
+// Liveness probe budget for retireExistingSidecar's fast path: only needs to
+// cover one connect+status round trip against a live endpoint. A dead endpoint
+// rejects at connect time (~2ms), so this ceiling only bites for a hung pipe.
+const RETIRE_PROBE_TIMEOUT_MS = 400;
 
 // Baseline status wait budget by platform, before the daemon-only legacy
 // migration override. win32 gets the wider AV-scan headroom, linux gets the
@@ -543,13 +549,71 @@ export async function waitForStatus<T>(
   }
 }
 
+/**
+ * Probe whether a prior generation is listening on the stamp's private IPC
+ * endpoint. Resolves `true` only when the endpoint demonstrably answered, `false`
+ * when it demonstrably did not (transport-level ENOENT / ECONNREFUSED), and
+ * `null` when the probe was inconclusive (timeout, application error while the
+ * runtime is still starting, or any unexpected transport failure).
+ *
+ * The classification is transport-faithful: `requestJsonIpc` surfaces OS
+ * connect failures as the raw socket error (with a `code`, e.g. ENOENT for a
+ * Windows named pipe that does not exist), while an endpoint whose server
+ * accepted the connection rejects with a reconstructed `Error` carrying no
+ * `code` — e.g. "sidecar runtime is starting" from the pre-ready gate. Only
+ * that answered shape counts as alive so a booting prior generation is still
+ * retired through the full flow rather than raced.
+ */
+async function probeSidecarEndpointAnswered(
+  stamp: SidecarStamp,
+  deps: { getSidecarStatus?: typeof getSidecarStatus } = {},
+): Promise<boolean | null> {
+  const getStatus = deps.getSidecarStatus ?? getSidecarStatus;
+  try {
+    await getStatus(stamp, { timeoutMs: RETIRE_PROBE_TIMEOUT_MS });
+    return true;
+  } catch (error) {
+    const code = (error as { code?: unknown } | null)?.code;
+    if (code === "ENOENT" || code === "ECONNREFUSED") return false;
+    return null;
+  }
+}
+
+/**
+ * Windows process enumeration (powershell Get-CimInstance) costs ~2.2-2.6s per
+ * invocation, and the retire atomic inside `stopSidecar` runs it two to three
+ * times per spawn — measured 5.7-6.1s per sidecar spawn even when no prior
+ * generation exists, where the flow's only possible outcome is alreadyStopped.
+ * Probe the cheap signals first and only enter the full flow when something is
+ * actually there to retire (see #8056).
+ */
 export async function retireExistingSidecar(
   stamp: SidecarStamp,
   logPath: string,
   deps: {
     stop?: typeof stopSidecar;
+    findSidecarProcesses?: typeof findSidecarProcesses;
+    getSidecarStatus?: typeof getSidecarStatus;
   } = {},
 ): Promise<void> {
+  const answered = await probeSidecarEndpointAnswered(stamp, deps);
+  if (answered !== true) {
+    const findProcesses = deps.findSidecarProcesses ?? findSidecarProcesses;
+    const prior = await findProcesses(stamp).catch(() => null);
+    if (prior != null && prior.length === 0) {
+      // Nothing is listening on the private endpoint and the precise process
+      // scan finds no stamped generation: the full retire flow could only
+      // return alreadyStopped, so skip it and its repeated enumerations.
+      // Skipping is safe for the child about to spawn: the IPC server unlinks
+      // a stale endpoint before binding (createJsonIpcServer/prepareIpcPath),
+      // so no leftover state can break the new bind.
+      await appendSidecarLifecycleLog(
+        logPath,
+        `[open-design packaged] no prior ${stamp.app} generation found; skipping retire`,
+      );
+      return;
+    }
+  }
   await appendSidecarLifecycleLog(
     logPath,
     `[open-design packaged] retiring prior ${stamp.app} generation before launch`,

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -216,11 +216,33 @@ describe('packaged stale sidecar retirement', () => {
     }
   }
 
+  // Probes that force the pre-#8056 behavior: endpoint inconclusive and the
+  // precise scan sees a live stamped generation, so the full retire flow runs.
+  const liveGenerationProbes = () => ({
+    findSidecarProcesses: vi.fn(async () => [{ command: 'daemon --od-stamp-app=daemon', pid: 4321, ppid: 1 }]),
+    getSidecarStatus: vi.fn(async () => {
+      throw new Error('sidecar runtime is starting');
+    }),
+  });
+
+  // Probes for the common clean-boot case: nothing listens on the private
+  // endpoint (transport-level ENOENT) and the precise scan finds no stamped
+  // process, so retire can be skipped without entering the lifecycle atomic.
+  const noPriorGenerationProbes = () => ({
+    findSidecarProcesses: vi.fn(async () => []),
+    getSidecarStatus: vi.fn(async () => {
+      const error = new Error('connect ENOENT');
+      (error as NodeJS.ErrnoException).code = 'ENOENT';
+      throw error;
+    }),
+  });
+
   it('delegates a clean first boot to the sidecar lifecycle atomic', async () => {
     await withLog(async (logPath) => {
       const stop = vi.fn(async () => ({ ...stopped({ matchedPids: [] }), alreadyStopped: true }));
       await expect(retireExistingSidecar(testStamp(), logPath, {
         stop,
+        ...liveGenerationProbes(),
       })).resolves.toBeUndefined();
       expect(stop).toHaveBeenCalledOnce();
     });
@@ -231,6 +253,7 @@ describe('packaged stale sidecar retirement', () => {
       const stop = vi.fn(async () => stopped());
       await expect(retireExistingSidecar(testStamp(), logPath, {
         stop,
+        ...liveGenerationProbes(),
       })).resolves.toBeUndefined();
       expect(stop).toHaveBeenCalledOnce();
     });
@@ -241,6 +264,7 @@ describe('packaged stale sidecar retirement', () => {
       const stop = vi.fn(async () => stopped());
       await expect(retireExistingSidecar(testStamp(APP_KEYS.WEB), logPath, {
         stop,
+        ...liveGenerationProbes(),
       })).resolves.toBeUndefined();
       expect(stop).toHaveBeenCalledOnce();
     });
@@ -250,6 +274,7 @@ describe('packaged stale sidecar retirement', () => {
     await withLog(async (logPath) => {
       await expect(retireExistingSidecar(testStamp(APP_KEYS.WEB), logPath, {
         stop: async () => stopped({ matchedPids: [], staleEndpointRemoved: true }),
+        ...liveGenerationProbes(),
       })).resolves.toBeUndefined();
     });
   });
@@ -258,7 +283,128 @@ describe('packaged stale sidecar retirement', () => {
     await withLog(async (logPath) => {
       await expect(retireExistingSidecar(testStamp(APP_KEYS.WEB), logPath, {
         stop: async () => stopped({ remainingPids: [4321] }),
+        ...liveGenerationProbes(),
       })).rejects.toThrow('generation remains: 4321');
+    });
+  });
+
+  it('skips the lifecycle atomic on a clean boot when no prior generation exists', async () => {
+    await withLog(async (logPath) => {
+      const stop = vi.fn(async () => stopped());
+      const probes = noPriorGenerationProbes();
+      await expect(retireExistingSidecar(testStamp(), logPath, {
+        stop,
+        ...probes,
+      })).resolves.toBeUndefined();
+      expect(stop).not.toHaveBeenCalled();
+      expect(probes.findSidecarProcesses).toHaveBeenCalledOnce();
+      expect(probes.getSidecarStatus).toHaveBeenCalledWith(
+        testStamp(),
+        { timeoutMs: 400 },
+      );
+    });
+  });
+
+  it('records the skip in the sidecar lifecycle log', async () => {
+    await withLog(async (logPath) => {
+      await retireExistingSidecar(testStamp(APP_KEYS.WEB), logPath, {
+        stop: vi.fn(),
+        ...noPriorGenerationProbes(),
+      });
+      const log = readFileSync(logPath, 'utf8');
+      expect(log).toContain('no prior web generation found; skipping retire');
+      expect(log).not.toContain('retiring prior web generation');
+    });
+  });
+
+  it('retires through the full flow when the endpoint answers but the scan disagrees', async () => {
+    await withLog(async (logPath) => {
+      const stop = vi.fn(async () => stopped());
+      const getSidecarStatus = vi.fn(async () => ({ state: 'running' }) as unknown as Record<string, unknown>);
+      await expect(retireExistingSidecar(testStamp(), logPath, {
+        stop,
+        getSidecarStatus: getSidecarStatus as unknown as typeof import('@open-design/sidecar').getSidecarStatus,
+        findSidecarProcesses: vi.fn(async () => []),
+      })).resolves.toBeUndefined();
+      expect(stop).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('retires through the full flow when the endpoint is dead but a stamped process lingers', async () => {
+    await withLog(async (logPath) => {
+      const stop = vi.fn(async () => stopped());
+      await expect(retireExistingSidecar(testStamp(), logPath, {
+        stop,
+        getSidecarStatus: vi.fn(async () => {
+          const error = new Error('connect ECONNREFUSED');
+          (error as NodeJS.ErrnoException).code = 'ECONNREFUSED';
+          throw error;
+        }),
+        findSidecarProcesses: vi.fn(async () => [
+          { command: 'daemon --od-stamp-app=daemon', pid: 4321, ppid: 1 },
+        ]),
+      })).resolves.toBeUndefined();
+      expect(stop).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('falls back to the full flow when both probes fail to answer', async () => {
+    await withLog(async (logPath) => {
+      const stop = vi.fn(async () => stopped());
+      await expect(retireExistingSidecar(testStamp(), logPath, {
+        stop,
+        getSidecarStatus: vi.fn(async () => {
+          throw new Error('IPC request timed out');
+        }),
+        findSidecarProcesses: vi.fn(async () => {
+          throw new Error('enumeration failed');
+        }),
+      })).resolves.toBeUndefined();
+      expect(stop).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('fails closed into the full flow when process enumeration errors, never skipping retire', async () => {
+    // If findSidecarProcesses cannot answer, "no prior generation" must NOT be
+    // the conclusion: the fast path falls through to stopSidecar, preserving
+    // the pre-#8056 fail-closed behavior for an enumeration outage.
+    await withLog(async (logPath) => {
+      const stop = vi.fn(async () => stopped());
+      await expect(retireExistingSidecar(testStamp(), logPath, {
+        stop,
+        getSidecarStatus: vi.fn(async () => {
+          const error = new Error('connect ENOENT');
+          (error as NodeJS.ErrnoException).code = 'ENOENT';
+          throw error;
+        }),
+        findSidecarProcesses: vi.fn(async () => {
+          throw new Error('Get-CimInstance failed');
+        }),
+      })).resolves.toBeUndefined();
+      expect(stop).toHaveBeenCalledOnce();
+      const log = readFileSync(logPath, 'utf8');
+      expect(log).toContain('retiring prior daemon generation');
+      expect(log).not.toContain('skipping retire');
+    });
+  });
+
+  it('lets the next child launch when only a stale endpoint remains and nothing is running', async () => {
+    // A stale endpoint (dead socket/pipe no process owns) with no stamped
+    // process behind it must not block the launch: the skip path runs, and
+    // createJsonIpcServer's bind-time cleanup (prepareIpcPath) removes the
+    // stale endpoint before the new child binds.
+    await withLog(async (logPath) => {
+      const stop = vi.fn(async () => stopped());
+      await expect(retireExistingSidecar(testStamp(APP_KEYS.WEB), logPath, {
+        stop,
+        getSidecarStatus: vi.fn(async () => {
+          const error = new Error('connect ECONNREFUSED');
+          (error as NodeJS.ErrnoException).code = 'ECONNREFUSED';
+          throw error;
+        }),
+        findSidecarProcesses: vi.fn(async () => []),
+      })).resolves.toBeUndefined();
+      expect(stop).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -364,6 +364,28 @@ describe('packaged stale sidecar retirement', () => {
     });
   });
 
+  it('retires through the full flow when the endpoint probe is inconclusive, even with an empty scan', async () => {
+    // answered === null (application-level error, no transport code) means the
+    // endpoint may be live but still starting: only a confirmed
+    // ENOENT/ECONNREFUSED probe may proceed to the scan-and-skip branch, so an
+    // inconclusive status request must fall through to stopSidecar even when
+    // the one snapshot this run takes sees nothing.
+    await withLog(async (logPath) => {
+      const stop = vi.fn(async () => stopped());
+      await expect(retireExistingSidecar(testStamp(), logPath, {
+        stop,
+        getSidecarStatus: vi.fn(async () => {
+          throw new Error('sidecar runtime is starting');
+        }),
+        findSidecarProcesses: vi.fn(async () => []),
+      })).resolves.toBeUndefined();
+      expect(stop).toHaveBeenCalledOnce();
+      const log = readFileSync(logPath, 'utf8');
+      expect(log).toContain('retiring prior daemon generation');
+      expect(log).not.toContain('skipping retire');
+    });
+  });
+
   it('fails closed into the full flow when process enumeration errors, never skipping retire', async () => {
     // If findSidecarProcesses cannot answer, "no prior generation" must NOT be
     // the conclusion: the fast path falls through to stopSidecar, preserving


### PR DESCRIPTION
## What

Fast-path `retireExistingSidecar` so a clean boot (no prior sidecar generation running) does not enter the full retire lifecycle before spawning each sidecar. First slice of #8056, as scoped in the review discussion there.

## Why

Every packaged sidecar spawn first "retires" a prior generation via `stopSidecar`, whose observe → retire → verify chain enumerates processes **2–3 times per spawn**. On win32 each enumeration shells out to `powershell Get-CimInstance Win32_Process` — measured **2.2–2.6s per call** on two machines' worth of runs — so a clean boot, where the flow's only possible outcome is `alreadyStopped`, burns **5.7–6.1s per sidecar (~11s total)** before either child process even spawns. The isolation measurements (also in #8056):

| Operation | Cost |
|---|---|
| `Get-CimInstance Win32_Process` full scan (`packages/platform/src/process.ts`) | 2.2–2.6s |
| Connect to nonexistent `\.\pipe\…` (fails) | ~2ms |
| POSIX `ps` enumeration | ~30ms (unaffected) |

## What users will see

Packaged launches on Windows reach an interactive app noticeably sooner on a clean boot (~8s instead of ~16–24s for the 0.22.2 payload in the measured configurations); no settings, dialogs, or flows change. When a prior generation is genuinely running, the existing full stop lifecycle still runs exactly as before, so "relaunch cleanly replaces the old generation" behavior is unchanged — the fast path only applies when it is proven nothing is there.

## How

Probe in escalating cost order, fail-closed at every step:

1. **One `getSidecarStatus` request** against the stamp's private IPC endpoint (~2ms when nothing listens). The transport already classifies outcomes: OS connect errors (`ENOENT` on win32 named pipes, `ECONNREFUSED` on unix sockets) mean nothing is bound; an application-level error (e.g. "sidecar runtime is starting") or a successful response means the endpoint **answered** and a live generation is behind it.
2. **Only when the probe demonstrably failed at the transport level** (`answered === false`: confirmed `ENOENT`/`ECONNREFUSED`), one `findSidecarProcesses` scan. If it returns empty, log `no prior … generation found; skipping retire` and return without entering the lifecycle atomic.

Anything else — endpoint answered, probe inconclusive (`answered === null`: timeout, pre-ready application error, unexpected transport failure), scan inconclusive, **or enumeration errored** — falls through to the existing full retire flow unchanged. So:

- a **live private endpoint** still enters the full stop path;
- an **inconclusive probe** (endpoint may be live but still starting) never reaches the scan-and-skip branch — it goes straight to the full stop path, even when the one scan this run takes sees nothing;
- a **dead endpoint with no stamped process** skips, and the next child still launches (a stale endpoint cannot block it: `createJsonIpcServer`'s `prepareIpcPath` unlinks stale endpoints at bind time);
- an **enumeration failure fails closed** into the full flow — it is never interpreted as "no prior generation".

The probe/scan pair is injectable through the existing `deps` seam, mirroring how `stop` is already injected, so the tests pin each outcome directly.

## Surface area

- [x] **None** — internal packaged startup lifecycle (retire-before-spawn fast path) and its tests only; no UI, settings, IPC surface, or data-layout changes.

## Tests

Extended the existing `packaged stale sidecar retirement` block rather than adding a new suite; the five pre-existing cases now inject probes that force the pre-#8056 behavior (endpoint answered / scan sees a generation → full flow), keeping their assertions intact. New cases:

- clean boot skips the lifecycle atomic (stop never called; probe called with the 400ms budget)
- the skip is recorded in the lifecycle log and the "retiring prior …" line is absent
- live endpoint → full stop even when the scan disagrees
- dead endpoint + lingering stamped process → full stop
- both probes fail → full stop (fail-closed)
- **enumeration error → full stop, never skip** (fail-closed, per review request)
- **inconclusive endpoint probe (application-level error) + empty scan → full stop, never skip** (fail-closed, per review: only `answered === false` may reach the scan-and-skip branch)
- **stale endpoint, nothing running → launch proceeds** (stop never called)

`vitest run tests/sidecars.test.ts`: **68 passed** (55 pre-existing + 13 in this block). `tsc -p tsconfig.json --noEmit` and `tsc -p tsconfig.tests.json --noEmit` are clean for both changed files.

## Validation

- `apps/packaged`: `pnpm exec vitest run tests/sidecars.test.ts` → **68 passed (0 failed)**, including the new inconclusive-probe regression case asserting `stop` is still called when `getSidecarStatus` rejects with an application `Error` and `findSidecarProcesses` returns `[]`.
- `apps/packaged`: `tsc -p tsconfig.json --noEmit` and `tsc -p tsconfig.tests.json --noEmit` → both clean after building `@open-design/desktop` (the fresh-clone `@open-design/desktop/main` resolution error noted originally does not reproduce once desktop is built).
- Review changes pushed as `4c59227` on this branch.

## Scope

The parallel web-start, plugin digest fingerprint, splash floor, and `NODE_COMPILE_CACHE` items from #8056 are deliberately **not** in this PR — kept separate per the review discussion so the Windows regression surface here stays minimal. Measured effect of this slice alone on the 0.22.2 win32 payload: retire cost per spawn drops from 5.7–6.1s to a ~2ms probe + one scan, contributing the largest share of the ~16–24s → ~8s launch improvement.

Fixes the retire-existing-sidecar slice of #8056.
