### PR TITLE
fix(web): collapse custom choice from expanded row

### DIFF
--- a/apps/web/src/components/QuestionForm.tsx
+++ b/apps/web/src/components/QuestionForm.tsx
@@ -390,6 +390,10 @@ export const QuestionFormView = forwardRef<QuestionFormHandle, Props>(function Q
       <div
         className="qf-chip qf-chip-other qf-chip-on qf-chip-open"
         data-chat-scroll-anchor={`question-own:${q.id}`}
+        onClick={(event) => {
+          if (event.target instanceof Element && event.target.closest('button, textarea')) return;
+          toggleOther(q);
+        }}
       >
         <button
           type="button"

--- a/apps/web/tests/components/QuestionForm.test.tsx
+++ b/apps/web/tests/components/QuestionForm.test.tsx
@@ -388,6 +388,24 @@ describe('QuestionFormView', () => {
     expect(container.querySelector('.qf-chip-other')?.contains(input)).toBe(true);
   });
 
+  it('collapses an expanded custom choice from either the row or its checkbox', () => {
+    const { container } = render(
+      <QuestionFormView form={richForm} interactive onSubmit={vi.fn()} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Write your own' }));
+    const expandedRow = container.querySelector('.qf-chip-other.qf-chip-open');
+    if (!expandedRow) throw new Error('expected expanded custom choice');
+    fireEvent.click(screen.getByTestId('qf-input'));
+    expect(screen.queryByTestId('qf-input')).not.toBeNull();
+    fireEvent.click(expandedRow);
+    expect(screen.queryByTestId('qf-input')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Write your own' }));
+    fireEvent.click(screen.getByLabelText('Write your own'));
+    expect(screen.queryByTestId('qf-input')).toBeNull();
+  });
+
   it('deselects fixed options when Other opens and collapses when one is picked', () => {
     const { container } = render(
       <QuestionFormView form={richForm} interactive onSubmit={vi.fn()} />,


### PR DESCRIPTION
Fixes #8079

## Why

I picked up #8079 after the reported behavior was reproduced and the expected interaction was confirmed. Once “Write your own” expanded, only its small checkbox control could collapse the choice; the surrounding option row and label looked clickable but did nothing.

This made the custom choice behave differently from the other checkbox rows and left users with an unexpectedly narrow target for deselecting it.

## What users will see

Clicking either the checkbox control or the surrounding expanded “Write your own” row now collapses the custom choice. Clicking inside the textarea still keeps it open for editing.

## Surface area

- [x] **UI** — fixes an existing question-form interaction in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Captured from an actual namespaced desktop runtime using synthetic question-form data.

Collapsed entry point:

<img width="2560" height="1800" alt="Collapsed Write your own choice" src="https://github.com/user-attachments/assets/38538c9a-bc99-4f7f-ba0a-c25622ed14ee" />

Expanded row before deselection:

<img width="2560" height="1800" alt="Expanded Write your own choice" src="https://github.com/user-attachments/assets/82e1bcd4-4dd8-4697-8de3-344735b40b03" />

## Bug fix verification

- Test path: `apps/web/tests/components/QuestionForm.test.tsx`
- Red on `main`: yes — the new focused spec failed because a row click left the textarea mounted.
- Green on this branch: yes — the same spec verifies row click, checkbox click, and textarea-click preservation.

## Validation

- `corepack pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/QuestionForm.test.tsx --maxWorkers=2` — 48 passed
- `corepack pnpm typecheck`
- `corepack pnpm guard`
- Actual desktop runtime: label/row click and checkbox-control click each reduced `.qf-own-input` from one element to zero
- Diff-scoped publication leak check: no findings