### PR TITLE
Return NixOS Modules

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -29,7 +29,7 @@ Business layer:
 - Business workflows decide what happened and what should be requested next.
 - `ci.yml` is the main low-privilege PR, merge-queue, and manual validation gate (application merge bar only).
 - `ci.yml` should resolve runners, compose scope and convergence decisions in its Linux `plan` job, run validation, and produce typed handoff artifacts.
-- Docker image checks are standalone and outside the merge gate. Do not re-attach `docker-image.yml` to `Validate workspace`.
+- Packaging checks are standalone and outside the merge gate: `nix.yml` (flake check) and `docker-image.yml` (image validate + publish). Do not re-attach them to `Validate workspace`.
 - Business workflows should not perform trusted writes to PR comments or branches when a capability workflow can do it.
 
 Atomic capability layer:

--- a/.github/config/scopes.json
+++ b/.github/config/scopes.json
@@ -75,10 +75,11 @@
       "exact": [".github/scripts/pack.py", ".github/scripts/release.py", ".github/workflows/convergence-exact.atom.yml", ".github/workflows/release-exact.yml"]
     },
     "medium-exempt": {
+      "prefixes": ["nix/"],
       "exact": [
-        ".gitignore", ".editorconfig",
+        ".gitignore", ".editorconfig", "flake.nix", "flake.lock",
         ".github/workflows/autofix.atom.yml", ".github/workflows/comment.atom.yml",
-        ".github/workflows/report.atom.yml", ".github/workflows/docker-image.yml"
+        ".github/workflows/report.atom.yml", ".github/workflows/docker-image.yml", ".github/workflows/nix.yml"
       ],
       "regexes": ["\\.(?:md|mdx|txt)$"],
       "exclude": ["match://certain-surface"]

--- a/.github/scripts/handoff.py
+++ b/.github/scripts/handoff.py
@@ -363,24 +363,21 @@ def self_check() -> None:
             ),
             encoding="utf-8",
         )
-        autofix = handoff_dir(root, "autofix", "example-generated-fix")
+        autofix = handoff_dir(root, "autofix", "nix-pnpm-deps")
         autofix.mkdir(parents=True)
-        (autofix / "patch.diff").write_text(
-            "diff --git a/generated/example.txt b/generated/example.txt\n",
-            encoding="utf-8",
-        )
+        (autofix / "patch.diff").write_text("diff --git a/nix/pnpm-deps.nix b/nix/pnpm-deps.nix\n", encoding="utf-8")
         (autofix / "metadata.json").write_text(
             json.dumps(
                 {
                     "schema_version": SCHEMA_VERSION,
                     "kind": "autofix",
-                    "id": "example-generated-fix",
+                    "id": "nix-pnpm-deps",
                     "pr_number": 12,
                     "head_sha": "a" * 40,
                     "base_sha": "b" * 40,
                     "run_id": 34,
-                    "allowed_paths": ["generated/example.txt"],
-                    "commit_message": "chore: apply generated autofix",
+                    "allowed_paths": ["nix/pnpm-deps.nix"],
+                    "commit_message": "chore(nix): refresh pnpm deps hash",
                 }
             ),
             encoding="utf-8",
@@ -425,7 +422,7 @@ def self_check() -> None:
         assert artifact_name("report", "visual-pr") == "handoff-report-visual-pr"
         assert artifact_name("convergence", "ci-results") == "handoff-convergence-ci-results"
         assert validate_entry("comment", comment)["marker"] == marker
-        assert validate_entry("autofix", autofix)["allowed_paths"] == ["generated/example.txt"]
+        assert validate_entry("autofix", autofix)["allowed_paths"] == ["nix/pnpm-deps.nix"]
         assert validate_entry("report", report)["artifact_pattern"] == "visual-pr-capture-12-34-*"
         assert validate_entry("convergence", convergence)["policy"] == "ci-v1"
         assert len(candidate_entry_dirs(root, "comment")) == 1

--- a/.github/workflows/autofix.atom.yml
+++ b/.github/workflows/autofix.atom.yml
@@ -124,6 +124,72 @@ jobs:
         run: |
           set -euo pipefail
 
+          upsert_nix_fallback_comment() {
+            local id="$1"
+            local pr_number="$2"
+            local patch_path="$3"
+            local reason="$4"
+
+            if [ "$id" != "nix-pnpm-deps" ]; then
+              echo "No fallback comment handler configured for autofix handoff $id."
+              return 0
+            fi
+
+            local marker="<!-- nix-hash-refresh -->"
+            local body_path="$RUNNER_TEMP/nix-hash-refresh-fallback-$id.md"
+            local payload_file="$RUNNER_TEMP/nix-hash-refresh-fallback-$id.json"
+            {
+              printf '%s\n' "$marker"
+              printf "A generated Nix hash refresh is available for this PR, but the automated same-repo push did not complete: %s\n\n" "$reason"
+              printf "Apply the diff below with \`git apply\`:\n\n"
+              printf '```diff\n'
+              cat "$patch_path"
+              printf '\n```\n'
+            } > "$body_path"
+
+            jq -n --rawfile body "$body_path" '{body: $body}' > "$payload_file"
+            local comment_id
+            comment_id="$(
+              gh api --paginate "repos/$REPO/issues/$pr_number/comments" \
+                | jq -r --arg marker "$marker" '.[] | select((.body // "") | contains($marker)) | .id' \
+                | tail -n 1 || true
+            )"
+            if [ -n "$comment_id" ]; then
+              gh api --method PATCH "repos/$REPO/issues/comments/$comment_id" --input "$payload_file" >/dev/null
+              echo "Updated Nix hash fallback comment on PR $pr_number."
+            else
+              gh api --method POST "repos/$REPO/issues/$pr_number/comments" --input "$payload_file" >/dev/null
+              echo "Created Nix hash fallback comment on PR $pr_number."
+            fi
+          }
+
+          clear_nix_fallback_comment() {
+            local id="$1"
+            local pr_number="$2"
+
+            if [ "$id" != "nix-pnpm-deps" ]; then
+              return 0
+            fi
+
+            local marker="<!-- nix-hash-refresh -->"
+            local comment_ids
+            comment_ids="$(
+              gh api --paginate "repos/$REPO/issues/$pr_number/comments" \
+                | jq -r --arg marker "$marker" '.[] | select((.body // "") | contains($marker)) | .id' || true
+            )"
+            if [ -z "$comment_ids" ]; then
+              echo "No stale Nix hash fallback comment found on PR $pr_number."
+              return 0
+            fi
+
+            while IFS= read -r comment_id; do
+              if [ -n "$comment_id" ]; then
+                gh api --method DELETE "repos/$REPO/issues/comments/$comment_id" >/dev/null
+                echo "Deleted stale Nix hash fallback comment $comment_id on PR $pr_number."
+              fi
+            done <<< "$comment_ids"
+          }
+
           while IFS= read -r entry_json; do
             id="$(jq -r '.id' <<< "$entry_json")"
             pr_number="$(jq -r '.pr_number' <<< "$entry_json")"
@@ -168,6 +234,7 @@ jobs:
 
             if [ -z "${BOT_TOKEN:-}" ]; then
               echo "Skipping autofix handoff $id because bot token is unavailable."
+              upsert_nix_fallback_comment "$id" "$pr_number" "$patch_path" "bot credentials were unavailable"
               continue
             fi
 
@@ -185,7 +252,7 @@ jobs:
             fi
             if ! git apply --check "$patch_path"; then
               cd "$GITHUB_WORKSPACE"
-              echo "Skipping autofix handoff $id because the generated patch did not apply cleanly."
+              upsert_nix_fallback_comment "$id" "$pr_number" "$patch_path" "the generated patch did not apply cleanly"
               continue
             fi
             git apply "$patch_path"
@@ -211,9 +278,10 @@ jobs:
             git commit -m "$commit_message"
             if ! git push origin "HEAD:refs/heads/$head_ref"; then
               cd "$GITHUB_WORKSPACE"
-              echo "Skipping autofix handoff $id because the bot push failed."
+              upsert_nix_fallback_comment "$id" "$pr_number" "$patch_path" "the bot push failed"
               continue
             fi
             cd "$GITHUB_WORKSPACE"
+            clear_nix_fallback_comment "$id" "$pr_number"
             echo "Applied autofix handoff $id to PR $pr_number."
           done < "$ENTRIES_PATH"

--- a/.github/workflows/dsh-upstream-drift.yml
+++ b/.github/workflows/dsh-upstream-drift.yml
@@ -8,7 +8,7 @@ name: dsh-upstream-drift
 # agent def — both halves of our own config — so it stays green while both are
 # equally stale. This compares them against the registry instead.
 #
-# Standalone and outside the merge gate, like docker-image.yml: an
+# Standalone and outside the merge gate, like nix.yml and docker-image.yml: an
 # upstream release is not a reason to fail a PR.
 
 on:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,55 @@
+name: nix
+
+# Standalone Nix packaging check. Not part of core merge validation (ci.yml).
+# Triggered when flake/lock/nix inputs change; red here does not block merge.
+
+on:
+  pull_request:
+    paths:
+      - "nix/**"
+      - "flake.nix"
+      - "flake.lock"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "package.json"
+      - "scripts/update-nix-pnpm-deps-hash.ts"
+      - ".github/workflows/nix.yml"
+  push:
+    branches: [main]
+    paths:
+      - "nix/**"
+      - "flake.nix"
+      - "flake.lock"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "package.json"
+      - "scripts/update-nix-pnpm-deps-hash.ts"
+      - ".github/workflows/nix.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nix-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  flake-check:
+    name: nix flake check
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: nix flake check
+        run: nix flake check --print-build-logs --keep-going

--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,7 @@ specs/change/active
 .ralph/
 docs/superpowers/
 
-# direnv
+# Nix and direnv
 .direnv/
 .envrc
 # Local secrets (PostHog keys, BYOK creds for local testing, etc.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,7 +358,7 @@ Before changing any prompt text — in any of those locations — read `docs/pro
   validation.
 - After package, workspace, or command-entry changes, run `pnpm install` so workspace links and generated dist entries stay fresh.
 - For agent-stream / parser changes (`apps/daemon/src/runtimes/claude-stream.ts`, `json-event-stream.ts`, `qoder-stream.ts`, etc.), replay a recorded session through the mock CLIs in `mocks/` to verify event shapes round-trip without burning provider budget. PATH-overlay activation: `export PATH="$PWD/mocks/bin:$PATH" OD_MOCKS_TRACE=<8-char-id> OD_MOCKS_NO_DELAY=1`. See `mocks/README.md` for the trace catalog and selection knobs.
-- Docker image smoke/publish lives only in `.github/workflows/docker-image.yml` and is outside the core `ci.yml` / `Validate workspace` / merge queue gate.
+- Treat every `pnpm-lock.yaml` change that affects Nix packaging as requiring a Nix pnpm deps hash refresh when you maintain the flake. `nix/pnpm-deps.nix` is a generated lock artifact; use `pnpm nix:update-hash` then re-run `nix flake check --print-build-logs --keep-going` locally. Standalone `.github/workflows/nix.yml` runs flake check when nix/lock inputs change; it is **not** part of core `ci.yml` / `Validate workspace` / merge queue. Docker image smoke/publish lives only in `.github/workflows/docker-image.yml` and is likewise outside the merge gate.
 - Before marking regular work ready, run at least `pnpm guard` and `pnpm typecheck`, plus the package-scoped tests/builds that match the files changed. Do not use or add root `pnpm test`/`pnpm build` aliases.
 - For local web runtime loops, prefer `pnpm tools-dev run web --daemon-port <port> --web-port <port>`.
 - For e2e tests that need a tools-dev daemon/web runtime, use the shared tools-dev harness under `e2e/lib/tools-dev/` and the framework suite adapters (`e2e/lib/playwright/suite.ts`, `e2e/lib/vitest/suite.ts`). Do not hand-spawn `tools-dev` from test cases or duplicate lifecycle helpers under framework-specific folders.
@@ -386,6 +386,7 @@ For a worked example of one full loop (red e2e spec → fix → green), see `e2e
 
 ```bash
 pnpm install
