### PR TITLE
fix(dsh-runtime): map 0.1.5 assistant stream and settlement events

### DIFF
--- a/packages/dsh-runtime/src/index.ts
+++ b/packages/dsh-runtime/src/index.ts
@@ -36,7 +36,7 @@ export const inject = [
   'sessionPersistence',
 ];
 
-const PLUGIN_VERSION = '0.1.0';
+const PLUGIN_VERSION = '0.1.1';
 
 type Output = { write(chunk: string): unknown };
 type ExitFallbackTimer = { unref(): unknown };
@@ -77,6 +77,118 @@ function contentText(content: readonly ContentBlock[]): string {
   };
   visit(content);
   return text.join('');
+}
+
+// Visible assistant text excludes reasoning so thinking never leaks into result.output.
+function assistantVisibleText(content: readonly ContentBlock[]): string {
+  const text: string[] = [];
+  const visit = (blocks: readonly ContentBlock[]) => {
+    for (const block of blocks) {
+      if (block.type === 'text') text.push(block.text);
+      if (block.type === 'tool-result') visit(block.content);
+    }
+  };
+  visit(content);
+  return text.join('');
+}
+
+type TextSource = 'stream' | 'legacy' | 'settlement';
+type ThinkingSource = 'stream' | 'legacy';
+type AssistantDelta = { type?: unknown; text?: unknown };
+
+type TurnOutput = {
+  assistantOutput: string;
+  textFromStream: boolean;
+  textFromLegacy: boolean;
+  textFromSettlement: boolean;
+  thinkingFromStream: boolean;
+  thinkingFromLegacy: boolean;
+};
+
+function createTurnOutput(): TurnOutput {
+  return {
+    assistantOutput: '',
+    textFromStream: false,
+    textFromLegacy: false,
+    textFromSettlement: false,
+    thinkingFromStream: false,
+    thinkingFromLegacy: false,
+  };
+}
+
+function asDelta(chunk: unknown): AssistantDelta {
+  return typeof chunk === 'object' && chunk !== null ? chunk as AssistantDelta : {};
+}
+
+function deltaText(chunk: AssistantDelta): string {
+  return typeof chunk.text === 'string' ? chunk.text : '';
+}
+
+function textTaken(turn: TurnOutput, source: TextSource): boolean {
+  if (source === 'stream') return turn.textFromLegacy || turn.textFromSettlement;
+  if (source === 'legacy') return turn.textFromStream || turn.textFromSettlement;
+  return turn.textFromStream || turn.textFromLegacy;
+}
+
+function markText(turn: TurnOutput, source: TextSource): void {
+  if (source === 'stream') turn.textFromStream = true;
+  else if (source === 'legacy') turn.textFromLegacy = true;
+  else turn.textFromSettlement = true;
+}
+
+function thinkingTaken(turn: TurnOutput, source: ThinkingSource): boolean {
+  return source === 'stream' ? turn.thinkingFromLegacy : turn.thinkingFromStream;
+}
+
+function markThinking(turn: TurnOutput, source: ThinkingSource): void {
+  if (source === 'stream') turn.thinkingFromStream = true;
+  else turn.thinkingFromLegacy = true;
+}
+
+function emitTextDelta(
+  output: Output,
+  request: ExecuteCommand,
+  turn: TurnOutput,
+  text: string,
+  source: TextSource,
+): void {
+  if (text === '' || textTaken(turn, source)) return;
+  writeFrame(output, { v: 1, type: 'text', request_id: request.request_id, content: text });
+  turn.assistantOutput += text;
+  markText(turn, source);
+}
+
+function emitThinkingDelta(
+  output: Output,
+  request: ExecuteCommand,
+  turn: TurnOutput,
+  text: string,
+  source: ThinkingSource,
+): void {
+  if (text === '' || thinkingTaken(turn, source)) return;
+  writeFrame(output, { v: 1, type: 'thinking', request_id: request.request_id, content: text });
+  markThinking(turn, source);
+}
+
+function emitAssistantChunk(
+  output: Output,
+  request: ExecuteCommand,
+  turn: TurnOutput,
+  chunk: unknown,
+  source: ThinkingSource,
+): void {
+  const delta = asDelta(chunk);
+  if (delta.type === 'text-delta') emitTextDelta(output, request, turn, deltaText(delta), source);
+  else if (delta.type === 'reasoning-delta') emitThinkingDelta(output, request, turn, deltaText(delta), source);
+}
+
+// 0.1.1 Events has session/event but not agent/assistant-stream. Subscribe by name.
+function onRuntimeEvent(
+  ctx: Context,
+  name: string,
+  listener: (...args: unknown[]) => void,
+): () => void {
+  return (ctx.on as unknown as (event: string, fn: (...args: unknown[]) => void) => () => void)(name, listener);
 }
 
 function resultStatus(reason: TurnEndReason | undefined): 'completed' | 'cancelled' | 'failed' {
@@ -211,17 +323,12 @@ function emitSessionEvent(
   provider: string,
   model: string,
   event: SessionEvent,
+  turn: TurnOutput,
 ): void {
   switch (event.type) {
-    case 'assistant/chunk': {
-      const chunk = event.data.chunk;
-      if (chunk.type === 'text-delta' && chunk.text !== '') {
-        writeFrame(output, { v: 1, type: 'text', request_id: request.request_id, content: chunk.text });
-      } else if (chunk.type === 'reasoning-delta' && chunk.text !== '') {
-        writeFrame(output, { v: 1, type: 'thinking', request_id: request.request_id, content: chunk.text });
-      }
+    case 'assistant/chunk':
+      emitAssistantChunk(output, request, turn, event.data.chunk, 'legacy');
       return;
-    }
     case 'tool/call':
       writeFrame(output, {
         v: 1,
@@ -243,12 +350,32 @@ function emitSessionEvent(
         is_error: event.data.message.content[0].isError === true,
       });
       return;
-    case 'assistant/message':
+    case 'assistant/message': {
       if (event.data.usage) writeFrame(output, usageFrame(request.request_id, provider, model, event.data.usage));
+      // Settlement fills text only when live/legacy chunks never arrived (0.1.5).
+      emitTextDelta(output, request, turn, assistantVisibleText(event.data.message.content), 'settlement');
       return;
+    }
     default:
       return;
   }
+}
+
+function emitAssistantStream(
+  output: Output,
+  request: ExecuteCommand,
+  sessionId: unknown,
+  turn: TurnOutput,
+  payload: unknown,
+): void {
+  const data = typeof payload === 'object' && payload !== null
+    ? payload as { agent?: { session?: { id?: unknown } }; frame?: { type?: unknown; chunk?: unknown } }
+    : {};
+  const payloadSessionId = data.agent?.session?.id;
+  // Fused 0.1.5 dispatch injects agent; a bare { frame } emit is still this turn.
+  if (payloadSessionId !== undefined && String(payloadSessionId) !== String(sessionId)) return;
+  if (data.frame?.type !== 'chunk') return;
+  emitAssistantChunk(output, request, turn, data.frame.chunk, 'stream');
 }
 
 async function execute(
@@ -269,19 +396,19 @@ async function execute(
   let handle: AgentHandle | undefined;
   let firstSeq = Number.POSITIVE_INFINITY;
   let turnEnd: SessionEvent<'turn/end'> | undefined;
-  let assistantOutput = '';
+  const turn = createTurnOutput();
   const setup = (agentCtx: Context) => {
     const selected: ModelSelectionRef = { current: selection, assembled: undefined };
     installModelSelection(agentCtx, selected);
   };
-  let disposeEvent = () => {};
+  let disposeListeners = () => {};
   const onSessionEvent = (session: { id: unknown }, event: SessionEvent) => {
     if (String(session.id) !== String(sessionId) || event.seq < firstSeq) return;
-    emitSessionEvent(output, request, selection.provider, selection.model, event);
-    if (event.type === 'assistant/chunk' && event.data.chunk.type === 'text-delta') {
-      assistantOutput += event.data.chunk.text;
-    }
+    emitSessionEvent(output, request, selection.provider, selection.model, event, turn);
     if (event.type === 'turn/end') turnEnd = event;
+  };
+  const onAssistantStream = (payload: unknown) => {
+    emitAssistantStream(output, request, sessionId, turn, payload);
   };
 
   try {
@@ -329,7 +456,12 @@ async function execute(
       return;
     }
     firstSeq = handle.agent.session.seq + 1;
-    disposeEvent = ctx.on('session/event', onSessionEvent);
+    const disposeSession = ctx.on('session/event', onSessionEvent);
+    const disposeStream = onRuntimeEvent(ctx, 'agent/assistant-stream', onAssistantStream);
+    disposeListeners = () => {
+      disposeSession();
+      disposeStream();
+    };
     await handle.agent.followup(createUserMessage({
       content: [{ type: 'text', text: request.prompt }],
       source: { kind: 'user' },
@@ -350,7 +482,7 @@ async function execute(
       request_id: request.request_id,
       status,
       session_id: String(sessionId),
-      ...terminalOutput(assistantOutput),
+      ...terminalOutput(turn.assistantOutput),
       stop_reason: reason?.kind ?? 'unknown',
       resume_rejected: false,
       ...(failed === undefined ? {} : { error: failed }),
@@ -370,7 +502,7 @@ async function execute(
       error: errorFacts(error, 'DSH_PROFILE_EXECUTION_FAILED'),
     });
   } finally {
-    disposeEvent();
+    disposeListeners();
     await handle?.dispose().catch(() => undefined);
     onHandle(undefined);
   }
@@ -471,12 +603,14 @@ export function apply(ctx: Context): void {
 }
 
 export const internals = {
+  assistantVisibleText,
   contentText,
   createCancellationLatch,
   errorFacts,
   emitSessionEvent,
   execute,
   listModelCatalog,
+  pluginVersion: PLUGIN_VERSION,
   requestProfileExit,
   resultStatus,
   resultError,

--- a/packages/dsh-runtime/tests/events.test.ts
+++ b/packages/dsh-runtime/tests/events.test.ts
@@ -1,0 +1,283 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'vitest';
+import { internals } from '../src/index.js';
+
+type OdFrame = {
+  type: string;
+  content?: string;
+  output?: string;
+  status?: string;
+  input_tokens?: number;
+  output_tokens?: number;
+};
+
+type SessionEmit = {
+  session: (event: unknown) => void;
+  stream: (frame: unknown, sessionId?: string | null) => void;
+};
+
+const USAGE = { inputTokens: 3, outputTokens: 5 };
+
+function turnEnd(seq: number) {
+  return { type: 'turn/end', seq, data: { reason: { kind: 'completed' } } };
+}
+
+async function runTurn(emit: (api: SessionEmit) => void): Promise<OdFrame[]> {
+  const chunks: string[] = [];
+  const listeners = new Map<string, (...args: unknown[]) => void>();
+  const handle = {
+    agent: {
+      session: { seq: 0, id: 'sess-1' },
+      whenIdle: async () => {},
+      followup: async () => {
+        emit({
+          session(event) {
+            listeners.get('session/event')?.({ id: 'sess-1' }, event);
+          },
+          stream(frame, sessionId = 'sess-1') {
+            listeners.get('agent/assistant-stream')?.(
+              sessionId === null
+                ? { frame }
+                : { agent: { session: { id: sessionId } }, frame },
+            );
+          },
+        });
+      },
+    },
+    dispose: async () => {},
+  };
+  const ctx = {
+    agentDefaultModel: {
+      currentSelection: () => ({
+        provider: 'deepseek-official',
+        model: 'deepseek-chat',
+      }),
+    },
+    agents: {
+      resume: async () => handle,
+    },
+    on: (name: string, fn: (...args: unknown[]) => void) => {
+      listeners.set(name, fn);
+      return () => listeners.delete(name);
+    },
+    sessions: { flush: async () => {} },
+  };
+  await internals.execute(
+    ctx as never,
+    {
+      v: 1,
+      type: 'execute',
+      request_id: 'run-1',
+      cwd: '/project',
+      prompt: 'say ok',
+      mcp_servers: [],
+      resume_session_id: 'sess-1',
+    },
+    { write: (chunk: string) => chunks.push(chunk) },
+    () => {},
+    new AbortController().signal,
+  );
+  return chunks.map((chunk) => JSON.parse(chunk) as OdFrame);
+}
+
+function framesOf(frames: OdFrame[], type: string): OdFrame[] {
+  return frames.filter((frame) => frame.type === type);
+}
+
+describe('@open-design/dsh-runtime 0.1.5 event contract', () => {
+  test('advertises plugin 0.1.1 as the compatibility generation', () => {
+    assert.equal(internals.pluginVersion, '0.1.1');
+  });
+
+  test('F1 legacy assistant/chunk still fills text and result.output', async () => {
+    const frames = await runTurn(({ session }) => {
+      session({
+        type: 'assistant/chunk',
+        seq: 1,
+        data: { chunk: { type: 'text-delta', text: 'ok' } },
+      });
+      session(turnEnd(2));
+    });
+    assert.deepEqual(
+      framesOf(frames, 'text').map((frame) => frame.content),
+      ['ok'],
+    );
+    const result = frames.at(-1);
+    assert.equal(result?.type, 'result');
+    assert.equal(result?.status, 'completed');
+    assert.equal(result?.output, 'ok');
+  });
+
+  test('F2 settlement-only assistant/message fills text, usage, and result.output', async () => {
+    const frames = await runTurn(({ session }) => {
+      session({
+        type: 'assistant/message',
+        seq: 1,
+        data: {
+          usage: USAGE,
+          message: { content: [{ type: 'text', text: 'ok' }] },
+        },
+      });
+      session(turnEnd(2));
+    });
+    assert.deepEqual(
+      framesOf(frames, 'text').map((frame) => frame.content),
+      ['ok'],
+    );
+    assert.deepEqual(
+      framesOf(frames, 'usage').map((frame) => ({
+        input_tokens: frame.input_tokens,
+        output_tokens: frame.output_tokens,
+      })),
+      [{ input_tokens: 3, output_tokens: 5 }],
+    );
+    assert.equal(frames.at(-1)?.output, 'ok');
+  });
+
+  test('F3 live stream then settlement emits text once', async () => {
+    const frames = await runTurn(({ session, stream }) => {
+      stream({ type: 'start', turn: 1, step: 1 });
+      stream({ type: 'chunk', chunk: { type: 'text-delta', text: 'ok' } });
+      stream({
+        type: 'end',
+        outcome: { kind: 'committed', eventType: 'assistant/message' },
+      });
+      session({
+        type: 'assistant/message',
+        seq: 1,
+        data: {
+          usage: USAGE,
+          message: { content: [{ type: 'text', text: 'ok' }] },
+        },
+      });
+      session(turnEnd(2));
+    });
+    assert.deepEqual(
+      framesOf(frames, 'text').map((frame) => frame.content),
+      ['ok'],
+    );
+    assert.equal(framesOf(frames, 'usage').length, 1);
+    assert.equal(frames.at(-1)?.output, 'ok');
+  });
+
+  test('F4 reasoning stays out of result.output', async () => {
+    const frames = await runTurn(({ session, stream }) => {
+      stream({
+        type: 'chunk',
+        chunk: { type: 'reasoning-delta', text: 'hmm' },
+      });
+      stream({ type: 'chunk', chunk: { type: 'text-delta', text: 'ok' } });
+      session(turnEnd(1));
+    });
+    assert.deepEqual(
+      framesOf(frames, 'thinking').map((frame) => frame.content),
+      ['hmm'],
+    );
+    assert.deepEqual(
+      framesOf(frames, 'text').map((frame) => frame.content),
+      ['ok'],
+    );
+    assert.equal(frames.at(-1)?.output, 'ok');
+  });
+
+  test('F5 assistant/attempt is not user-visible text', async () => {
+    const frames = await runTurn(({ session }) => {
+      session({
+        type: 'assistant/attempt',
+        seq: 1,
+        data: {
+          message: { content: [{ type: 'text', text: 'retry' }] },
+          stream: [{ type: 'text-chunks', texts: ['retry'] }],
+        },
+      });
+      session(turnEnd(2));
+    });
+    assert.deepEqual(framesOf(frames, 'text'), []);
+    assert.equal(frames.at(-1)?.output, undefined);
+  });
+
+  test('F6 empty assistant/message keeps usage and omits output', async () => {
+    const frames = await runTurn(({ session }) => {
+      session({
+        type: 'assistant/message',
+        seq: 1,
+        data: {
+          usage: USAGE,
+          message: { content: [] },
+        },
+      });
+      session(turnEnd(2));
+    });
+    assert.deepEqual(framesOf(frames, 'text'), []);
+    assert.equal(framesOf(frames, 'usage').length, 1);
+    assert.equal(frames.at(-1)?.output, undefined);
+  });
+
+  test('settlement fallback uses text blocks only, not reasoning', async () => {
+    assert.equal(
+      internals.assistantVisibleText([
+        { type: 'reasoning', text: 'hmm' },
+        { type: 'text', text: 'ok' },
+      ]),
+      'ok',
+    );
+    const frames = await runTurn(({ session }) => {
+      session({
+        type: 'assistant/message',
+        seq: 1,
+        data: {
+          message: {
+            content: [
+              { type: 'reasoning', text: 'hmm' },
+              { type: 'text', text: 'ok' },
+            ],
+          },
+        },
+      });
+      session(turnEnd(2));
+    });
+    assert.deepEqual(
+      framesOf(frames, 'text').map((frame) => frame.content),
+      ['ok'],
+    );
+    assert.equal(frames.at(-1)?.output, 'ok');
+  });
+
+  test('legacy chunk wins over a later live stream duplicate', async () => {
+    const frames = await runTurn(({ session, stream }) => {
+      session({
+        type: 'assistant/chunk',
+        seq: 1,
+        data: { chunk: { type: 'text-delta', text: 'ok' } },
+      });
+      stream({ type: 'chunk', chunk: { type: 'text-delta', text: 'ok' } });
+      session(turnEnd(2));
+    });
+    assert.deepEqual(
+      framesOf(frames, 'text').map((frame) => frame.content),
+      ['ok'],
+    );
+    assert.equal(frames.at(-1)?.output, 'ok');
+  });
+
+  test('live stream without injected agent still fills text', async () => {
+    const frames = await runTurn(({ session, stream }) => {
+      stream({ type: 'chunk', chunk: { type: 'text-delta', text: 'ok' } }, null);
+      session(turnEnd(1));
+    });
+    assert.deepEqual(
+      framesOf(frames, 'text').map((frame) => frame.content),
+      ['ok'],
+    );
+    assert.equal(frames.at(-1)?.output, 'ok');
+  });
+
+  test('live stream from another session is ignored', async () => {
+    const frames = await runTurn(({ session, stream }) => {
+      stream({ type: 'chunk', chunk: { type: 'text-delta', text: 'nope' } }, 'other');
+      session(turnEnd(1));
+    });
+    assert.deepEqual(framesOf(frames, 'text'), []);
+    assert.equal(frames.at(-1)?.output, undefined);
+  });
+});

--- a/specs/change/20260911-dsh-0.1.5-event-compat/spec.md
+++ b/specs/change/20260911-dsh-0.1.5-event-compat/spec.md
@@ -1,0 +1,339 @@
+---
+id: 20260911-dsh-0.1.5-event-compat
+name: DeepSeek Harness 0.1.5 session-event compatibility
+status: proposed
+created: "2026-09-11"
+zh-CN: spec.zh-CN.md
+issues:
+  - https://github.com/nexu-io/open-design/issues/7992
+  - https://github.com/nexu-io/open-design/issues/6944
+not:
+  - https://github.com/nexu-io/open-design/pull/7993
+---
+
+# DSH 0.1.5 event-contract + resume generation
+
+## 1. Why
+
+OpenDesign sells DeepSeek Harness as a first-class runtime. npm `latest` is
+already `dsh` **0.1.5-rc.1**. The installed `@open-design/dsh-runtime` still
+treats `assistant/chunk` as the only source of assistant text.
+
+On 0.1.5 that session event is gone. Probe and model listing still work, so
+the product looks connected. A real run reports `status: "completed"` with an
+empty assistant message. The Settings connection test fails as
+`settings.testUnknown` with detail `exit 0`.
+
+This is a silent protocol-generation break, not a detection bug.
+
+Maintainer confirmation is in #7992: `emitSessionEvent()` maps `assistant/chunk`
+into `text` / `thinking`; `assistant/message` currently contributes usage only;
+`assistantOutput` is assembled only from chunk text-deltas. #7825 widened the
+version/install policy to 0.1.2 and did **not** cover this event-contract
+change. Version-policy widening to 0.1.5 must wait until the event path is
+verified.
+
+#7993 occupies the issue with a +15/−482 rewrite of `packages/dsh-runtime/src/index.ts`
+that replaces the runtime with a detached `eventEmitter.on` snippet. Looper
+requested changes: the package no longer compiles. This spec does not take over
+that PR and does not copy its patch.
+
+#6944 is the sibling hole: native resume is decided from model / cwd / cursor
+**before spawn**. The profile adapter contract also requires DSH executable
+identity, protocol generation, and plugin compatibility generation. A 0.1.2
+session resumed under 0.1.5 (or the reverse) is an unsafe skip-transcript.
+
+## 2. Goals
+
+- [ ] On `dsh` 0.1.5-rc.1, a connection test and a one-turn run both produce
+      assistant text. `result.output` is present when the model returned text.
+- [ ] Live `text` / `thinking` frames still stream; settlement does not reprint
+      the same text.
+- [ ] `dsh` 0.1.2 (`assistant/chunk`) keeps working without a plugin rebuild
+      per user CLI.
+- [ ] `assistant/attempt` is never shown as user-visible assistant text.
+- [ ] OD JSONL to the daemon stays `protocol_version: 1`. No new frame types.
+- [ ] Follow-up PR: a stored Harness session is not resumed across a plugin or
+      CLI generation mismatch; the turn reseeds with the full transcript.
+- [ ] This change does **not** widen `supportedVersionPattern` to 0.1.5. That
+      is a third PR after the event path is green on a real 0.1.5 profile.
+
+## 3. User stories
+
+### Story 1: 0.1.5 connection test and first turn
+
+**As a** user on `dsh` 0.1.5-rc.1
+**I want** Settings → Local CLI → DeepSeek Harness → Test, and a first Studio
+turn, to show the model reply
+**So that** the advertised Harness integration is usable on npm `latest`
+
+**Acceptance Criteria:**
+
+- [ ] Connection test no longer fails with `exit 0` solely because
+      `result.output` is missing after a completed turn.
+- [ ] A completed run writes at least one `text` frame when the model returned
+      non-empty text, and `result.output` equals the concatenated text deltas.
+- [ ] Usage frames still come from `assistant/message` when usage is present.
+
+### Story 2: live stream without double-print
+
+**As a** user watching a long Harness turn
+**I want** tokens to appear as they are generated
+**So that** the Studio does not sit empty until settlement
+
+**Acceptance Criteria:**
+
+- [ ] `agent/assistant-stream` chunk frames with `text-delta` / `reasoning-delta`
+      become OD `text` / `thinking` frames as they arrive.
+- [ ] The later `assistant/message` does not emit a second copy of that text.
+- [ ] If no live chunk arrived (settlement-only), one `text` frame is emitted
+      from `assistant/message` content so the UI and `result.output` still fill.
+
+### Story 3: 0.1.2 still works
+
+**As a** user pinned to `dsh` 0.1.2-rc.1
+**I want** the same plugin to keep mapping `assistant/chunk`
+**So that** upgrading OpenDesign does not break a still-supported CLI
+
+**Acceptance Criteria:**
+
+- [ ] A fixture that only emits `assistant/chunk` text-deltas produces the same
+      `text` frames and `result.output` as today.
+- [ ] The plugin does not require the user's `dsh` to export 0.1.5 TypeScript
+      types. Event handling is structural (duck-typed).
+
+### Story 4: resume does not cross generations (PR-B)
+
+**As a** user who upgrades `dsh` or the OpenDesign profile plugin mid-conversation
+**I want** the next turn to start a fresh Harness session with full transcript
+**So that** skip-transcript resume cannot replay history under a different
+event contract
+
+**Acceptance Criteria:**
+
+- [ ] Resume guard compares stored vs current: DSH CLI version, profile
+      `plugin_version`, and OD JSONL `protocol_version`.
+- [ ] Mismatch → `invalidationReason` set, `isResuming === false`, full
+      transcript reseed. No attempt to pass `resume_session_id`.
+- [ ] Same generation + existing model/cwd/cursor guards still resume.
+
+## 4. Technical approach
+
+### 4.1 Two PRs, one generation model
+
+| PR               | Issue              | Surface                                                            | Why split                                                    |
+| ---------------- | ------------------ | ------------------------------------------------------------------ | ------------------------------------------------------------ |
+| **PR-A**         | #7992              | `packages/dsh-runtime` (+ its tests)                               | Event contract. Can merge without a daemon schema change.    |
+| **PR-B**         | #6944              | `apps/daemon` resume + contracts + tests                           | Persist/compare generation. Needs a new invalidation reason. |
+| **PR-C (later)** | follow-up to #7992 | `deepseek-harness.ts` version policy, peer ranges, installer tests | Only after PR-A is verified on real 0.1.5.                   |
+
+Do not combine PR-A with version-policy widening. Lefarcen: the 0.1.2 pin is
+the workaround until the event path is proven.
+
+Do not take over #7993. Open a new branch from current `main`. If #7993 is
+still open, comment on #7992 that this work implements the typed runtime path
+Looper asked for, rather than replacing `index.ts`.
+
+### 4.2 Where text actually lives in 0.1.5
+
+Source of truth is the local `deepseek-harness` tree (0.1.5-rc.1):
+
+```text
+live (process-local, transient)
+  ctx.on('agent/assistant-stream', { agent, frame })
+    frame.type === 'chunk'
+      frame.chunk.type === 'text-delta'      → OD `text`
+      frame.chunk.type === 'reasoning-delta' → OD `thinking`
+
+durable settlement (session log)
+  session/event  type === 'assistant/message'
+    data.message.content[]   final blocks
+    data.stream[]            compact timed stream (replay, not live UI)
+    data.usage               token usage
+  session/event  type === 'assistant/attempt'
+    failed / retried / cancelled / stream-error settlement
+    not a user-visible assistant message
+
+legacy (0.1.2 and old-log migration only)
+  session/event  type === 'assistant/chunk'
+    data.chunk.type === 'text-delta' | 'reasoning-delta'
+```
+
+The plugin today only listens to `session/event` and only accumulates
+`assistant/chunk` text-deltas. `assistant/message` writes usage and returns.
+
+OD JSONL frames (`text`, `thinking`, `tool_call`, `tool_result`, `usage`,
+`result`) do not change. Daemon `dsh-profile-jsonl` parser does not change in
+PR-A.
+
+### 4.3 PR-A mapping (normative)
+
+Introduce a small accumulator owned by `execute()`, not a rewrite of `apply()`.
+`emitSessionEvent` stays the session-event mapper; live stream is a second
+listener. Both write through the same helpers.
+
+Per execute turn, after `firstSeq` is set:
+
+1. Subscribe `session/event` (existing) and `agent/assistant-stream` (new).
+2. Ignore events whose `session.id` / `agent.session.id` ≠ this turn's session.
+3. Ignore `session/event` with `event.seq < firstSeq` (existing resume trim).
+4. Live stream `start` / `end` frames: no OD frames.
+5. Live stream `chunk`:
+   - `text-delta` with non-empty text → `text` frame; append to `assistantOutput`
+   - `reasoning-delta` with non-empty text → `thinking` frame; do **not** append
+     to `assistantOutput` (matches today's chunk path)
+   - other chunk types: ignore for OD JSONL (tool deltas already have
+     `tool/call` + `tool/result` session events)
+6. Legacy `assistant/chunk`: keep today's mapping. If live stream already
+   produced text for this turn, still accept legacy chunks only when they appear
+   (a 0.1.2 process will not emit live stream). A 0.1.5 process must not emit
+   both; if a fixture does, first writer wins for `assistantOutput` and the
+   second source must not emit duplicate `text` frames.
+7. `assistant/message`:
+   - always emit `usage` when `data.usage` is present (today)
+   - if `assistantOutput === ''`, take text from `data.message.content` via
+     existing `contentText()` (text + nested tool-result text; skip using
+     reasoning blocks as `result.output` — `contentText` currently joins
+     reasoning too; **change: `result.output` / fallback `text` frames use
+     text blocks only**, so thinking does not leak into the visible answer)
+   - if fallback text is non-empty, emit one `text` frame and set
+     `assistantOutput`
+8. `assistant/attempt`: no `text`, no `thinking`, no `assistantOutput` mutation.
+   Usage on attempt is ignored unless we later learn 0.1.5 puts usage only
+   there; first implementation follows current `assistant/message`-only usage.
+9. `result.output` remains `terminalOutput(assistantOutput)`: omitted when empty.
+
+`PLUGIN_VERSION` bumps from `0.1.0` to `0.1.1`. Probe `plugin_version` is the
+compatibility generation PR-B will persist. `PROTOCOL_VERSION` stays `1`.
+
+Do not bump `packages/dsh-runtime` peerDependencies to 0.1.5 in PR-A. The
+plugin runs inside the user's `dsh` process. Structural event handling must
+compile against the current 0.1.1-rc.2 peers.
+
+### 4.4 Dedup rule (one sentence)
+
+A turn emits each visible text delta at most once: live stream XOR legacy
+chunk XOR settlement fallback, with live/legacy preferred over settlement.
+
+### 4.5 PR-A tests (red before green)
+
+Add tests next to `packages/dsh-runtime/tests/protocol.test.ts` (or a sibling
+`events.test.ts`). Drive `internals.emitSessionEvent` / a new exported
+accumulator through a fake `ctx.on` in `internals.execute`, same style as the
+existing cancel tests.
+
+| Fixture             | Session events / stream frames                                                             | Expected OD frames                                             |
+| ------------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
+| F1 legacy-chunk     | `assistant/chunk` text-delta `"ok"` then `turn/end` completed                              | `text:"ok"`, `result.output==="ok"`                            |
+| F2 settlement-only  | no chunk; `assistant/message` content `[{type:text,text:"ok"}]` + usage + `turn/end`       | one `text:"ok"`, `usage`, `result.output==="ok"`               |
+| F3 live-then-settle | stream chunk text-delta `"ok"` then `assistant/message` content `"ok"` + usage             | one `text:"ok"` (not two), `usage`, `result.output==="ok"`     |
+| F4 thinking         | stream reasoning-delta `"hmm"` then text-delta `"ok"`                                      | `thinking` then `text`, `result.output==="ok"` (not `"hmmok"`) |
+| F5 attempt          | `assistant/attempt` with content/stream text, then `turn/end` completed with empty message | no `text`, no `result.output`                                  |
+| F6 empty message    | `assistant/message` content `[]` (max-tokens / content-less) + usage                       | `usage` only; no `output` field                                |
+
+F2 is the #7992 reproduction. Tests must go red on current `main`.
+
+Do not spawn a real `dsh` in unit tests. Optional later: a manual validation
+note in the PR (`dsh` 0.1.5-rc.1 `--stdio` smoke).
+
+### 4.6 PR-B resume generation
+
+Today `evaluateResumeInvalidation` compares model, cwd, and last-message
+cursor. Contract §7 also requires:
+
+- DSH executable identity / tested compatibility family
+- profile protocol generation (`protocol_version`)
+- plugin compatibility generation (`plugin_version`)
+
+Resume is chosen **before** spawn. Detection already has `dsh --version` and
+`--probe`. Persist those values with the session row; compare them on the next
+`resolveAgentResumeContext` using the **current** detection snapshot.
+
+Plan:
+
+1. Extend `AGENT_SESSION_INVALIDATION_REASONS` with `runtime_incompatible`.
+2. Persist an opaque `runtimeGeneration` string on `agent_sessions` for
+   `deepseek-harness` only in this PR (other adapters leave it null → no new
+   invalidation). Suggested encoding:
+   `dsh:${cliVersion}|plugin:${pluginVersion}|proto:${protocolVersion}`
+3. Current generation is assembled from the same fields detection already
+   stored for the selected agent (CLI version + last successful probe
+   `plugin_version` + constant protocol `1`).
+4. Null stored generation (rows written before this PR) → `missing_cursor`
+   **or** a one-time `runtime_incompatible` reseed. Prefer treating missing
+   generation as incompatible so a 0.1.2 session is not skip-transcript resumed
+   onto a 0.1.1 plugin after the user upgrades. Document that one extra reseed
+   after upgrade is expected.
+5. Tests in `apps/daemon/tests/agent-session-resume.test.ts`: same model/cwd/
+   cursor but different plugin version → not resuming; identical generation →
+   resuming.
+
+Do not parse Harness session files. Do not change `DSH_HOME`.
+
+### 4.7 Out of scope
+
+- Taking over or force-pushing #7993
+- Widening `supportedVersionPattern` / peer ranges to 0.1.5 (PR-C)
+- #7471 git-install `files` / `prepare`
+- #7249 Windows PowerShell media stdout
+- New ACP/SDK transport (`deepseek-harness-sdk-adapter.md`)
+- Changing daemon JSONL frame vocabulary
+- Tool-call live deltas (`tool-call-delta`); session `tool/call` + `tool/result`
+  remain the tool-card source (adapter spec §9)
+
+## 5. Files (expected)
+
+PR-A:
+
+- `packages/dsh-runtime/src/index.ts` — dual listeners, accumulator, version bump
+- `packages/dsh-runtime/tests/events.test.ts` — F1–F6
+- `packages/dsh-runtime/tests/protocol.test.ts` — only if probe version assertion needs `0.1.1`
+- `specs/current/deepseek-harness-profile-adapter.md` — §9 table: live stream
+  source; plugin 0.1.1
+
+PR-B:
+
+- `packages/contracts/src/api/agent-sessions.ts`
+- `apps/daemon/src/agent-session-resume.ts` + db upsert/read
+- `apps/daemon/tests/agent-session-resume.test.ts`
+- daemon SQLite migration for the new column (follow existing agent_sessions
+  migrations; do not invent a second store)
+
+## 6. Risks
+
+| Risk                                         | Handling                                                                                                                              |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.1.2 Cordis has no `agent/assistant-stream` | Subscribe anyway; unused listener is inert.                                                                                           |
+| `contentText()` currently joins reasoning    | Fallback path uses text blocks only.                                                                                                  |
+| Live + settlement double-print               | First-writer-wins; F3 locks it.                                                                                                       |
+| #7993 still open                             | New PR from `main`; do not stack on the broken branch.                                                                                |
+| Resume schema change                         | Isolated in PR-B; missing generation reseeds once.                                                                                    |
+| Version policy lag                           | Users on 0.1.5 still see `untested-version` until PR-C. Text must work anyway. Untested warning is acceptable; empty replies are not. |
+
+## 7. Validation
+
+PR-A:
+
+- [ ] New F1–F6 tests red on `main`, green on the branch
+- [ ] `pnpm --filter @open-design/dsh-runtime test`
+- [ ] `pnpm --filter @open-design/dsh-runtime typecheck`
+- [ ] `pnpm typecheck` / `pnpm guard` as required by the PR template
+- [ ] Manual: `dsh --profile open-design --stdio` against 0.1.5-rc.1, connection
+      test + one HTML-producing turn (note in PR body if the environment has a
+      key)
+
+PR-B:
+
+- [ ] Resume unit tests for generation mismatch / match / missing
+- [ ] Existing `agent-session-resume.test.ts` cases still pass
+
+## 8. Boundary with #7993
+
+#7993 is not a starting point. It deletes the runtime entrypoint. The correct
+patch keeps `apply` / `serve` / `execute` / cancellation / exit-fallback and
+adds structural event mapping plus fixtures.
+
+If #7993 is merged before this work lands, re-evaluate: if it only adds a
+settlement fallback without live stream and without F3/F4/F5, follow up; if it
+restores the entrypoint and matches this mapping, stop and review instead of
+duplicating.

--- a/specs/current/deepseek-harness-profile-adapter.md
+++ b/specs/current/deepseek-harness-profile-adapter.md
@@ -325,6 +325,15 @@ The initial product proof is intentionally artifact-oriented:
 
 ## 9. Event normalization
 
+The profile plugin (`plugin_version` 0.1.1) maps Harness events onto the same
+OD JSONL frames. Live tokens come from process-local
+`agent/assistant-stream` chunk frames (`text-delta` → `text`,
+`reasoning-delta` → `thinking`). Durable settlement is `assistant/message`
+(usage always; text only when no live/legacy chunk already filled
+`result.output`). `assistant/attempt` is not user-visible text. `dsh` 0.1.2
+still arrives as `assistant/chunk`. A turn emits each visible text delta at
+most once.
+
 | Profile frame | OpenDesign event |
 | --- | --- |
 | `thinking` | `thinking_start`, then `thinking_delta` |


### PR DESCRIPTION
Fixes #7992

## Why

I hit this while pairing OpenDesign's `@open-design/dsh-runtime` against the current npm `dsh` (`0.1.5-rc.1`). Probe and `--models` still work, so the product looks connected. A real turn reports `status: "completed"` with no `text` / `thinking` frames and no `result.output`, which is why Settings → Test fails as `settings.testUnknown` / `exit 0`.

Root cause matches Lefarcen's note on #7992: the plugin only maps `assistant/chunk`, and `assistant/message` currently contributes usage. In 0.1.5 that chunk event is gone. Live tokens are `agent/assistant-stream`; settlement is `assistant/message`. `assistant/attempt` is not user-visible text.

This is a new branch from current `main`. It does not take over #7993 (that PR replaced the typed runtime entrypoint and no longer compiled).

## What users will see

- DeepSeek Harness on `dsh` 0.1.5-rc.1 can produce assistant text again. A completed turn writes `text` frames and `result.output` when the model returned text.
- Live tokens still stream; the later `assistant/message` does not reprint the same text.
- Users still on `dsh` 0.1.2 keep the existing `assistant/chunk` path.
- The untested-version warning for 0.1.5 remains. This PR does **not** widen `supportedVersionPattern`. Empty replies were the bug; the warning can wait for a follow-up after a real 0.1.5 profile smoke.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

The runtime plugin is an installed Harness profile. JSONL frame types are unchanged (`protocol_version` stays `1`). Users on 0.1.5 go from empty completed turns to visible text; that is a bug fix, not a new default.

## Screenshots

n/a — no UI surface.

## Bug fix verification

- Test path that reproduces the bug: `packages/dsh-runtime/tests/events.test.ts` (F2 is the #7992 settlement-only repro; F1/F3-F6 lock legacy, live+settlement, thinking, attempt, and empty message)
- Did the test go red on `main` and green on this branch? yes — F2/F3/F4 fail on current `main` because `assistant/message` writes usage only and there is no `agent/assistant-stream` listener
- If a red spec was not cheap to write, explain why and what verification you did instead. n/a

## Validation

- `pnpm --filter @open-design/dsh-runtime test` — 23 passed
- `pnpm --filter @open-design/dsh-runtime typecheck` — passed
- Did not run full `pnpm guard` in this environment (local Node is v22; repo wants ~24). Package-scoped tests/typecheck cover the changed files.
- No real `dsh` 0.1.5 API-key smoke in this environment. Happy to run `dsh --profile open-design --stdio` against 0.1.5-rc.1 if a reviewer wants the frame dump.

## Notes for review

- `PLUGIN_VERSION` is `0.1.1` (compatibility generation). Peer ranges stay on 0.1.1-rc.2; live stream is duck-typed so the package still compiles.
- First writer wins among live stream / legacy chunk / settlement. Reasoning never enters `result.output`.
- Version-policy widening to 0.1.5 is intentionally out of scope (Lefarcen: prove the event path first).
- Resume generation (`runtime_incompatible`, #6944) is a follow-up, not this PR.
