### PR TITLE
fix grok-build follow-up turns to resume native CLI session

### DIFF
--- a/apps/daemon/src/runtimes/defs/grok-build.ts
+++ b/apps/daemon/src/runtimes/defs/grok-build.ts
@@ -87,6 +87,14 @@ export const grokBuildAgentDef = {
       '--no-plan',
       '--always-approve',
     ];
+    // Same daemon-specified UUID path as Claude: first spawn mints
+    // newSessionId; follow-ups pass --resume and skip the flattened transcript.
+    // `--prompt-file` is valid with both flags.
+    if (typeof runtimeContext.resumeSessionId === 'string' && runtimeContext.resumeSessionId) {
+      args.push('--resume', runtimeContext.resumeSessionId);
+    } else if (typeof runtimeContext.newSessionId === 'string' && runtimeContext.newSessionId) {
+      args.push('--session-id', runtimeContext.newSessionId);
+    }
     if (options.model && options.model !== DEFAULT_MODEL_OPTION.id) {
       args.push('--model', options.model);
     }
@@ -105,6 +113,7 @@ export const grokBuildAgentDef = {
   promptViaFile: true,
   promptViaStdin: false,
   streamFormat: 'plain',
+  resumesSessionViaCli: true,
   installUrl: 'https://x.ai/cli',
   docsUrl: 'https://x.ai/cli',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/tests/runtimes/grok-build-resume-args.test.ts
+++ b/apps/daemon/tests/runtimes/grok-build-resume-args.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { grokBuildAgentDef } from '../../src/runtimes/defs/grok-build.js';
+
+const PROMPT_FILE = '/tmp/od-grok-prompt.md';
+
+function grokArgs(runtimeContext: Record<string, unknown> = {}, options: Record<string, unknown> = {}) {
+  return grokBuildAgentDef.buildArgs('prompt', [], [], options, {
+    promptFilePath: PROMPT_FILE,
+    ...runtimeContext,
+  });
+}
+
+describe('grok-build buildArgs session resume', () => {
+  it('emits --session-id with the minted id on a create turn', () => {
+    const args = grokArgs({
+      newSessionId: '11111111-1111-4111-8111-111111111111',
+      resumeSessionId: null,
+    });
+    expect(args).toContain('--prompt-file');
+    expect(args[args.indexOf('--prompt-file') + 1]).toBe(PROMPT_FILE);
+    expect(args).toContain('--session-id');
+    expect(args[args.indexOf('--session-id') + 1]).toBe(
+      '11111111-1111-4111-8111-111111111111',
+    );
+    expect(args).not.toContain('--resume');
+  });
+
+  it('emits --resume with the stored id on a resume turn', () => {
+    const args = grokArgs({
+      newSessionId: '22222222-2222-4222-8222-222222222222',
+      resumeSessionId: '33333333-3333-4333-8333-333333333333',
+    });
+    expect(args).toContain('--resume');
+    expect(args[args.indexOf('--resume') + 1]).toBe(
+      '33333333-3333-4333-8333-333333333333',
+    );
+    expect(args).not.toContain('--session-id');
+  });
+
+  it('emits neither session flag when no session context is supplied', () => {
+    const args = grokArgs({});
+    expect(args).not.toContain('--resume');
+    expect(args).not.toContain('--session-id');
+    expect(args).toEqual([
+      '--prompt-file',
+      PROMPT_FILE,
+      '--no-plan',
+      '--always-approve',
+    ]);
+  });
+
+  it('keeps model overrides after the session flags', () => {
+    const args = grokArgs(
+      { resumeSessionId: '33333333-3333-4333-8333-333333333333' },
+      { model: 'grok-4.6' },
+    );
+    const resumeIndex = args.indexOf('--resume');
+    const modelIndex = args.indexOf('--model');
+    expect(resumeIndex).toBeGreaterThan(-1);
+    expect(modelIndex).toBeGreaterThan(resumeIndex);
+    expect(args[modelIndex + 1]).toBe('grok-4.6');
+  });
+
+  it('declares it resumes its session via the CLI', () => {
+    expect(grokBuildAgentDef.resumesSessionViaCli).toBe(true);
+  });
+});

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -436,6 +436,21 @@ At run completion, the daemon scans the captured plain stdout for `<artifact>` b
 
 The identifier is slugged before use, collisions receive `-2`, `-3`, etc., and outputs without a supported `<artifact>` block are left unchanged. This daemon-side extraction keeps headless runs and web-attached runs aligned: the project file exists even when no browser is present to parse the chat stream.
 
+### 5.14 Grok Build
+
+- Invocation is `grok --prompt-file <path> --no-plan --always-approve`. Model
+  and reasoning (`--effort`) flags are appended when applicable. The composed
+  prompt is staged to a temp file because recent Grok CLI builds require
+  `-p/--single` as an argv value and OD prompts exceed safe argv limits.
+- Native session resume uses the same daemon-specified UUID path as Claude:
+  the first spawn passes `--session-id <uuid>`; follow-ups pass
+  `--resume <uuid>` and skip the flattened transcript. `resumesSessionViaCli`
+  is set so the shared engine can do that skip. `--prompt-file` is valid with
+  both session flags.
+- Streaming stays `plain` until a daemon-side parser exists for Grok's
+  `streaming-json` schema. Auth is the user's `grok login` / `~/.grok/auth.json`;
+  OD does not inject credentials.
+
 ## 6. Runtime metadata and UI
 
 There is no public `agents.capabilities()` method and no generalized


### PR DESCRIPTION
## Why

I hit this myself on packaged Open Design 0.22.2 with Grok Build: every follow-up turn spawned a new `grok` process and re-injected the full plugin + project + transcript. The user-visible failure is that Grok rediscovers the repository on messages like "now add tests" even though the CLI already supports `--session-id` / `--resume`.

Claude / Codex / OpenCode already opt into `resumesSessionViaCli`. Grok's adapter did not, so the shared engine treated it as a stateless plain adapter. This is the same gap called out in `specs/change/20260618-stability-performance-3408/agent-cli-session-resume.md`.

## What users will see

Follow-up turns with **Grok Build** continue the same native Grok session instead of restarting. Second-turn prompts stay small; Grok remembers the previous turn without searching the repo again. First turn of a new conversation is unchanged (still bootstraps).

No UI, settings, or picker change. Existing Grok auth (`grok login`) is unchanged.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — grok-build follow-ups now resume the native CLI session instead of flattening the transcript
- [ ] **None**

## Screenshots

n/a (no UI)

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/runtimes/grok-build-resume-args.test.ts`
- Did the test go red on `main` and green on this branch? The new spec asserts `resumesSessionViaCli === true` and `--session-id` / `--resume` argv. That is red on current `main` (flag unset, neither flag emitted) and green with this adapter change.
- Live packaged 0.22.2 proof (same argv path, patched locally then confirmed in the app):
  - Turn 1 `nativeSessionRecovery.state=captured_not_resumed`, `acquisition=daemon-specified`, `continuation=native-resume-by-id`, prompt cache miss `new-session`, composed prompt 66340 bytes.
  - Turn 2 same conversation: `state=resumed`, same session handle sha256 `3a60c8ef974d9d42…`, prompt cache hit, composed prompt 5746 bytes, user request was only the latest message. Grok answered the remembered word without rediscovery.
  - Grok CLI 1.0.30 also accepts `--prompt-file` with `--resume` (missing-session exit 1: `Session "…" not found locally`).

## Validation

- Adapter change is the Claude-shaped `resumesSessionViaCli` + `--session-id` / `--resume` wiring already used by `claude.ts`.
- Added `grok-build-resume-args.test.ts` mirroring `claude-resume-args.test.ts` (grok still requires `promptFilePath`).
- Documented the session flags in `docs/agent-adapters.md` §5.14.
- Live two-turn Grok Build conversation on packaged 0.22.2 as above.
- Did not run full `pnpm guard` / workspace typecheck in this sparse checkout; CI should run the new vitest file.