+pnpm nix:update-hash
 pnpm tools-dev
 pnpm tools-serve start updater
 pnpm tools-dev start web

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - [Fixed] Long speaker notes are now scrollable inside the presenter view instead of being clipped when notes push the layout past the viewport. (#6271)
-- [Changed] Retired the official Nix flake, Home Manager/NixOS modules, and lockfile-coupled Nix CI maintenance. OpenDesign still discovers agent CLIs installed through Nix profiles on NixOS and nix-darwin hosts.
 
 ## [0.9.0] - 2026-05-29
 

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ pnpm tools-dev run web
 
 Open the URL printed by `tools-dev`; development ports are allocated dynamically unless you pass explicit port flags.
 
-Node `~24`, pnpm `10.33.x`. WSL2 users, see [`docs/wsl-setup.md`](docs/wsl-setup.md); native Windows users, see [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md). Full quickstart, env vars, and packaged build flow → [`QUICKSTART.md`](QUICKSTART.md).
+Node `~24`, pnpm `10.33.x`. WSL2 users, see [`docs/wsl-setup.md`](docs/wsl-setup.md); native Windows users, see [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md). Full quickstart, env vars, Nix flake, and packaged build flow → [`QUICKSTART.md`](QUICKSTART.md).
 
 ### A full workflow — from brief to artifact
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <h1 align="center">OpenDesign: The open-source Claude Design alternative</h1>
 
+**UNOFFICIAL FORK**
+
+I forked the original repo to bring back the nix module and flake that was removed a few days ago at the time of writing this. I will not be adding my own new features or making any other changes. This repo is sole responsibility will be to maintain the nixos, flake and home-manager modules for open-design as it is updated. If your issues are to do with the nix packaging of open-design submit them here otherwise submit those to the official repo and when fixes are committed they will be brought in here.
+
 > ⚡ **[OpenDesign Cloud — the official model service.](https://open-design.ai/zh/pricing/)** One recharge to use both agent and image models inside OpenDesign: GPT, Claude, and DeepSeek for agents; GPT Image 2.0, Seedream 5.0 Pro, and Nano Banana 2.0 for images.
 >
 > 🚀 **[DeepSeek V4 Flash and V4 Pro are now available.](https://open-design.ai/zh/pricing/)** Put top-tier intelligence to work across prototypes, decks, design systems, and everyday agent tasks. OpenDesign members can use both models without limits for two weeks, directly inside the app.

--- a/apps/daemon/src/critique/__fixtures__/run-prerelease.ts
+++ b/apps/daemon/src/critique/__fixtures__/run-prerelease.ts
@@ -42,7 +42,7 @@ const ADAPTERS: readonly PrereleaseAdapter[] = [
 
 /**
  * Anchor the run at the project's `.od/` data dir by default; the
- * Playwright and other supervised runtimes that already set
+ * Home Manager / NixOS / Playwright runtimes that already set
  * `OD_DATA_DIR` keep their isolation here too.
  */
 function resolveDataDir(): string {

--- a/apps/daemon/src/media/config.ts
+++ b/apps/daemon/src/media/config.ts
@@ -13,9 +13,9 @@
 // The default is unchanged for workspace-local installs. (1) lets a
 // supervisor relocate just the credentials file. (2) means installs
 // that already set OD_DATA_DIR for the rest of the daemon's runtime
-// state (immutable-image installs and the packaged daemon at
-// apps/packaged/src/sidecars.ts:createPackagedDaemonManagedPathEnv)
-// get media-config there too without
+// state (Nix-store / immutable-image installs, the packaged daemon at
+// apps/packaged/src/sidecars.ts:createPackagedDaemonManagedPathEnv,
+// the Home Manager / NixOS modules) get media-config there too without
 // any extra plumbing. Both env values are resolved with the same
 // semantics as OD_DATA_DIR in server.ts:resolveDataDir(): the shared
 // expandHomePrefix() helper handles `~`, `$HOME`, and `${HOME}` (with

--- a/apps/daemon/tests/media/config.test.ts
+++ b/apps/daemon/tests/media/config.test.ts
@@ -363,9 +363,9 @@ describe('media-config OpenAI auth-file fallback', () => {
     });
 
     it('falls back to OD_DATA_DIR when OD_MEDIA_CONFIG_DIR is unset', async () => {
-      // The packaged daemon (apps/packaged/src/sidecars.ts) and other
-      // supervised runtimes already set OD_DATA_DIR for the rest of the
-      // daemon's runtime state. media-config should
+      // Packaged daemon (apps/packaged/src/sidecars.ts) and the
+      // Home Manager / NixOS modules already set OD_DATA_DIR for the
+      // rest of the daemon's runtime state. media-config should
       // co-locate there without needing a second env var.
       process.env.OD_DATA_DIR = overrideRoot;
       await writeProvidersAt(overrideRoot, {

--- a/docs/i18n/README.ar.md
+++ b/docs/i18n/README.ar.md
@@ -335,7 +335,7 @@ pnpm tools-dev run web
 
 افتح الرابط الذي يطبعه `tools-dev`؛ تُخصَّص منافذ التطوير ديناميكيًا ما لم تمرر أعلام منافذ صريحة.
 
-‏Node `~24`، وpnpm `10.33.x`. مستخدمو Windows، راجعوا [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md). البدء السريع الكامل، ومتغيرات البيئة، وسير بناء الحزمة ← [`QUICKSTART.md`](../../QUICKSTART.md).
+‏Node `~24`، وpnpm `10.33.x`. مستخدمو Windows، راجعوا [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md). البدء السريع الكامل، ومتغيرات البيئة، وNix flake، وسير بناء الحزمة ← [`QUICKSTART.md`](../../QUICKSTART.md).
 
 ### سير عمل كامل — من الموجز إلى المخرَج
 

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -333,7 +333,7 @@ pnpm tools-dev run web
 
 Öffne die von `tools-dev` ausgegebene URL; Entwicklungsports werden dynamisch vergeben, sofern keine Port-Flags angegeben sind.
 
-Node `~24`, pnpm `10.33.x`. Windows-Nutzer, siehe [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md). Vollständiger Schnellstart, Umgebungsvariablen und der gepackte Build-Ablauf → [`QUICKSTART.de.md`](QUICKSTART.de.md).
+Node `~24`, pnpm `10.33.x`. Windows-Nutzer, siehe [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md). Vollständiger Schnellstart, Umgebungsvariablen, Nix-Flake und der gepackte Build-Ablauf → [`QUICKSTART.de.md`](QUICKSTART.de.md).
 
 ### Ein vollständiger Workflow — vom Briefing zum Artefakt
 

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -333,7 +333,7 @@ pnpm tools-dev run web
 
 Abre la URL que imprime `tools-dev`; los puertos de desarrollo se asignan dinámicamente salvo que indiques flags de puerto.
 
-Node `~24`, pnpm `10.33.x`. Usuarios de Windows, consulten [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md). Inicio rápido completo, variables de entorno y flujo de compilación empaquetada → [`QUICKSTART.md`](../../QUICKSTART.md).
+Node `~24`, pnpm `10.33.x`. Usuarios de Windows, consulten [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md). Inicio rápido completo, variables de entorno, Nix flake y flujo de compilación empaquetada → [`QUICKSTART.md`](../../QUICKSTART.md).
 
 ### Un flujo de trabajo completo — del brief al artefacto
 

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -333,7 +333,7 @@ pnpm tools-dev run web
 
 Ouvrez l'URL affichée par `tools-dev` ; les ports de développement sont attribués dynamiquement sans flags explicites.
 
-Node `~24`, pnpm `10.33.x`. Utilisateurs de Windows, consultez [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md). Démarrage rapide complet, variables d'environnement et flux de build packagé → [`QUICKSTART.fr.md`](QUICKSTART.fr.md).
+Node `~24`, pnpm `10.33.x`. Utilisateurs de Windows, consultez [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md). Démarrage rapide complet, variables d'environnement, Nix flake et flux de build packagé → [`QUICKSTART.fr.md`](QUICKSTART.fr.md).
 
 ### Un workflow complet — du brief à l'artefact
 

--- a/docs/i18n/README.ja-JP.md
+++ b/docs/i18n/README.ja-JP.md
@@ -333,7 +333,7 @@ pnpm tools-dev run web
 
 `tools-dev` が表示した URL を開いてください。明示的なポートフラグがなければ、開発ポートは動的に割り当てられます。
 
-Node `~24`、pnpm `10.33.x`。Windows ユーザーは [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md) を参照してください。完全なクイックスタート、環境変数、パッケージ化されたビルドフロー → [`QUICKSTART.ja-JP.md`](QUICKSTART.ja-JP.md)。
+Node `~24`、pnpm `10.33.x`。Windows ユーザーは [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md) を参照してください。完全なクイックスタート、環境変数、Nix flake、パッケージ化されたビルドフロー → [`QUICKSTART.ja-JP.md`](QUICKSTART.ja-JP.md)。
 
 ### 完全なワークフロー — ブリーフからアーティファクトまで
 

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -333,7 +333,7 @@ pnpm tools-dev run web
 
 `tools-dev`가 출력한 URL을 여세요. 명시적인 포트 플래그가 없으면 개발 포트는 동적으로 배정됩니다.
 
-Node `~24`, pnpm `10.33.x`. Windows 사용자는 [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md)를 참고하세요. 전체 빠른 시작, 환경 변수, 패키징 빌드 흐름 → [`QUICKSTART.ko.md`](QUICKSTART.ko.md).
+Node `~24`, pnpm `10.33.x`. Windows 사용자는 [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md)를 참고하세요. 전체 빠른 시작, 환경 변수, Nix flake, 패키징 빌드 흐름 → [`QUICKSTART.ko.md`](QUICKSTART.ko.md).
 
 ### 전체 워크플로 — 브리프에서 아티팩트까지
 

--- a/docs/i18n/README.pt-BR.md
+++ b/docs/i18n/README.pt-BR.md
@@ -333,7 +333,7 @@ pnpm tools-dev run web
 
 Abra a URL impressa por `tools-dev`; as portas de desenvolvimento são alocadas dinamicamente sem flags explícitos.
 
-Node `~24`, pnpm `10.33.x`. Usuários de Windows, veja [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md). Início rápido completo, variáveis de ambiente e fluxo de build empacotado → [`QUICKSTART.pt-BR.md`](QUICKSTART.pt-BR.md).
+Node `~24`, pnpm `10.33.x`. Usuários de Windows, veja [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md). Início rápido completo, variáveis de ambiente, Nix flake e fluxo de build empacotado → [`QUICKSTART.pt-BR.md`](QUICKSTART.pt-BR.md).
 
 ### Um fluxo de trabalho completo — do briefing ao artefato
 

--- a/docs/i18n/README.ru.md
+++ b/docs/i18n/README.ru.md
@@ -342,7 +342,7 @@ pnpm tools-dev run web
 
 Откройте URL, напечатанный `tools-dev`; без явных флагов порты разработки назначаются динамически.
 
-Node `~24`, pnpm `10.33.x`. Пользователям WSL2 см. [`docs/wsl-setup.md`](../../docs/wsl-setup.md); пользователям нативной Windows — [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md). Полный быстрый старт, переменные окружения и процесс упакованной сборки → [`QUICKSTART.md`](../../QUICKSTART.md).
+Node `~24`, pnpm `10.33.x`. Пользователям WSL2 см. [`docs/wsl-setup.md`](../../docs/wsl-setup.md); пользователям нативной Windows — [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md). Полный быстрый старт, переменные окружения, Nix flake и процесс упакованной сборки → [`QUICKSTART.md`](../../QUICKSTART.md).
 
 ### Полный рабочий процесс — от брифа до артефакта
 

--- a/docs/i18n/README.th.md
+++ b/docs/i18n/README.th.md
@@ -329,7 +329,7 @@ pnpm tools-dev run web
 
 เปิด URL ที่ `tools-dev` พิมพ์ออกมา; development ports จะถูกจัดสรรแบบ dynamic เว้นแต่ส่ง port flags ชัดเจน.
 
-Node `~24`, pnpm `10.33.x`. ผู้ใช้ Windows ดู [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md). Quickstart เต็ม, env vars และ packaged build flow → [`QUICKSTART.th.md`](QUICKSTART.th.md).
+Node `~24`, pnpm `10.33.x`. ผู้ใช้ Windows ดู [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md). Quickstart เต็ม, env vars, Nix flake และ packaged build flow → [`QUICKSTART.th.md`](QUICKSTART.th.md).
 
 ### Workflow เต็ม — จาก brief ถึง artifact
 

--- a/docs/i18n/README.tr.md
+++ b/docs/i18n/README.tr.md
@@ -333,7 +333,7 @@ pnpm tools-dev run web
 
 `tools-dev` tarafından yazdırılan URL'yi açın; açık port bayrakları verilmezse geliştirme portları dinamik atanır.
 
-Node `~24`, pnpm `10.33.x`. Windows kullanıcıları, bkz. [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md). Tam hızlı başlangıç, ortam değişkenleri ve paketlenmiş derleme akışı → [`QUICKSTART.md`](../../QUICKSTART.md).
+Node `~24`, pnpm `10.33.x`. Windows kullanıcıları, bkz. [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md). Tam hızlı başlangıç, ortam değişkenleri, Nix flake ve paketlenmiş derleme akışı → [`QUICKSTART.md`](../../QUICKSTART.md).
 
 ### Eksiksiz bir iş akışı — özetten artifact'e
 

--- a/docs/i18n/README.uk.md
+++ b/docs/i18n/README.uk.md
@@ -333,7 +333,7 @@ pnpm tools-dev run web
 
 Відкрийте URL, надрукований `tools-dev`; без явних портових прапорців порти розробки призначаються динамічно.
 
-Node `~24`, pnpm `10.33.x`. Користувачі Windows, див. [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md). Повний швидкий старт, змінні середовища та процес упакованого збирання → [`QUICKSTART.md`](../../QUICKSTART.md).
+Node `~24`, pnpm `10.33.x`. Користувачі Windows, див. [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md). Повний швидкий старт, змінні середовища, Nix flake та процес упакованого збирання → [`QUICKSTART.md`](../../QUICKSTART.md).
 
 ### Повний робочий процес — від брифа до артефакта
 

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -338,7 +338,7 @@ pnpm tools-dev run web
 
 打开 `tools-dev` 打印的 URL；除非显式传入端口参数，开发端口会动态分配。
 
-Node `~24`，pnpm `10.33.x`。Windows 用户请参见 [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md)。完整的快速开始指南、环境变量和打包构建流程 → [`QUICKSTART.zh-CN.md`](QUICKSTART.zh-CN.md)。
+Node `~24`，pnpm `10.33.x`。Windows 用户请参见 [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md)。完整的快速开始指南、环境变量、Nix flake 和打包构建流程 → [`QUICKSTART.zh-CN.md`](QUICKSTART.zh-CN.md)。
 
 ### 一个完整的工作流——从需求到工件
 

--- a/docs/i18n/README.zh-TW.md
+++ b/docs/i18n/README.zh-TW.md
@@ -344,7 +344,7 @@ pnpm tools-dev run web
 
 請開啟 `tools-dev` 印出的 URL；除非明確傳入連接埠參數，開發連接埠會動態配置。
 
-Node `~24`、pnpm `10.33.x`。WSL2 使用者請參見 [`docs/wsl-setup.md`](../../docs/wsl-setup.md)；原生 Windows 使用者請參見 [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md)。完整快速開始、環境變數與打包建置流程 → [`QUICKSTART.zh-TW.md`](QUICKSTART.zh-TW.md)。
+Node `~24`、pnpm `10.33.x`。WSL2 使用者請參見 [`docs/wsl-setup.md`](../../docs/wsl-setup.md)；原生 Windows 使用者請參見 [`docs/windows-troubleshooting.md`](../../docs/windows-troubleshooting.md)。完整快速開始、環境變數、Nix flake 與打包建置流程 → [`QUICKSTART.zh-TW.md`](QUICKSTART.zh-TW.md)。
 
 ### 完整工作流程——從需求到 artifact
 

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -52,6 +52,7 @@ const rerunInfraCancelScriptPath = join(workspaceRoot, ".github", "scripts", "re
 const bakePluginPreviewsWorkflowPath = join(workspaceRoot, ".github", "workflows", "bake-plugin-previews.yml");
 const bakePluginPreviewsPrWorkflowPath = join(workspaceRoot, ".github", "workflows", "bake-plugin-previews-pr.yml");
 const dockerImageWorkflowPath = join(workspaceRoot, ".github", "workflows", "docker-image.yml");
+const flakePath = join(workspaceRoot, "flake.nix");
 const backportAutomergeWorkflowPath = join(workspaceRoot, ".github", "workflows", "backport-automerge.yml");
 const bakePreviewsAutomergeWorkflowPath = join(
   workspaceRoot,
@@ -1391,13 +1392,15 @@ process.stdin.on("end", () => {
       run_ui_p0: true,
       run_preflight: true,
     });
-    // Docker packaging is not part of core scopes / Validate workspace.
+    // Packaging (nix / docker) is no longer part of core scopes / Validate workspace.
     for (const plan of await Promise.all([
       runScopesPrint("merge_group", {}),
       runScopesPrint("workflow_dispatch", { inputs: {} }),
       runScopesPrint("pull_request", { pull_request: { number: 1 } }, ["apps/web/src/app/page.tsx"]),
     ])) {
+      expect(plan).not.toHaveProperty("run_nix_validation");
       expect(plan).not.toHaveProperty("run_docker_build");
+      expect(plan).not.toHaveProperty("nix_validation_required");
       expect(plan).not.toHaveProperty("docker_validation_required");
     }
   });
@@ -1666,12 +1669,15 @@ process.stdin.on("end", () => {
     });
   }, T.medium);
 
-  it("[P2] keeps Docker packaging off the core Validate workspace gate", async () => {
+  it("[P2] keeps packaging (nix/docker) off the core Validate workspace gate", async () => {
     const workflow = await readFile(ciWorkflowPath, "utf8");
     const validate = sectionBetween(workflow, "  validate:", "  runtime_summary:");
 
+    expect(workflow).not.toContain("nix_validation:");
     expect(workflow).not.toContain("docker_pr:");
+    expect(validate).not.toContain("nix_validation");
     expect(validate).not.toContain("docker_pr");
+    expect(validate).not.toContain("run_nix_validation");
     expect(validate).not.toContain("run_docker_build");
     expect(validate).toContain("Check workspace validation jobs");
 
@@ -1751,6 +1757,16 @@ process.stdin.on("end", () => {
       plan: { result: "success", outputs: { run: JSON.stringify(run) } },
       e2e_vitest: { result: "failure" },
     })).resolves.toBe(false);
+  });
+
+  it("[P1] includes launcher protocol in the Nix daemon workspace build", async () => {
+    const flake = await readFile(flakePath, "utf8");
+    const daemonWorkspaces = sectionBetween(flake, "      daemonWorkspacePaths = [", "      ];");
+
+    expect(daemonWorkspaces).toContain('"packages/launcher-proto"');
+    expect(daemonWorkspaces.indexOf('"packages/launcher-proto"')).toBeLessThan(
+      daemonWorkspaces.indexOf('"apps/daemon"'),
+    );
   });
 
   it("[P2] routes trusted Linux CI through the Nexu runner fleet", async () => {
@@ -2144,7 +2160,7 @@ process.stdin.on("end", () => {
     ]);
 
     // Core ci still produces comment + report handoffs (needs-validation, visual).
-    // No current core-ci producer emits autofix handoffs.
+    // Packaging hash autofix left core ci with nix — no ci-produced autofix handoffs for now.
     expect(ciWorkflow).toContain("handoff.py dir comment");
     expect(ciWorkflow).toContain("handoff.py dir report");
     expect(ciWorkflow).toContain("convergence.py handoff");
@@ -2153,6 +2169,7 @@ process.stdin.on("end", () => {
     expect(ciWorkflow).toContain("handoff-convergence-");
     expect(ciWorkflow).not.toContain("handoff.py dir autofix");
     expect(ciWorkflow).not.toContain("handoff-autofix-");
+    expect(ciWorkflow).not.toContain("nix-hash-autofix");
     expect(ciWorkflow).not.toContain("visual-pr-comment");
     expect(commentWorkflow).toContain("artifact-pattern comment");
     expect(commentWorkflow).toContain("merge-multiple: false");
@@ -2188,6 +2205,7 @@ process.stdin.on("end", () => {
     for (const workflow of [commentWorkflow, autofixWorkflow]) {
       expect(workflow).toContain("python3 .github/scripts/handoff.py self-check");
       expect(workflow).toContain("github.event.workflow_run.event == 'pull_request'");
+      expect(workflow).not.toContain("nix/pnpm-deps.nix");
       expect(workflow).not.toContain("visual-report");
     }
     expect(reportWorkflow).toContain("python3 .github/scripts/handoff.py self-check");

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,187 @@
+{
+  "nodes": {
+    "dream2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "purescript-overlay": "purescript-overlay",
+        "pyproject-nix": "pyproject-nix"
+      },
+      "locked": {
+        "lastModified": 1765953015,
+        "narHash": "sha256-5FBZbbWR1Csp3Y2icfRkxMJw/a/5FGg8hCXej2//bbI=",
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "rev": "69eb01fa0995e1e90add49d8ca5bcba213b0416f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777679572,
+        "narHash": "sha256-egYNbRrkn+6SwTHinhdb6WUfzzdC3nXfCRqS321VylY=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "9cb587ade2aa1b4a7257f0238d41072690b0ca4f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "purescript-overlay": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "dream2nix",
+          "nixpkgs"
+        ],
+        "slimlock": "slimlock"
+      },
+      "locked": {
+        "lastModified": 1728546539,
+        "narHash": "sha256-Sws7w0tlnjD+Bjck1nv29NjC5DbL6nH5auL9Ex9Iz2A=",
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "rev": "4ad4c15d07bd899d7346b331f377606631eb0ee4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "dream2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1763017646,
+        "narHash": "sha256-Z+R2lveIp6Skn1VPH3taQIuMhABg1IizJd8oVdmdHsQ=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "47bd6f296502842643078d66128f7b5e5370790c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "dream2nix": "dream2nix",
+        "flake-utils": "flake-utils",
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "slimlock": {
+      "inputs": {
+        "nixpkgs": [
+          "dream2nix",
+          "purescript-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688756706,
+        "narHash": "sha256-xzkkMv3neJJJ89zo3o2ojp7nFeaZc2G0fYwNXNJRFlo=",
+        "owner": "thomashoneyman",
+        "repo": "slimlock",
+        "rev": "cf72723f59e2340d24881fd7bf61cb113b4c407c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "slimlock",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,206 @@
+{
+  description = "OpenDesign — local-first design product. Daemon (`od` CLI) + Next.js static web frontend.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    dream2nix = {
+      url = "github:nix-community/dream2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    dream2nix,
+    home-manager,
+  }: let
+    filterProjectSource = includePaths:
+      nixpkgs.lib.cleanSourceWith {
+        src = self;
+        filter = path: type: let
+          root = toString self;
+          pathStr = toString path;
+          rel = nixpkgs.lib.removePrefix (root + "/") pathStr;
+          matches = includePath:
+            rel == includePath
+            || nixpkgs.lib.hasPrefix (includePath + "/") rel
+            || (type == "directory" && nixpkgs.lib.hasPrefix (rel + "/") includePath);
+        in
+          rel == ""
+          || builtins.any matches includePaths;
+      };
+
+    perSystem = flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {inherit system;};
+      nodejs = pkgs.nodejs_24;
+      workspacePackageManifests = workspacePaths:
+        map (workspacePath: "${workspacePath}/package.json") workspacePaths;
+      # Keep in sync with .github/workflows/ci.yml change_scopes
+      # nix_validation_required filter.
+      daemonWorkspacePaths = [
+        "packages/release"
+        "packages/contracts"
+        "packages/registry-protocol"
+        "packages/agui-adapter"
+        "packages/plugin-runtime"
+        "packages/sidecar-proto"
+        "packages/launcher-proto"
+        "packages/sidecar"
+        "packages/platform"
+        "packages/diagnostics"
+        "apps/daemon"
+      ];
+      # Keep in sync with .github/workflows/ci.yml change_scopes
+      # nix_validation_required filter.
+      webWorkspacePaths = [
+        "packages/release"
+        "packages/components"
+        "packages/contracts"
+        "packages/host"
+        "packages/platform"
+        "packages/sidecar"
+        "packages/sidecar-proto"
+        "apps/web"
+      ];
+      daemonSrc = filterProjectSource ([
+        "package.json"
+        "pnpm-lock.yaml"
+        "pnpm-workspace.yaml"
+        "tsconfig.json"
+        "assets"
+        "plugins"
+        "skills"
+        "design-systems"
+        "design-templates"
+        "craft"
+        "prompt-templates"
+      ]
+      ++ daemonWorkspacePaths);
+      webSrc = filterProjectSource ([
+        "package.json"
+        "pnpm-lock.yaml"
+        "pnpm-workspace.yaml"
+        "tsconfig.json"
+      ]
+      ++ webWorkspacePaths);
+      pnpmDepsBaseInputs = [
+        "package.json"
+        "pnpm-lock.yaml"
+        "pnpm-workspace.yaml"
+      ];
+      daemonPnpmDepsSrc = filterProjectSource (
+        pnpmDepsBaseInputs ++ workspacePackageManifests daemonWorkspacePaths
+      );
+      webPnpmDepsSrc = filterProjectSource (
+        pnpmDepsBaseInputs ++ workspacePackageManifests webWorkspacePaths
+      );
+
+      # nixpkgs ships pnpm 10.33.0; the repo's package.json declares
+      # `engines.pnpm: ">=10.33.2 <11"` and pnpm refuses to install
+      # against an older binary. Override the upstream tarball to
+      # the exact version pinned by `packageManager`. Bump the url
+      # + hash in lockstep with package.json#packageManager.
+      #
+      # When bumping versions, run the following to get a new hash:
+      #
+      # ```bash
+      # nix store prefetch-file --hash-type sha256 \
+      #   https://registry.npmjs.org/pnpm/-/pnpm-${NEW_VERSION}.tgz
+      # ```
+      pnpm_10 = pkgs.pnpm_10.overrideAttrs (_old: rec {
+        version = "10.33.2";
+        src = pkgs.fetchurl {
+          url = "https://registry.npmjs.org/pnpm/-/pnpm-${version}.tgz";
+          hash = "sha256-envPE9f2zrOUbAOXg3PZm+n94cr8MAC9/tTE95EWdhA=";
+        };
+      });
+
+      daemon = pkgs.callPackage ./nix/package-daemon.nix {
+        inherit dream2nix nixpkgs system nodejs pnpm_10;
+        src = daemonSrc;
+        pnpmDepsSrc = daemonPnpmDepsSrc;
+        workspacePaths = daemonWorkspacePaths;
+      };
+      web = pkgs.callPackage ./nix/package-web.nix {
+        inherit dream2nix nixpkgs system nodejs pnpm_10;
+        src = webSrc;
+        pnpmDepsSrc = webPnpmDepsSrc;
+        workspacePaths = webWorkspacePaths;
+      };
+    in {
+      packages = {
+        inherit daemon web;
+        default = daemon;
+      };
+
+      # Wrap `od` with `--no-open` for `nix run`: the daemon package
+      # builds the daemon workspace only, not `apps/web/out/`, so the
+      # browser would otherwise auto-open onto an empty static dir.
+      #
+      # Set OD_DATA_DIR to a writable location when unset. The Nix store
+      # is read-only at runtime, so the daemon cannot write to its default
+      # `<projectRoot>/.od` location under `nix run`.
+      apps.default = {
+        type = "app";
+        program = "${pkgs.writeShellScript "od-nix-run" ''
+          export OD_DATA_DIR="''${OD_DATA_DIR:-$HOME/.od}"
+          exec ${daemon}/bin/od --no-open "$@"
+        ''}";
+        meta.description = "OpenDesign local daemon (`od`)";
+      };
+
+      devShells.default = pkgs.mkShell {
+        packages = [
+          nodejs
+          pnpm_10
+        ];
+        shellHook = ''
+          echo "🎨 OpenDesign dev shell loaded!"
+          echo ""
+          echo "Language runtimes:"
+          echo "  - 🐢 Node.js: $(node --version 2>/dev/null || echo 'not found')"
+          echo "  - 📦 pnpm:    $(pnpm --version 2>/dev/null || echo 'not found')"
+          echo ""
+          echo "Quick start:"
+          echo "  - 🚀 pnpm install"
+          echo "  - 🚀 pnpm tools-dev    # local lifecycle entry point"
+          echo ""
+        '';
+      };
+
+      checks = {
+        daemon = daemon;
+        web = web;
+      };
+
+      formatter = pkgs.nixpkgs-fmt;
+    });
+
+    moduleCommon = import ./nix/module-common.nix;
+  in
+    perSystem
+    // {
+      homeManagerModules = rec {
+        open-design = import ./nix/home-manager.nix {
+          inherit moduleCommon;
+          flake = self;
+        };
+        default = open-design;
+      };
+
+      nixosModules = rec {
+        open-design = import ./nix/nixos.nix {
+          inherit moduleCommon;
+          flake = self;
+        };
+        default = open-design;
+      };
+    };
+}

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,258 @@
+# OpenDesign — Nix flake
+
+This flake exposes OpenDesign as a reproducible package, a `nix run` entry
+point, a dev shell, and Home Manager / NixOS modules. The architecture
+mirrors the runtime: the **daemon** (`od` CLI, Express API on `/api/*`)
+and the **web frontend** (Next.js static SPA at `apps/web/out/`) are
+**separate packages** and **separate services** — you can run either or
+both.
+
+## Outputs
+
+| Output                                     | What it is                                                                             |
+| ------------------------------------------ | -------------------------------------------------------------------------------------- |
+| `packages.<system>.daemon`                 | The `@open-design/daemon` package — produces `bin/od`. Default output.                 |
+| `packages.<system>.web`                    | The Next.js static export (`apps/web/out/`) ready to drop into any static file server. |
+| `apps.<system>.default`                    | `nix run github:nexu-io/open-design` — boots the daemon.                               |
+| `devShells.<system>.default`               | Node 24 + Corepack-pinned pnpm 10.33 — reproduces `pnpm install` locally.              |
+| `homeManagerModules.{default,open-design}` | Home Manager module — primary individual-developer interface.                          |
+| `nixosModules.{default,open-design}`       | NixOS module — secondary, for shared/server installs.                                  |
+
+## Try it without installing
+
+```bash
+nix run github:nexu-io/open-design        # boots the daemon on :7457
+nix develop github:nexu-io/open-design    # drop into the dev shell
+```
+
+## (1) Home Manager — the recommended path
+
+For an individual workstation, add the flake as an input and import the
+default module:
+
+```nix
+{
+  inputs.open-design.url = "github:nexu-io/open-design";
+
+  outputs = { self, home-manager, open-design, ... }: {
+    homeConfigurations.you = home-manager.lib.homeManagerConfiguration {
+      modules = [
+        open-design.homeManagerModules.default
+        {
+          services.open-design = {
+            enable = true;
+            autoStart = true;            # systemd --user / launchd agent
+            webFrontend.enable = true;   # also run the static SPA on :5174
+          };
+        }
+      ];
+    };
+  };
+}
+```
+
+What this wires up:
+
+- Linux: `systemd --user` units `open-design.service` and (optionally)
+  `open-design-web.service`. `systemctl --user status open-design`.
+- macOS: `launchd` agents `io.nexu.open-design` and (optionally)
+  `io.nexu.open-design-web`. `launchctl print gui/$UID/io.nexu.open-design`.
+- Before documenting or changing daemon storage, you MUST read root
+  [`AGENTS.md`](../AGENTS.md) → **Daemon data directory contract**. This README
+  MUST NOT restate it.
+
+## (2) NixOS — for shared/server installs
+
+```nix
+{
+  imports = [ inputs.open-design.nixosModules.default ];
+
+  services.open-design = {
+    enable = true;
+    autoStart = true;
+    openFirewall = true;
+    webFrontend.enable = true;
+    user = "open-design";
+    group = "open-design";
+  };
+}
+```
+
+This creates a system user, drops a tmpfiles rule for `/var/lib/open-design`,
+and runs the daemon under hardened systemd (`ProtectSystem=strict`,
+`PrivateTmp`, `ReadWritePaths` scoped to the data directory). Use this
+when you want a single shared instance — for individual user
+configuration prefer the Home Manager module.
+
+## (3) `webFrontend` — when to use it, when to bring your own server
+
+OpenDesign's frontend is a static SPA that issues relative `/api/*`,
+`/artifacts/*`, and `/frames/*` requests. Three serving options:
+
+| Option                                 | When                                                                                                                                                                                                              |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `webFrontend.enable = true`            | You want one-line setup. The module spawns a tiny Caddy file server on `webFrontend.port` (default `5174`) that serves the SPA and reverse-proxies the three path prefixes to the daemon.                         |
+| `webFrontend.enable = false` (default) | You're running nginx / Caddy / Apache / Traefik yourself. Point your server's document root at `${pkgs.open-design.web}` (or the `packages.<system>.web` output) and replicate the proxy contract in section (4). |
+| Skip the frontend entirely             | You only need the daemon's API for headless agent dispatch.                                                                                                                                                       |
+
+The two services are independent. `autoStart` controls the daemon;
+`webFrontend.enable` controls the static server. Mix freely.
+
+> **Bring-your-own-server gotcha:** if your proxy listens on any
+> origin that differs from the daemon's bind (different host _or_
+> different port — even loopback split-port like
+> `http://127.0.0.1:8080` while the daemon stays on `:7457`), the
+> daemon's same-origin gate will 403 the SPA's writes until you tell
+> it about that origin. Either set
+> `services.open-design.webFrontend.allowedOrigins = [ "<your-proxy-origin>" ]`
+> (which feeds `OD_ALLOWED_ORIGINS`) or, for the loopback-only
+> split-port case, set `extraEnv.OD_WEB_PORT = "<proxy-port>"`. See
+> section (4) for the full decision tree.
+
+### Exposing the bundled frontend on a non-loopback host
+
+By default `webFrontend.host = "127.0.0.1"` so enabling the bundled
+caddy does not publish anything beyond loopback. To intentionally
+share with a LAN, two settings must be widened together — the
+modules assert at eval time that the second is set whenever the
+first is widened:
+
+```nix
+services.open-design.webFrontend = {
+  enable = true;
+  host = "0.0.0.0";  # caddy listener
+  # Every external origin browsers will load the SPA from. The daemon
+  # matches each entry against the browser's `Origin` header AND adds
+  # its host:port to the `Host`-header allowlist (Caddy v2 reverse_proxy
+  # preserves the original Host upstream by default), so list each
+  # scheme + hostname combo you actually use.
+  allowedOrigins = [
+    "http://laptop.local:5174"
+    "https://laptop.local:5174"
+  ];
+};
+# On NixOS you also need:
+services.open-design.openFirewall = true;
+```
+
+Under the hood `allowedOrigins` is forwarded to the daemon as the
+`OD_ALLOWED_ORIGINS` environment variable (comma-separated). If you
+run the daemon outside the modules — for example, behind your own
+nginx/caddy — set `OD_ALLOWED_ORIGINS` directly in the daemon's
+environment with the same shape:
+
+```
+OD_ALLOWED_ORIGINS=http://host1:port,https://host1:port,http://host2:port
+```
+
+Each entry must be a bare origin (`scheme://host[:port]`); only
+`http://` and `https://` schemes are accepted, and the daemon refuses
+to start if any entry fails to parse. The variable widens only the
+general `/api/*` same-origin gate — connector-credential and
+live-artifact preview/refresh routes stay strictly loopback-only by
+design.
+
+## (4) Same-origin proxying contract
+
+The web package is built with `OD_DAEMON_URL = ""` so the bundled JS
+issues **relative** requests — `/api/*`, `/artifacts/*`, `/frames/*` —
+instead of baking a daemon URL into the export. There is no runtime
+config endpoint; the SPA does not read `OD_DAEMON_URL` from the
+serving environment.
+
+The serving contract is therefore: **the static export must be served
+same-origin with a reverse proxy to the daemon**. The bundled caddy
+service does exactly this — `webFrontend` listens on
+`webFrontend.port` and reverse-proxies the three path prefixes above
+to `127.0.0.1:<cfg.port>`, with `flush_interval -1` and no `encode` on
+`/api/*` so SSE streams flush immediately (gzip would buffer chunked
+responses for ~80s and surface as `ERR_INCOMPLETE_CHUNKED_ENCODING`).
+
+If you serve the static bundle yourself, replicate that shape:
+
+- Document root → `${pkgs.open-design.web}` (or
+  `packages.<system>.web`).
+- Reverse-proxy `/api/*`, `/artifacts/*`, `/frames/*` to the daemon's
+  bind address; `/api/*` must stream chunks immediately and skip
+  response compression.
+- SPA fallback for unmatched paths → `index.html`.
+
+The static-server's environment does not need any OpenDesign env
+vars — but **the daemon's environment usually does**, because its
+same-origin gate is built from `OD_BIND_HOST:port` (loopback hosts
+included). The browser's `Origin` and `Host` are whatever your proxy
+exposes, so unless that matches `127.0.0.1:<daemon-port>` exactly,
+the daemon will 403 every PUT/POST until told otherwise:
+
+| Your custom-server setup                                                                                                                    | What to set on the daemon                                                                                                                         |
+| ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Proxy at `http://127.0.0.1:<daemon-port>` (same host, same port — unusual)                                                                  | Nothing.                                                                                                                                          |
+| Proxy at a loopback host but different port (e.g. `http://127.0.0.1:8080` while daemon is on `:7457`)                                       | Either `extraEnv.OD_WEB_PORT = "8080"` (whitelists `8080` on every loopback host) or `services.open-design.webFrontend.allowedOrigins`.           |
+| Proxy on any non-loopback host (LAN IP, mDNS name, Tailscale name, public domain — `https://od.example.com`, `http://laptop.local:5174`, …) | `services.open-design.webFrontend.allowedOrigins = [ "<full origin>" ]`. List every scheme + host[:port] combo a browser might load the SPA from. |
+
+`webFrontend.allowedOrigins` is forwarded to the daemon as
+`OD_ALLOWED_ORIGINS`; if you run the daemon outside the modules,
+export `OD_ALLOWED_ORIGINS` directly with the same shape (see
+section (3)). The variable widens only the general `/api/*` gate —
+connector-credential and live-artifact preview/refresh routes stay
+strictly loopback-only by design.
+
+## (5) Secrets — DO NOT put them in your Nix config
+
+The `environmentFile` option takes a path to a `KEY=VALUE` file that the
+service unit reads. Use it for BYOK API keys (Anthropic, OpenAI, Gemini),
+provider tokens, and anything else you do not want world-readable in
+`/nix/store`.
+
+Recommended secret managers:
+
+- [sops-nix](https://github.com/Mic92/sops-nix) — age- or PGP-encrypted
+  YAML, decrypted into runtime files at activation.
+- [agenix](https://github.com/ryantm/agenix) — age-encrypted single
+  files, dropped into `/run/agenix/` at boot.
+
+Either renders to a file like `/run/secrets/open-design.env`; pass that
+path:
+
+```nix
+services.open-design.environmentFile = "/run/secrets/open-design.env";
+```
+
+Never inline a secret with `pkgs.writeText` or `home.file`.
+
+## First-build hash pinning
+
+`nix/pnpm-deps.nix` is the generated single source of truth for the
+vendored pnpm store hash used by both `nix/package-daemon.nix` and
+`nix/package-web.nix`. Treat it like a lock artifact, not a hand-edited
+source file. If `pnpm-lock.yaml` changes and you are intentionally
+maintaining the Nix packaging, run:
+
+```bash
+pnpm nix:update-hash
+```
+
+The script temporarily swaps one consumer to `lib.fakeHash`, runs the
+matching `nix build .#<consumer> --print-build-logs`, extracts the
+expected hash from the failure output, writes it back into
+`nix/pnpm-deps.nix`, and restores the consumer file. The script runs via
+`node --experimental-strip-types`, so CI can invoke it without first
+installing the workspace.
+
+## CI
+
+Nix validation is a **standalone** workflow (`.github/workflows/nix.yml`), not
+part of core merge validation (`ci.yml` / `Validate workspace` / merge queue).
+It runs `nix flake check` on pull requests and `main` pushes that touch flake,
+lock, or `nix/**` inputs (plus manual `workflow_dispatch`).
+
+Refresh a stale `nix/pnpm-deps.nix` locally:
+
+```bash
+pnpm nix:update-hash
+nix flake check --print-build-logs --keep-going
+```
+
+The flake filters each derivation down to only the workspace packages it
+actually installs, so unrelated package/tool changes stay off the slower Nix
+path and do not churn the other derivation's pnpm store hash.

--- a/nix/README.md
+++ b/nix/README.md
@@ -13,7 +13,7 @@ both.
 | ------------------------------------------ | -------------------------------------------------------------------------------------- |
 | `packages.<system>.daemon`                 | The `@open-design/daemon` package — produces `bin/od`. Default output.                 |
 | `packages.<system>.web`                    | The Next.js static export (`apps/web/out/`) ready to drop into any static file server. |
-| `apps.<system>.default`                    | `nix run github:nexu-io/open-design` — boots the daemon.                               |
+| `apps.<system>.default`                    | `nix run github:shaqaruden/open-design` — boots the daemon.                               |
 | `devShells.<system>.default`               | Node 24 + Corepack-pinned pnpm 10.33 — reproduces `pnpm install` locally.              |
 | `homeManagerModules.{default,open-design}` | Home Manager module — primary individual-developer interface.                          |
 | `nixosModules.{default,open-design}`       | NixOS module — secondary, for shared/server installs.                                  |
@@ -21,8 +21,8 @@ both.
 ## Try it without installing
 
 ```bash
-nix run github:nexu-io/open-design        # boots the daemon on :7457
-nix develop github:nexu-io/open-design    # drop into the dev shell
+nix run github:shaqaruden/open-design        # boots the daemon on :7457
+nix develop github:shaqaruden/open-design    # drop into the dev shell
 ```
 
 ## (1) Home Manager — the recommended path
@@ -32,7 +32,7 @@ default module:
 
 ```nix
 {
-  inputs.open-design.url = "github:nexu-io/open-design";
+  inputs.open-design.url = "github:shaqaruden/open-design";
 
   outputs = { self, home-manager, open-design, ... }: {
     homeConfigurations.you = home-manager.lib.homeManagerConfiguration {

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -1,0 +1,293 @@
+# Home Manager module for OpenDesign — primary interface for individual
+# developers. Linux uses systemd --user units; macOS uses launchd agents.
+#
+# Both the daemon and the optional web frontend are user-scoped and run
+# as the user's UID — there is no system user, no setuid, and no
+# privileged port binding by default.
+#
+# Usage:
+#   imports = [ inputs.open-design.homeManagerModules.default ];
+#   services.open-design = {
+#     enable = true;
+#     autoStart = true;
+#     webFrontend.enable = true;
+#   };
+{
+  moduleCommon,
+  flake,
+}: {
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.open-design;
+
+  commonOpts = moduleCommon {
+    inherit lib pkgs flake;
+    defaultDataDir = "${config.home.homeDirectory}/.od";
+  };
+
+  daemonExe = lib.getExe cfg.package;
+
+  # Static file server. caddy is the sweet spot: single binary, handles
+  # SPA-style fallback if any deep link bypasses the trailingSlash
+  # directories Next.js emits, and ~30MB is acceptable for an opt-in
+  # service. Users who want lighter can override
+  # `services.open-design.webFrontend.package` and bring their own
+  # server — though that disables the bundled service in favor of
+  # whatever they wire up.
+  caddy = pkgs.caddy;
+
+  # Synthesize a Caddyfile pointing at the static package's out tree.
+  #
+  # The web frontend is a static SPA bundled at build time with
+  # `OD_DAEMON_URL=""`, so the bundled JS calls relative URLs like
+  # `/api/agents`, `/artifacts/...`, and `/frames/...`. The daemon
+  # serves those routes on `cfg.port`; caddy reverse-proxies them so
+  # the SPA works same-origin without CORS or runtime config.
+  #
+  # /api/* needs SSE-safe proxying:
+  #   * `flush_interval -1`         → stream chunks immediately
+  #   * no `encode` on the API route → gzip would buffer chunked SSE
+  #     responses for ~80s and surface as ERR_INCOMPLETE_CHUNKED_ENCODING
+  #     in browsers (same failure mode QUICKSTART.md calls out for
+  #     nginx).
+  #   * generous read/write timeouts for long-running streams.
+  #
+  # Site address is explicitly `http://` — a bare `host:port` lets Caddy
+  # pick the listener scheme by port, which collides with `auto_https
+  # off` and surfaces as TLS errors when the browser hits plain HTTP.
+  caddyfile = pkgs.writeText "open-design-web.Caddyfile" ''
+    {
+      auto_https off
+      admin off
+      persist_config off
+    }
+
+    http://${cfg.webFrontend.host}:${toString cfg.webFrontend.port} {
+      handle /api/* {
+        reverse_proxy 127.0.0.1:${toString cfg.port} {
+          flush_interval -1
+          transport http {
+            read_timeout 86400s
+            write_timeout 86400s
+          }
+        }
+      }
+      handle /artifacts/* {
+        reverse_proxy 127.0.0.1:${toString cfg.port}
+      }
+      handle /frames/* {
+        reverse_proxy 127.0.0.1:${toString cfg.port}
+      }
+      handle {
+        root * ${cfg.webFrontend.package}
+        try_files {path} {path}/ /index.html
+        file_server
+        encode gzip
+      }
+    }
+  '';
+
+  # systemd --user units (and macOS launchd agents) start with a minimal
+  # default PATH that excludes Home Manager and NixOS user-profile bin
+  # directories. The daemon scans `process.env.PATH` for agent CLIs, so
+  # without an explicit PATH the UI reports "no agents detected" even when
+  # claude / codex / opencode / ... are installed.
+  #
+  # `${config.home.profileDirectory}/bin` covers both standalone HM
+  # (~/.nix-profile/bin) and HM-as-NixOS-module (/etc/profiles/per-user/<u>/bin).
+  # The remaining Linux entries pick up wrappers, the system profile, and
+  # the default Nix profile. Darwin gets the standard launchd PATH.
+  daemonPathEntries =
+    ["${config.home.profileDirectory}/bin"]
+    ++ lib.optionals pkgs.stdenv.isLinux [
+      "/run/wrappers/bin"
+      "/etc/profiles/per-user/${config.home.username}/bin"
+      "/run/current-system/sw/bin"
+      "/nix/var/nix/profiles/default/bin"
+      "/usr/local/bin"
+      "/usr/bin"
+      "/bin"
+    ]
+    ++ lib.optionals pkgs.stdenv.isDarwin [
+      "/usr/local/bin"
+      "/usr/bin"
+      "/bin"
+      "/usr/sbin"
+      "/sbin"
+    ]
+    ++ cfg.extraBinPaths;
+
+  # Conservative loopback check used to gate the allowedOrigins
+  # assertion. Anything not matched here requires the operator to
+  # declare external origins explicitly so the daemon's CSRF gate
+  # actually accepts SPA writes.
+  isLoopbackHost = h:
+    h == "127.0.0.1"
+    || h == "localhost"
+    || h == "::1"
+    || h == "[::1]"
+    || lib.hasPrefix "127." h;
+
+  daemonEnv =
+    {
+      OD_PORT = toString cfg.port;
+      OD_DATA_DIR = toString cfg.dataDir;
+      PATH = lib.concatStringsSep ":" daemonPathEntries;
+    }
+    // lib.optionalAttrs cfg.webFrontend.enable {
+      # Tell the daemon's same-origin allowlist about the caddy port,
+      # otherwise PUT/POST requests from the SPA served on
+      # `webFrontend.port` get 403'd by the /api middleware
+      # (apps/daemon/src/server.ts buildAllowedOrigins).
+      OD_WEB_PORT = toString cfg.webFrontend.port;
+    }
+    // lib.optionalAttrs (cfg.webFrontend.allowedOrigins != []) {
+      # Operator-declared external origins for the LAN-exposure escape
+      # hatch (webFrontend.host non-loopback). Honored regardless of
+      # `webFrontend.enable` so users who serve the SPA through their
+      # own reverse proxy (or expose the daemon's `/api` directly) can
+      # still widen the daemon's same-origin allowlist via this
+      # option. Comma-joined; parsed by configuredAllowedOrigins() in
+      # apps/daemon/src/origin-validation.ts.
+      OD_ALLOWED_ORIGINS = lib.concatStringsSep "," cfg.webFrontend.allowedOrigins;
+    }
+    // cfg.extraEnv;
+
+  envToList = e: lib.mapAttrsToList (k: v: "${k}=${v}") e;
+in {
+  options.services.open-design = commonOpts;
+
+  config = lib.mkIf cfg.enable (lib.mkMerge [
+    {
+      home.packages = [cfg.package];
+
+      # Ensure the data directory exists ahead of first daemon launch.
+      # mkdir -p so this is safe to re-run.
+      home.activation.openDesignDataDir = lib.hm.dag.entryAfter ["writeBoundary"] ''
+        run mkdir -p ${lib.escapeShellArg (toString cfg.dataDir)}
+      '';
+
+      # Fail-closed: if the operator widens the bundled caddy bind to
+      # a non-loopback interface but does not declare which external
+      # origins the SPA will be loaded from, the daemon's CSRF gate
+      # will silently 403 every PUT/POST. Catch that at eval time so
+      # the broken state never reaches the user's session.
+      assertions = [
+        {
+          assertion =
+            !cfg.webFrontend.enable
+            || isLoopbackHost cfg.webFrontend.host
+            || cfg.webFrontend.allowedOrigins != [];
+          message = ''
+            services.open-design.webFrontend.host = "${cfg.webFrontend.host}" exposes the
+            bundled web frontend on a non-loopback interface, but
+            services.open-design.webFrontend.allowedOrigins is empty.
+
+            The daemon's same-origin allowlist would reject every API
+            write the SPA issues from that host. Either keep the
+            default loopback bind, or declare every external origin
+            the SPA will be loaded from, e.g.
+
+              services.open-design.webFrontend.allowedOrigins = [
+                "http://laptop.local:''${toString cfg.webFrontend.port}"
+              ];
+          '';
+        }
+      ];
+    }
+
+    # ----- Linux: systemd --user units --------------------------------
+    (lib.mkIf (pkgs.stdenv.isLinux && cfg.autoStart) {
+      systemd.user.services.open-design = {
+        Unit = {
+          Description = "OpenDesign daemon (user service)";
+          After = ["network-online.target"];
+          Wants = ["network-online.target"];
+        };
+        Install.WantedBy = ["default.target"];
+        Service =
+          {
+            Type = "simple";
+            ExecStart = "${daemonExe} --port ${toString cfg.port} --no-open";
+            Environment = envToList daemonEnv;
+            Restart = "on-failure";
+            RestartSec = 3;
+          }
+          // lib.optionalAttrs (cfg.environmentFile != null) {
+            EnvironmentFile = toString cfg.environmentFile;
+          };
+      };
+    })
+
+    (lib.mkIf (pkgs.stdenv.isLinux && cfg.webFrontend.enable) {
+      systemd.user.services.open-design-web = {
+        Unit = {
+          Description = "OpenDesign web frontend (static file server)";
+          After = ["network-online.target"];
+          Wants = ["network-online.target"];
+        };
+        Install.WantedBy = ["default.target"];
+        Service = {
+          Type = "simple";
+          ExecStart = "${lib.getExe caddy} run --config ${caddyfile} --adapter caddyfile";
+          Restart = "on-failure";
+          RestartSec = 3;
+        };
+      };
+    })
+
+    # ----- macOS: launchd agents -------------------------------------
+    (lib.mkIf (pkgs.stdenv.isDarwin && cfg.autoStart) (let
+      # launchd has no EnvironmentFile equivalent. When the user supplies
+      # one, wrap the daemon exec in a tiny shell that sources the file
+      # at runtime — keeps secrets out of the world-readable Nix store
+      # while still honoring the documented `environmentFile` option on
+      # Darwin (parity with the Linux systemd path above).
+      daemonLaunchScript = pkgs.writeShellScript "open-design-daemon-launch" ''
+        set -a
+        . ${lib.escapeShellArg (toString cfg.environmentFile)}
+        set +a
+        exec ${lib.escapeShellArg daemonExe} --port ${toString cfg.port} --no-open
+      '';
+      programArguments =
+        if cfg.environmentFile != null
+        then [(toString daemonLaunchScript)]
+        else [daemonExe "--port" (toString cfg.port) "--no-open"];
+    in {
+      launchd.agents.open-design = {
+        enable = true;
+        config = {
+          Label = "io.nexu.open-design";
+          ProgramArguments = programArguments;
+          RunAtLoad = true;
+          KeepAlive = true;
+          EnvironmentVariables = daemonEnv;
+          StandardOutPath = "${cfg.dataDir}/open-design.out.log";
+          StandardErrorPath = "${cfg.dataDir}/open-design.err.log";
+        };
+      };
+    }))
+
+    (lib.mkIf (pkgs.stdenv.isDarwin && cfg.webFrontend.enable) {
+      launchd.agents.open-design-web = {
+        enable = true;
+        config = {
+          Label = "io.nexu.open-design-web";
+          ProgramArguments = [
+            (lib.getExe caddy)
+            "run"
+            "--config"
+            (toString caddyfile)
+            "--adapter"
+            "caddyfile"
+          ];
+          RunAtLoad = true;
+          KeepAlive = true;
+        };
+      };
+    })
+  ]);
+}

--- a/nix/module-common.nix
+++ b/nix/module-common.nix
@@ -1,0 +1,244 @@
+# Shared option definitions for the OpenDesign Home Manager and NixOS
+# modules. Returns a plain attrset of options (NOT a NixOS module). The
+# consuming module imports this and merges the result into its own
+# `options.<scope>.open-design`.
+#
+# The two callers differ only in:
+#   - default `dataDir` (HM: $HOME/.od; NixOS: /var/lib/open-design)
+#   - service supervision (HM: systemd --user / launchd agents;
+#     NixOS: system systemd units + dynamic user)
+# Everything else — port, autoStart, environmentFile, agents, webFrontend —
+# is identical across both, so it lives here.
+{
+  lib,
+  pkgs,
+  flake,
+  defaultDataDir,
+}: let
+  # `pkgs.system` is a legacy alias removed when consumers set
+  # `nixpkgs.config.allowAliases = false`. Use the canonical attribute
+  # path so the module evaluates under both default and strict configs.
+  systemAttr = pkgs.stdenv.hostPlatform.system;
+
+  flakePackages =
+    if flake ? packages.${pkgs.stdenv.hostPlatform.system}
+    then flake.packages.${pkgs.stdenv.hostPlatform.system}
+    else {};
+in {
+  enable = lib.mkEnableOption "OpenDesign — local-first design product daemon";
+
+  package = lib.mkOption {
+    type = lib.types.package;
+    default =
+      flakePackages.daemon or (throw
+        "open-design: no daemon package available for ${pkgs.stdenv.hostPlatform.system}; set services.open-design.package explicitly");
+    defaultText = lib.literalExpression "open-design.packages.\${pkgs.stdenv.hostPlatform.system}.daemon";
+    description = "The OpenDesign daemon package providing the `od` binary.";
+  };
+
+  port = lib.mkOption {
+    type = lib.types.port;
+    default = 7457;
+    description = ''
+      TCP port the daemon API binds to. Passed to `od --port`.
+
+      The static SPA issues relative `/api/*`, `/artifacts/*`, and
+      `/frames/*` requests, so whatever fronts the bundle (the
+      built-in `webFrontend` caddy or your own nginx/Caddy) must
+      reverse-proxy those three path prefixes to `127.0.0.1:<this
+      port>` and serve same-origin with the SPA. There is no runtime
+      `OD_DAEMON_URL` injection — see section (4) of `nix/README.md`.
+    '';
+  };
+
+  dataDir = lib.mkOption {
+    type = lib.types.path;
+    default = defaultDataDir;
+    defaultText =
+      lib.literalExpression
+      (
+        if defaultDataDir == "/var/lib/open-design"
+        then "\"/var/lib/open-design\""
+        else "\"\${config.home.homeDirectory}/.od\""
+      );
+    description = ''
+      Directory holding the daemon's runtime state: SQLite database
+      (`app.sqlite`), per-project working trees under `projects/<id>/`,
+      and saved artifact bundles under `artifacts/`.
+    '';
+  };
+
+  autoStart = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+    description = ''
+      Whether to register a service that starts the daemon automatically.
+      Independent of `webFrontend.enable` — you can run either or both.
+    '';
+  };
+
+  environmentFile = lib.mkOption {
+    type = lib.types.nullOr lib.types.path;
+    default = null;
+    description = ''
+      Path to a file containing `KEY=VALUE` lines passed to the daemon's
+      service environment. Use this for runtime secrets (BYOK API keys,
+      provider tokens, etc.).
+
+      WARNING: never put secret values directly into Nix configuration —
+      the Nix store is world-readable. Generate this file out-of-band
+      with sops-nix (https://github.com/Mic92/sops-nix) or agenix
+      (https://github.com/ryantm/agenix).
+    '';
+    example = "/run/secrets/open-design.env";
+  };
+
+  extraEnv = lib.mkOption {
+    type = lib.types.attrsOf lib.types.str;
+    default = {};
+    description = ''
+      Additional non-secret environment variables for the daemon
+      service (e.g. `OD_CODEX_DISABLE_PLUGINS = "1"`). Secrets belong
+      in `environmentFile`, not here.
+    '';
+    example = lib.literalExpression ''
+      {
+        OD_CODEX_DISABLE_PLUGINS = "1";
+      }
+    '';
+  };
+
+  extraBinPaths = lib.mkOption {
+    type = lib.types.listOf lib.types.str;
+    default = [];
+    description = ''
+      Extra absolute directories to prepend to the daemon service's
+      PATH. The daemon discovers agent CLIs (claude, codex, gemini,
+      opencode, ...) by scanning `process.env.PATH` at runtime, but
+      systemd unit and macOS launchd agent invocations launch with a
+      minimal default PATH that excludes Home Manager / NixOS user
+      profiles — so without entries here the daemon will report
+      "no agents detected" even when the CLIs are installed.
+
+      Both modules pre-populate PATH with sensible defaults for their
+      context (Home Manager: the user's HM profile and, on NixOS, the
+      per-user/system profile dirs; NixOS: the system profile and
+      wrapper dirs). Use this option to add additional locations
+      (custom installs under `/opt`, project-local `bin/`, etc.).
+    '';
+    example = lib.literalExpression ''[ "/opt/agents/bin" ]'';
+  };
+
+  webFrontend = {
+    # The OpenDesign web frontend is a static SPA built by
+    # `apps/web` → `apps/web/out/`. The daemon is a separate Express
+    # process that serves the JSON API at `/api/*`. The SPA is built
+    # with `OD_DAEMON_URL=""`, so the bundled JS issues relative
+    # `/api/*`, `/artifacts/*`, and `/frames/*` requests and expects
+    # the static-server in front of it to reverse-proxy those to the
+    # daemon — there is no runtime daemon-URL injection.
+    #
+    # Enabling `webFrontend` runs a tiny static file server (caddy) that
+    # hosts the SPA on a sibling port and proxies the three path
+    # prefixes back to the daemon. This is for users who just want
+    # `nix run`-style convenience without configuring nginx/caddy by
+    # hand.
+    #
+    # If you already serve the static export through your own reverse
+    # proxy, leave `webFrontend.enable = false`, point your server's
+    # document root at `${cfg.webFrontend.package}`, and replicate the
+    # reverse-proxy rules (with SSE-safe streaming on `/api/*`).
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Run a lightweight static file server for the Next.js export.
+        Independent of the daemon service: enable either or both.
+      '';
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      # Confirmed via QUICKSTART.md examples (`--web-port 5175`) and
+      # tools-dev defaults — pick 5174 to leave 5175 free for the dev
+      # tools-dev workflow on the same machine.
+      default = 5174;
+      description = ''
+        TCP port the static file server binds to. The bundled caddy
+        serves the SPA on this port and reverse-proxies the SPA's
+        relative API requests (`/api/*`, `/artifacts/*`, `/frames/*`)
+        to the daemon at `127.0.0.1:''${toString cfg.port}`, so the
+        browser sees a single same-origin endpoint.
+      '';
+    };
+
+    host = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = ''
+        Interface address the static file server binds to. Defaults to
+        loopback so enabling `webFrontend` does not expose the bundled
+        proxy (which forwards `/api/*`, `/artifacts/*`, and `/frames/*`
+        to the local daemon) to other hosts on the network.
+
+        For shared deployments set this to `"0.0.0.0"` (or a specific
+        interface address) AND populate `webFrontend.allowedOrigins`
+        with every external origin the SPA will be loaded from — the
+        daemon's same-origin gate is fail-closed and would otherwise
+        reject API writes proxied by caddy with a 403. On NixOS you
+        must additionally set `services.open-design.openFirewall =
+        true` for inbound traffic to reach the listener.
+
+        Note: certain sensitive routes (connector credentials, live
+        artifact preview/refresh) remain strictly loopback-only even
+        when `allowedOrigins` is set; that is intentional.
+      '';
+    };
+
+    allowedOrigins = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      description = ''
+        Full HTTP(S) origins (`scheme://host[:port]`, no path) the
+        daemon should accept as same-site for `/api/*` requests in
+        addition to its built-in loopback set. Honored regardless of
+        `webFrontend.enable` — set this whenever the browser-facing
+        origin differs from the daemon's bind address, including the
+        following cases:
+
+          * Bundled caddy on a non-loopback host: SPA loaded from
+            `http://<lan-host>:''${toString cfg.webFrontend.port}` cannot
+            issue PUT/POST through the bundled proxy without this set.
+          * Custom nginx/Caddy out front (`webFrontend.enable = false`)
+            on a non-loopback host or any port other than
+            `''${toString cfg.port}` — including loopback split-port
+            setups like `http://127.0.0.1:8080`.
+
+        For the loopback split-port case specifically, an alternative is
+        to set `extraEnv.OD_WEB_PORT = "<proxy-port>"`, which whitelists
+        that port on every loopback host without enumerating origins.
+
+        Each entry is forwarded to the daemon via the `OD_ALLOWED_ORIGINS`
+        env var. The daemon both compares it verbatim against the
+        browser's `Origin` header AND admits its host:port to the
+        `Host`-header allowlist (Caddy v2 reverse_proxy preserves the
+        original Host upstream by default, so widening only the Origin
+        check would still 403 same-site GETs at the Host check). List
+        every hostname/scheme combo a user might access (LAN IP, mDNS
+        name, Tailscale name, http and https separately if both are
+        reachable). Loopback origins on the daemon's own port are
+        already accepted unconditionally — do not bother listing those.
+      '';
+      example = ["http://laptop.local:5174" "https://laptop.local:5174"];
+    };
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default =
+        flakePackages.web or (throw
+          "open-design: no web package available for ${pkgs.stdenv.hostPlatform.system}; set services.open-design.webFrontend.package explicitly");
+      defaultText = lib.literalExpression "open-design.packages.\${pkgs.stdenv.hostPlatform.system}.web";
+      description = "Built static export to serve (Next.js out/ tree).";
+    };
+  };
+}

--- a/nix/nixos.nix
+++ b/nix/nixos.nix
@@ -1,0 +1,267 @@
+# NixOS module for OpenDesign — secondary interface for shared/server
+# installs (e.g. running the daemon as a long-lived service on a team
+# build host). For individual developer machines, prefer the Home
+# Manager module (nix/home-manager.nix).
+#
+# Usage:
+#   imports = [ inputs.open-design.nixosModules.default ];
+#   services.open-design = {
+#     enable = true;
+#     autoStart = true;
+#     openFirewall = true;
+#     webFrontend.enable = true;
+#   };
+{
+  moduleCommon,
+  flake,
+}: {
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.open-design;
+
+  commonOpts = moduleCommon {
+    inherit lib pkgs flake;
+    defaultDataDir = "/var/lib/open-design";
+  };
+
+  daemonExe = lib.getExe cfg.package;
+  caddy = pkgs.caddy;
+
+  # See nix/home-manager.nix for the rationale behind these handle
+  # blocks. The static SPA calls `/api/*`, `/artifacts/*`, `/frames/*`
+  # at the same origin; caddy proxies those to the daemon. SSE on
+  # `/api/*` requires no buffering (flush_interval, no encode).
+  caddyfile = pkgs.writeText "open-design-web.Caddyfile" ''
+    {
+      auto_https off
+      admin off
+      persist_config off
+    }
+
+    http://${cfg.webFrontend.host}:${toString cfg.webFrontend.port} {
+      handle /api/* {
+        reverse_proxy 127.0.0.1:${toString cfg.port} {
+          flush_interval -1
+          transport http {
+            read_timeout 86400s
+            write_timeout 86400s
+          }
+        }
+      }
+      handle /artifacts/* {
+        reverse_proxy 127.0.0.1:${toString cfg.port}
+      }
+      handle /frames/* {
+        reverse_proxy 127.0.0.1:${toString cfg.port}
+      }
+      handle {
+        root * ${cfg.webFrontend.package}
+        try_files {path} {path}/ /index.html
+        file_server
+        encode gzip
+      }
+    }
+  '';
+
+  hardening = {
+    NoNewPrivileges = true;
+    ProtectSystem = "strict";
+    ProtectHome = true;
+    PrivateTmp = true;
+    ProtectKernelTunables = true;
+    ProtectKernelModules = true;
+    ProtectControlGroups = true;
+    RestrictSUIDSGID = true;
+    LockPersonality = true;
+  };
+
+  # System systemd units launch with a minimal default PATH that excludes
+  # NixOS profile dirs where agent CLIs live. The daemon scans
+  # `process.env.PATH` to discover them, so an explicit PATH is required
+  # or the UI reports "no agents detected". The service runs as a system
+  # user, so per-user profile dirs aren't included by default — operators
+  # who install agents into a specific location should add it via
+  # `services.open-design.extraBinPaths`.
+  daemonPathEntries =
+    [
+      "/run/wrappers/bin"
+      "/run/current-system/sw/bin"
+      "/nix/var/nix/profiles/default/bin"
+      "/usr/local/bin"
+      "/usr/bin"
+      "/bin"
+    ]
+    ++ cfg.extraBinPaths;
+
+  # Conservative loopback check used to gate the allowedOrigins
+  # assertion. See nix/home-manager.nix for the rationale.
+  isLoopbackHost = h:
+    h == "127.0.0.1"
+    || h == "localhost"
+    || h == "::1"
+    || h == "[::1]"
+    || lib.hasPrefix "127." h;
+
+  daemonEnvironment =
+    {
+      OD_PORT = toString cfg.port;
+      OD_DATA_DIR = toString cfg.dataDir;
+      PATH = lib.concatStringsSep ":" daemonPathEntries;
+    }
+    // lib.optionalAttrs cfg.webFrontend.enable {
+      # See nix/home-manager.nix — the daemon's /api origin allowlist
+      # needs to know about the caddy port or it will 403 SPA writes.
+      OD_WEB_PORT = toString cfg.webFrontend.port;
+    }
+    // lib.optionalAttrs (cfg.webFrontend.allowedOrigins != []) {
+      # Operator-declared external origins for the LAN-exposure escape
+      # hatch. Honored regardless of `webFrontend.enable` so operators
+      # exposing the daemon's `/api` directly (no bundled caddy in
+      # front) — the path documented under `openFirewall` — can still
+      # widen the daemon's same-origin allowlist via this option.
+      # Comma-joined; parsed by configuredAllowedOrigins() in
+      # apps/daemon/src/origin-validation.ts.
+      OD_ALLOWED_ORIGINS = lib.concatStringsSep "," cfg.webFrontend.allowedOrigins;
+    }
+    // cfg.extraEnv;
+in {
+  options.services.open-design =
+    commonOpts
+    // {
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = "open-design";
+        description = "User the daemon runs as.";
+      };
+
+      group = lib.mkOption {
+        type = lib.types.str;
+        default = "open-design";
+        description = "Group the daemon runs as.";
+      };
+
+      openFirewall = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Open the daemon `port` in the system firewall, plus
+          `webFrontend.port` when the bundled web service is enabled.
+
+          Note: by default both the daemon and the bundled web frontend
+          bind to loopback only, so opening the firewall has no effect
+          until you also widen the bind address — set
+          `services.open-design.webFrontend.host = "0.0.0.0"` and
+          declare `services.open-design.webFrontend.allowedOrigins` so
+          the daemon's CSRF gate accepts the externally reachable
+          origin the SPA is loaded from.
+
+          If you also need the daemon's `/api` exposed directly (i.e.
+          without the bundled caddy in front), set
+          `extraEnv.OD_BIND_HOST` to the externally reachable address
+          (e.g. a LAN IP or Tailscale host) — not `0.0.0.0`, since the
+          daemon's `Origin` allowlist is built from the literal bind
+          host and browsers send `Origin: http://<actual-host>:<port>`,
+          not `http://0.0.0.0:<port>`. Alternatively keep
+          `OD_BIND_HOST = "0.0.0.0"` and add the externally reachable
+          origin (e.g. `http://laptop.local:7456`) to
+          `webFrontend.allowedOrigins`, which feeds `OD_ALLOWED_ORIGINS`.
+        '';
+      };
+    };
+
+  config = lib.mkIf cfg.enable (lib.mkMerge [
+    {
+      users.users.${cfg.user} = {
+        isSystemUser = true;
+        group = cfg.group;
+        home = cfg.dataDir;
+        description = "OpenDesign daemon";
+      };
+      users.groups.${cfg.group} = {};
+
+      systemd.tmpfiles.rules = [
+        "d ${toString cfg.dataDir} 0750 ${cfg.user} ${cfg.group} - -"
+      ];
+
+      networking.firewall.allowedTCPPorts =
+        lib.optional cfg.openFirewall cfg.port
+        ++ lib.optional (cfg.openFirewall && cfg.webFrontend.enable) cfg.webFrontend.port;
+
+      # Fail-closed: if the operator widens the bundled caddy bind to
+      # a non-loopback interface but does not declare which external
+      # origins the SPA will be loaded from, the daemon's CSRF gate
+      # will silently 403 every PUT/POST. Catch that at eval time.
+      assertions = [
+        {
+          assertion =
+            !cfg.webFrontend.enable
+            || isLoopbackHost cfg.webFrontend.host
+            || cfg.webFrontend.allowedOrigins != [];
+          message = ''
+            services.open-design.webFrontend.host = "${cfg.webFrontend.host}" exposes the
+            bundled web frontend on a non-loopback interface, but
+            services.open-design.webFrontend.allowedOrigins is empty.
+
+            The daemon's same-origin allowlist would reject every API
+            write the SPA issues from that host. Either keep the
+            default loopback bind, or declare every external origin
+            the SPA will be loaded from, e.g.
+
+              services.open-design.webFrontend.allowedOrigins = [
+                "http://laptop.local:''${toString cfg.webFrontend.port}"
+              ];
+          '';
+        }
+      ];
+    }
+
+    (lib.mkIf cfg.autoStart {
+      systemd.services.open-design = {
+        description = "OpenDesign daemon";
+        wantedBy = ["multi-user.target"];
+        after = ["network-online.target"];
+        wants = ["network-online.target"];
+
+        environment = daemonEnvironment;
+
+        serviceConfig =
+          {
+            Type = "simple";
+            User = cfg.user;
+            Group = cfg.group;
+            ExecStart = "${daemonExe} --port ${toString cfg.port} --no-open";
+            Restart = "on-failure";
+            RestartSec = 3;
+            ReadWritePaths = [(toString cfg.dataDir)];
+          }
+          // hardening
+          // lib.optionalAttrs (cfg.environmentFile != null) {
+            EnvironmentFile = toString cfg.environmentFile;
+          };
+      };
+    })
+
+    (lib.mkIf cfg.webFrontend.enable {
+      systemd.services.open-design-web = {
+        description = "OpenDesign web frontend (static file server)";
+        wantedBy = ["multi-user.target"];
+        after = ["network-online.target"];
+        wants = ["network-online.target"];
+
+        serviceConfig =
+          {
+            Type = "simple";
+            User = cfg.user;
+            Group = cfg.group;
+            ExecStart = "${lib.getExe caddy} run --config ${caddyfile} --adapter caddyfile";
+            Restart = "on-failure";
+            RestartSec = 3;
+          }
+          // hardening;
+      };
+    })
+  ]);
+}

--- a/nix/package-daemon.nix
+++ b/nix/package-daemon.nix
@@ -1,0 +1,217 @@
+{
+  lib,
+  stdenv,
+  dream2nix,
+  nixpkgs,
+  system,
+  nodejs,
+  pnpm_10,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  src,
+  pnpmDepsSrc ? src,
+  workspacePaths,
+  makeWrapper,
+  python3,
+  gnumake,
+  pkg-config,
+}:
+# Builds the @open-design/daemon workspace package — produces $out/bin/od.
+#
+# Implementation note on dream2nix:
+#   The flake takes `dream2nix` as an input (per the project's Nix
+#   contract) but the build itself uses stdenv.mkDerivation. dream2nix's
+#   nodejs builders consume npm's package-lock.json — they have no
+#   first-class pnpm-lock.yaml + workspace builder yet. When upstream
+#   ships one, swap this file for a thin dream2nix module — the inputs
+#   are already wired.
+#
+# pnpm version note:
+#   `package.json` declares `engines.pnpm` and pnpm enforces it on
+#   `pnpm install` (regardless of `engine-strict`). The nixpkgs
+#   default `pnpm` is generally incompatible — older than the
+#   floor or newer than the ceiling depending on which nixpkgs
+#   the consumer follows. The flake overrides `pkgs.pnpm_10` to
+#   the exact tarball pinned by `packageManager` (see flake.nix
+#   for the override + hash bump). This derivation uses
+#   `pnpm_10` for both phases: in `nativeBuildInputs` so the
+#   install-phase `pnpmConfigHook` resolves it from PATH, and
+#   `pnpm = pnpm_10` to `fetchPnpmDeps` to override its
+#   `pkgs.pnpm` default.
+#
+# Workspace siblings the daemon depends on are built in dependency order
+# before the daemon itself; tsc emits each package's dist/, which is what
+# the daemon resolves at runtime via pnpm's symlinked node_modules.
+let
+  pname = "open-design-daemon";
+  version = (lib.importJSON ../package.json).version;
+
+  pnpmDepsHash = (import ./pnpm-deps.nix).daemonHash;
+  pnpmWorkspaceFilters = map (workspacePath: "./${workspacePath}") workspacePaths;
+in
+  stdenv.mkDerivation (finalAttrs: {
+    inherit pname version src;
+
+    pnpmWorkspaces = pnpmWorkspaceFilters;
+
+    nativeBuildInputs = [
+      nodejs
+      pnpm_10
+      pnpmConfigHook
+      makeWrapper
+      # Required to rebuild better-sqlite3's native binding from source.
+      # node-gyp drives this via Python; gnumake/pkg-config + the C++
+      # compiler from stdenv complete the toolchain.
+      python3
+      gnumake
+      pkg-config
+    ];
+
+    # `fetchPnpmDeps` defaults to `pkgs.pnpm`; pin to the flake's
+    # `pnpm_10` so the dep-fetch matches the install phase.
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs) pname version;
+      src = pnpmDepsSrc;
+      hash = pnpmDepsHash;
+      pnpm = pnpm_10;
+      pnpmWorkspaces = pnpmWorkspaceFilters;
+      fetcherVersion = 3;
+    };
+
+    env.NODE_ENV = "production";
+
+    # pnpm_10.configHook runs in postConfigureHooks: it unpacks
+    # `pnpmDeps`, points pnpm at the unpacked store, and runs
+    # `pnpm install --offline --ignore-scripts --frozen-lockfile`.
+    # No custom configurePhase needed.
+
+    buildPhase = ''
+      runHook preBuild
+
+      # Build better-sqlite3's native binding from source.
+      #
+      # Why from source on Node 24:
+      #   better-sqlite3 (even 12.9.0, latest as of 2026-05) only
+      #   publishes prebuilds up to node-v131 (Node 22). No v137
+      #   (Node 24) prebuild exists. `prebuild-install` would itself
+      #   fail the GitHub fetch and fall through to a compile, so we
+      #   skip the download attempt entirely and compile.
+      #
+      # Why not `pnpm rebuild`:
+      #   In pnpm 10, `onlyBuiltDependencies` interacts with the
+      #   "approve-builds" consent gate; `pnpm rebuild <pkg>` silently
+      #   no-ops in some configurations. Invoke node-gyp directly to
+      #   sidestep all of that.
+      #
+      # Env vars:
+      #   * npm_config_nodedir → use the headers shipped with the
+      #     nixpkgs nodejs we're already building against, so node-gyp
+      #     doesn't try to fetch them from nodejs.org/dist (no network
+      #     in the build sandbox).
+      #   * npm_config_build_from_source → tell better-sqlite3's
+      #     prebuild-install fallback chain to skip the CDN download
+      #     and compile.
+      #
+      # node-gyp lookup:
+      #   nixpkgs nodejs ships node-gyp bundled inside npm at
+      #   ${nodejs}/lib/node_modules/npm/bin/node-gyp-bin. Putting
+      #   that on PATH gives us a `node-gyp` shim without depending
+      #   on pnpm-exec resolving from inside better-sqlite3's tree
+      #   (better-sqlite3 doesn't list node-gyp as a direct dep).
+      export npm_config_nodedir=${nodejs}
+      export npm_config_build_from_source=true
+      export PATH="${nodejs}/lib/node_modules/npm/bin/node-gyp-bin:$PATH"
+
+      bsq_dir=$(find node_modules/.pnpm -mindepth 2 -maxdepth 4 \
+        -type d -path '*/better-sqlite3@*/node_modules/better-sqlite3' \
+        -print -quit)
+      if [ -z "$bsq_dir" ]; then
+        echo "ERROR: better-sqlite3 not found under node_modules/.pnpm — pnpm install may have failed" >&2
+        exit 1
+      fi
+
+      echo "Building better-sqlite3 from source at $bsq_dir"
+      ( cd "$bsq_dir" && node-gyp rebuild --release --build-from-source )
+
+      # Fail fast if the .node file didn't land where bindings.js
+      # looks for it. Without this assertion, a silent skip produces
+      # a "valid" derivation that crashes at runtime with
+      # "Could not locate the bindings file".
+      if [ ! -f "$bsq_dir/build/Release/better_sqlite3.node" ]; then
+        echo "ERROR: better_sqlite3.node was not produced at $bsq_dir/build/Release/" >&2
+        find "$bsq_dir" -name '*.node' -print >&2 || true
+        exit 1
+      fi
+
+      for target in ${lib.escapeShellArgs workspacePaths}; do
+        pnpm -C "$target" run --if-present build
+      done
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/lib/open-design $out/bin
+
+      # Copy the whole workspace tree — pnpm's symlinks under node_modules
+      # resolve sibling packages by relative paths, so we cannot prune to
+      # just apps/daemon.
+      cp -r . $out/lib/open-design/
+
+      # Runtime package exports point at dist/. Keep workspace package
+      # manifests for Node resolution and prune source/test/build config files
+      # before Nix fixup scans the output tree.
+      for target in ${lib.escapeShellArgs workspacePaths}; do
+        if [ "$target" = "apps/daemon" ]; then
+          find "$out/lib/open-design/$target" -mindepth 1 -maxdepth 1 \
+            ! -name dist \
+            ! -name bin \
+            ! -name node_modules \
+            ! -name package.json \
+            -exec rm -rf {} +
+        else
+          find "$out/lib/open-design/$target" -mindepth 1 -maxdepth 1 \
+            ! -name dist \
+            ! -name node_modules \
+            ! -name package.json \
+            -exec rm -rf {} +
+        fi
+      done
+
+      # Root devDependencies expose non-daemon workspaces via pnpm symlinks,
+      # but the daemon derivation intentionally filters those sources out
+      # when they are not needed at runtime. Prune the dangling symlinks from
+      # the copied node_modules tree so Nix fixup does not fail on broken
+      # links.
+      rm -f \
+        $out/lib/open-design/node_modules/@open-design/components \
+        $out/lib/open-design/node_modules/@open-design/tools-dev \
+        $out/lib/open-design/node_modules/@open-design/tools-pack \
+        $out/lib/open-design/node_modules/@open-design/tools-release \
+        $out/lib/open-design/node_modules/@open-design/tools-serve \
+        $out/lib/open-design/node_modules/.bin/tools-dev \
+        $out/lib/open-design/node_modules/.bin/tools-pack \
+        $out/lib/open-design/node_modules/.bin/tools-release \
+        $out/lib/open-design/node_modules/.bin/tools-serve
+
+      chmod +x $out/lib/open-design/apps/daemon/dist/cli.js
+
+      makeWrapper ${nodejs}/bin/node $out/bin/od \
+        --add-flags $out/lib/open-design/apps/daemon/dist/cli.js \
+        --set NODE_ENV production
+      runHook postInstall
+    '';
+
+    passthru = {
+      inherit nodejs;
+      pnpmDeps = finalAttrs.pnpmDeps;
+    };
+
+    meta = with lib; {
+      description = "OpenDesign daemon — local agent orchestrator + API (`od` CLI)";
+      homepage = "https://github.com/nexu-io/open-design";
+      license = licenses.asl20;
+      mainProgram = "od";
+      platforms = platforms.linux ++ platforms.darwin;
+    };
+  })

--- a/nix/package-web.nix
+++ b/nix/package-web.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  stdenv,
+  dream2nix,
+  nixpkgs,
+  system,
+  nodejs,
+  pnpm_10,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  src,
+  pnpmDepsSrc ? src,
+  workspacePaths,
+}:
+# Builds the @open-design/web Next.js static export.
+#
+# Output layout: $out/ contains the contents of `apps/web/out/` (an
+# index.html plus _next/ and asset subdirectories). Drop $out into any
+# static file server.
+#
+# OD_DAEMON_URL is set to "" at build time so the bundled JS issues
+# relative requests (`/api/*`, `/artifacts/*`, `/frames/*`) instead of
+# baking a build-time daemon URL into the export. The serving
+# environment is therefore expected to be same-origin with the daemon —
+# the bundled caddy in the modules reverse-proxies those paths to
+# `127.0.0.1:<cfg.port>`, and a custom nginx/caddy must do the same.
+let
+  pname = "open-design-web";
+  version = (lib.importJSON ../package.json).version;
+
+  pnpmDepsHash = (import ./pnpm-deps.nix).webHash;
+  pnpmWorkspaceFilters = map (workspacePath: "./${workspacePath}") workspacePaths;
+  dependencyBuildPaths = lib.filter (workspacePath: workspacePath != "apps/web") workspacePaths;
+in
+  stdenv.mkDerivation (finalAttrs: {
+    inherit pname version src;
+
+    pnpmWorkspaces = pnpmWorkspaceFilters;
+
+    nativeBuildInputs = [
+      nodejs
+      pnpm_10
+      pnpmConfigHook
+    ];
+
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs) pname version;
+      src = pnpmDepsSrc;
+      hash = pnpmDepsHash;
+      # Force the deps-fetch derivation to use the flake's pinned
+      # pnpm_10 as well. fetchPnpmDeps defaults to `pkgs.pnpm` when
+      # the `pnpm` arg is omitted.
+      pnpm = pnpm_10;
+      pnpmWorkspaces = pnpmWorkspaceFilters;
+      fetcherVersion = 3;
+    };
+
+    env = {
+      NODE_ENV = "production";
+      OD_DAEMON_URL = "";
+    };
+
+    buildPhase = ''
+      runHook preBuild
+      for target in ${lib.escapeShellArgs dependencyBuildPaths}; do
+        pnpm -C "$target" run --if-present build
+      done
+
+      # next.config.ts gates static-export emission on NODE_ENV=production
+      # and writes to apps/web/out/.
+      pnpm --filter @open-design/web run build
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp -r apps/web/out/. $out/
+      runHook postInstall
+    '';
+
+    passthru = {
+      inherit nodejs;
+      pnpmDeps = finalAttrs.pnpmDeps;
+    };
+
+    meta = with lib; {
+      description = "OpenDesign — Next.js static SPA (apps/web)";
+      homepage = "https://github.com/nexu-io/open-design";
+      license = licenses.asl20;
+      platforms = platforms.linux ++ platforms.darwin;
+    };
+  })

--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -1,0 +1,14 @@
+{
+  # Vendored pnpm store hashes for the workspace packages built by the flake.
+  # Generated lock artifact; do not hand-edit outside intentional Nix maintenance.
+  #
+  # The daemon and web derivations now build from different filtered source
+  # trees, so each fetchPnpmDeps invocation needs its own fixed-output hash.
+  # Refresh a hash whenever pnpm-lock.yaml or that derivation's source filter
+  # changes:
+  # 1. Temporarily set the consuming `hash = lib.fakeHash;`
+  # 2. Run the relevant nix build/flake check
+  # 3. Copy the expected hash printed by Nix into the matching field below
+  daemonHash = "sha256-ujXjphrP9TvyLvIFaiplOfWMhQEbMsy74KkCmqALkus=";
+  webHash = "sha256-OfTksoOcxLu6OairFxQEYLQomj1JFCDEA3maKiH+9bQ=";
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "tools-pack": "pnpm exec tools-pack",
     "tools-release": "pnpm exec tools-release",
     "tools-serve": "pnpm exec tools-serve",
+    "nix:update-hash": "node --experimental-strip-types ./scripts/update-nix-pnpm-deps-hash.ts",
     "guard": "tsx ./scripts/guard.ts",
     "lint:craft": "tsx ./scripts/lint-craft-references.ts",
     "i18n:check": "tsx ./scripts/i18n-check.ts",

--- a/scripts/approve-fork-pr-workflows.ts
+++ b/scripts/approve-fork-pr-workflows.ts
@@ -117,11 +117,14 @@ export function isDeniedChangedPath(path: string): boolean {
     path.startsWith(".github/") ||
     path.startsWith("scripts/") ||
     path.startsWith("e2e/scripts/") ||
+    path.startsWith("nix/") ||
     path.startsWith("tools/pack/") ||
     path === "package.json" ||
     path.endsWith("/package.json") ||
     path === "pnpm-lock.yaml" ||
     path === "pnpm-workspace.yaml" ||
+    path === "flake.nix" ||
+    path === "flake.lock" ||
     /(^|\/)tsconfig(\.[^.]+)*\.json$/.test(path) ||
     /(^|\/)(next|vite|vitest|playwright|astro|postcss|tailwind|eslint|prettier|wrangler|electron-builder)(\.config)?\.[^.]+$/.test(
       path,

--- a/scripts/update-nix-pnpm-deps-hash.ts
+++ b/scripts/update-nix-pnpm-deps-hash.ts
@@ -1,0 +1,104 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { spawnSync } from "node:child_process";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const sharedHashPath = path.join(repoRoot, "nix/pnpm-deps.nix");
+
+const consumerHashLine = "      hash = pnpmDepsHash;";
+const fakeHashLine = "      hash = lib.fakeHash;";
+const maxNixOutputBufferBytes = 32 * 1024 * 1024;
+
+const consumers = [
+  {
+    hashKey: "daemonHash",
+    consumerPath: path.join(repoRoot, "nix/package-daemon.nix"),
+    nixCommand: ["build", ".#daemon", "--print-build-logs"],
+  },
+  {
+    hashKey: "webHash",
+    consumerPath: path.join(repoRoot, "nix/package-web.nix"),
+    nixCommand: ["build", ".#web", "--print-build-logs"],
+  },
+] as const;
+
+function extractExpectedHash(output: string): string | null {
+  const matches = [...output.matchAll(/got:\s*(sha256-[A-Za-z0-9+/=]+)/g)];
+  return matches.at(-1)?.[1] ?? null;
+}
+
+async function main(): Promise<void> {
+  const updates: string[] = [];
+
+  for (const consumer of consumers) {
+    const originalConsumer = await readFile(consumer.consumerPath, "utf8");
+    if (!originalConsumer.includes(consumerHashLine)) {
+      throw new Error(
+        `Expected to find \`${consumerHashLine.trim()}\` in ${path.relative(repoRoot, consumer.consumerPath)}`,
+      );
+    }
+
+    const fakeHashConsumer = originalConsumer.replace(consumerHashLine, fakeHashLine);
+
+    await writeFile(consumer.consumerPath, fakeHashConsumer, "utf8");
+
+    try {
+      const result = spawnSync("nix", consumer.nixCommand, {
+        cwd: repoRoot,
+        encoding: "utf8",
+        maxBuffer: maxNixOutputBufferBytes,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+
+      if (result.error) {
+        throw new Error(`Failed to execute nix: ${result.error.message}`);
+      }
+
+      if (result.status === 0) {
+        throw new Error(
+          `nix ${consumer.nixCommand.join(" ")} unexpectedly succeeded after replacing the fixed-output hash with lib.fakeHash.`,
+        );
+      }
+
+      const combinedOutput = `${result.stdout}${result.stderr}`;
+      const nextHash = extractExpectedHash(combinedOutput);
+      if (!nextHash) {
+        throw new Error(
+          "nix build failed without reporting a fixed-output hash mismatch (`got: sha256-...`). " +
+            `Refusing to update ${path.relative(repoRoot, sharedHashPath)}.\n\n${combinedOutput}`,
+        );
+      }
+
+      const originalSharedHash = await readFile(sharedHashPath, "utf8");
+      const hashPattern = new RegExp(`${consumer.hashKey} = \"sha256-[A-Za-z0-9+/=]+\";`);
+      if (!hashPattern.test(originalSharedHash)) {
+        throw new Error(
+          `Expected to find \`${consumer.hashKey} = \"sha256-...\";\` in ${path.relative(repoRoot, sharedHashPath)}`,
+        );
+      }
+
+      const updatedSharedHash = originalSharedHash.replace(
+        hashPattern,
+        `${consumer.hashKey} = "${nextHash}";`,
+      );
+
+      if (updatedSharedHash === originalSharedHash) {
+        updates.push(`${consumer.hashKey} already pins ${nextHash}`);
+        continue;
+      }
+
+      await writeFile(sharedHashPath, updatedSharedHash, "utf8");
+      updates.push(`${consumer.hashKey} -> ${nextHash}`);
+    } finally {
+      await writeFile(consumer.consumerPath, originalConsumer, "utf8");
+    }
+  }
+
+  process.stdout.write(
+    `Updated ${path.relative(repoRoot, sharedHashPath)} (${updates.join(", ")}).\n` +
+      `Re-run \`nix flake check --print-build-logs --keep-going\` to confirm.\n`,
+  );
+}
+
+await main();


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #

## Why

<!-- Why are you opening this PR? Cover two things:
       - Your use case — what made you write this today? Did you hit it yourself
         while building on top of OD, are you scratching an itch for a team, or
         are you speculatively adding for others? All are fine, but say which.
       - The pain being addressed — user-facing problem, technical debt, a prod
         issue, or unblocking another change.
     For non-trivial features, please open a discussion or issue first to align
     on scope and UX before writing code. -->


## What users will see

<!-- Describe the change from a user's perspective, not in code terms. Examples:
       - "Settings → AI Providers has a new 'Custom endpoint' field, off by default"
       - "Right-clicking a design file shows a new 'Duplicate' option"
       - "Default model changed from X to Y — existing users will notice on first launch"
       - "New `od skills install <name>` subcommand"
     Skip this section only if you check "None" below. -->


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

<!-- If you checked "UI" above, attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->


## Bug fix verification

<!-- Skip if this PR isn't a bug fix.

     Per AGENTS.md → "Bug follow-up workflow", bugs should be encoded as a
     falsifiable test that goes red before the source change. Confirm:
       - Test path that reproduces the bug:
       - Did the test go red on `main` and green on this branch? (yes / no)
       - If a red spec wasn't cheap to write, explain why and what verification
         you did instead. -->

-


## Validation

<!-- What you actually ran. Default minimum: `pnpm guard` + `pnpm typecheck`,
     plus the package-scoped tests/build for the files you changed
     (e.g. `pnpm --filter @open-design/web test`). -->

-
